### PR TITLE
release 0.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
- we now offer a `lock_revision` API, though it is likely to change
- we are now panic safe, but only in a single threaded context