### PR TITLE
Api 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Using salsa is as easy as 1, 2, 3...
    and queries you will need. We'll start with one such trait, but
    later on you can use more than one to break up your system into
    components (or spread your code across crates).
-2. **Implement the queries** using the `query_definition!` macro.
+2. **Implement the query functions** where appropriate.
 3. Define the **database struct**, which contains the storage for all
    the inputs/queries you will be using. The query struct will contain
    the storage for all of the inputs/queries and may also contain

--- a/README.md
+++ b/README.md
@@ -30,16 +30,15 @@ of **queries**. Queries come in two basic varieties:
 
 Using salsa is as easy as 1, 2, 3...
 
-1. Define one or more **query context traits** that contain the inputs
+1. Define one or more **database traits** that contain the inputs
    and queries you will need. We'll start with one such trait, but
    later on you can use more than one to break up your system into
    components (or spread your code across crates).
 2. **Implement the queries** using the `query_definition!` macro.
-3. **Implement the query context trait** for your query context
-   struct, which contains a full listing of all the inputs/queries you
-   will be using. The query struct will contain the storage for all of
-   the inputs/queries and may also contain anything else that your
-   code needs (e.g., configuration data).
+3. Define the **database struct**, which contains the storage for all
+   the inputs/queries you will be using. The query struct will contain
+   the storage for all of the inputs/queries and may also contain
+   anything else that your code needs (e.g., configuration data).
   
 To see an example of this in action, check out [the `hello_world`
 example](examples/hello_world/main.rs), which has a number of comments

--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ Yehuda Katz, and Michael Woerister.
 
 ## Key idea
 
-The key idea of `salsa` is that you define your program as a set
-of **queries**. Queries come in two basic varieties:
+The key idea of `salsa` is that you define your program as a set of
+**queries**. Every query is used like function `K -> V` that maps from
+some key of type `K` to a value of type `V`. Queries come in two basic
+varieties:
 
 - **Inputs**: the base inputs to your system. You can change these
   whenever you like.
@@ -30,12 +32,12 @@ of **queries**. Queries come in two basic varieties:
 
 Using salsa is as easy as 1, 2, 3...
 
-1. Define one or more **database traits** that contain the inputs
-   and queries you will need. We'll start with one such trait, but
+1. Define one or more **query groups** that contain the inputs
+   and queries you will need. We'll start with one such group, but
    later on you can use more than one to break up your system into
    components (or spread your code across crates).
-2. **Implement the query functions** where appropriate.
-3. Define the **database struct**, which contains the storage for all
+2. Define the **query functions** where appropriate.
+3. Define the **database**, which contains the storage for all
    the inputs/queries you will be using. The query struct will contain
    the storage for all of the inputs/queries and may also contain
    anything else that your code needs (e.g., configuration data).

