### PR TITLE
introduce garbage collection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,5 @@ log = "0.4.5"
 smallvec = "0.6.5"
 
 [dev-dependencies]
-difference = "2.0"
+diff = "0.1.0"
 env_logger = "0.5.13"

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -5,6 +5,7 @@ use crate::plumbing::QueryStorageOps;
 use crate::Database;
 use crate::Query;
 use crate::QueryTable;
+use std::iter::FromIterator;
 
 pub trait DebugQueryTable {
     type Key;
@@ -13,6 +14,11 @@ pub trait DebugQueryTable {
     /// **constant**, meaning that it can never change, no matter what
     /// values the inputs take on from this point.
     fn is_constant(&self, key: Self::Key) -> bool;
+
+    /// Get the (current) set of the keys in the query table.
+    fn keys<C>(&self) -> C
+    where
+        C: FromIterator<Self::Key>;
 }
 
 impl<DB, Q> DebugQueryTable for QueryTable<'_, DB, Q>
@@ -24,5 +30,12 @@ where
 
     fn is_constant(&self, key: Q::Key) -> bool {
         self.storage.is_constant(self.db, &key)
+    }
+
+    fn keys<C>(&self) -> C
+    where
+        C: FromIterator<Q::Key>,
+    {
+        self.storage.keys(self.db)
     }
 }

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -4,13 +4,13 @@ use crate::plumbing::QueryFunction;
 use crate::plumbing::QueryStorageOps;
 use crate::plumbing::UncheckedMutQueryStorageOps;
 use crate::runtime::ChangedAt;
-use crate::runtime::QueryDescriptorSet;
+use crate::runtime::FxIndexSet;
 use crate::runtime::Revision;
 use crate::runtime::Runtime;
 use crate::runtime::RuntimeId;
 use crate::runtime::StampedValue;
 use crate::Database;
-use log::debug;
+use log::{debug, info};
 use parking_lot::Mutex;
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use rustc_hash::FxHashMap;
@@ -18,6 +18,7 @@ use smallvec::SmallVec;
 use std::marker::PhantomData;
 use std::ops::Deref;
 use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::Arc;
 
 /// Memoized queries store the result plus a list of the other queries
 /// that they invoked. This means we can avoid recomputing them when
@@ -157,22 +158,56 @@ where
     Q: QueryFunction<DB>,
     DB: Database,
 {
-    /// Last time the value has actually changed.
-    /// changed_at can be less than verified_at.
-    changed_at: ChangedAt,
-
     /// The result of the query, if we decide to memoize it.
     value: Option<Q::Value>,
 
-    /// The inputs that went into our query, if we are tracking them.
-    inputs: QueryDescriptorSet<DB>,
-
-    /// Last time that we checked our inputs to see if they have
-    /// changed. If this is equal to the current revision, then the
-    /// value is up to date. If not, we need to check our inputs and
-    /// see if any of them have changed since our last check -- if so,
-    /// we'll need to re-execute.
+    /// Last revision when this memo was verified (if there are
+    /// untracked inputs, this will also be when the memo was
+    /// created).
     verified_at: Revision,
+
+    /// Last revision when the memoized value was observed to change.
+    changed_at: Revision,
+
+    /// The inputs that went into our query, if we are tracking them.
+    inputs: MemoInputs<DB>,
+}
+
+/// An insertion-order-preserving set of queries. Used to track the
+/// inputs accessed during query execution.
+pub(crate) enum MemoInputs<DB: Database> {
+    // No inputs
+    Constant,
+
+    // Non-empty set of inputs fully known
+    Tracked {
+        inputs: Arc<FxIndexSet<DB::QueryDescriptor>>,
+    },
+
+    // Unknown quantity of inputs
+    Untracked,
+}
+
+impl<DB: Database> MemoInputs<DB> {
+    fn is_constant(&self) -> bool {
+        if let MemoInputs::Constant = self {
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl<DB: Database> std::fmt::Debug for MemoInputs<DB> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MemoInputs::Constant => fmt.debug_struct("Constant").finish(),
+            MemoInputs::Tracked { inputs } => {
+                fmt.debug_struct("Tracked").field("inputs", inputs).finish()
+            }
+            MemoInputs::Untracked => fmt.debug_struct("Untracked").finish(),
+        }
+    }
 }
 
 impl<DB, Q, MP> Default for DerivedStorage<DB, Q, MP>
@@ -213,7 +248,7 @@ where
 
         let revision_now = runtime.current_revision();
 
