### PR TITLE
publish v0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa"
-version = "0.6.2"
+version = "0.7.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
Changes:
- correct dead locks and add parallel stress test (#72)
- we now panic if you `get` an input that has not been `set` and
  we do not compare inputs for equality (thus dropped `Default` and `Eq`
  bounds) (#69)
- more safeguards panic in `PanicGuard` (#71)