--- a/examples/compiler/class_table.rs
+++ b/examples/compiler/class_table.rs
@@ -3,7 +3,7 @@ use salsa::{query_definition, query_prototype};
 use std::sync::Arc;
 
 query_prototype! {
-    pub trait ClassTableQueryContext: compiler::CompilerQueryContext {
+    pub trait ClassTableDatabase: compiler::CompilerDatabase {
         /// Get the fields.
         fn fields() for Fields;
 
@@ -19,19 +19,19 @@ query_prototype! {
 pub struct DefId(usize);
 
 query_definition! {
-    pub AllClasses(_: &impl ClassTableQueryContext, (): ()) -> Arc<Vec<DefId>> {
+    pub AllClasses(_: &impl ClassTableDatabase, (): ()) -> Arc<Vec<DefId>> {
         Arc::new(vec![DefId(0), DefId(10)]) // dummy impl
     }
 }
 
 query_definition! {
-    pub Fields(_: &impl ClassTableQueryContext, class: DefId) -> Arc<Vec<DefId>> {
+    pub Fields(_: &impl ClassTableDatabase, class: DefId) -> Arc<Vec<DefId>> {
         Arc::new(vec![DefId(class.0 + 1), DefId(class.0 + 2)]) // dummy impl
     }
 }
 
 query_definition! {
-    pub AllFields(query: &impl ClassTableQueryContext, (): ()) -> Arc<Vec<DefId>> {
+    pub AllFields(query: &impl ClassTableDatabase, (): ()) -> Arc<Vec<DefId>> {
         Arc::new(
             query.all_classes()
                 .get(())

--- a/examples/compiler/class_table.rs
+++ b/examples/compiler/class_table.rs
@@ -5,13 +5,19 @@ use std::sync::Arc;
 query_prototype! {
     pub trait ClassTableDatabase: compiler::CompilerDatabase {
         /// Get the fields.
-        fn fields() for Fields;
+        fn fields(class: DefId) -> Arc<Vec<DefId>> {
+            type Fields;
+        }
 
         /// Get the list of all classes
-        fn all_classes() for AllClasses;
+        fn all_classes(key: ()) -> Arc<Vec<DefId>> {
+            type AllClasses;
+        }
 
         /// Get the list of all fields
-        fn all_fields() for AllFields;
+        fn all_fields(key: ()) -> Arc<Vec<DefId>> {
+            type AllFields;
+        }
     }
 }
 
@@ -31,14 +37,13 @@ query_definition! {
 }
 
 query_definition! {
-    pub AllFields(query: &impl ClassTableDatabase, (): ()) -> Arc<Vec<DefId>> {
+    pub AllFields(db: &impl ClassTableDatabase, (): ()) -> Arc<Vec<DefId>> {
         Arc::new(
-            query.all_classes()
-                .get(())
+            db.all_classes(())
                 .iter()
                 .cloned()
                 .flat_map(|def_id| {
-                    let fields = query.fields().get(def_id);
+                    let fields = db.fields(def_id);
                     (0..fields.len()).map(move |i| fields[i])
                 })
                 .collect()

--- a/examples/compiler/class_table.rs
+++ b/examples/compiler/class_table.rs
@@ -24,28 +24,22 @@ query_prototype! {
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct DefId(usize);
 
-impl<DB: ClassTableDatabase> salsa::QueryFunction<DB> for AllClasses {
-    fn execute(_: &DB, (): ()) -> Arc<Vec<DefId>> {
-        Arc::new(vec![DefId(0), DefId(10)]) // dummy impl
-    }
+fn all_classes(_: &impl ClassTableDatabase, (): ()) -> Arc<Vec<DefId>> {
+    Arc::new(vec![DefId(0), DefId(10)]) // dummy impl
 }
 
-impl<DB: ClassTableDatabase> salsa::QueryFunction<DB> for Fields {
-    fn execute(_: &DB, class: DefId) -> Arc<Vec<DefId>> {
-        Arc::new(vec![DefId(class.0 + 1), DefId(class.0 + 2)]) // dummy impl
-    }
+fn fields(_: &impl ClassTableDatabase, class: DefId) -> Arc<Vec<DefId>> {
+    Arc::new(vec![DefId(class.0 + 1), DefId(class.0 + 2)]) // dummy impl
 }
 
-impl<DB: ClassTableDatabase> salsa::QueryFunction<DB> for AllFields {
-    fn execute(db: &DB, (): ()) -> Arc<Vec<DefId>> {
-        Arc::new(
-            db.all_classes(())
-                .iter()
-                .cloned()
-                .flat_map(|def_id| {
-                    let fields = db.fields(def_id);
-                    (0..fields.len()).map(move |i| fields[i])
-                }).collect(),
-        )
-    }
+fn all_fields(db: &impl ClassTableDatabase, (): ()) -> Arc<Vec<DefId>> {
+    Arc::new(
+        db.all_classes(())
+            .iter()
+            .cloned()
+            .flat_map(|def_id| {
+                let fields = db.fields(def_id);
+                (0..fields.len()).map(move |i| fields[i])
+            }).collect(),
+    )
 }

--- a/examples/compiler/class_table.rs
+++ b/examples/compiler/class_table.rs
@@ -1,8 +1,7 @@
 use crate::compiler;
-use salsa::query_prototype;
 use std::sync::Arc;
 
-query_prototype! {
+salsa::query_group! {
     pub trait ClassTableDatabase: compiler::CompilerDatabase {
         /// Get the fields.
         fn fields(class: DefId) -> Arc<Vec<DefId>> {

--- a/examples/compiler/class_table.rs
+++ b/examples/compiler/class_table.rs
@@ -1,5 +1,5 @@
 use crate::compiler;
-use salsa::{query_definition, query_prototype};
+use salsa::query_prototype;
 use std::sync::Arc;
 
 query_prototype! {
@@ -24,20 +24,20 @@ query_prototype! {
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct DefId(usize);
 
-query_definition! {
-    pub AllClasses(_: &impl ClassTableDatabase, (): ()) -> Arc<Vec<DefId>> {
+impl<DB: ClassTableDatabase> salsa::QueryFunction<DB> for AllClasses {
+    fn execute(_: &DB, (): ()) -> Arc<Vec<DefId>> {
         Arc::new(vec![DefId(0), DefId(10)]) // dummy impl
     }
 }
 
-query_definition! {
-    pub Fields(_: &impl ClassTableDatabase, class: DefId) -> Arc<Vec<DefId>> {
+impl<DB: ClassTableDatabase> salsa::QueryFunction<DB> for Fields {
+    fn execute(_: &DB, class: DefId) -> Arc<Vec<DefId>> {
         Arc::new(vec![DefId(class.0 + 1), DefId(class.0 + 2)]) // dummy impl
     }
 }
 
-query_definition! {
-    pub AllFields(db: &impl ClassTableDatabase, (): ()) -> Arc<Vec<DefId>> {
+impl<DB: ClassTableDatabase> salsa::QueryFunction<DB> for AllFields {
+    fn execute(db: &DB, (): ()) -> Arc<Vec<DefId>> {
         Arc::new(
             db.all_classes(())
                 .iter()
@@ -45,8 +45,7 @@ query_definition! {
                 .flat_map(|def_id| {
                     let fields = db.fields(def_id);
                     (0..fields.len()).map(move |i| fields[i])
-                })
-                .collect()
+                }).collect(),
         )
     }
 }

--- a/examples/compiler/compiler.rs
+++ b/examples/compiler/compiler.rs
@@ -1,4 +1,4 @@
-pub trait CompilerQueryContext: salsa::QueryContext {
+pub trait CompilerDatabase: salsa::Database {
     fn interner(&self) -> &Interner;
 }
 

--- a/examples/compiler/main.rs
+++ b/examples/compiler/main.rs
@@ -2,12 +2,12 @@ mod class_table;
 mod compiler;
 mod implementation;
 
-use self::class_table::ClassTableQueryContext;
-use self::implementation::QueryContextImpl;
+use self::class_table::ClassTableDatabase;
+use self::implementation::DatabaseImpl;
 
 #[test]
 fn test() {
-    let query = QueryContextImpl::default();
+    let query = DatabaseImpl::default();
     let all_def_ids = query.all_fields().read();
     assert_eq!(
         format!("{:?}", all_def_ids),
@@ -16,7 +16,7 @@ fn test() {
 }
 
 fn main() {
-    let query = QueryContextImpl::default();
+    let query = DatabaseImpl::default();
     for f in query.all_fields().read().iter() {
         println!("{:?}", f);
     }

--- a/examples/compiler/main.rs
+++ b/examples/compiler/main.rs
@@ -8,7 +8,7 @@ use self::implementation::DatabaseImpl;
 #[test]
 fn test() {
     let query = DatabaseImpl::default();
-    let all_def_ids = query.all_fields().read();
+    let all_def_ids = query.all_fields(());
     assert_eq!(
         format!("{:?}", all_def_ids),
         "[DefId(1), DefId(2), DefId(11), DefId(12)]"
@@ -17,7 +17,7 @@ fn test() {
 
 fn main() {
     let query = DatabaseImpl::default();
-    for f in query.all_fields().read().iter() {
+    for f in query.all_fields(()).iter() {
         println!("{:?}", f);
     }
 }

--- a/examples/hello_world/README.md
+++ b/examples/hello_world/README.md
@@ -12,18 +12,18 @@ In your program, however, you rarely interact with the **actual**
 database struct. Instead, you interact with database **traits** that
 you define. These traits define the set of queries that you need for
 any given piece of code. You define them using the
-`salsa::query_prototype!` macro.
+`salsa::query_group!` macro.
 
 Here is a simple example of a database trait from the `hello_world`
 example. It defines exactly two queries: `input_string` and
-`length`. You see that the `query_prototype!` macro just lists out the
+`length`. You see that the `query_group!` macro just lists out the
 names of the queries as methods (e.g., `input_string()`) and also a
 path to a type that will define the query (`InputString`). It doesn't
 give many other details: those are specified in the query definition
 that comes later. XXX out of date
 
 ```rust
-salsa::query_prototype! {
+salsa::query_group! {
     trait HelloWorldDatabase: salsa::Database {
         fn input_string(key: ()) -> Arc<String> {
             type InputString;

--- a/examples/hello_world/README.md
+++ b/examples/hello_world/README.md
@@ -1,30 +1,30 @@
 The `hello_world` example is intended to walk through the very basics
 of a salsa setup. Here is a more detailed writeup.
 
-### Step 1: Define the query context trait
+### Step 1: Define the database trait
 
-The **query context** is the central struct that holds all the state
-for your application. It has the current values of all your inputs,
-the values of any memoized queries you have executed thus far, and
+The **database** is the central struct that holds all the state for
+your application. It has the current values of all your inputs, the
+values of any memoized queries you have executed thus far, and
 dependency information between them.
 
 In your program, however, you rarely interact with the **actual**
-query context struct. Instead, you interact with query context
-**traits** that you define. These traits define the set of queries
-that you need for any given piece of code. You define them using
-the `salsa::query_prototype!` macro.
+database struct. Instead, you interact with database **traits** that
+you define. These traits define the set of queries that you need for
+any given piece of code. You define them using the
+`salsa::query_prototype!` macro.
 
-Here is a simple example of a query context trait from the
-`hello_world` example. It defines exactly two queries: `input_string`
-and `length`. You see that the `query_prototype!` macro just lists out
-the names of the queries as methods (e.g., `input_string()`) and also a
+Here is a simple example of a database trait from the `hello_world`
+example. It defines exactly two queries: `input_string` and
+`length`. You see that the `query_prototype!` macro just lists out the
+names of the queries as methods (e.g., `input_string()`) and also a
 path to a type that will define the query (`InputString`). It doesn't
 give many other details: those are specified in the query definition
 that comes later.
 
 ```rust
 salsa::query_prototype! {
-    trait HelloWorldContext: salsa::QueryContext {
+    trait HelloWorldDatabase: salsa::Database {
         fn input_string() for InputString;
         fn length() for Length;
     }
@@ -58,9 +58,9 @@ Next let's define the `length` query, which is a function query:
 
 ```rust
 salsa::query_definition! {
-    Length(context: &impl HelloWorldContext, _key: ()) -> usize {
+    Length(db: &impl HelloWorldDatabase, _key: ()) -> usize {
         // Read the input string:
-        let input_string = context.input_string().get(());
+        let input_string = db.input_string().get(());
 
         // Return its length:
         input_string.len()
@@ -73,18 +73,18 @@ Like the `InputString` query, `Length` has a **key** and a **value**
 second argument (`_key`), and the type of the value is specified from
 the return type (`usize`).
 
-You can also see that functions take a first argument, the `context`,
-which always has the form `&impl <SomeContextTrait>`. This `context`
-value gives access to all the other queries that are listed in the
-context trait that you specify.
+You can also see that functions take a first argument, the `db`, which
+always has the form `&impl <SomeDatabaseTrait>`. This `db` value gives
+access to all the other queries that are listed in the context trait
+that you specify.
 
 In the first line of the function we see how we invoke a query:
 
 ```rust
-let input_string = context.input_string().get(());
+let input_string = db.input_string().get(());
 ```
 
-When you invoke `context.input_string()`, what you get back is called
+When you invoke `db.input_string()`, what you get back is called
 a `QueryTable` -- it offers a few methods that let you interact with
 the query. The main method you will use though is `get(key)` which --
 given a `key` -- computes and returns the up-to-date value. In the
@@ -93,31 +93,31 @@ value has been set by the user (if no value has been set yet, it
 returns the `Default::default()` value; all query inputs must
 implement `Default`).
 
-### Step 3: Implement the query context trait
+### Step 3: Define the database struct that implements the database trait
 
-The final step is to create the **query context struct** which will
-implement your query context trait(s). This struct combines all the
-parts of your system into one whole; it can also add custom state of
-your own (such as an interner or configuration). In our simple example
+The final step is to create the **database struct** which will
+implement your database trait(s). This struct combines all the parts
+of your system into one whole; it can also add custom state of your
+own (such as an interner or configuration). In our simple example
 though we won't do any of that. The only field that you **actually**
 need is a reference to the **salsa runtime**; then you must also
-implement the `QueryContext` trait to tell salsa where to find this
+implement the `salsa::Database` trait to tell salsa where to find this
 runtime:
 
 ```rust
 #[derive(Default)]
-struct QueryContextStruct {
-    runtime: salsa::runtime::Runtime<QueryContextStruct>,
+struct DatabaseStruct {
+    runtime: salsa::runtime::Runtime<DatabaseStruct>,
 }
 
-impl salsa::QueryContext for QueryContextImpl {
-    fn salsa_runtime(&self) -> &salsa::runtime::Runtime<QueryContextStruct> {
+impl salsa::Database for DatabaseStruct {
+    fn salsa_runtime(&self) -> &salsa::runtime::Runtime<DatabaseStruct> {
         &self.runtime
     }
 }
 ```
 
-Next, you must use the `query_context_storage!` to define the "storage
+Next, you must use the `database_storage!` to define the "storage
 struct" for your type. This storage struct contains all the hashmaps
 and other things that salsa uses to store the values for your
 queries. You won't need to interact with it directly. To use the
@@ -125,12 +125,12 @@ macro, you basically list out all the traits and each of the queries
 within those traits:
 
 ```rust
-query_context_storage! {
-    struct QueryContextStorage for QueryContextStruct {
-    //     ^^^^^^^^^^^^^^^^^^^     ------------------
-    //     name of the type        the name of your context type
+salsa::database_storage! {
+    struct DatabaseStorage for DatabaseStruct {
+    //     ^^^^^^^^^^^^^^^     --------------
+    //     name of the type    the name of your context type
     //     we will make
-        impl HelloWorldContext {
+        impl HelloWorldDatabase {
             fn input_string() for InputString;
             fn length() for Length;
         }
@@ -138,22 +138,20 @@ query_context_storage! {
 }
 ```
 
-The `query_context_storage` macro will also implement the
-`HelloWorldContext` trait for your query context type.
+The `database_storage` macro will also implement the
+`HelloWorldDatabase` trait for your query context type.
 
-Now that we've defined our query context, we can start using it:
+Now that we've defined our database, we can start using it:
 
 ```rust
 fn main() {
-    let context = QueryContextStruct::default();
+    let db = DatabaseStruct::default();
 
-    println!("Initially, the length is {}.", context.length().get(()));
+    println!("Initially, the length is {}.", db.length().get(()));
 
-    context
-        .input_string()
-        .set((), Arc::new(format!("Hello, world")));
+    db.input_string().set((), Arc::new(format!("Hello, world")));
 
-    println!("Now, the length is {}.", context.length().get(()));
+    println!("Now, the length is {}.", db.length().get(()));
 }
 ```
 

--- a/examples/hello_world/README.md
+++ b/examples/hello_world/README.md
@@ -20,18 +20,24 @@ example. It defines exactly two queries: `input_string` and
 names of the queries as methods (e.g., `input_string()`) and also a
 path to a type that will define the query (`InputString`). It doesn't
 give many other details: those are specified in the query definition
-that comes later.
+that comes later. XXX out of date
 
 ```rust
 salsa::query_prototype! {
     trait HelloWorldDatabase: salsa::Database {
-        fn input_string() for InputString;
-        fn length() for Length;
+        fn input_string(key: ()) -> Arc<String> {
+            type InputString;
+            storage input;
+        }
+
+        fn length(key: ()) -> usize {
+            type Length;
+        }
     }
 }
 ```
 
-### Step 2: Define the queries
+### Step 2: Define the query bodies
 
 The actual query definitions are made using the
 `salsa::query_definition` macro. For an **input query**, such as

--- a/examples/hello_world/README.md
+++ b/examples/hello_world/README.md
@@ -1,26 +1,19 @@
 The `hello_world` example is intended to walk through the very basics
 of a salsa setup. Here is a more detailed writeup.
 
-### Step 1: Define the database trait
+### Step 1: Define a query group
 
-The **database** is the central struct that holds all the state for
-your application. It has the current values of all your inputs, the
-values of any memoized queries you have executed thus far, and
-dependency information between them.
+A **query group** is a collection of queries (both inputs and
+functions) that are defined in one particular spot. Each query group
+represents some subset of the full set of queries you will use in your
+application. Query groups can also depend on one another: so you might
+have some basic query group A and then another query group B that uses
+the queries from A and adds a few more. (These relationships must form
+a DAG at present, but that is due to Rust's restrictions around
+supertraits, which are likely to be lifted.)
 
-In your program, however, you rarely interact with the **actual**
-database struct. Instead, you interact with database **traits** that
-you define. These traits define the set of queries that you need for
-any given piece of code. You define them using the
-`salsa::query_group!` macro.
-
-Here is a simple example of a database trait from the `hello_world`
-example. It defines exactly two queries: `input_string` and
-`length`. You see that the `query_group!` macro just lists out the
-names of the queries as methods (e.g., `input_string()`) and also a
-path to a type that will define the query (`InputString`). It doesn't
-give many other details: those are specified in the query definition
-that comes later. XXX out of date
+Each query group is defined via an invocation of `salsa::query_group!`
+macro. This is the invocation used in `hello_world`:
 
 ```rust
 salsa::query_group! {
@@ -37,78 +30,93 @@ salsa::query_group! {
 }
 ```
 
-### Step 2: Define the query bodies
+This invocation will in fact expand to a number of things you can
+later use and name. First and foremost is the **query group trait**,
+here called `HelloWorldDatabase`. As the name suggests, this trait
+will ultimately be implemented by the **database**, which is the
+struct in your application that contains the store for all queries and
+any other global state that persists beyond a single query execution.
+In writing your application, though, we never work with a concrete
+database struct: instead we work against a generic struct through
+traits, thus capturing the subset of functionality that we actually
+need.
 
-The actual query definitions are made using the
-`salsa::query_definition` macro. For an **input query**, such as
-`input_string`, these resemble a variable definition:
+The `HelloWorldDatabase` trait has one supertrait:
+`salsa::Database`. If we were defining more query groups in our
+application, and we wanted to invoke some of those queries from within
+this query group, we might list those query groupes here. You can also
+list any other traits you want, so long as your final database type
+implements them (this lets you add custom state and so forth to your
+database).
+
+Within this trait, we list out the queries that this group provides.
+Here, there are two: `input_string` and `length`. For each query, you
+specify the key and value type of the query in the form of a function:
+but the "fn body" is obviously not real Rust syntax. Rather, it's just
+used to specify a few bits of metadata about the query. We'll see how
+to define the fn body in the next step.
+
+**For each query.** For each query, we must **always** define a `type`
+(e.g., `type InputString;`).  The macro will define a type with this
+name alongside the trait: you can use this name later to specify which
+query you are talking about. This is needed for some of the more
+advanced methods (we'll discuss them later).
+
+You can also optionally define the **storage** for a query via a
+declaration like `storage <s>;`. The most common kind of storage is
+either *memoized* (the default) or *input*. An *input* is a special
+sort of query that is not defined by a function: rather, it gets its
+values via explicit `set` operations (we'll see them later). In our
+case, we define one input query (`input_string`) and one memoized
+query (`length`).
+
+### Step 2: Define the query functions
+
+Once you've defined your query group, you have to give the function
+definition for every non-input query. In our case, that is the query
+`length`. To do this, you simply define a function with the
+appropriate name in the same module as the query group; if you would
+prefer to use a different name or location, you write `use fn
+path::to::other_fn;` in the query definition to tell us where to find
+it.
+
+The query function for `length` looks like:
 
 ```rust
-salsa::query_definition! {
-    InputString: Map<(), Arc<String>>;
+fn length(db: &impl HelloWorldDatabase, (): ()) -> usize {
+    // Read the input string:
+    let input_string = db.input_string(());
+
+    // Return its length:
+    input_string.len()
 }
 ```
 
-Here, the `Map` is actually a keyword -- you have to write it.  The
-idea is that each query isn't defining a single value: they are always
-a mapping from some **key** to some **value** -- in this case, though,
-the type of the key is just the unit type `()` (so in a sense this
-*is* a single value). The value type would be `Arc<String>`.
+Note that every query function takes two arguments: the first is your
+database, which you access via a generic that references your trait
+(e.g., `impl HelloWorldDatabase`). The second is the key -- in this
+simple example, that's just `()`.
 
-Note that both keys and values are cloned with relative frequency, so
-it's a good idea to pick types that can be cheaply cloned. Also, for
-the incremental system to work, keys and value types must not employ
-"interior mutability" (no `Mutex` or `AtomicUsize` etc).
-
-Next let's define the `length` query, which is a function query:
+**Invoking a query.** In the first line of the function we see how to
+invoke a query for a given key:
 
 ```rust
-salsa::query_definition! {
-    Length(db: &impl HelloWorldDatabase, _key: ()) -> usize {
-        // Read the input string:
-        let input_string = db.input_string().get(());
-
-        // Return its length:
-        input_string.len()
-    }
-}
+let input_string = db.input_string(());
 ```
 
-Like the `InputString` query, `Length` has a **key** and a **value**
--- but this time the type of the key is specified as the type of the
-second argument (`_key`), and the type of the value is specified from
-the return type (`usize`).
+You simply call the function and give the key you want -- in this case
+`()`.
 
-You can also see that functions take a first argument, the `db`, which
-always has the form `&impl <SomeDatabaseTrait>`. This `db` value gives
-access to all the other queries that are listed in the context trait
-that you specify.
-
-In the first line of the function we see how we invoke a query:
-
-```rust
-let input_string = db.input_string().get(());
-```
-
-When you invoke `db.input_string()`, what you get back is called
-a `QueryTable` -- it offers a few methods that let you interact with
-the query. The main method you will use though is `get(key)` which --
-given a `key` -- computes and returns the up-to-date value. In the
-case of an input query like `input_string`, this just returns whatever
-value has been set by the user (if no value has been set yet, it
-returns the `Default::default()` value; all query inputs must
-implement `Default`).
-
-### Step 3: Define the database struct that implements the database trait
+### Step 3: Define the database struct
 
 The final step is to create the **database struct** which will
-implement your database trait(s). This struct combines all the parts
-of your system into one whole; it can also add custom state of your
-own (such as an interner or configuration). In our simple example
-though we won't do any of that. The only field that you **actually**
-need is a reference to the **salsa runtime**; then you must also
-implement the `salsa::Database` trait to tell salsa where to find this
-runtime:
+implement the traits from each of your query groups. This struct
+combines all the parts of your system into one whole; it can also add
+custom state of your own (such as an interner or configuration). In
+our simple example though we won't do any of that. The only field that
+you **actually** need is a reference to the **salsa runtime**; then
+you must also implement the `salsa::Database` trait to tell salsa
+where to find this runtime:
 
 ```rust
 #[derive(Default)]
@@ -147,7 +155,8 @@ salsa::database_storage! {
 The `database_storage` macro will also implement the
 `HelloWorldDatabase` trait for your query context type.
 
-Now that we've defined our database, we can start using it:
+**Use the database.** Now that we've defined our database, we can
+start using it:
 
 ```rust
 fn main() {
@@ -155,13 +164,28 @@ fn main() {
 
     println!("Initially, the length is {}.", db.length().get(()));
 
-    db.input_string().set((), Arc::new(format!("Hello, world")));
+    db.query(InputString)
+        .set((), Arc::new(format!("Hello, world")));
 
     println!("Now, the length is {}.", db.length().get(()));
 }
 ```
 
-And if we run this code:
+One thing to notice here is how we set the value for an input query:
+
+```rust
+    db.query(InputString)
+        .set((), Arc::new(format!("Hello, world")));
+```
+
+The `db.query(Foo)` method takes as argument the query type that
+characterizes your query. It gives back a "query table" type, which
+offers you more advanced methods beyond simply executing the query
+(for example, for input queries, you can invoke `set`). In fact, the
+standard call `db.query_name(key)` to access a query is just a
+shorthand for `db.query(QueryType).get(key)`.
+
+Finally, if we run this code:
 
 ```bash
 > cargo run --example hello_world

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -1,4 +1,4 @@
-use salsa::Query;
+use salsa::Database;
 use std::sync::Arc;
 
 ///////////////////////////////////////////////////////////////////////////
@@ -77,7 +77,8 @@ fn main() {
 
     println!("Initially, the length is {}.", db.length(()));
 
-    InputString.set(&db, (), Arc::new(format!("Hello, world")));
+    db.query(InputString)
+        .set((), Arc::new(format!("Hello, world")));
 
     println!("Now, the length is {}.", db.length(()));
 }

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -1,15 +1,15 @@
 use std::sync::Arc;
 
 ///////////////////////////////////////////////////////////////////////////
-// Step 1. Define the query context trait
+// Step 1. Define the database trait
 
-// Define a **query context trait** listing out all the prototypes
+// Define a **database trait** listing out all the prototypes
 // that are defined in this section of the code (in real applications
 // you would have many of these). For each query, we just give the
 // name of the accessor method (`input_string`) and link that to a
 // query type (`InputString`) that will be defined later.
 salsa::query_prototype! {
-    trait HelloWorldContext: salsa::QueryContext {
+    trait HelloWorldDatabase: salsa::Database {
         fn input_string() for InputString;
         fn length() for Length;
     }
@@ -28,13 +28,13 @@ salsa::query_definition! {
 // Define a **function query**. It too has a key and value type, but
 // it is defined with a function that -- given the key -- computes the
 // value. This function is supplied with a context (an `&impl
-// HelloWorldContext`) that gives access to other queries. The runtime
+// HelloWorldDatabase`) that gives access to other queries. The runtime
 // will track which queries you use so that we can incrementally
 // update memoized results.
 salsa::query_definition! {
-    Length(context: &impl HelloWorldContext, _key: ()) -> usize {
+    Length(db: &impl HelloWorldDatabase, _key: ()) -> usize {
         // Read the input string:
-        let input_string = context.input_string().get(());
+        let input_string = db.input_string().get(());
 
         // Return its length:
         input_string.len()
@@ -42,29 +42,29 @@ salsa::query_definition! {
 }
 
 ///////////////////////////////////////////////////////////////////////////
-// Step 3. Implement the query context trait.
+// Step 3. Define the database struct that implements the database trait
 
-// Define the actual query context struct. This must contain a salsa
+// Define the actual database struct. This must contain a salsa
 // runtime but can also contain anything else you need.
 #[derive(Default)]
-struct QueryContextStruct {
-    runtime: salsa::runtime::Runtime<QueryContextStruct>,
+struct DatabaseStruct {
+    runtime: salsa::runtime::Runtime<DatabaseStruct>,
 }
 
 // Tell salsa where to find the runtime in your context.
-impl salsa::QueryContext for QueryContextStruct {
-    fn salsa_runtime(&self) -> &salsa::runtime::Runtime<QueryContextStruct> {
+impl salsa::Database for DatabaseStruct {
+    fn salsa_runtime(&self) -> &salsa::runtime::Runtime<DatabaseStruct> {
         &self.runtime
     }
 }
 
 // Define the full set of queries that your context needs. This would
-// in general combine (and implement) all the query context traits in
+// in general combine (and implement) all the database traits in
 // your application into one place, allocating storage for all of
 // them.
-salsa::query_context_storage! {
-    pub struct QueryContextStorage for QueryContextStruct {
-        impl HelloWorldContext {
+salsa::database_storage! {
+    struct DatabaseStorage for DatabaseStruct {
+        impl HelloWorldDatabase {
             fn input_string() for InputString;
             fn length() for Length;
         }
@@ -73,13 +73,11 @@ salsa::query_context_storage! {
 
 // This shows how to use a query.
 fn main() {
-    let context = QueryContextStruct::default();
+    let db = DatabaseStruct::default();
 
-    println!("Initially, the length is {}.", context.length().get(()));
+    println!("Initially, the length is {}.", db.length().get(()));
 
-    context
-        .input_string()
-        .set((), Arc::new(format!("Hello, world")));
+    db.input_string().set((), Arc::new(format!("Hello, world")));
 
-    println!("Now, the length is {}.", context.length().get(()));
+    println!("Now, the length is {}.", db.length().get(()));
 }

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -2,22 +2,42 @@ use salsa::Database;
 use std::sync::Arc;
 
 ///////////////////////////////////////////////////////////////////////////
-// Step 1. Define the database trait
+// Step 1. Define the query group
 
-// Define a **database trait** listing out all the prototypes
-// that are defined in this section of the code (in real applications
-// you would have many of these). For each query, we just give the
-// name of the accessor method (`input_string`) and link that to a
-// query type (`InputString`) that will be defined later.
+// A **query group** is a collection of queries (both inputs and
+// functions) that are defined in one particular spot. Each query group
+// represents some subset of the full set of queries you will use in your
+// application. Query groups can also depend on one another: so you might
+// have some basic query group A and then another query group B that uses
+// the queries from A and adds a few more. (These relationships must form
+// a DAG at present, but that is due to Rust's restrictions around
+// supertraits, which are likely to be lifted.)
 salsa::query_group! {
     trait HelloWorldDatabase: salsa::Database {
+        // For each query, we give the name, input type (here, `()`)
+        // and the output type `Arc<String>`. Inside the "fn body" we
+        // give some other configuration.
         fn input_string(key: ()) -> Arc<String> {
+            // The type we will generate to represent this query.
             type InputString;
+
+            // Specify the queries' "storage" -- in this case, this is
+            // an *input query*, which means that its value changes
+            // only when it is explicitly *set* (see the `main`
+            // function below).
             storage input;
         }
 
+        // This is a *derived query*, meaning its value is specified by
+        // a function (see Step 2, below).
         fn length(key: ()) -> usize {
             type Length;
+
+            // No explicit storage defaults to `storage memoized;`
+            //
+            // The function that defines this query is (by default) a
+            // function with the same name as the query in the
+            // containing module (e.g., `length`).
         }
     }
 }
@@ -25,12 +45,14 @@ salsa::query_group! {
 ///////////////////////////////////////////////////////////////////////////
 // Step 2. Define the queries.
 
-// Define a **function query**. It too has a key and value type, but
-// it is defined with a function that -- given the key -- computes the
-// value. This function is supplied with a context (an `&impl
-// HelloWorldDatabase`) that gives access to other queries. The runtime
-// will track which queries you use so that we can incrementally
-// update memoized results.
+// Define the **function** for the `length` query. This function will
+// be called whenever the query's value must be recomputed. After it
+// is called once, its result is typically memoized, unless we think
+// that one of the inputs may have changed. Its first argument (`db`)
+// is the "database", which is the type that contains the storage for
+// all of the queries in the system -- we never know the concrete type
+// here, we only know the subset of methods we care about (defined by
+// the `HelloWorldDatabase` trait we specified above).
 fn length(db: &impl HelloWorldDatabase, (): ()) -> usize {
     // Read the input string:
     let input_string = db.input_string(());
@@ -40,7 +62,7 @@ fn length(db: &impl HelloWorldDatabase, (): ()) -> usize {
 }
 
 ///////////////////////////////////////////////////////////////////////////
-// Step 3. Define the database struct that implements the database trait
+// Step 3. Define the database struct
 
 // Define the actual database struct. This must contain a salsa
 // runtime but can also contain anything else you need.

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -13,7 +13,9 @@ salsa::query_prototype! {
     trait HelloWorldDatabase: salsa::Database {
         fn input_string(key: ()) -> Arc<String> {
             type InputString;
+            storage input;
         }
+
         fn length(key: ()) -> usize {
             type Length;
         }
@@ -23,21 +25,14 @@ salsa::query_prototype! {
 ///////////////////////////////////////////////////////////////////////////
 // Step 2. Define the queries.
 
-// Define an **input query**. Like all queries, it is a map from a key
-// (of type `()`) to a value (of type `Arc<String>`). All values begin
-// as `Default::default` but you can assign them new values.
-salsa::query_definition! {
-    InputString: Map<(), Arc<String>>;
-}
-
 // Define a **function query**. It too has a key and value type, but
 // it is defined with a function that -- given the key -- computes the
 // value. This function is supplied with a context (an `&impl
 // HelloWorldDatabase`) that gives access to other queries. The runtime
 // will track which queries you use so that we can incrementally
 // update memoized results.
-salsa::query_definition! {
-    Length(db: &impl HelloWorldDatabase, _key: ()) -> usize {
+impl<DB: HelloWorldDatabase> salsa::QueryFunction<DB> for Length {
+    fn execute(db: &DB, _key: ()) -> usize {
         // Read the input string:
         let input_string = db.input_string(());
 

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -1,3 +1,4 @@
+use salsa::Query;
 use std::sync::Arc;
 
 ///////////////////////////////////////////////////////////////////////////
@@ -10,8 +11,12 @@ use std::sync::Arc;
 // query type (`InputString`) that will be defined later.
 salsa::query_prototype! {
     trait HelloWorldDatabase: salsa::Database {
-        fn input_string() for InputString;
-        fn length() for Length;
+        fn input_string(key: ()) -> Arc<String> {
+            type InputString;
+        }
+        fn length(key: ()) -> usize {
+            type Length;
+        }
     }
 }
 
@@ -34,7 +39,7 @@ salsa::query_definition! {
 salsa::query_definition! {
     Length(db: &impl HelloWorldDatabase, _key: ()) -> usize {
         // Read the input string:
-        let input_string = db.input_string().get(());
+        let input_string = db.input_string(());
 
         // Return its length:
         input_string.len()
@@ -75,9 +80,9 @@ salsa::database_storage! {
 fn main() {
     let db = DatabaseStruct::default();
 
-    println!("Initially, the length is {}.", db.length().get(()));
+    println!("Initially, the length is {}.", db.length(()));
 
-    db.input_string().set((), Arc::new(format!("Hello, world")));
+    InputString.set(&db, (), Arc::new(format!("Hello, world")));
 
-    println!("Now, the length is {}.", db.length().get(()));
+    println!("Now, the length is {}.", db.length(()));
 }

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -31,14 +31,12 @@ salsa::query_prototype! {
 // HelloWorldDatabase`) that gives access to other queries. The runtime
 // will track which queries you use so that we can incrementally
 // update memoized results.
-impl<DB: HelloWorldDatabase> salsa::QueryFunction<DB> for Length {
-    fn execute(db: &DB, _key: ()) -> usize {
-        // Read the input string:
-        let input_string = db.input_string(());
+fn length(db: &impl HelloWorldDatabase, (): ()) -> usize {
+    // Read the input string:
+    let input_string = db.input_string(());
 
-        // Return its length:
-        input_string.len()
-    }
+    // Return its length:
+    input_string.len()
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 // you would have many of these). For each query, we just give the
 // name of the accessor method (`input_string`) and link that to a
 // query type (`InputString`) that will be defined later.
-salsa::query_prototype! {
+salsa::query_group! {
     trait HelloWorldDatabase: salsa::Database {
         fn input_string(key: ()) -> Arc<String> {
             type InputString;

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -3,8 +3,8 @@ use crate::runtime::Revision;
 use crate::runtime::StampedValue;
 use crate::CycleDetected;
 use crate::Database;
-use crate::Query;
 use crate::QueryDescriptor;
+use crate::QueryFunction;
 use crate::QueryStorageOps;
 use crate::QueryTable;
 use log::debug;
@@ -23,7 +23,7 @@ use std::hash::Hash;
 /// storage requirements.
 pub struct DependencyStorage<DB, Q>
 where
-    Q: Query<DB>,
+    Q: QueryFunction<DB>,
     DB: Database,
 {
     map: RwLock<FxHashMap<Q::Key, QueryState<DB>>>,
@@ -61,7 +61,7 @@ where
 
 impl<DB, Q> Default for DependencyStorage<DB, Q>
 where
-    Q: Query<DB>,
+    Q: QueryFunction<DB>,
     DB: Database,
 {
     fn default() -> Self {
@@ -73,7 +73,7 @@ where
 
 impl<DB, Q> DependencyStorage<DB, Q>
 where
-    Q: Query<DB>,
+    Q: QueryFunction<DB>,
     DB: Database,
 {
     fn read(
@@ -166,7 +166,7 @@ where
 
 impl<DB, Q> QueryStorageOps<DB, Q> for DependencyStorage<DB, Q>
 where
-    Q: Query<DB>,
+    Q: QueryFunction<DB>,
     DB: Database,
 {
     fn try_fetch<'q>(

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -2,8 +2,8 @@ use crate::runtime::QueryDescriptorSet;
 use crate::runtime::Revision;
 use crate::runtime::StampedValue;
 use crate::CycleDetected;
+use crate::Database;
 use crate::Query;
-use crate::QueryContext;
 use crate::QueryDescriptor;
 use crate::QueryStorageOps;
 use crate::QueryTable;
@@ -21,32 +21,32 @@ use std::hash::Hash;
 /// "Dependency" queries just track their dependencies and not the
 /// actual value (which they produce on demand). This lessens the
 /// storage requirements.
-pub struct DependencyStorage<QC, Q>
+pub struct DependencyStorage<DB, Q>
 where
-    Q: Query<QC>,
-    QC: QueryContext,
+    Q: Query<DB>,
+    DB: Database,
 {
-    map: RwLock<FxHashMap<Q::Key, QueryState<QC>>>,
+    map: RwLock<FxHashMap<Q::Key, QueryState<DB>>>,
 }
 
 /// Defines the "current state" of query's memoized results.
-enum QueryState<QC>
+enum QueryState<DB>
 where
-    QC: QueryContext,
+    DB: Database,
 {
     /// We are currently computing the result of this query; if we see
     /// this value in the table, it indeeds a cycle.
     InProgress,
 
     /// We have computed the query already, and here is the result.
-    Memoized(Memo<QC>),
+    Memoized(Memo<DB>),
 }
 
-struct Memo<QC>
+struct Memo<DB>
 where
-    QC: QueryContext,
+    DB: Database,
 {
-    inputs: QueryDescriptorSet<QC>,
+    inputs: QueryDescriptorSet<DB>,
 
     /// Last time that we checked our inputs to see if they have
     /// changed. If this is equal to the current revision, then the
@@ -59,10 +59,10 @@ where
     changed_at: Revision,
 }
 
-impl<QC, Q> Default for DependencyStorage<QC, Q>
+impl<DB, Q> Default for DependencyStorage<DB, Q>
 where
-    Q: Query<QC>,
-    QC: QueryContext,
+    Q: Query<DB>,
+    DB: Database,
 {
     fn default() -> Self {
         DependencyStorage {
@@ -71,18 +71,18 @@ where
     }
 }
 
-impl<QC, Q> DependencyStorage<QC, Q>
+impl<DB, Q> DependencyStorage<DB, Q>
 where
-    Q: Query<QC>,
-    QC: QueryContext,
+    Q: Query<DB>,
+    DB: Database,
 {
     fn read(
         &self,
-        query: &QC,
+        db: &DB,
         key: &Q::Key,
-        descriptor: &QC::QueryDescriptor,
+        descriptor: &DB::QueryDescriptor,
     ) -> Result<StampedValue<Q::Value>, CycleDetected> {
-        let revision_now = query.salsa_runtime().current_revision();
+        let revision_now = db.salsa_runtime().current_revision();
 
         debug!(
             "{:?}({:?}): invoked at {:?}",
@@ -106,15 +106,15 @@ where
 
         // Note that, unlike with a memoized query, we must always
         // re-execute.
-        let (stamped_value, inputs) = query
+        let (stamped_value, inputs) = db
             .salsa_runtime()
-            .execute_query_implementation::<Q>(query, descriptor, key);
+            .execute_query_implementation::<Q>(db, descriptor, key);
 
         // We assume that query is side-effect free -- that is, does
         // not mutate the "inputs" to the query system. Sanity check
         // that assumption here, at least to the best of our ability.
         assert_eq!(
-            query.salsa_runtime().current_revision(),
+            db.salsa_runtime().current_revision(),
             revision_now,
             "revision altered during query execution",
         );
@@ -144,9 +144,9 @@ where
 
     fn overwrite_placeholder(
         &self,
-        map_write: &mut FxHashMap<Q::Key, QueryState<QC>>,
+        map_write: &mut FxHashMap<Q::Key, QueryState<DB>>,
         key: &Q::Key,
-        value: Option<QueryState<QC>>,
+        value: Option<QueryState<DB>>,
     ) {
         let old_value = if let Some(v) = value {
             map_write.insert(key.clone(), v)
@@ -164,34 +164,32 @@ where
     }
 }
 
-impl<QC, Q> QueryStorageOps<QC, Q> for DependencyStorage<QC, Q>
+impl<DB, Q> QueryStorageOps<DB, Q> for DependencyStorage<DB, Q>
 where
-    Q: Query<QC>,
-    QC: QueryContext,
+    Q: Query<DB>,
+    DB: Database,
 {
     fn try_fetch<'q>(
         &self,
-        query: &'q QC,
+        db: &'q DB,
         key: &Q::Key,
-        descriptor: &QC::QueryDescriptor,
+        descriptor: &DB::QueryDescriptor,
     ) -> Result<Q::Value, CycleDetected> {
-        let StampedValue { value, changed_at } = self.read(query, key, &descriptor)?;
+        let StampedValue { value, changed_at } = self.read(db, key, &descriptor)?;
 
-        query
-            .salsa_runtime()
-            .report_query_read(descriptor, changed_at);
+        db.salsa_runtime().report_query_read(descriptor, changed_at);
 
         Ok(value)
     }
 
     fn maybe_changed_since(
         &self,
-        query: &'q QC,
+        db: &'q DB,
         revision: Revision,
         key: &Q::Key,
-        _descriptor: &QC::QueryDescriptor,
+        _descriptor: &DB::QueryDescriptor,
     ) -> bool {
-        let revision_now = query.salsa_runtime().current_revision();
+        let revision_now = db.salsa_runtime().current_revision();
 
         debug!(
             "{:?}({:?})::maybe_changed_since(revision={:?}, revision_now={:?})",
@@ -228,7 +226,7 @@ where
         if memo
             .inputs
             .iter()
-            .all(|old_input| !old_input.maybe_changed_since(query, memo.verified_at))
+            .all(|old_input| !old_input.maybe_changed_since(db, memo.verified_at))
         {
             memo.verified_at = revision_now;
             self.overwrite_placeholder(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,7 +316,7 @@ macro_rules! query_group {
         @query_fn[
             storage(input);
             method_name($method_name:ident);
-            fn_path($($fn_path:tt)+);
+            fn_path($fn_path:path);
             $($rest:tt)*
         ]
     ) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,7 +219,7 @@ impl DefaultKey for () {
 ///
 /// ```ignore
 /// trait TypeckDatabase {
-///     query_prototype! {
+///     query_group! {
 ///         /// Comments or other attributes can go here
 ///         fn my_query(input: u32) -> u64 {
 ///             type MyQuery;
@@ -230,11 +230,11 @@ impl DefaultKey for () {
 /// }
 /// ```
 #[macro_export]
-macro_rules! query_prototype {
+macro_rules! query_group {
     (
         $(#[$attr:meta])* $v:vis trait $name:ident { $($t:tt)* }
     ) => {
-        $crate::query_prototype! {
+        $crate::query_group! {
             attr[$(#[$attr])*];
             headers[$v, $name, ];
             tokens[{ $($t)* }];
@@ -244,7 +244,7 @@ macro_rules! query_prototype {
     (
         $(#[$attr:meta])* $v:vis trait $name:ident : $($t:tt)*
     ) => {
-        $crate::query_prototype! {
+        $crate::query_group! {
             attr[$(#[$attr])*];
             headers[$v, $name, ];
             tokens[$($t)*];
@@ -286,10 +286,10 @@ macro_rules! query_prototype {
             {
                 type Key = $key_ty;
                 type Value = $value_ty;
-                type Storage = $crate::query_prototype! { @storage_ty[DB, Self, $($storage)*] };
+                type Storage = $crate::query_group! { @storage_ty[DB, Self, $($storage)*] };
             }
 
-            $crate::query_prototype! {
+            $crate::query_group! {
                 @query_fn[
                     storage($($storage)*);
                     method_name($method_name);
@@ -335,7 +335,7 @@ macro_rules! query_prototype {
         ]
     ) => {
         // default to `use fn $method_name`
-        $crate::query_prototype! {
+        $crate::query_group! {
             @query_fn[
                 storage($($storage)*);
                 method_name($method_name);
@@ -372,7 +372,7 @@ macro_rules! query_prototype {
         headers[$($headers:tt)*];
         tokens[$token:tt $($tokens:tt)*];
     ) => {
-        $crate::query_prototype! {
+        $crate::query_group! {
             attr[$($attr)*];
             headers[$($headers)* $token];
             tokens[$($tokens)*];
@@ -384,7 +384,7 @@ macro_rules! query_prototype {
         // Default case:
         @storage_ty[$DB:ident, $Self:ident, ]
     ) => {
-        $crate::query_prototype! { @storage_ty[$DB, $Self, memoized] }
+        $crate::query_group! { @storage_ty[$DB, $Self, memoized] }
     };
 
     (

--- a/src/memoized.rs
+++ b/src/memoized.rs
@@ -3,8 +3,8 @@ use crate::runtime::Revision;
 use crate::runtime::StampedValue;
 use crate::CycleDetected;
 use crate::Database;
-use crate::Query;
 use crate::QueryDescriptor;
+use crate::QueryFunction;
 use crate::QueryStorageOps;
 use crate::QueryTable;
 use log::debug;
@@ -23,7 +23,7 @@ use std::hash::Hash;
 /// none of those inputs have changed.
 pub struct MemoizedStorage<DB, Q>
 where
-    Q: Query<DB>,
+    Q: QueryFunction<DB>,
     DB: Database,
 {
     map: RwLock<FxHashMap<Q::Key, QueryState<DB, Q>>>,
@@ -32,7 +32,7 @@ where
 /// Defines the "current state" of query's memoized results.
 enum QueryState<DB, Q>
 where
-    Q: Query<DB>,
+    Q: QueryFunction<DB>,
     DB: Database,
 {
     /// We are currently computing the result of this query; if we see
@@ -45,7 +45,7 @@ where
 
 struct Memo<DB, Q>
 where
-    Q: Query<DB>,
+    Q: QueryFunction<DB>,
     DB: Database,
 {
     stamped_value: StampedValue<Q::Value>,
@@ -62,7 +62,7 @@ where
 
 impl<DB, Q> Default for MemoizedStorage<DB, Q>
 where
-    Q: Query<DB>,
+    Q: QueryFunction<DB>,
     DB: Database,
 {
     fn default() -> Self {
@@ -74,7 +74,7 @@ where
 
 impl<DB, Q> MemoizedStorage<DB, Q>
 where
-    Q: Query<DB>,
+    Q: QueryFunction<DB>,
     DB: Database,
 {
     fn read(
@@ -206,7 +206,7 @@ where
 
 impl<DB, Q> QueryStorageOps<DB, Q> for MemoizedStorage<DB, Q>
 where
-    Q: Query<DB>,
+    Q: QueryFunction<DB>,
     DB: Database,
 {
     fn try_fetch<'q>(

--- a/src/memoized.rs
+++ b/src/memoized.rs
@@ -2,8 +2,8 @@ use crate::runtime::QueryDescriptorSet;
 use crate::runtime::Revision;
 use crate::runtime::StampedValue;
 use crate::CycleDetected;
+use crate::Database;
 use crate::Query;
-use crate::QueryContext;
 use crate::QueryDescriptor;
 use crate::QueryStorageOps;
 use crate::QueryTable;
@@ -21,36 +21,36 @@ use std::hash::Hash;
 /// Memoized queries store the result plus a list of the other queries
 /// that they invoked. This means we can avoid recomputing them when
 /// none of those inputs have changed.
-pub struct MemoizedStorage<QC, Q>
+pub struct MemoizedStorage<DB, Q>
 where
-    Q: Query<QC>,
-    QC: QueryContext,
+    Q: Query<DB>,
+    DB: Database,
 {
-    map: RwLock<FxHashMap<Q::Key, QueryState<QC, Q>>>,
+    map: RwLock<FxHashMap<Q::Key, QueryState<DB, Q>>>,
 }
 
 /// Defines the "current state" of query's memoized results.
-enum QueryState<QC, Q>
+enum QueryState<DB, Q>
 where
-    Q: Query<QC>,
-    QC: QueryContext,
+    Q: Query<DB>,
+    DB: Database,
 {
     /// We are currently computing the result of this query; if we see
     /// this value in the table, it indeeds a cycle.
     InProgress,
 
     /// We have computed the query already, and here is the result.
-    Memoized(Memo<QC, Q>),
+    Memoized(Memo<DB, Q>),
 }
 
-struct Memo<QC, Q>
+struct Memo<DB, Q>
 where
-    Q: Query<QC>,
-    QC: QueryContext,
+    Q: Query<DB>,
+    DB: Database,
 {
     stamped_value: StampedValue<Q::Value>,
 
-    inputs: QueryDescriptorSet<QC>,
+    inputs: QueryDescriptorSet<DB>,
 
     /// Last time that we checked our inputs to see if they have
     /// changed. If this is equal to the current revision, then the
@@ -60,10 +60,10 @@ where
     verified_at: Revision,
 }
 
-impl<QC, Q> Default for MemoizedStorage<QC, Q>
+impl<DB, Q> Default for MemoizedStorage<DB, Q>
 where
-    Q: Query<QC>,
-    QC: QueryContext,
+    Q: Query<DB>,
+    DB: Database,
 {
     fn default() -> Self {
         MemoizedStorage {
@@ -72,18 +72,18 @@ where
     }
 }
 
-impl<QC, Q> MemoizedStorage<QC, Q>
+impl<DB, Q> MemoizedStorage<DB, Q>
 where
-    Q: Query<QC>,
-    QC: QueryContext,
+    Q: Query<DB>,
+    DB: Database,
 {
     fn read(
         &self,
-        query: &QC,
+        db: &DB,
         key: &Q::Key,
-        descriptor: &QC::QueryDescriptor,
+        descriptor: &DB::QueryDescriptor,
     ) -> Result<StampedValue<Q::Value>, CycleDetected> {
-        let revision_now = query.salsa_runtime().current_revision();
+        let revision_now = db.salsa_runtime().current_revision();
 
         debug!(
             "{:?}({:?}): invoked at {:?}",
@@ -129,7 +129,7 @@ where
         // inputs and check whether they are out of date.
         if let Some(QueryState::Memoized(old_memo)) = &mut old_value {
             if old_memo.inputs.iter().all(|old_input| {
-                !old_input.maybe_changed_since(query, old_memo.stamped_value.changed_at)
+                !old_input.maybe_changed_since(db, old_memo.stamped_value.changed_at)
             }) {
                 debug!("{:?}({:?}): inputs still valid", Q::default(), key);
 
@@ -147,15 +147,15 @@ where
 
         // Query was not previously executed or value is potentially
         // stale. Let's execute!
-        let (mut stamped_value, inputs) = query
+        let (mut stamped_value, inputs) = db
             .salsa_runtime()
-            .execute_query_implementation::<Q>(query, descriptor, key);
+            .execute_query_implementation::<Q>(db, descriptor, key);
 
         // We assume that query is side-effect free -- that is, does
         // not mutate the "inputs" to the query system. Sanity check
         // that assumption here, at least to the best of our ability.
         assert_eq!(
-            query.salsa_runtime().current_revision(),
+            db.salsa_runtime().current_revision(),
             revision_now,
             "revision altered during query execution",
         );
@@ -189,9 +189,9 @@ where
 
     fn overwrite_placeholder(
         &self,
-        map_write: &mut FxHashMap<Q::Key, QueryState<QC, Q>>,
+        map_write: &mut FxHashMap<Q::Key, QueryState<DB, Q>>,
         key: &Q::Key,
-        value: QueryState<QC, Q>,
+        value: QueryState<DB, Q>,
     ) {
         let old_value = map_write.insert(key.clone(), value);
         assert!(
@@ -204,34 +204,32 @@ where
     }
 }
 
-impl<QC, Q> QueryStorageOps<QC, Q> for MemoizedStorage<QC, Q>
+impl<DB, Q> QueryStorageOps<DB, Q> for MemoizedStorage<DB, Q>
 where
-    Q: Query<QC>,
-    QC: QueryContext,
+    Q: Query<DB>,
+    DB: Database,
 {
     fn try_fetch<'q>(
         &self,
-        query: &'q QC,
+        db: &'q DB,
         key: &Q::Key,
-        descriptor: &QC::QueryDescriptor,
+        descriptor: &DB::QueryDescriptor,
     ) -> Result<Q::Value, CycleDetected> {
-        let StampedValue { value, changed_at } = self.read(query, key, &descriptor)?;
+        let StampedValue { value, changed_at } = self.read(db, key, &descriptor)?;
 
-        query
-            .salsa_runtime()
-            .report_query_read(descriptor, changed_at);
+        db.salsa_runtime().report_query_read(descriptor, changed_at);
 
         Ok(value)
     }
 
     fn maybe_changed_since(
         &self,
-        query: &'q QC,
+        db: &'q DB,
         revision: Revision,
         key: &Q::Key,
-        descriptor: &QC::QueryDescriptor,
+        descriptor: &DB::QueryDescriptor,
     ) -> bool {
-        let revision_now = query.salsa_runtime().current_revision();
+        let revision_now = db.salsa_runtime().current_revision();
 
         debug!(
             "{:?}({:?})::maybe_changed_since(revision={:?}, revision_now={:?})",
@@ -256,7 +254,7 @@ where
         }
 
         // Otherwise fall back to the full read to compute the result.
-        match self.read(query, key, descriptor) {
+        match self.read(db, key, descriptor) {
             Ok(v) => v.changed_at > revision,
             Err(CycleDetected) => true,
         }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,5 +1,6 @@
 use crate::Database;
 use crate::Query;
+use crate::QueryFunction;
 use log::debug;
 use rustc_hash::FxHasher;
 use std::cell::RefCell;
@@ -94,7 +95,7 @@ where
         key: &Q::Key,
     ) -> (StampedValue<Q::Value>, QueryDescriptorSet<DB>)
     where
-        Q: Query<DB>,
+        Q: QueryFunction<DB>,
     {
         debug!("{:?}({:?}): executing query", Q::default(), key);
 

--- a/src/volatile.rs
+++ b/src/volatile.rs
@@ -2,7 +2,7 @@ use crate::runtime::Revision;
 use crate::runtime::StampedValue;
 use crate::CycleDetected;
 use crate::Database;
-use crate::Query;
+use crate::QueryFunction;
 use crate::QueryStorageOps;
 use crate::QueryTable;
 use log::debug;
@@ -20,7 +20,7 @@ use std::hash::Hash;
 /// ask for the result of such a query, it is recomputed.
 pub struct VolatileStorage<DB, Q>
 where
-    Q: Query<DB>,
+    Q: QueryFunction<DB>,
     DB: Database,
 {
     /// We don't store the results of volatile queries,
@@ -30,7 +30,7 @@ where
 
 impl<DB, Q> Default for VolatileStorage<DB, Q>
 where
-    Q: Query<DB>,
+    Q: QueryFunction<DB>,
     DB: Database,
 {
     fn default() -> Self {
@@ -42,7 +42,7 @@ where
 
 impl<DB, Q> QueryStorageOps<DB, Q> for VolatileStorage<DB, Q>
 where
-    Q: Query<DB>,
+    Q: QueryFunction<DB>,
     DB: Database,
 {
     fn try_fetch<'q>(

--- a/tests/cycles.rs
+++ b/tests/cycles.rs
@@ -33,35 +33,35 @@ salsa::query_prototype! {
         }
         fn volatile_a(key: ()) -> () {
             type VolatileA;
+            storage volatile;
         }
         fn volatile_b(key: ()) -> () {
             type VolatileB;
+            storage volatile;
         }
     }
 }
 
-salsa::query_definition! {
-    crate MemoizedA(db: &impl Database, (): ()) -> () {
+impl<DB: Database> salsa::QueryFunction<DB> for MemoizedA {
+    fn execute(db: &DB, (): ()) -> () {
         db.memoized_b(())
     }
 }
 
-salsa::query_definition! {
-    crate MemoizedB(db: &impl Database, (): ()) -> () {
+impl<DB: Database> salsa::QueryFunction<DB> for MemoizedB {
+    fn execute(db: &DB, (): ()) -> () {
         db.memoized_a(())
     }
 }
 
-salsa::query_definition! {
-    #[storage(volatile)]
-    crate VolatileA(db: &impl Database, (): ()) -> () {
+impl<DB: Database> salsa::QueryFunction<DB> for VolatileA {
+    fn execute(db: &DB, (): ()) -> () {
         db.volatile_b(())
     }
 }
 
-salsa::query_definition! {
-    #[storage(volatile)]
-    crate VolatileB(db: &impl Database, (): ()) -> () {
+impl<DB: Database> salsa::QueryFunction<DB> for VolatileB {
+    fn execute(db: &DB, (): ()) -> () {
         db.volatile_a(())
     }
 }

--- a/tests/cycles.rs
+++ b/tests/cycles.rs
@@ -42,28 +42,20 @@ salsa::query_prototype! {
     }
 }
 
-impl<DB: Database> salsa::QueryFunction<DB> for MemoizedA {
-    fn execute(db: &DB, (): ()) -> () {
-        db.memoized_b(())
-    }
+fn memoized_a(db: &impl Database, (): ()) -> () {
+    db.memoized_b(())
 }
 
-impl<DB: Database> salsa::QueryFunction<DB> for MemoizedB {
-    fn execute(db: &DB, (): ()) -> () {
-        db.memoized_a(())
-    }
+fn memoized_b(db: &impl Database, (): ()) -> () {
+    db.memoized_a(())
 }
 
-impl<DB: Database> salsa::QueryFunction<DB> for VolatileA {
-    fn execute(db: &DB, (): ()) -> () {
-        db.volatile_b(())
-    }
+fn volatile_a(db: &impl Database, (): ()) -> () {
+    db.volatile_b(())
 }
 
-impl<DB: Database> salsa::QueryFunction<DB> for VolatileB {
-    fn execute(db: &DB, (): ()) -> () {
-        db.volatile_a(())
-    }
+fn volatile_b(db: &impl Database, (): ()) -> () {
+    db.volatile_a(())
 }
 
 #[test]

--- a/tests/cycles.rs
+++ b/tests/cycles.rs
@@ -22,7 +22,7 @@ salsa::database_storage! {
     }
 }
 
-salsa::query_prototype! {
+salsa::query_group! {
     trait Database: salsa::Database {
         // `a` and `b` depend on each other and form a cycle
         fn memoized_a(key: ()) -> () {

--- a/tests/incremental/implementation.rs
+++ b/tests/incremental/implementation.rs
@@ -4,7 +4,7 @@ use crate::memoized_dep_inputs;
 use crate::memoized_inputs;
 use crate::memoized_volatile;
 
-crate trait TestContext: salsa::QueryContext {
+crate trait TestContext: salsa::Database {
     fn clock(&self) -> &Counter;
     fn log(&self) -> &Log;
 }
@@ -41,7 +41,7 @@ impl TestContextImpl {
     }
 }
 
-salsa::query_context_storage! {
+salsa::database_storage! {
     crate struct TestContextImplStorage for TestContextImpl {
         impl memoized_dep_inputs::MemoizedDepInputsContext {
             fn dep_memoized2() for memoized_dep_inputs::Memoized2;
@@ -75,7 +75,7 @@ impl TestContext for TestContextImpl {
     }
 }
 
-impl salsa::QueryContext for TestContextImpl {
+impl salsa::Database for TestContextImpl {
     fn salsa_runtime(&self) -> &salsa::runtime::Runtime<TestContextImpl> {
         &self.runtime
     }

--- a/tests/incremental/memoized_dep_inputs.rs
+++ b/tests/incremental/memoized_dep_inputs.rs
@@ -1,7 +1,7 @@
 use crate::implementation::{TestContext, TestContextImpl};
 use salsa::Database;
 
-salsa::query_prototype! {
+salsa::query_group! {
     crate trait MemoizedDepInputsContext: TestContext {
         fn dep_memoized2(key: ()) -> usize {
             type Memoized2;

--- a/tests/incremental/memoized_dep_inputs.rs
+++ b/tests/incremental/memoized_dep_inputs.rs
@@ -24,25 +24,19 @@ salsa::query_prototype! {
     }
 }
 
-impl<DB: MemoizedDepInputsContext> salsa::QueryFunction<DB> for Memoized2 {
-    fn execute(db: &DB, (): ()) -> usize {
-        db.log().add("Memoized2 invoked");
-        db.dep_memoized1(())
-    }
+fn dep_memoized2(db: &impl MemoizedDepInputsContext, (): ()) -> usize {
+    db.log().add("Memoized2 invoked");
+    db.dep_memoized1(())
 }
 
-impl<DB: MemoizedDepInputsContext> salsa::QueryFunction<DB> for Memoized1 {
-    fn execute(db: &DB, (): ()) -> usize {
-        db.log().add("Memoized1 invoked");
-        db.dep_derived1(()) * 2
-    }
+fn dep_memoized1(db: &impl MemoizedDepInputsContext, (): ()) -> usize {
+    db.log().add("Memoized1 invoked");
+    db.dep_derived1(()) * 2
 }
 
-impl<DB: MemoizedDepInputsContext> salsa::QueryFunction<DB> for Derived1 {
-    fn execute(db: &DB, (): ()) -> usize {
-        db.log().add("Derived1 invoked");
-        db.dep_input1(()) / 2
-    }
+fn dep_derived1(db: &impl MemoizedDepInputsContext, (): ()) -> usize {
+    db.log().add("Derived1 invoked");
+    db.dep_input1(()) / 2
 }
 
 #[test]

--- a/tests/incremental/memoized_dep_inputs.rs
+++ b/tests/incremental/memoized_dep_inputs.rs
@@ -1,26 +1,37 @@
 use crate::implementation::{TestContext, TestContextImpl};
+use salsa::Query;
 
 salsa::query_prototype! {
     crate trait MemoizedDepInputsContext: TestContext {
-        fn dep_memoized2() for Memoized2;
-        fn dep_memoized1() for Memoized1;
-        fn dep_derived1() for Derived1;
-        fn dep_input1() for Input1;
-        fn dep_input2() for Input2;
+        fn dep_memoized2(key: ()) -> usize {
+            type Memoized2;
+        }
+        fn dep_memoized1(key: ()) -> usize {
+            type Memoized1;
+        }
+        fn dep_derived1(key: ()) -> usize {
+            type Derived1;
+        }
+        fn dep_input1(key: ()) -> usize {
+            type Input1;
+        }
+        fn dep_input2(key: ()) -> usize {
+            type Input2;
+        }
     }
 }
 
 salsa::query_definition! {
     crate Memoized2(db: &impl MemoizedDepInputsContext, (): ()) -> usize {
         db.log().add("Memoized2 invoked");
-        db.dep_memoized1().read()
+        db.dep_memoized1(())
     }
 }
 
 salsa::query_definition! {
     crate Memoized1(db: &impl MemoizedDepInputsContext, (): ()) -> usize {
         db.log().add("Memoized1 invoked");
-        db.dep_derived1().read() * 2
+        db.dep_derived1(()) * 2
     }
 }
 
@@ -28,7 +39,7 @@ salsa::query_definition! {
     #[storage(dependencies)]
     crate Derived1(db: &impl MemoizedDepInputsContext, (): ()) -> usize {
         db.log().add("Derived1 invoked");
-        db.dep_input1().read() / 2
+        db.dep_input1(()) / 2
     }
 }
 
@@ -42,30 +53,30 @@ salsa::query_definition! {
 
 #[test]
 fn revalidate() {
-    let query = TestContextImpl::default();
+    let db = &TestContextImpl::default();
 
     // Initial run starts from Memoized2:
-    let v = query.dep_memoized2().read();
+    let v = db.dep_memoized2(());
     assert_eq!(v, 0);
-    query.assert_log(&["Memoized2 invoked", "Memoized1 invoked", "Derived1 invoked"]);
+    db.assert_log(&["Memoized2 invoked", "Memoized1 invoked", "Derived1 invoked"]);
 
     // After that, we first try to validate Memoized1 but wind up
     // running Memoized2. Note that we don't try to validate
     // Derived1, so it is invoked by Memoized1.
-    query.dep_input1().set((), 44);
-    let v = query.dep_memoized2().read();
+    Input1.set(db, (), 44);
+    let v = db.dep_memoized2(());
     assert_eq!(v, 44);
-    query.assert_log(&["Memoized1 invoked", "Derived1 invoked", "Memoized2 invoked"]);
+    db.assert_log(&["Memoized1 invoked", "Derived1 invoked", "Memoized2 invoked"]);
 
     // Here validation of Memoized1 succeeds so Memoized2 never runs.
-    query.dep_input1().set((), 45);
-    let v = query.dep_memoized2().read();
+    Input1.set(db, (), 45);
+    let v = db.dep_memoized2(());
     assert_eq!(v, 44);
-    query.assert_log(&["Memoized1 invoked", "Derived1 invoked"]);
+    db.assert_log(&["Memoized1 invoked", "Derived1 invoked"]);
 
     // Here, a change to input2 doesn't affect us, so nothing runs.
-    query.dep_input2().set((), 45);
-    let v = query.dep_memoized2().read();
+    Input2.set(db, (), 45);
+    let v = db.dep_memoized2(());
     assert_eq!(v, 44);
-    query.assert_log(&[]);
+    db.assert_log(&[]);
 }

--- a/tests/incremental/memoized_dep_inputs.rs
+++ b/tests/incremental/memoized_dep_inputs.rs
@@ -1,5 +1,5 @@
 use crate::implementation::{TestContext, TestContextImpl};
-use salsa::Query;
+use salsa::Database;
 
 salsa::query_prototype! {
     crate trait MemoizedDepInputsContext: TestContext {
@@ -57,19 +57,19 @@ fn revalidate() {
     // After that, we first try to validate Memoized1 but wind up
     // running Memoized2. Note that we don't try to validate
     // Derived1, so it is invoked by Memoized1.
-    Input1.set(db, (), 44);
+    db.query(Input1).set((), 44);
     let v = db.dep_memoized2(());
     assert_eq!(v, 44);
     db.assert_log(&["Memoized1 invoked", "Derived1 invoked", "Memoized2 invoked"]);
 
     // Here validation of Memoized1 succeeds so Memoized2 never runs.
-    Input1.set(db, (), 45);
+    db.query(Input1).set((), 45);
     let v = db.dep_memoized2(());
     assert_eq!(v, 44);
     db.assert_log(&["Memoized1 invoked", "Derived1 invoked"]);
 
     // Here, a change to input2 doesn't affect us, so nothing runs.
-    Input2.set(db, (), 45);
+    db.query(Input2).set((), 45);
     let v = db.dep_memoized2(());
     assert_eq!(v, 44);
     db.assert_log(&[]);

--- a/tests/incremental/memoized_dep_inputs.rs
+++ b/tests/incremental/memoized_dep_inputs.rs
@@ -11,44 +11,38 @@ salsa::query_prototype! {
         }
         fn dep_derived1(key: ()) -> usize {
             type Derived1;
+            storage dependencies;
         }
         fn dep_input1(key: ()) -> usize {
             type Input1;
+            storage input;
         }
         fn dep_input2(key: ()) -> usize {
             type Input2;
+            storage input;
         }
     }
 }
 
-salsa::query_definition! {
-    crate Memoized2(db: &impl MemoizedDepInputsContext, (): ()) -> usize {
+impl<DB: MemoizedDepInputsContext> salsa::QueryFunction<DB> for Memoized2 {
+    fn execute(db: &DB, (): ()) -> usize {
         db.log().add("Memoized2 invoked");
         db.dep_memoized1(())
     }
 }
 
-salsa::query_definition! {
-    crate Memoized1(db: &impl MemoizedDepInputsContext, (): ()) -> usize {
+impl<DB: MemoizedDepInputsContext> salsa::QueryFunction<DB> for Memoized1 {
+    fn execute(db: &DB, (): ()) -> usize {
         db.log().add("Memoized1 invoked");
         db.dep_derived1(()) * 2
     }
 }
 
-salsa::query_definition! {
-    #[storage(dependencies)]
-    crate Derived1(db: &impl MemoizedDepInputsContext, (): ()) -> usize {
+impl<DB: MemoizedDepInputsContext> salsa::QueryFunction<DB> for Derived1 {
+    fn execute(db: &DB, (): ()) -> usize {
         db.log().add("Derived1 invoked");
         db.dep_input1(()) / 2
     }
-}
-
-salsa::query_definition! {
-    crate Input1: Map<(), usize>;
-}
-
-salsa::query_definition! {
-    crate Input2: Map<(), usize>;
 }
 
 #[test]

--- a/tests/incremental/memoized_dep_inputs.rs
+++ b/tests/incremental/memoized_dep_inputs.rs
@@ -11,24 +11,24 @@ salsa::query_prototype! {
 }
 
 salsa::query_definition! {
-    crate Memoized2(query: &impl MemoizedDepInputsContext, (): ()) -> usize {
-        query.log().add("Memoized2 invoked");
-        query.dep_memoized1().read()
+    crate Memoized2(db: &impl MemoizedDepInputsContext, (): ()) -> usize {
+        db.log().add("Memoized2 invoked");
+        db.dep_memoized1().read()
     }
 }
 
 salsa::query_definition! {
-    crate Memoized1(query: &impl MemoizedDepInputsContext, (): ()) -> usize {
-        query.log().add("Memoized1 invoked");
-        query.dep_derived1().read() * 2
+    crate Memoized1(db: &impl MemoizedDepInputsContext, (): ()) -> usize {
+        db.log().add("Memoized1 invoked");
+        db.dep_derived1().read() * 2
     }
 }
 
 salsa::query_definition! {
     #[storage(dependencies)]
-    crate Derived1(query: &impl MemoizedDepInputsContext, (): ()) -> usize {
-        query.log().add("Derived1 invoked");
-        query.dep_input1().read() / 2
+    crate Derived1(db: &impl MemoizedDepInputsContext, (): ()) -> usize {
+        db.log().add("Derived1 invoked");
+        db.dep_input1().read() / 2
     }
 }
 

--- a/tests/incremental/memoized_inputs.rs
+++ b/tests/incremental/memoized_inputs.rs
@@ -1,10 +1,17 @@
 use crate::implementation::{TestContext, TestContextImpl};
+use salsa::Query;
 
 salsa::query_prototype! {
     crate trait MemoizedInputsContext: TestContext {
-        fn max() for Max;
-        fn input1() for Input1;
-        fn input2() for Input2;
+        fn max(key: ()) -> usize {
+            type Max;
+        }
+        fn input1(key: ()) -> usize {
+            type Input1;
+        }
+        fn input2(key: ()) -> usize {
+            type Input2;
+        }
     }
 }
 
@@ -12,8 +19,8 @@ salsa::query_definition! {
     crate Max(db: &impl MemoizedInputsContext, (): ()) -> usize {
         db.log().add("Max invoked");
         std::cmp::max(
-            db.input1().read(),
-            db.input2().read(),
+            db.input1(()),
+            db.input2(()),
         )
     }
 }
@@ -28,39 +35,39 @@ salsa::query_definition! {
 
 #[test]
 fn revalidate() {
-    let query = TestContextImpl::default();
+    let db = &TestContextImpl::default();
 
-    let v = query.max().read();
+    let v = db.max(());
     assert_eq!(v, 0);
-    query.assert_log(&["Max invoked"]);
+    db.assert_log(&["Max invoked"]);
 
-    let v = query.max().read();
+    let v = db.max(());
     assert_eq!(v, 0);
-    query.assert_log(&[]);
+    db.assert_log(&[]);
 
-    query.input1().set((), 44);
-    query.assert_log(&[]);
+    Input1.set(db, (), 44);
+    db.assert_log(&[]);
 
-    let v = query.max().read();
+    let v = db.max(());
     assert_eq!(v, 44);
-    query.assert_log(&["Max invoked"]);
+    db.assert_log(&["Max invoked"]);
 
-    let v = query.max().read();
+    let v = db.max(());
     assert_eq!(v, 44);
-    query.assert_log(&[]);
+    db.assert_log(&[]);
 
-    query.input1().set((), 44);
-    query.assert_log(&[]);
-    query.input2().set((), 66);
-    query.assert_log(&[]);
-    query.input1().set((), 64);
-    query.assert_log(&[]);
+    Input1.set(db, (), 44);
+    db.assert_log(&[]);
+    Input2.set(db, (), 66);
+    db.assert_log(&[]);
+    Input1.set(db, (), 64);
+    db.assert_log(&[]);
 
-    let v = query.max().read();
+    let v = db.max(());
     assert_eq!(v, 66);
-    query.assert_log(&["Max invoked"]);
+    db.assert_log(&["Max invoked"]);
 
-    let v = query.max().read();
+    let v = db.max(());
     assert_eq!(v, 66);
-    query.assert_log(&[]);
+    db.assert_log(&[]);
 }

--- a/tests/incremental/memoized_inputs.rs
+++ b/tests/incremental/memoized_inputs.rs
@@ -9,11 +9,11 @@ salsa::query_prototype! {
 }
 
 salsa::query_definition! {
-    crate Max(query: &impl MemoizedInputsContext, (): ()) -> usize {
-        query.log().add("Max invoked");
+    crate Max(db: &impl MemoizedInputsContext, (): ()) -> usize {
+        db.log().add("Max invoked");
         std::cmp::max(
-            query.input1().read(),
-            query.input2().read(),
+            db.input1().read(),
+            db.input2().read(),
         )
     }
 }

--- a/tests/incremental/memoized_inputs.rs
+++ b/tests/incremental/memoized_inputs.rs
@@ -8,29 +8,20 @@ salsa::query_prototype! {
         }
         fn input1(key: ()) -> usize {
             type Input1;
+            storage input;
         }
         fn input2(key: ()) -> usize {
             type Input2;
+            storage input;
         }
     }
 }
 
-salsa::query_definition! {
-    crate Max(db: &impl MemoizedInputsContext, (): ()) -> usize {
+impl<DB: MemoizedInputsContext> salsa::QueryFunction<DB> for Max {
+    fn execute(db: &DB, (): ()) -> usize {
         db.log().add("Max invoked");
-        std::cmp::max(
-            db.input1(()),
-            db.input2(()),
-        )
+        std::cmp::max(db.input1(()), db.input2(()))
     }
-}
-
-salsa::query_definition! {
-    crate Input1: Map<(), usize>;
-}
-
-salsa::query_definition! {
-    crate Input2: Map<(), usize>;
 }
 
 #[test]

--- a/tests/incremental/memoized_inputs.rs
+++ b/tests/incremental/memoized_inputs.rs
@@ -17,11 +17,9 @@ salsa::query_prototype! {
     }
 }
 
-impl<DB: MemoizedInputsContext> salsa::QueryFunction<DB> for Max {
-    fn execute(db: &DB, (): ()) -> usize {
-        db.log().add("Max invoked");
-        std::cmp::max(db.input1(()), db.input2(()))
-    }
+fn max(db: &impl MemoizedInputsContext, (): ()) -> usize {
+    db.log().add("Max invoked");
+    std::cmp::max(db.input1(()), db.input2(()))
 }
 
 #[test]

--- a/tests/incremental/memoized_inputs.rs
+++ b/tests/incremental/memoized_inputs.rs
@@ -1,7 +1,7 @@
 use crate::implementation::{TestContext, TestContextImpl};
 use salsa::Database;
 
-salsa::query_prototype! {
+salsa::query_group! {
     crate trait MemoizedInputsContext: TestContext {
         fn max(key: ()) -> usize {
             type Max;

--- a/tests/incremental/memoized_inputs.rs
+++ b/tests/incremental/memoized_inputs.rs
@@ -1,5 +1,5 @@
 use crate::implementation::{TestContext, TestContextImpl};
-use salsa::Query;
+use salsa::Database;
 
 salsa::query_prototype! {
     crate trait MemoizedInputsContext: TestContext {
@@ -36,7 +36,7 @@ fn revalidate() {
     assert_eq!(v, 0);
     db.assert_log(&[]);
 
-    Input1.set(db, (), 44);
+    db.query(Input1).set((), 44);
     db.assert_log(&[]);
 
     let v = db.max(());
@@ -47,11 +47,11 @@ fn revalidate() {
     assert_eq!(v, 44);
     db.assert_log(&[]);
 
-    Input1.set(db, (), 44);
+    db.query(Input1).set((), 44);
     db.assert_log(&[]);
-    Input2.set(db, (), 66);
+    db.query(Input2).set((), 66);
     db.assert_log(&[]);
-    Input1.set(db, (), 64);
+    db.query(Input1).set((), 64);
     db.assert_log(&[]);
 
     let v = db.max(());

--- a/tests/incremental/memoized_volatile.rs
+++ b/tests/incremental/memoized_volatile.rs
@@ -18,26 +18,20 @@ salsa::query_prototype! {
     }
 }
 
-impl<DB: MemoizedVolatileContext> salsa::QueryFunction<DB> for Memoized2 {
-    fn execute(db: &DB, (): ()) -> usize {
-        db.log().add("Memoized2 invoked");
-        db.memoized1(())
-    }
+fn memoized2(db: &impl MemoizedVolatileContext, (): ()) -> usize {
+    db.log().add("Memoized2 invoked");
+    db.memoized1(())
 }
 
-impl<DB: MemoizedVolatileContext> salsa::QueryFunction<DB> for Memoized1 {
-    fn execute(db: &DB, (): ()) -> usize {
-        db.log().add("Memoized1 invoked");
-        let v = db.volatile(());
-        v / 2
-    }
+fn memoized1(db: &impl MemoizedVolatileContext, (): ()) -> usize {
+    db.log().add("Memoized1 invoked");
+    let v = db.volatile(());
+    v / 2
 }
 
-impl<DB: MemoizedVolatileContext> salsa::QueryFunction<DB> for Volatile {
-    fn execute(db: &DB, (): ()) -> usize {
-        db.log().add("Volatile invoked");
-        db.clock().increment()
-    }
+fn volatile(db: &impl MemoizedVolatileContext, (): ()) -> usize {
+    db.log().add("Volatile invoked");
+    db.clock().increment()
 }
 
 #[test]

--- a/tests/incremental/memoized_volatile.rs
+++ b/tests/incremental/memoized_volatile.rs
@@ -13,28 +13,28 @@ salsa::query_prototype! {
         }
         fn volatile(key: ()) -> usize {
             type Volatile;
+            storage volatile;
         }
     }
 }
 
-salsa::query_definition! {
-    crate Memoized2(db: &impl MemoizedVolatileContext, (): ()) -> usize {
+impl<DB: MemoizedVolatileContext> salsa::QueryFunction<DB> for Memoized2 {
+    fn execute(db: &DB, (): ()) -> usize {
         db.log().add("Memoized2 invoked");
         db.memoized1(())
     }
 }
 
-salsa::query_definition! {
-    crate Memoized1(db: &impl MemoizedVolatileContext, (): ()) -> usize {
+impl<DB: MemoizedVolatileContext> salsa::QueryFunction<DB> for Memoized1 {
+    fn execute(db: &DB, (): ()) -> usize {
         db.log().add("Memoized1 invoked");
         let v = db.volatile(());
         v / 2
     }
 }
 
-salsa::query_definition! {
-    #[storage(volatile)]
-    crate Volatile(db: &impl MemoizedVolatileContext, (): ()) -> usize {
+impl<DB: MemoizedVolatileContext> salsa::QueryFunction<DB> for Volatile {
+    fn execute(db: &DB, (): ()) -> usize {
         db.log().add("Volatile invoked");
         db.clock().increment()
     }

--- a/tests/incremental/memoized_volatile.rs
+++ b/tests/incremental/memoized_volatile.rs
@@ -1,5 +1,5 @@
 use crate::implementation::{TestContext, TestContextImpl};
-use salsa::QueryContext;
+use salsa::Database;
 
 salsa::query_prototype! {
     crate trait MemoizedVolatileContext: TestContext {
@@ -12,25 +12,25 @@ salsa::query_prototype! {
 }
 
 salsa::query_definition! {
-    crate Memoized2(query: &impl MemoizedVolatileContext, (): ()) -> usize {
-        query.log().add("Memoized2 invoked");
-        query.memoized1().read()
+    crate Memoized2(db: &impl MemoizedVolatileContext, (): ()) -> usize {
+        db.log().add("Memoized2 invoked");
+        db.memoized1().read()
     }
 }
 
 salsa::query_definition! {
-    crate Memoized1(query: &impl MemoizedVolatileContext, (): ()) -> usize {
-        query.log().add("Memoized1 invoked");
-        let v = query.volatile().read();
+    crate Memoized1(db: &impl MemoizedVolatileContext, (): ()) -> usize {
+        db.log().add("Memoized1 invoked");
+        let v = db.volatile().read();
         v / 2
     }
 }
 
 salsa::query_definition! {
     #[storage(volatile)]
-    crate Volatile(query: &impl MemoizedVolatileContext, (): ()) -> usize {
-        query.log().add("Volatile invoked");
-        query.clock().increment()
+    crate Volatile(db: &impl MemoizedVolatileContext, (): ()) -> usize {
+        db.log().add("Volatile invoked");
+        db.clock().increment()
     }
 }
 

--- a/tests/incremental/memoized_volatile.rs
+++ b/tests/incremental/memoized_volatile.rs
@@ -1,7 +1,7 @@
 use crate::implementation::{TestContext, TestContextImpl};
 use salsa::Database;
 
-salsa::query_prototype! {
+salsa::query_group! {
     crate trait MemoizedVolatileContext: TestContext {
         // Queries for testing a "volatile" value wrapped by
         // memoization.

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -1,0 +1,14 @@
+salsa::query_group! {
+    trait MyDatabase: salsa::Database {
+        fn my_query(key: ()) -> () {
+            type MyQuery;
+            use fn another_module::another_name;
+        }
+    }
+}
+
+mod another_module {
+    pub(crate) fn another_name(_: &impl crate::MyDatabase, (): ()) -> () {}
+}
+
+fn main() {}

--- a/tests/storage_varieties/implementation.rs
+++ b/tests/storage_varieties/implementation.rs
@@ -2,21 +2,21 @@ use crate::queries;
 use std::cell::Cell;
 
 #[derive(Default)]
-pub struct QueryContextImpl {
-    runtime: salsa::runtime::Runtime<QueryContextImpl>,
+pub struct DatabaseImpl {
+    runtime: salsa::runtime::Runtime<DatabaseImpl>,
     counter: Cell<usize>,
 }
 
-salsa::query_context_storage! {
-    pub struct QueryContextImplStorage for QueryContextImpl {
-        impl queries::QueryContext {
+salsa::database_storage! {
+    pub struct DatabaseImplStorage for DatabaseImpl {
+        impl queries::Database {
             fn memoized() for queries::Memoized;
             fn volatile() for queries::Volatile;
         }
     }
 }
 
-impl queries::CounterContext for QueryContextImpl {
+impl queries::Counter for DatabaseImpl {
     fn increment(&self) -> usize {
         let v = self.counter.get();
         self.counter.set(v + 1);
@@ -24,8 +24,8 @@ impl queries::CounterContext for QueryContextImpl {
     }
 }
 
-impl salsa::QueryContext for QueryContextImpl {
-    fn salsa_runtime(&self) -> &salsa::runtime::Runtime<QueryContextImpl> {
+impl salsa::Database for DatabaseImpl {
+    fn salsa_runtime(&self) -> &salsa::runtime::Runtime<DatabaseImpl> {
         &self.runtime
     }
 }

--- a/tests/storage_varieties/queries.rs
+++ b/tests/storage_varieties/queries.rs
@@ -4,8 +4,12 @@ crate trait Counter: salsa::Database {
 
 salsa::query_prototype! {
     crate trait Database: Counter {
-        fn memoized() for Memoized;
-        fn volatile() for Volatile;
+        fn memoized(key: ()) -> usize {
+            type Memoized;
+        }
+        fn volatile(key: ()) -> usize {
+            type Volatile;
+        }
     }
 }
 

--- a/tests/storage_varieties/queries.rs
+++ b/tests/storage_varieties/queries.rs
@@ -1,9 +1,9 @@
-crate trait CounterContext: salsa::QueryContext {
+crate trait Counter: salsa::Database {
     fn increment(&self) -> usize;
 }
 
 salsa::query_prototype! {
-    crate trait QueryContext: CounterContext {
+    crate trait Database: Counter {
         fn memoized() for Memoized;
         fn volatile() for Volatile;
     }
@@ -12,8 +12,8 @@ salsa::query_prototype! {
 salsa::query_definition! {
     /// Because this query is memoized, we only increment the counter
     /// the first time it is invoked.
-    crate Memoized(query: &impl QueryContext, (): ()) -> usize {
-        query.increment()
+    crate Memoized(db: &impl Database, (): ()) -> usize {
+        db.increment()
     }
 }
 
@@ -21,7 +21,7 @@ salsa::query_definition! {
     /// Because this query is volatile, each time it is invoked,
     /// we will increment the counter.
     #[storage(volatile)]
-    crate Volatile(query: &impl QueryContext, (): ()) -> usize {
-        query.increment()
+    crate Volatile(db: &impl Database, (): ()) -> usize {
+        db.increment()
     }
 }

--- a/tests/storage_varieties/queries.rs
+++ b/tests/storage_varieties/queries.rs
@@ -2,7 +2,7 @@ crate trait Counter: salsa::Database {
     fn increment(&self) -> usize;
 }
 
-salsa::query_prototype! {
+salsa::query_group! {
     crate trait Database: Counter {
         fn memoized(key: ()) -> usize {
             type Memoized;

--- a/tests/storage_varieties/queries.rs
+++ b/tests/storage_varieties/queries.rs
@@ -16,16 +16,12 @@ salsa::query_prototype! {
 
 /// Because this query is memoized, we only increment the counter
 /// the first time it is invoked.
-impl<DB: Database> salsa::QueryFunction<DB> for Memoized {
-    fn execute(db: &DB, (): ()) -> usize {
-        db.increment()
-    }
+fn memoized(db: &impl Database, (): ()) -> usize {
+    db.increment()
 }
 
 /// Because this query is volatile, each time it is invoked,
 /// we will increment the counter.
-impl<DB: Database> salsa::QueryFunction<DB> for Volatile {
-    fn execute(db: &DB, (): ()) -> usize {
-        db.increment()
-    }
+fn volatile(db: &impl Database, (): ()) -> usize {
+    db.increment()
 }

--- a/tests/storage_varieties/queries.rs
+++ b/tests/storage_varieties/queries.rs
@@ -9,23 +9,23 @@ salsa::query_prototype! {
         }
         fn volatile(key: ()) -> usize {
             type Volatile;
+            storage volatile;
         }
     }
 }
 
-salsa::query_definition! {
-    /// Because this query is memoized, we only increment the counter
-    /// the first time it is invoked.
-    crate Memoized(db: &impl Database, (): ()) -> usize {
+/// Because this query is memoized, we only increment the counter
+/// the first time it is invoked.
+impl<DB: Database> salsa::QueryFunction<DB> for Memoized {
+    fn execute(db: &DB, (): ()) -> usize {
         db.increment()
     }
 }
 
-salsa::query_definition! {
-    /// Because this query is volatile, each time it is invoked,
-    /// we will increment the counter.
-    #[storage(volatile)]
-    crate Volatile(db: &impl Database, (): ()) -> usize {
+/// Because this query is volatile, each time it is invoked,
+/// we will increment the counter.
+impl<DB: Database> salsa::QueryFunction<DB> for Volatile {
+    fn execute(db: &DB, (): ()) -> usize {
         db.increment()
     }
 }

--- a/tests/storage_varieties/tests.rs
+++ b/tests/storage_varieties/tests.rs
@@ -1,11 +1,11 @@
 #![cfg(test)]
 
-use crate::implementation::QueryContextImpl;
-use crate::queries::QueryContext;
+use crate::implementation::DatabaseImpl;
+use crate::queries::Database;
 
 #[test]
 fn memoized_twice() {
-    let query = QueryContextImpl::default();
+    let query = DatabaseImpl::default();
     let v1 = query.memoized().read();
     let v2 = query.memoized().read();
     assert_eq!(v1, v2);
@@ -13,7 +13,7 @@ fn memoized_twice() {
 
 #[test]
 fn volatile_twice() {
-    let query = QueryContextImpl::default();
+    let query = DatabaseImpl::default();
     let v1 = query.volatile().read();
     let v2 = query.volatile().read();
     assert_eq!(v1 + 1, v2);
@@ -21,7 +21,7 @@ fn volatile_twice() {
 
 #[test]
 fn intermingled() {
-    let query = QueryContextImpl::default();
+    let query = DatabaseImpl::default();
     let v1 = query.volatile().read();
     let v2 = query.memoized().read();
     let v3 = query.volatile().read();

--- a/tests/storage_varieties/tests.rs
+++ b/tests/storage_varieties/tests.rs
@@ -6,26 +6,26 @@ use crate::queries::Database;
 #[test]
 fn memoized_twice() {
     let query = DatabaseImpl::default();
-    let v1 = query.memoized().read();
-    let v2 = query.memoized().read();
+    let v1 = query.memoized(());
+    let v2 = query.memoized(());
     assert_eq!(v1, v2);
 }
 
 #[test]
 fn volatile_twice() {
     let query = DatabaseImpl::default();
-    let v1 = query.volatile().read();
-    let v2 = query.volatile().read();
+    let v1 = query.volatile(());
+    let v2 = query.volatile(());
     assert_eq!(v1 + 1, v2);
 }
 
 #[test]
 fn intermingled() {
     let query = DatabaseImpl::default();
-    let v1 = query.volatile().read();
-    let v2 = query.memoized().read();
-    let v3 = query.volatile().read();
-    let v4 = query.memoized().read();
+    let v1 = query.volatile(());
+    let v2 = query.memoized(());
+    let v3 = query.volatile(());
+    let v4 = query.memoized(());
 
     assert_eq!(v1 + 1, v2);
     assert_eq!(v2 + 1, v3);


### PR DESCRIPTION
This is a big revision of the way you interact with Salsa. It's probably not 100% complete, but there are a few important changes:

- Rename "query context" to "database"
- The `query_prototype` macro — which I would still like to rename — now generates *both* the query accessor functions *and* the query types themselves, so you specify everything except for the query function in one place (i.e., key/value type, etc).
- This means you can now do `db.my_query(key)` instead of `db.my_query().get(key)`
- To set values, you currently do `db.query(MyQuery).set(key, value)`. This will also be the way to do other less-standard things, like parallel operations where you invoke a query across many keys at once.
- The `query_definition` macro is gone. For non-input queries, you now do `fn my_query(db: &impl MyDatabase, key: Key) -> Value { .. }` in the same module; if you prefer to put the fn elsewhere, you can write `use fn $path;` to make an explicit link.

There were many motivations:

- database is a great name
- `db.my_query().get(key)` is annoying and I keep forgetting to do it
- you can now read the `query_prototype!` and get everything you would need to know as a user; rustdoc should also look better
- rustfmt doesn't work on the contents of macros, so having the fn body in a macro was not working well for me