-        debug!(
+        info!(
             "{:?}({:?}): invoked at {:?}",
             Q::default(),
             key,
@@ -270,31 +305,29 @@ where
         // first things first, let's walk over each of our previous
         // inputs and check whether they are out of date.
         if let Some(memo) = &mut old_memo {
-            if let Some(value) = memo.verify_memoized_value(db) {
-                debug!("{:?}({:?}): inputs still valid", Q::default(), key);
-                // If none of out inputs have changed since the last time we refreshed
-                // our value, then our value must still be good. We'll just patch
-                // the verified-at date and re-use it.
-                memo.verified_at = revision_now;
-                let changed_at = memo.changed_at;
+            if let Some(value) = memo.validate_memoized_value(db, revision_now) {
+                info!(
+                    "{:?}({:?}): validated old memoized value",
+                    Q::default(),
+                    key
+                );
 
-                let new_value = StampedValue { value, changed_at };
                 self.overwrite_placeholder(
                     runtime,
                     descriptor,
                     key,
                     old_memo.unwrap(),
-                    &new_value,
+                    &value,
                     panic_guard,
                 );
-                return Ok(new_value);
+                return Ok(value);
             }
         }
 
         // Query was not previously executed, or value is potentially
         // stale, or value is absent. Let's execute!
-        let (mut stamped_value, inputs) = runtime.execute_query_implementation(descriptor, || {
-            debug!("{:?}({:?}): executing query", Q::default(), key);
+        let mut result = runtime.execute_query_implementation(descriptor, || {
+            info!("{:?}({:?}): executing query", Q::default(), key);
 
             if !self.should_track_inputs(key) {
                 runtime.report_untracked_read();
@@ -318,35 +351,63 @@ where
         // old value.
         if let Some(old_memo) = &old_memo {
             if let Some(old_value) = &old_memo.value {
-                if MP::memoized_value_eq(&old_value, &stamped_value.value) {
-                    assert!(old_memo.changed_at.revision <= stamped_value.changed_at.revision);
-                    stamped_value.changed_at.revision = old_memo.changed_at.revision;
+                if MP::memoized_value_eq(&old_value, &result.value) {
+                    assert!(old_memo.changed_at <= result.changed_at.revision);
+                    result.changed_at.revision = old_memo.changed_at;
                 }
             }
         }
 
+        let new_value = StampedValue {
+            value: result.value,
+            changed_at: result.changed_at,
+        };
+
         {
             let value = if self.should_memoize_value(key) {
-                Some(stamped_value.value.clone())
+                Some(new_value.value.clone())
             } else {
                 None
             };
+
+            let inputs = match result.subqueries {
+                None => MemoInputs::Untracked,
+
+                Some(descriptors) => {
+                    // If all things that we read were constants, then
+                    // we don't need to track our inputs: our value
+                    // can never be invalidated.
+                    //
+                    // If OTOH we read at least *some* non-constant
+                    // inputs, then we do track our inputs (even the
+                    // constants), so that if we run the GC, we know
+                    // which constants we looked at.
+                    if descriptors.is_empty() || result.changed_at.is_constant {
+                        MemoInputs::Constant
+                    } else {
+                        MemoInputs::Tracked {
+                            inputs: Arc::new(descriptors),
+                        }
+                    }
+                }
+            };
+
             self.overwrite_placeholder(
                 runtime,
                 descriptor,
                 key,
                 Memo {
-                    changed_at: stamped_value.changed_at,
                     value,
-                    inputs,
+                    changed_at: result.changed_at.revision,
                     verified_at: revision_now,
+                    inputs,
                 },
-                &stamped_value,
+                &new_value,
                 panic_guard,
             );
         }
 
-        Ok(stamped_value)
+        Ok(new_value)
     }
 
     /// Helper for `read`:
@@ -400,29 +461,17 @@ where
             }
 
             Some(QueryState::Memoized(memo)) => {
-                debug!(
-                    "{:?}({:?}): found memoized value verified_at={:?}",
-                    Q::default(),
-                    key,
-                    memo.verified_at,
-                );
+                debug!("{:?}({:?}): found memoized value", Q::default(), key);
 
-                // We've found that the query is definitely up-to-date.
-                // If the value is also memoized, return it.
-                // Otherwise fallback to recomputing the value.
-                if memo.verified_at == revision_now {
-                    if let Some(value) = &memo.value {
-                        debug!(
-                            "{:?}({:?}): returning memoized value (changed_at={:?})",
-                            Q::default(),
-                            key,
-                            memo.changed_at,
-                        );
-                        return ProbeState::UpToDate(Ok(StampedValue {
-                            value: value.clone(),
-                            changed_at: memo.changed_at,
-                        }));
-                    }
+                if let Some(value) = memo.probe_memoized_value(revision_now) {
+                    info!(
+                        "{:?}({:?}): returning memoized value changed at {:?}",
+                        Q::default(),
+                        key,
+                        value.changed_at
+                    );
+
+                    return ProbeState::UpToDate(Ok(value));
                 }
             }
 
@@ -589,85 +638,95 @@ where
             revision_now,
         );
 
-        let descriptors = {
-            let map = self.map.read();
-            match map.get(key) {
-                // If somebody depends on us, but we have no map
-                // entry, that must mean that it was found to be out
-                // of date and removed.
-                None => return true,
+        // Acquire read lock to start. In some of the arms below, we
+        // drop this explicitly.
+        let map = self.map.read();
 
-                // This value is being actively recomputed. Wait for
-                // that thread to finish (assuming it's not dependent
-                // on us...) and check its associated revision.
-                Some(QueryState::InProgress { id, waiting }) => {
-                    let other_id = *id;
-                    return match self
-                        .register_with_in_progress_thread(runtime, descriptor, other_id, waiting)
-                    {
-                        Ok(rx) => {
-                            // Release our lock on `self.map`, so other thread
-                            // can complete.
-                            std::mem::drop(map);
+        // Look for a memoized value.
+        let memo = match map.get(key) {
+            // If somebody depends on us, but we have no map
+            // entry, that must mean that it was found to be out
+            // of date and removed.
+            None => return true,
 
-                            let value = rx.recv().unwrap();
-                            return value.changed_at.changed_since(revision);
-                        }
+            // This value is being actively recomputed. Wait for
+            // that thread to finish (assuming it's not dependent
+            // on us...) and check its associated revision.
+            Some(QueryState::InProgress { id, waiting }) => {
+                let other_id = *id;
+                match self.register_with_in_progress_thread(runtime, descriptor, other_id, waiting)
+                {
+                    Ok(rx) => {
+                        // Release our lock on `self.map`, so other thread
+                        // can complete.
+                        std::mem::drop(map);
 
-                        // Consider a cycle to have changed.
+                        let value = rx.recv().unwrap();
+                        return value.changed_at.changed_since(revision);
+                    }
+
+                    // Consider a cycle to have changed.
+                    Err(CycleDetected) => return true,
+                }
+            }
+
+            Some(QueryState::Memoized(memo)) => memo,
+        };
+
+        if memo.verified_at == revision_now {
+            return memo.changed_at > revision;
+        }
+
+        let inputs = match &memo.inputs {
+            MemoInputs::Untracked => {
+                // we don't know the full set of
+                // inputs, so if there is a new
+                // revision, we must assume it is
+                // dirty
+                return true;
+            }
+
+            MemoInputs::Constant => None,
+
+            MemoInputs::Tracked { inputs } => {
+                // At this point, the value may be dirty (we have
+                // to check the descriptors). If we have a cached
+                // value, we'll just fall back to invoking `read`,
+                // which will do that checking (and a bit more) --
+                // note that we skip the "pure read" part as we
+                // already know the result.
+                assert!(inputs.len() > 0);
+                if memo.value.is_some() {
+                    std::mem::drop(map);
+                    return match self.read_upgrade(db, key, descriptor, revision_now) {
+                        Ok(v) => v.changed_at.changed_since(revision),
                         Err(CycleDetected) => true,
                     };
                 }
 
-                Some(QueryState::Memoized(memo)) => {
-                    // If our memo is still up to date, then check if we've
-                    // changed since the revision.
-                    if memo.verified_at == revision_now {
-                        return memo.changed_at.changed_since(revision);
-                    }
-
-                    // As a special case, if we have no inputs, we are
-                    // always clean. No need to update `verified_at`.
-                    if let QueryDescriptorSet::Constant = memo.inputs {
-                        return false;
-                    }
-
-                    // At this point, the value may be dirty (we have
-                    // to check the descriptors). If we have a cached
-                    // value, we'll just fall back to invoking `read`,
-                    // which will do that checking (and a bit more) --
-                    // note that we skip the "pure read" part as we
-                    // already know the result.
-                    if memo.value.is_some() {
-                        drop(map);
-                        return match self.read_upgrade(db, key, descriptor, revision_now) {
-                            Ok(v) => v.changed_at.changed_since(revision),
-                            Err(CycleDetected) => true,
-                        };
-                    }
-
-                    // If there are no inputs or we don't know the
-                    // inputs, we can answer right away.
-                    match &memo.inputs {
-                        QueryDescriptorSet::Constant => return false,
-                        QueryDescriptorSet::Untracked => return true,
-                        QueryDescriptorSet::Tracked { descriptors } => descriptors.clone(),
-                    }
-                }
+                Some(inputs.clone())
             }
         };
 
-        let maybe_changed = descriptors
+        // We have a **tracked set of inputs**
+        // (found in `descriptors`) that need to
+        // be validated.
+        std::mem::drop(map);
+
+        // Iterate the inputs and see if any have maybe changed.
+        let maybe_changed = inputs
             .iter()
-            .filter(|descriptor| descriptor.maybe_changed_since(db, revision))
-            .inspect(|old_input| {
+            .flat_map(|inputs| inputs.iter())
+            .filter(|input| input.maybe_changed_since(db, revision))
+            .inspect(|input| {
                 debug!(
                     "{:?}({:?}): input `{:?}` may have changed",
                     Q::default(),
                     key,
-                    old_input
+                    input
                 )
-            }).next()
+            })
+            .next()
             .is_some();
 
         // Either way, we have to update our entry.
@@ -700,7 +759,7 @@ where
         match map_read.get(key) {
             None => false,
             Some(QueryState::InProgress { .. }) => panic!("query in progress"),
-            Some(QueryState::Memoized(memo)) => memo.changed_at.is_constant(),
+            Some(QueryState::Memoized(memo)) => memo.inputs.is_constant(),
         }
     }
 }
@@ -717,18 +776,16 @@ where
         let mut map_write = self.map.write();
 
         let current_revision = db.salsa_runtime().current_revision();
-        let changed_at = ChangedAt {
-            is_constant: false,
-            revision: current_revision,
-        };
 
         map_write.insert(
             key,
             QueryState::Memoized(Memo {
                 value: Some(value),
-                changed_at,
-                inputs: QueryDescriptorSet::default(),
+                changed_at: current_revision,
                 verified_at: current_revision,
+                inputs: MemoInputs::Tracked {
+                    inputs: Default::default(),
+                },
             }),
         );
     }
@@ -739,53 +796,90 @@ where
     Q: QueryFunction<DB>,
     DB: Database,
 {
-    fn verify_memoized_value(&self, db: &DB) -> Option<Q::Value> {
+    fn validate_memoized_value(
+        &mut self,
+        db: &DB,
+        revision_now: Revision,
+    ) -> Option<StampedValue<Q::Value>> {
         // If we don't have a memoized value, nothing to validate.
-        if let Some(v) = &self.value {
-            // If inputs are still valid.
-            if self.verify_inputs(db) {
-                return Some(v.clone());
+        let value = self.value.as_ref()?;
+
+        assert!(self.verified_at != revision_now);
+        let verified_at = self.verified_at;
+
+        let is_constant = match &mut self.inputs {
+            // We can't validate values that had untracked inputs; just have to
+            // re-execute.
+            MemoInputs::Untracked { .. } => {
+                return None;
             }
+
+            // Constant: no changed input
+            MemoInputs::Constant => true,
+
+            // Check whether any of our inputs changed since the
+            // **last point where we were verified** (not since we
+            // last changed). This is important: if we have
+            // memoized values, then an input may have changed in
+            // revision R2, but we found that *our* value was the
+            // same regardless, so our change date is still
+            // R1. But our *verification* date will be R2, and we
+            // are only interested in finding out whether the
+            // input changed *again*.
+            MemoInputs::Tracked { inputs } => {
+                let changed_input = inputs
+                    .iter()
+                    .filter(|input| input.maybe_changed_since(db, verified_at))
+                    .next();
+
+                if let Some(input) = changed_input {
+                    debug!(
+                        "{:?}::validate_memoized_value: `{:?}` may have changed",
+                        Q::default(),
+                        input
+                    );
+
+                    return None;
+                }
+
+                false
+            }
+        };
+
+        self.verified_at = revision_now;
+        Some(StampedValue {
+            changed_at: ChangedAt {
+                is_constant,
+                revision: self.changed_at,
+            },
+            value: value.clone(),
+        })
+    }
+
+    /// Returns the memoized value *if* it is known to be update in the given revision.
+    fn probe_memoized_value(&self, revision_now: Revision) -> Option<StampedValue<Q::Value>> {
+        let value = self.value.as_ref()?;
+
+        debug!(
+            "probe_memoized_value(verified_at={:?}, changed_at={:?})",
+            self.verified_at, self.changed_at,
+        );
+
+        if self.verified_at == revision_now {
+            let is_constant = match self.inputs {
+                MemoInputs::Constant => true,
+                _ => false,
+            };
+
+            return Some(StampedValue {
+                changed_at: ChangedAt {
+                    is_constant,
+                    revision: self.changed_at,
+                },
+                value: value.clone(),
+            });
         }
 
         None
-    }
-
-    fn verify_inputs(&self, db: &DB) -> bool {
-        match &self.inputs {
-            QueryDescriptorSet::Constant => {
-                debug_assert!(self.changed_at.is_constant);
-                true
-            }
-
-            QueryDescriptorSet::Tracked { descriptors } => {
-                debug_assert!(!descriptors.is_empty());
-                debug_assert!(!self.changed_at.is_constant);
-
-                // Check whether any of our inputs changed since the
-                // **last point where we were verified** (not since we
-                // last changed). This is important: if we have
-                // memoized values, then an input may have changed in
-                // revision R2, but we found that *our* value was the
-                // same regardless, so our change date is still
-                // R1. But our *verification* date will be R2, and we
-                // are only interested in finding out whether the
-                // input changed *again*.
-                let changed_input = descriptors
-                    .iter()
-                    .filter(|old_input| old_input.maybe_changed_since(db, self.verified_at))
-                    .inspect(|old_input| {
-                        debug!(
-                            "{:?}::verify_descriptors: `{:?}` may have changed",
-                            Q::default(),
-                            old_input
-                        )
-                    }).next();
-
-                changed_input.is_none()
-            }
-
-            QueryDescriptorSet::Untracked => false,
-        }
     }
 }

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -774,6 +774,14 @@ where
             Some(QueryState::Memoized(memo)) => memo.inputs.is_constant(),
         }
     }
+
+    fn keys<C>(&self, _db: &DB) -> C
+    where
+        C: std::iter::FromIterator<Q::Key>,
+    {
+        let map = self.map.read();
+        map.keys().cloned().collect()
+    }
 }
 
 impl<DB, Q, MP> QueryStorageMassOps<DB> for DerivedStorage<DB, Q, MP>

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -651,7 +651,7 @@ where
                     match &memo.inputs {
                         QueryDescriptorSet::Constant => return false,
                         QueryDescriptorSet::Untracked => return true,
-                        QueryDescriptorSet::Tracked(descriptors) => descriptors.clone(),
+                        QueryDescriptorSet::Tracked { descriptors } => descriptors.clone(),
                     }
                 }
             }
@@ -759,14 +759,14 @@ where
                 true
             }
 
-            QueryDescriptorSet::Tracked(inputs) => {
-                debug_assert!(!inputs.is_empty());
+            QueryDescriptorSet::Tracked { descriptors } => {
+                debug_assert!(!descriptors.is_empty());
                 debug_assert!(match self.changed_at {
                     ChangedAt::Constant(_) => false,
                     ChangedAt::Revision(_) => true,
                 });
 
-                // Check whether any of our inputs change since the
+                // Check whether any of our inputs changed since the
                 // **last point where we were verified** (not since we
                 // last changed). This is important: if we have
                 // memoized values, then an input may have changed in
@@ -775,12 +775,12 @@ where
                 // R1. But our *verification* date will be R2, and we
                 // are only interested in finding out whether the
                 // input changed *again*.
-                let changed_input = inputs
+                let changed_input = descriptors
                     .iter()
                     .filter(|old_input| old_input.maybe_changed_since(db, self.verified_at))
                     .inspect(|old_input| {
                         debug!(
-                            "{:?}::verify_inputs: `{:?}` may have changed",
+                            "{:?}::verify_descriptors: `{:?}` may have changed",
                             Q::default(),
                             old_input
                         )

--- a/src/input.rs
+++ b/src/input.rs
@@ -8,6 +8,7 @@ use crate::runtime::Revision;
 use crate::runtime::StampedValue;
 use crate::Database;
 use crate::Query;
+use crate::SweepStrategy;
 use log::debug;
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use rustc_hash::FxHashMap;
@@ -215,7 +216,7 @@ where
     DB: Database,
     Q::Value: Default,
 {
-    fn sweep(&self, _db: &DB) {}
+    fn sweep(&self, _db: &DB, _strategy: SweepStrategy) {}
 }
 
 impl<DB, Q> InputQueryStorageOps<DB, Q> for InputStorage<DB, Q>

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,6 @@
 use crate::plumbing::CycleDetected;
 use crate::plumbing::InputQueryStorageOps;
+use crate::plumbing::QueryStorageMassOps;
 use crate::plumbing::QueryStorageOps;
 use crate::plumbing::UncheckedMutQueryStorageOps;
 use crate::runtime::ChangedAt;
@@ -198,6 +199,15 @@ where
             .map(|v| v.changed_at.is_constant)
             .unwrap_or(false)
     }
+}
+
+impl<DB, Q> QueryStorageMassOps<DB> for InputStorage<DB, Q>
+where
+    Q: Query<DB>,
+    DB: Database,
+    Q::Value: Default,
+{
+    fn sweep(&self, _db: &DB) {}
 }
 
 impl<DB, Q> InputQueryStorageOps<DB, Q> for InputStorage<DB, Q>

--- a/src/input.rs
+++ b/src/input.rs
@@ -199,6 +199,14 @@ where
             .map(|v| v.changed_at.is_constant)
             .unwrap_or(false)
     }
+
+    fn keys<C>(&self, _db: &DB) -> C
+    where
+        C: std::iter::FromIterator<Q::Key>,
+    {
+        let map = self.map.read();
+        map.keys().cloned().collect()
+    }
 }
 
 impl<DB, Q> QueryStorageMassOps<DB> for InputStorage<DB, Q>

--- a/src/input.rs
+++ b/src/input.rs
@@ -80,13 +80,10 @@ where
                 // still intact, they just have conservative
                 // dependencies. The next revision, they may wind up
                 // with something more precise.
-                if is_constant.0 && !old_value.changed_at.is_constant() {
+                if is_constant.0 && !old_value.changed_at.is_constant {
                     let mut map = RwLockUpgradableReadGuard::upgrade(map);
                     let old_value = map.get_mut(key).unwrap();
-                    old_value.changed_at = ChangedAt {
-                        is_constant: true,
-                        revision: db.salsa_runtime().current_revision(),
-                    };
+                    old_value.changed_at.is_constant = true;
                 }
 
                 return;
@@ -121,7 +118,7 @@ where
         match map.entry(key) {
             Entry::Occupied(mut entry) => {
                 assert!(
-                    !entry.get().changed_at.is_constant(),
+                    !entry.get().changed_at.is_constant,
                     "modifying `{:?}({:?})`, which was previously marked as constant (old value `{:?}`, new value `{:?}`)",
                     Q::default(),
                     entry.key(),
@@ -198,7 +195,7 @@ where
         let map_read = self.map.read();
         map_read
             .get(key)
-            .map(|v| v.changed_at.is_constant())
+            .map(|v| v.changed_at.is_constant)
             .unwrap_or(false)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,17 @@ pub trait Database: plumbing::DatabaseStorageTypes + plumbing::DatabaseOps {
     /// consume are marked as used.  You then invoke this method to
     /// remove other values that were not needed for your main query
     /// results.
+    ///
+    /// **A note on atomicity.** Since `sweep_all` removes data that
+    /// hasn't been actively used since the last revision, executing
+    /// `sweep_all` concurrently with `set` operations is not
+    /// recommended.  It won't do any *harm* -- but it may cause more
+    /// data to be discarded then you expect, leading to more
+    /// re-computation. You can use the [`lock_revision`][] method to
+    /// guarantee atomicity (or execute `sweep_all` from the same
+    /// threads that would be performing a `set`).
+    ///
+    /// [`lock_revision`]: struct.Runtime.html#method.lock_revision
     fn sweep_all(&self) {
         self.salsa_runtime().sweep_all(self);
     }

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -1,6 +1,7 @@
 use crate::Database;
 use crate::Query;
 use crate::QueryTable;
+use crate::SweepStrategy;
 use std::fmt::Debug;
 use std::hash::Hash;
 
@@ -41,7 +42,7 @@ pub trait DatabaseOps: Sized {
 /// query, unlike `QueryStorageOps`).
 pub trait QueryStorageMassOps<DB: Database> {
     /// Discards memoized values that are not up to date with the current revision.
-    fn sweep(&self, db: &DB);
+    fn sweep(&self, db: &DB, strategy: SweepStrategy);
 }
 
 pub trait QueryDescriptor<DB>: Clone + Debug + Eq + Hash + Send + Sync {

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -105,6 +105,11 @@ where
 
     /// Check if `key` is (currently) believed to be a constant.
     fn is_constant(&self, db: &DB, key: &Q::Key) -> bool;
+
+    /// Check if `key` is (currently) believed to be a constant.
+    fn keys<C>(&self, db: &DB) -> C
+    where
+        C: std::iter::FromIterator<Q::Key>;
 }
 
 /// An optional trait that is implemented for "user mutable" storage:

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -30,6 +30,20 @@ pub trait DatabaseStorageTypes: Sized {
     type DatabaseStorage: Default;
 }
 
+/// Internal operations that the runtime uses to operate on the database.
+pub trait DatabaseOps: Sized {
+    /// Executes the callback for each kind of query.
+    fn for_each_query(&self, op: impl FnMut(&dyn QueryStorageMassOps<Self>));
+}
+
+/// Internal operations performed on the query storage as a whole
+/// (note that these ops do not need to know the identity of the
+/// query, unlike `QueryStorageOps`).
+pub trait QueryStorageMassOps<DB: Database> {
+    /// Discards memoized values that are not up to date with the current revision.
+    fn sweep(&self, db: &DB);
+}
+
 pub trait QueryDescriptor<DB>: Clone + Debug + Eq + Hash + Send + Sync {
     /// Returns true if the value of this query may have changed since
     /// the given revision.

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -95,9 +95,11 @@ where
 
     /// See `Database::sweep`.
     pub(crate) fn sweep_all(&self, db: &DB) {
-        // Ensure that the revision doesn't change. Note that we don't
-        // need to stop the world though.
-        let _guard = self.shared_state.query_lock.read();
+        // Note that we do not acquire the query lock (or any locks)
+        // here.  Each table is capable of sweeping itself atomically
+        // and there is no need to bring things to a halt. That said,
+        // users may wish to guarantee atomicity.
+
         db.for_each_query(|query_storage| query_storage.sweep(db));
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,4 +1,4 @@
-use crate::Database;
+use crate::{Database, SweepStrategy};
 use lock_api::RawRwLock;
 use log::debug;
 use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockUpgradableReadGuard};
@@ -94,13 +94,13 @@ where
     }
 
     /// Default implementation for `Database::sweep_all`.
-    pub fn sweep_all(&self, db: &DB) {
+    pub fn sweep_all(&self, db: &DB, strategy: SweepStrategy) {
         // Note that we do not acquire the query lock (or any locks)
         // here.  Each table is capable of sweeping itself atomically
         // and there is no need to bring things to a halt. That said,
         // users may wish to guarantee atomicity.
 
-        db.for_each_query(|query_storage| query_storage.sweep(db));
+        db.for_each_query(|query_storage| query_storage.sweep(db, strategy));
     }
 
     /// Indicates that a derived query has begun to execute; if this is the

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -93,6 +93,14 @@ where
         self.increment_revision();
     }
 
+    /// See `Database::sweep`.
+    pub(crate) fn sweep_all(&self, db: &DB) {
+        // Ensure that the revision doesn't change. Note that we don't
+        // need to stop the world though.
+        let _guard = self.shared_state.query_lock.read();
+        db.for_each_query(|query_storage| query_storage.sweep(db));
+    }
+
     /// Indicates that a derived query has begun to execute; if this is the
     /// first derived query on this thread, then acquires a read-lock on the
     /// runtime to prevent us from moving to a new revision until that query

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -93,8 +93,8 @@ where
         self.increment_revision();
     }
 
-    /// See `Database::sweep`.
-    pub(crate) fn sweep_all(&self, db: &DB) {
+    /// Default implementation for `Database::sweep_all`.
+    pub fn sweep_all(&self, db: &DB) {
         // Note that we do not acquire the query lock (or any locks)
         // here.  Each table is capable of sweeping itself atomically
         // and there is no need to bring things to a halt. That said,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -264,7 +264,9 @@ where
                 if set.is_empty() {
                     QueryDescriptorSet::Constant
                 } else {
-                    QueryDescriptorSet::Tracked(Arc::new(set))
+                    QueryDescriptorSet::Tracked {
+                        descriptors: Arc::new(set),
+                    }
                 }
             }
         };
@@ -556,7 +558,9 @@ pub(crate) enum QueryDescriptorSet<DB: Database> {
     Constant,
 
     /// All reads were to tracked things:
-    Tracked(Arc<FxIndexSet<DB::QueryDescriptor>>),
+    Tracked {
+        descriptors: Arc<FxIndexSet<DB::QueryDescriptor>>,
+    },
 
     /// Some reads to an untracked thing:
     Untracked,
@@ -565,9 +569,12 @@ pub(crate) enum QueryDescriptorSet<DB: Database> {
 impl<DB: Database> std::fmt::Debug for QueryDescriptorSet<DB> {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            QueryDescriptorSet::Constant => write!(fmt, "Constant"),
-            QueryDescriptorSet::Tracked(set) => std::fmt::Debug::fmt(set, fmt),
-            QueryDescriptorSet::Untracked => write!(fmt, "Untracked"),
+            QueryDescriptorSet::Constant => fmt.debug_struct("Constant").finish(),
+            QueryDescriptorSet::Tracked { descriptors } => fmt
+                .debug_struct("Tracked")
+                .field("descriptors", descriptors)
+                .finish(),
+            QueryDescriptorSet::Untracked => fmt.debug_struct("Untracked").finish(),
         }
     }
 }

--- a/tests/gc/db.rs
+++ b/tests/gc/db.rs
@@ -1,0 +1,26 @@
+use crate::group;
+
+#[derive(Default)]
+pub struct DatabaseImpl {
+    runtime: salsa::Runtime<DatabaseImpl>,
+}
+
+impl salsa::Database for DatabaseImpl {
+    fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseImpl> {
+        &self.runtime
+    }
+}
+
+salsa::database_storage! {
+    pub struct DatabaseImplStorage for DatabaseImpl {
+        impl group::GcDatabase {
+            fn min() for group::Min;
+            fn max() for group::Max;
+            fn use_triangular() for group::UseTriangular;
+            fn fibonacci() for group::Fibonacci;
+            fn triangular() for group::Triangular;
+            fn compute() for group::Compute;
+            fn compute_all() for group::ComputeAll;
+        }
+    }
+}

--- a/tests/gc/db.rs
+++ b/tests/gc/db.rs
@@ -1,8 +1,10 @@
 use crate::group;
+use crate::log::{HasLog, Log};
 
 #[derive(Default)]
 pub struct DatabaseImpl {
     runtime: salsa::Runtime<DatabaseImpl>,
+    log: Log,
 }
 
 impl salsa::Database for DatabaseImpl {
@@ -22,5 +24,36 @@ salsa::database_storage! {
             fn compute() for group::Compute;
             fn compute_all() for group::ComputeAll;
         }
+    }
+}
+
+impl DatabaseImpl {
+    pub(crate) fn clear_log(&self) {
+        self.log().take();
+    }
+
+    pub(crate) fn assert_log(&self, expected_log: &[&str]) {
+        let expected_text = &format!("{:#?}", expected_log);
+        let actual_text = &format!("{:#?}", self.log().take());
+
+        if expected_text == actual_text {
+            return;
+        }
+
+        for diff in diff::lines(expected_text, actual_text) {
+            match diff {
+                diff::Result::Left(l) => println!("-{}", l),
+                diff::Result::Both(l, _) => println!(" {}", l),
+                diff::Result::Right(r) => println!("+{}", r),
+            }
+        }
+
+        panic!("incorrect log results");
+    }
+}
+
+impl HasLog for DatabaseImpl {
+    fn log(&self) -> &Log {
+        &self.log
     }
 }

--- a/tests/gc/derived_tests.rs
+++ b/tests/gc/derived_tests.rs
@@ -1,0 +1,162 @@
+use crate::db;
+use crate::group::*;
+use salsa::debug::DebugQueryTable;
+use salsa::Database;
+
+macro_rules! assert_keys {
+    ($db:expr, $($query:expr => ($($key:expr),*),)*) => {
+        $(
+            let mut keys = $db.query($query).keys::<Vec<_>>();
+            keys.sort();
+            assert_eq!(keys, vec![$($key),*], "query {:?} had wrong keys", $query);
+        )*
+    };
+}
+
+#[test]
+fn compute_one() {
+    let db = db::DatabaseImpl::default();
+
+    // Will compute fibonacci(5)
+    db.compute(5);
+
+    db.salsa_runtime().next_revision();
+
+    assert_keys! {
+        db,
+        Triangular => (),
+        Fibonacci => (0, 1, 2, 3, 4, 5),
+        Compute => (5),
+        UseTriangular => (),
+        Min => (),
+        Max => (),
+    }
+
+    // Memoized, but will compute fibonacci(5) again
+    db.compute(5);
+    db.sweep_all();
+
+    assert_keys! {
+        db,
+        Triangular => (),
+        Fibonacci => (5),
+        Compute => (5),
+        UseTriangular => (),
+        Min => (),
+        Max => (),
+    }
+}
+
+#[test]
+fn compute_switch() {
+    let db = db::DatabaseImpl::default();
+
+    // Will compute fibonacci(5)
+    assert_eq!(db.compute(5), 5);
+
+    // Change to triangular mode
+    db.query(UseTriangular).set(5, true);
+
+    // Now computes triangular(5)
+    assert_eq!(db.compute(5), 15);
+
+    // We still have entries for Fibonacci, even though they
+    // are not relevant to the most recent value of `Compute`
+    assert_keys! {
+        db,
+        Triangular => (0, 1, 2, 3, 4, 5),
+        Fibonacci => (0, 1, 2, 3, 4, 5),
+        Compute => (5),
+        UseTriangular => (5),
+        Min => (),
+        Max => (),
+    }
+
+    db.sweep_all();
+
+    // Now we just have `Triangular` and not `Fibonacci`
+    assert_keys! {
+        db,
+        Triangular => (0, 1, 2, 3, 4, 5),
+        Fibonacci => (),
+        Compute => (5),
+        UseTriangular => (5),
+        Min => (),
+        Max => (),
+    }
+
+    // Now run `compute` *again* in next revision.
+    db.salsa_runtime().next_revision();
+    assert_eq!(db.compute(5), 15);
+    db.sweep_all();
+
+    // We keep triangular, but just the outermost one.
+    assert_keys! {
+        db,
+        Triangular => (5),
+        Fibonacci => (),
+        Compute => (5),
+        UseTriangular => (5),
+        Min => (),
+        Max => (),
+    }
+}
+
+/// Test a query with multiple layers of keys.
+#[test]
+fn compute_all() {
+    let db = db::DatabaseImpl::default();
+
+    db.query(UseTriangular).set(1, true);
+    db.query(UseTriangular).set(3, true);
+    db.query(UseTriangular).set(5, true);
+
+    db.query(Min).set((), 0);
+    db.query(Max).set((), 6);
+
+    db.compute_all();
+    db.salsa_runtime().next_revision();
+    db.compute_all();
+    db.sweep_all();
+
+    assert_keys! {
+        db,
+        Triangular => (1, 3, 5),
+        Fibonacci => (0, 2, 4),
+        Compute => (0, 1, 2, 3, 4, 5),
+        ComputeAll => (()),
+        UseTriangular => (1, 3, 5),
+        Min => (()),
+        Max => (()),
+    }
+
+    // Reduce the range to exclude index 5.
+    db.query(Max).set((), 5);
+    db.compute_all();
+
+    assert_keys! {
+        db,
+        Triangular => (1, 3, 5),
+        Fibonacci => (0, 2, 4),
+        Compute => (0, 1, 2, 3, 4, 5),
+        ComputeAll => (()),
+        UseTriangular => (1, 3, 5),
+        Min => (()),
+        Max => (()),
+    }
+
+    db.sweep_all();
+
+    // We no longer used `Compute(5)` and `Triangular(5)`; note that
+    // `UseTriangular(5)` is not collected, as it is an input.
+    assert_keys! {
+        db,
+        Triangular => (1, 3),
+        Fibonacci => (0, 2, 4),
+        Compute => (0, 1, 2, 3, 4),
+        ComputeAll => (()),
+        UseTriangular => (1, 3, 5),
+        Min => (()),
+        Max => (()),
+    }
+}

--- a/tests/gc/derived_tests.rs
+++ b/tests/gc/derived_tests.rs
@@ -1,7 +1,7 @@
 use crate::db;
 use crate::group::*;
 use salsa::debug::DebugQueryTable;
-use salsa::Database;
+use salsa::{Database, SweepStrategy};
 
 macro_rules! assert_keys {
     ($db:expr, $($query:expr => ($($key:expr),*),)*) => {
@@ -34,7 +34,7 @@ fn compute_one() {
 
     // Memoized, but will compute fibonacci(5) again
     db.compute(5);
-    db.sweep_all();
+    db.sweep_all(SweepStrategy::default());
 
     assert_keys! {
         db,
@@ -72,7 +72,7 @@ fn compute_switch() {
         Max => (),
     }
 
-    db.sweep_all();
+    db.sweep_all(SweepStrategy::default());
 
     // Now we just have `Triangular` and not `Fibonacci`
     assert_keys! {
@@ -88,7 +88,7 @@ fn compute_switch() {
     // Now run `compute` *again* in next revision.
     db.salsa_runtime().next_revision();
     assert_eq!(db.compute(5), 15);
-    db.sweep_all();
+    db.sweep_all(SweepStrategy::default());
 
     // We keep triangular, but just the outermost one.
     assert_keys! {
@@ -117,7 +117,7 @@ fn compute_all() {
     db.compute_all();
     db.salsa_runtime().next_revision();
     db.compute_all();
-    db.sweep_all();
+    db.sweep_all(SweepStrategy::default());
 
     assert_keys! {
         db,
@@ -145,7 +145,7 @@ fn compute_all() {
         Max => (()),
     }
 
-    db.sweep_all();
+    db.sweep_all(SweepStrategy::default());
 
     // We no longer used `Compute(5)` and `Triangular(5)`; note that
     // `UseTriangular(5)` is not collected, as it is an input.

--- a/tests/gc/discard_values.rs
+++ b/tests/gc/discard_values.rs
@@ -1,0 +1,49 @@
+use crate::db;
+use crate::group::{Fibonacci, GcDatabase};
+use salsa::debug::DebugQueryTable;
+use salsa::{Database, SweepStrategy};
+
+#[test]
+fn sweep_default() {
+    let db = db::DatabaseImpl::default();
+
+    db.fibonacci(5);
+
+    let k: Vec<_> = db.query(Fibonacci).keys();
+    assert_eq!(k.len(), 6);
+
+    db.salsa_runtime().next_revision();
+
+    db.fibonacci(5);
+    db.fibonacci(3);
+
+    // fibonacci is a constant, so it will not be invalidated,
+    // hence we keep 3 and 5 but remove the rest.
+    db.sweep_all(SweepStrategy::default());
+    let mut k: Vec<_> = db.query(Fibonacci).keys();
+    k.sort();
+    assert_eq!(k, vec![3, 5]);
+
+    // Even though we ran the sweep, 5 is still in cache
+    db.clear_log();
+    db.fibonacci(5);
+    db.assert_log(&[]);
+
+    // Same but we discard values this time.
+    db.sweep_all(SweepStrategy::default().discard_values());
+    let mut k: Vec<_> = db.query(Fibonacci).keys();
+    k.sort();
+    assert_eq!(k, vec![3, 5]);
+
+    // Now we have to recompute
+    db.clear_log();
+    db.fibonacci(5);
+    db.assert_log(&[
+        "fibonacci(5)",
+        "fibonacci(4)",
+        "fibonacci(3)",
+        "fibonacci(2)",
+        "fibonacci(1)",
+        "fibonacci(0)",
+    ]);
+}

--- a/tests/gc/group.rs
+++ b/tests/gc/group.rs
@@ -1,0 +1,64 @@
+salsa::query_group! {
+    pub(crate) trait GcDatabase: salsa::Database {
+        fn min() -> usize {
+            type Min;
+            storage input;
+        }
+
+        fn max() -> usize {
+            type Max;
+            storage input;
+        }
+
+        fn use_triangular(key: usize) -> bool {
+            type UseTriangular;
+            storage input;
+        }
+
+        fn fibonacci(key: usize) -> usize {
+            type Fibonacci;
+        }
+
+        fn triangular(key: usize) -> usize {
+            type Triangular;
+        }
+
+        fn compute(key: usize) -> usize {
+            type Compute;
+        }
+
+        fn compute_all() -> Vec<usize> {
+            type ComputeAll;
+        }
+    }
+}
+
+fn fibonacci(db: &impl GcDatabase, key: usize) -> usize {
+    if key == 0 {
+        0
+    } else if key == 1 {
+        1
+    } else {
+        db.fibonacci(key - 1) + db.fibonacci(key - 2)
+    }
+}
+
+fn triangular(db: &impl GcDatabase, key: usize) -> usize {
+    if key == 0 {
+        0
+    } else {
+        db.triangular(key - 1) + key
+    }
+}
+
+fn compute(db: &impl GcDatabase, key: usize) -> usize {
+    if db.use_triangular(key) {
+        db.triangular(key)
+    } else {
+        db.fibonacci(key)
+    }
+}
+
+fn compute_all(db: &impl GcDatabase) -> Vec<usize> {
+    (db.min()..db.max()).map(|v| db.compute(v)).collect()
+}

--- a/tests/gc/group.rs
+++ b/tests/gc/group.rs
@@ -1,5 +1,7 @@
+use crate::log::HasLog;
+
 salsa::query_group! {
-    pub(crate) trait GcDatabase: salsa::Database {
+    pub(crate) trait GcDatabase: salsa::Database + HasLog {
         fn min() -> usize {
             type Min;
             storage input;
@@ -34,6 +36,7 @@ salsa::query_group! {
 }
 
 fn fibonacci(db: &impl GcDatabase, key: usize) -> usize {
+    db.log().add(format!("fibonacci({:?})", key));
     if key == 0 {
         0
     } else if key == 1 {
@@ -44,6 +47,7 @@ fn fibonacci(db: &impl GcDatabase, key: usize) -> usize {
 }
 
 fn triangular(db: &impl GcDatabase, key: usize) -> usize {
+    db.log().add(format!("triangular({:?})", key));
     if key == 0 {
         0
     } else {
@@ -52,6 +56,7 @@ fn triangular(db: &impl GcDatabase, key: usize) -> usize {
 }
 
 fn compute(db: &impl GcDatabase, key: usize) -> usize {
+    db.log().add(format!("compute({:?})", key));
     if db.use_triangular(key) {
         db.triangular(key)
     } else {
@@ -60,5 +65,6 @@ fn compute(db: &impl GcDatabase, key: usize) -> usize {
 }
 
 fn compute_all(db: &impl GcDatabase) -> Vec<usize> {
+    db.log().add("compute_all()");
     (db.min()..db.max()).map(|v| db.compute(v)).collect()
 }

--- a/tests/gc/log.rs
+++ b/tests/gc/log.rs
@@ -1,0 +1,20 @@
+use std::cell::RefCell;
+
+pub(crate) trait HasLog {
+    fn log(&self) -> &Log;
+}
+
+#[derive(Default)]
+pub(crate) struct Log {
+    data: RefCell<Vec<String>>,
+}
+
+impl Log {
+    pub(crate) fn add(&self, text: impl Into<String>) {
+        self.data.borrow_mut().push(text.into());
+    }
+
+    pub(crate) fn take(&self) -> Vec<String> {
+        std::mem::replace(&mut *self.data.borrow_mut(), vec![])
+    }
+}

--- a/tests/gc/main.rs
+++ b/tests/gc/main.rs
@@ -1,4 +1,6 @@
 mod db;
 mod derived_tests;
+mod discard_values;
 mod group;
+mod log;
 mod shallow_constant_tests;

--- a/tests/gc/main.rs
+++ b/tests/gc/main.rs
@@ -1,0 +1,4 @@
+mod db;
+mod derived_tests;
+mod group;
+mod shallow_constant_tests;

--- a/tests/gc/shallow_constant_tests.rs
+++ b/tests/gc/shallow_constant_tests.rs
@@ -1,7 +1,7 @@
 use crate::db;
 use crate::group::{Fibonacci, GcDatabase};
 use salsa::debug::DebugQueryTable;
-use salsa::Database;
+use salsa::{Database, SweepStrategy};
 
 // For constant values (like `fibonacci`), we only keep the values
 // that were used in the latest revision, not the sub-values that
@@ -18,7 +18,7 @@ fn one_rev() {
 
     // Everything was used in this revision, so
     // nothing gets collected.
-    db.sweep_all();
+    db.sweep_all(SweepStrategy::default());
     assert_eq!(k.len(), 6);
 }
 
@@ -35,7 +35,7 @@ fn two_rev_nothing() {
 
     // Nothing was used in this revision, so
     // everything gets collected.
-    db.sweep_all();
+    db.sweep_all(SweepStrategy::default());
 
     let k: Vec<_> = db.query(Fibonacci).keys();
     assert_eq!(k.len(), 0);
@@ -56,7 +56,7 @@ fn two_rev_one_use() {
 
     // fibonacci is a constant, so it will not be invalidated,
     // hence we keep `fibonacci(5)` but remove 0..=4.
-    db.sweep_all();
+    db.sweep_all(SweepStrategy::default());
 
     let k: Vec<_> = db.query(Fibonacci).keys();
     assert_eq!(k, vec![5]);
@@ -78,7 +78,7 @@ fn two_rev_two_uses() {
 
     // fibonacci is a constant, so it will not be invalidated,
     // hence we keep 3 and 5 but remove the rest.
-    db.sweep_all();
+    db.sweep_all(SweepStrategy::default());
 
     let mut k: Vec<_> = db.query(Fibonacci).keys();
     k.sort();

--- a/tests/gc/shallow_constant_tests.rs
+++ b/tests/gc/shallow_constant_tests.rs
@@ -1,0 +1,86 @@
+use crate::db;
+use crate::group::{Fibonacci, GcDatabase};
+use salsa::debug::DebugQueryTable;
+use salsa::Database;
+
+// For constant values (like `fibonacci`), we only keep the values
+// that were used in the latest revision, not the sub-values that
+// they required to be computed.
+
+#[test]
+fn one_rev() {
+    let db = db::DatabaseImpl::default();
+
+    db.fibonacci(5);
+
+    let k: Vec<_> = db.query(Fibonacci).keys();
+    assert_eq!(k.len(), 6);
+
+    // Everything was used in this revision, so
+    // nothing gets collected.
+    db.sweep_all();
+    assert_eq!(k.len(), 6);
+}
+
+#[test]
+fn two_rev_nothing() {
+    let db = db::DatabaseImpl::default();
+
+    db.fibonacci(5);
+
+    let k: Vec<_> = db.query(Fibonacci).keys();
+    assert_eq!(k.len(), 6);
+
+    db.salsa_runtime().next_revision();
+
+    // Nothing was used in this revision, so
+    // everything gets collected.
+    db.sweep_all();
+
+    let k: Vec<_> = db.query(Fibonacci).keys();
+    assert_eq!(k.len(), 0);
+}
+
+#[test]
+fn two_rev_one_use() {
+    let db = db::DatabaseImpl::default();
+
+    db.fibonacci(5);
+
+    let k: Vec<_> = db.query(Fibonacci).keys();
+    assert_eq!(k.len(), 6);
+
+    db.salsa_runtime().next_revision();
+
+    db.fibonacci(5);
+
+    // fibonacci is a constant, so it will not be invalidated,
+    // hence we keep `fibonacci(5)` but remove 0..=4.
+    db.sweep_all();
+
+    let k: Vec<_> = db.query(Fibonacci).keys();
+    assert_eq!(k, vec![5]);
+}
+
+#[test]
+fn two_rev_two_uses() {
+    let db = db::DatabaseImpl::default();
+
+    db.fibonacci(5);
+
+    let k: Vec<_> = db.query(Fibonacci).keys();
+    assert_eq!(k.len(), 6);
+
+    db.salsa_runtime().next_revision();
+
+    db.fibonacci(5);
+    db.fibonacci(3);
+
+    // fibonacci is a constant, so it will not be invalidated,
+    // hence we keep 3 and 5 but remove the rest.
+    db.sweep_all();
+
+    let mut k: Vec<_> = db.query(Fibonacci).keys();
+    k.sort();
+    assert_eq!(k, vec![3, 5]);
+}

--- a/tests/incremental/constants.rs
+++ b/tests/incremental/constants.rs
@@ -83,7 +83,7 @@ fn mixed_constant() {
 }
 
 #[test]
-fn becomes_constant() {
+fn becomes_constant_with_change() {
     let db = &TestContextImpl::default();
 
     db.query(ConstantsInput).set('a', 22);

--- a/tests/incremental/implementation.rs
+++ b/tests/incremental/implementation.rs
@@ -19,8 +19,6 @@ pub(crate) struct TestContextImpl {
 
 impl TestContextImpl {
     pub(crate) fn assert_log(&self, expected_log: &[&str]) {
-        use difference::{Changeset, Difference};
-
         let expected_text = &format!("{:#?}", expected_log);
         let actual_text = &format!("{:#?}", self.log().take());
 
@@ -28,13 +26,11 @@ impl TestContextImpl {
             return;
         }
 
-        let Changeset { diffs, .. } = Changeset::new(expected_text, actual_text, "\n");
-
-        for i in 0..diffs.len() {
-            match &diffs[i] {
-                Difference::Same(x) => println!(" {}", x),
-                Difference::Add(x) => println!("+{}", x),
-                Difference::Rem(x) => println!("-{}", x),
+        for diff in diff::lines(expected_text, actual_text) {
+            match diff {
+                diff::Result::Left(l) => println!("-{}", l),
+                diff::Result::Both(l, _) => println!(" {}", l),
+                diff::Result::Right(r) => println!("+{}", r),
             }
         }
 

--- a/tests/incremental/memoized_volatile.rs
+++ b/tests/incremental/memoized_volatile.rs
@@ -68,7 +68,7 @@ fn revalidate() {
     query.salsa_runtime().next_revision();
 
     query.memoized2();
-    query.assert_log(&["Volatile invoked", "Memoized1 invoked"]);
+    query.assert_log(&["Memoized1 invoked", "Volatile invoked"]);
 
     query.memoized2();
     query.assert_log(&[]);
@@ -79,7 +79,7 @@ fn revalidate() {
     query.salsa_runtime().next_revision();
 
     query.memoized2();
-    query.assert_log(&["Volatile invoked", "Memoized1 invoked", "Memoized2 invoked"]);
+    query.assert_log(&["Memoized1 invoked", "Volatile invoked", "Memoized2 invoked"]);
 
     query.memoized2();
     query.assert_log(&[]);


### PR DESCRIPTION
This PR adds two methods:

- `db.sweep_all()`, on the database
- `db.query(Foo).sweep()`, on an individual query

These methods will remove all table entries that were not needed in the most recent revision. The intention is that you can do something like this:

```rust
// Start a new revision:
db.salsa_runtime().next_revision();

// Some root query that does everything you need
// e.g., type-checks your program
db.root_query();

// Remove things the root query did not use
db.sweep_all();
```

It also changes how we handle constants. We used to ignore constant inputs **entirely** when doing computation (i.e., we did not record them as inputs). We now distinguish two cases:

- If a derived computation has a mix of constant and non-constant inputs, we will record the inputs faithfully.
- If a derived computation has **only** constant inputs (or no inputs), it is marked as constant and the list of inputs is discarded.

(Furthermore, we always update the `verified_at` keys for derived tests, even for constant inputs; we used to neglect this.)

This way, when we do a sweep, we can keep only those "outermost" constants C that were needed to compute the retained items.  The inputs to C are not kept around. You can see this in the tests: we compute e.g. `fibonacci(5)` but then when we collect we discard the keys for 0, 1, 2, 3, and 4.

Garbage collection does not require "stopping the world" — it operates per table and in parallel. I am not presently testing this. We really need to add some sort of "parallel stress testing", and in particular to cover the case where we collect an entry **as it is being computed**. Once https://github.com/salsa-rs/salsa/pull/63 lands, we should be able to test that case deterministically.

Fixes #7 