### PR TITLE
Re-export runtime

### DIFF
--- a/examples/compiler/implementation.rs
+++ b/examples/compiler/implementation.rs
@@ -8,14 +8,14 @@ use crate::compiler::{CompilerDatabase, Interner};
 /// persists longer than a single query execution.**
 ///
 /// Databases can contain whatever you want them to, but salsa
-/// requires you to add a `salsa::runtime::Runtime` member. Note
+/// requires you to add a `salsa::Runtime` member. Note
 /// though: you should be very careful if adding shared, mutable state
 /// to your context (e.g., a shared counter or some such thing). If
 /// mutations to that shared state affect the results of your queries,
 /// that's going to mess up the incremental results.
 #[derive(Default)]
 pub struct DatabaseImpl {
-    runtime: salsa::runtime::Runtime<DatabaseImpl>,
+    runtime: salsa::Runtime<DatabaseImpl>,
 
     /// An interner is an example of shared mutable state that would
     /// be ok: although the interner allocates internally when you
@@ -26,7 +26,7 @@ pub struct DatabaseImpl {
 
 /// This impl tells salsa where to find the salsa runtime.
 impl salsa::Database for DatabaseImpl {
-    fn salsa_runtime(&self) -> &salsa::runtime::Runtime<DatabaseImpl> {
+    fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseImpl> {
         &self.runtime
     }
 }

--- a/examples/hello_world/README.md
+++ b/examples/hello_world/README.md
@@ -121,11 +121,11 @@ where to find this runtime:
 ```rust
 #[derive(Default)]
 struct DatabaseStruct {
-    runtime: salsa::runtime::Runtime<DatabaseStruct>,
+    runtime: salsa::Runtime<DatabaseStruct>,
 }
 
 impl salsa::Database for DatabaseStruct {
-    fn salsa_runtime(&self) -> &salsa::runtime::Runtime<DatabaseStruct> {
+    fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseStruct> {
         &self.runtime
     }
 }

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -68,12 +68,12 @@ fn length(db: &impl HelloWorldDatabase, (): ()) -> usize {
 // runtime but can also contain anything else you need.
 #[derive(Default)]
 struct DatabaseStruct {
-    runtime: salsa::runtime::Runtime<DatabaseStruct>,
+    runtime: salsa::Runtime<DatabaseStruct>,
 }
 
 // Tell salsa where to find the runtime in your context.
 impl salsa::Database for DatabaseStruct {
-    fn salsa_runtime(&self) -> &salsa::runtime::Runtime<DatabaseStruct> {
+    fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseStruct> {
         &self.runtime
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,12 +22,14 @@ pub mod memoized;
 pub mod runtime;
 pub mod volatile;
 
+pub use crate::runtime::Runtime;
+
 /// The base trait which your "query context" must implement. Gives
 /// access to the salsa runtime, which you must embed into your query
 /// context (along with whatever other state you may require).
 pub trait Database: DatabaseStorageTypes {
     /// Gives access to the underlying salsa runtime.
-    fn salsa_runtime(&self) -> &runtime::Runtime<Self>;
+    fn salsa_runtime(&self) -> &Runtime<Self>;
 
     /// Get access to extra methods pertaining to a given query,
     /// notably `set` (for inputs).

--- a/tests/cycles.rs
+++ b/tests/cycles.rs
@@ -2,11 +2,11 @@
 
 #[derive(Default)]
 pub struct DatabaseImpl {
-    runtime: salsa::runtime::Runtime<DatabaseImpl>,
+    runtime: salsa::Runtime<DatabaseImpl>,
 }
 
 impl salsa::Database for DatabaseImpl {
-    fn salsa_runtime(&self) -> &salsa::runtime::Runtime<DatabaseImpl> {
+    fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseImpl> {
         &self.runtime
     }
 }

--- a/tests/incremental/implementation.rs
+++ b/tests/incremental/implementation.rs
@@ -11,7 +11,7 @@ crate trait TestContext: salsa::Database {
 
 #[derive(Default)]
 crate struct TestContextImpl {
-    runtime: salsa::runtime::Runtime<TestContextImpl>,
+    runtime: salsa::Runtime<TestContextImpl>,
     clock: Counter,
     log: Log,
 }
@@ -76,7 +76,7 @@ impl TestContext for TestContextImpl {
 }
 
 impl salsa::Database for TestContextImpl {
-    fn salsa_runtime(&self) -> &salsa::runtime::Runtime<TestContextImpl> {
+    fn salsa_runtime(&self) -> &salsa::Runtime<TestContextImpl> {
         &self.runtime
     }
 }

--- a/tests/set_unchecked.rs
+++ b/tests/set_unchecked.rs
@@ -29,11 +29,11 @@ fn double_length(db: &impl HelloWorldDatabase, (): ()) -> usize {
 
 #[derive(Default)]
 struct DatabaseStruct {
-    runtime: salsa::runtime::Runtime<DatabaseStruct>,
+    runtime: salsa::Runtime<DatabaseStruct>,
 }
 
 impl salsa::Database for DatabaseStruct {
-    fn salsa_runtime(&self) -> &salsa::runtime::Runtime<DatabaseStruct> {
+    fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseStruct> {
         &self.runtime
     }
 }

--- a/tests/storage_varieties/implementation.rs
+++ b/tests/storage_varieties/implementation.rs
@@ -3,7 +3,7 @@ use std::cell::Cell;
 
 #[derive(Default)]
 pub struct DatabaseImpl {
-    runtime: salsa::runtime::Runtime<DatabaseImpl>,
+    runtime: salsa::Runtime<DatabaseImpl>,
     counter: Cell<usize>,
 }
 
@@ -25,7 +25,7 @@ impl queries::Counter for DatabaseImpl {
 }
 
 impl salsa::Database for DatabaseImpl {
-    fn salsa_runtime(&self) -> &salsa::runtime::Runtime<DatabaseImpl> {
+    fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseImpl> {
         &self.runtime
     }
 }


### PR DESCRIPTION
cc #17 

I don't want to reorgonize the module structure significantly with #36 in flight, but I think it makes sense to re-export `Runtime` sooner, so that we have less client code to fix later :-) 