### PR TITLE
Simple logging methods

### DIFF
--- a/src/derived.rs
+++ b/src/derived.rs
@@ -315,7 +315,7 @@ where
                 );
 
                 db.salsa_event(|| Event {
-                    id: runtime.id(),
+                    runtime_id: runtime.id(),
                     kind: EventKind::DidValidateMemoizedValue {
                         descriptor: descriptor.clone(),
                     },
@@ -464,9 +464,9 @@ where
                         std::mem::drop(map);
 
                         db.salsa_event(|| Event {
-                            id: db.salsa_runtime().id(),
+                            runtime_id: db.salsa_runtime().id(),
                             kind: EventKind::WillBlockOn {
-                                other_id,
+                                other_runtime_id: other_id,
                                 descriptor: descriptor.clone(),
                             },
                         });

--- a/src/input.rs
+++ b/src/input.rs
@@ -84,7 +84,7 @@ where
             let mut map = self.map.write();
 
             db.salsa_event(|| Event {
-                id: db.salsa_runtime().id(),
+                runtime_id: db.salsa_runtime().id(),
                 kind: EventKind::WillChangeInputValue {
                     descriptor: descriptor.clone(),
                 },

--- a/src/input.rs
+++ b/src/input.rs
@@ -7,6 +7,8 @@ use crate::runtime::ChangedAt;
 use crate::runtime::Revision;
 use crate::runtime::StampedValue;
 use crate::Database;
+use crate::Event;
+use crate::EventKind;
 use crate::Query;
 use crate::SweepStrategy;
 use log::debug;
@@ -60,7 +62,14 @@ where
         panic!("no value set for {:?}({:?})", Q::default(), key)
     }
 
-    fn set_common(&self, db: &DB, key: &Q::Key, value: Q::Value, is_constant: IsConstant) {
+    fn set_common(
+        &self,
+        db: &DB,
+        key: &Q::Key,
+        descriptor: &DB::QueryDescriptor,
+        value: Q::Value,
+        is_constant: IsConstant,
+    ) {
         let key = key.clone();
 
         // The value is changing, so even if we are setting this to a
@@ -73,6 +82,13 @@ where
         // lock.
         db.salsa_runtime().with_incremented_revision(|next_revision| {
             let mut map = self.map.write();
+
+            db.salsa_event(|| Event {
+                id: db.salsa_runtime().id(),
+                kind: EventKind::WillChangeInputValue {
+                    descriptor: descriptor.clone(),
+                },
+            });
 
             // Do this *after* we acquire the lock, so that we are not
             // racing with somebody else to modify this same cell.
@@ -190,16 +206,22 @@ where
     Q: Query<DB>,
     DB: Database,
 {
-    fn set(&self, db: &DB, key: &Q::Key, value: Q::Value) {
+    fn set(&self, db: &DB, key: &Q::Key, descriptor: &DB::QueryDescriptor, value: Q::Value) {
         log::debug!("{:?}({:?}) = {:?}", Q::default(), key, value);
 
-        self.set_common(db, key, value, IsConstant(false))
+        self.set_common(db, key, descriptor, value, IsConstant(false))
     }
 
-    fn set_constant(&self, db: &DB, key: &Q::Key, value: Q::Value) {
+    fn set_constant(
+        &self,
+        db: &DB,
+        key: &Q::Key,
+        descriptor: &DB::QueryDescriptor,
+        value: Q::Value,
+    ) {
         log::debug!("{:?}({:?}) = {:?}", Q::default(), key, value);
 
-        self.set_common(db, key, value, IsConstant(true))
+        self.set_common(db, key, descriptor, value, IsConstant(true))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,14 +73,14 @@ pub trait Database: plumbing::DatabaseStorageTypes + plumbing::DatabaseOps {
 }
 
 pub struct Event<DB: Database> {
-    pub id: RuntimeId,
+    pub runtime_id: RuntimeId,
     pub kind: EventKind<DB>,
 }
 
 impl<DB: Database> fmt::Debug for Event<DB> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("Event")
-            .field("id", &self.id)
+            .field("runtime_id", &self.runtime_id)
             .field("kind", &self.kind)
             .finish()
     }
@@ -94,7 +94,7 @@ pub enum EventKind<DB: Database> {
     /// Executes before the "re-used" value is returned.
     DidValidateMemoizedValue { descriptor: DB::QueryDescriptor },
 
-    /// Indicates that another thread (with id `other_id`) is processing the
+    /// Indicates that another thread (with id `other_runtime_id`) is processing the
     /// given query (`descriptor`), so we will block until they
     /// finish.
     ///
@@ -104,7 +104,7 @@ pub enum EventKind<DB: Database> {
     /// (NB: you can find the `id` of the current thread via the
     /// `salsa_runtime`)
     WillBlockOn {
-        other_id: RuntimeId,
+        other_runtime_id: RuntimeId,
         descriptor: DB::QueryDescriptor,
     },
 
@@ -126,11 +126,11 @@ impl<DB: Database> fmt::Debug for EventKind<DB> {
                 .field("descriptor", descriptor)
                 .finish(),
             EventKind::WillBlockOn {
-                other_id,
+                other_runtime_id,
                 descriptor,
             } => fmt
                 .debug_struct("WillBlockOn")
-                .field("other_id", other_id)
+                .field("other_runtime_id", other_runtime_id)
                 .field("descriptor", descriptor)
                 .finish(),
             EventKind::WillChangeInputValue { descriptor } => fmt

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -121,9 +121,15 @@ where
     DB: Database,
     Q: Query<DB>,
 {
-    fn set(&self, db: &DB, key: &Q::Key, new_value: Q::Value);
+    fn set(&self, db: &DB, key: &Q::Key, descriptor: &DB::QueryDescriptor, new_value: Q::Value);
 
-    fn set_constant(&self, db: &DB, key: &Q::Key, new_value: Q::Value);
+    fn set_constant(
+        &self,
+        db: &DB,
+        key: &Q::Key,
+        descriptor: &DB::QueryDescriptor,
+        new_value: Q::Value,
+    );
 }
 
 /// An optional trait that is implemented for "user mutable" storage:

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -258,7 +258,7 @@ where
         debug!("{:?}: execute_query_implementation invoked", descriptor);
 
         db.salsa_event(|| Event {
-            id: db.salsa_runtime().id(),
+            runtime_id: db.salsa_runtime().id(),
             kind: EventKind::WillExecute {
                 descriptor: descriptor.clone(),
             },

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,4 +1,4 @@
-use crate::{Database, SweepStrategy};
+use crate::{Database, Event, EventKind, SweepStrategy};
 use lock_api::RawRwLock;
 use log::debug;
 use parking_lot::{Mutex, RwLock, RwLockReadGuard};
@@ -147,9 +147,21 @@ where
         RevisionGuard::new(&self.shared_state)
     }
 
+    /// The unique identifier attached to this `SalsaRuntime`. Each
+    /// forked runtime has a distinct identifier.
     #[inline]
-    pub(crate) fn id(&self) -> RuntimeId {
+    pub fn id(&self) -> RuntimeId {
         self.id
+    }
+
+    /// Returns the descriptor for the query that this thread is
+    /// actively executing (if any).
+    pub fn active_query(&self) -> Option<DB::QueryDescriptor> {
+        self.local_state
+            .borrow()
+            .query_stack
+            .last()
+            .map(|active_query| active_query.descriptor.clone())
     }
 
     /// Read current value of the revision counter.
@@ -239,10 +251,18 @@ where
 
     pub(crate) fn execute_query_implementation<V>(
         &self,
+        db: &DB,
         descriptor: &DB::QueryDescriptor,
         execute: impl FnOnce() -> V,
     ) -> ComputedQueryResult<DB, V> {
         debug!("{:?}: execute_query_implementation invoked", descriptor);
+
+        db.salsa_event(|| Event {
+            id: db.salsa_runtime().id(),
+            kind: EventKind::WillExecute {
+                descriptor: descriptor.clone(),
+            },
+        });
 
         // Push the active query onto the stack.
         let push_len = {
@@ -524,7 +544,7 @@ impl<DB: Database> ActiveQuery<DB> {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub(crate) struct RuntimeId {
+pub struct RuntimeId {
     counter: usize,
 }
 

--- a/tests/parallel/true_parallel.rs
+++ b/tests/parallel/true_parallel.rs
@@ -67,7 +67,7 @@ fn true_parallel_same_keys() {
     });
 
     // Thread 2 will wait until Thread 1 has entered sum and then --
-    // once it has set tself to block -- signal Thread 1 to
+    // once it has set itself to block -- signal Thread 1 to
     // continue. This way, we test out the mechanism of one thread
     // blocking on another.
     let thread2 = std::thread::spawn({

--- a/tests/parallel/true_parallel.rs
+++ b/tests/parallel/true_parallel.rs
@@ -66,13 +66,15 @@ fn true_parallel_same_keys() {
         }
     });
 
-    // Thread 2 will sync barrier *just* before calling `sum`. Doesn't
-    // guarantee the race we want but makes it highly likely.
+    // Thread 2 will wait until Thread 1 has entered sum and then --
+    // once it has set tself to block -- signal Thread 1 to
+    // continue. This way, we test out the mechanism of one thread
+    // blocking on another.
     let thread2 = std::thread::spawn({
         let db = db.fork();
         move || {
             db.knobs().signal.wait_for(1);
-            db.knobs().signal.signal(2);
+            db.knobs().signal_on_will_block.set(2);
             db.sum("abc")
         }
     });


### PR DESCRIPTION
This is an experimental branch.  It introduces a method `salsa_event` into the `Database` trait that defaults to a no-op. This event is given a closure (`event_fn`) which, when called, will produce information about what is happening -- the purpose of the closure is to defer any real work (notably, cloning the descriptor) if the `salsa_event` is not enabled.

This could be used for various purposes. For example, tests can override `salsa_event` and log the events somewhere, using them to reconstruct what happened. I was imagining though that we might provide some higher-level consumers at some point.

This branch uses `salsa_event` in the parallel test to force one thread blocks for another, which we could not do before.