### PR TITLE
make `fork` give you a `Frozen<DB>`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,7 @@ pub trait ParallelDatabase: Database + Send {
     /// cloning over each of the fields from `self` into this new
     /// copy. For the field that stores the salsa runtime, you should
     /// use [the `Runtime::snapshot` method][rfm] to create a snapshot of the
-    /// runtime. Finally, package up the result using `Frozen::new`,
+    /// runtime. Finally, package up the result using `Snapshot::new`,
     /// which is a simple wrapper type that only gives `&self` access
     /// to the database within (thus preventing the use of methods
     /// that may mutate the inputs):
@@ -211,8 +211,8 @@ pub trait ParallelDatabase: Database + Send {
     ///
     /// ```rust,ignore
     /// impl ParallelDatabase for MyDatabaseType {
-    ///     fn snapshot(&self) -> Frozen<Self> {
-    ///         Frozen::new(
+    ///     fn snapshot(&self) -> Snapshot<Self> {
+    ///         Snapshot::new(
     ///             MyDatabaseType {
     ///                 runtime: self.runtime.snapshot(self),
     ///                 other_field: self.other_field.clone(),
@@ -227,7 +227,7 @@ pub trait ParallelDatabase: Database + Send {
     /// This second handle is intended to be used from a separate
     /// thread. Using two database handles from the **same thread**
     /// can lead to deadlock.
-    fn snapshot(&self) -> Frozen<Self>;
+    fn snapshot(&self) -> Snapshot<Self>;
 }
 
 /// Simple wrapper struct that takes ownership of a database `DB`
@@ -235,23 +235,23 @@ pub trait ParallelDatabase: Database + Send {
 /// more details.
 ///
 /// [fm]: trait.ParallelDatabase#method.snapshot
-pub struct Frozen<DB>
+pub struct Snapshot<DB>
 where
     DB: ParallelDatabase,
 {
     db: DB,
 }
 
-impl<DB> Frozen<DB>
+impl<DB> Snapshot<DB>
 where
     DB: ParallelDatabase,
 {
     pub fn new(db: DB) -> Self {
-        Frozen { db }
+        Snapshot { db }
     }
 }
 
-impl<DB> std::ops::Deref for Frozen<DB>
+impl<DB> std::ops::Deref for Snapshot<DB>
 where
     DB: ParallelDatabase,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@ use derive_new::new;
 use std::fmt::{self, Debug};
 use std::hash::Hash;
 
-pub use crate::runtime::Frozen;
 pub use crate::runtime::Runtime;
 pub use crate::runtime::RuntimeId;
 
@@ -196,34 +195,71 @@ pub trait ParallelDatabase: Database + Send {
     ///
     /// [`is_current_revision_canceled`]: struct.Runtime.html#method.is_current_revision_canceled
     ///
+    /// # How to implement this
+    ///
+    /// Typically, this method will create a second copy of your
+    /// database type (`MyDatabaseType`, in the example below),
+    /// cloning over each of the fields from `self` into this new
+    /// copy. For the field that stores the salsa runtime, you should
+    /// use [the `Runtime::fork` method][rfm] to create a fork of the
+    /// runtime. Finally, package up the result using `Frozen::new`,
+    /// which is a simple wrapper type that only gives `&self` access
+    /// to the database within (thus preventing the use of methods
+    /// that may mutate the inputs):
+    ///
+    /// [rfm]: struct.Runtime.html#method.fork
+    ///
+    /// ```rust,ignore
+    /// impl ParallelDatabase for MyDatabaseType {
+    ///     fn fork(&self) -> Frozen<Self> {
+    ///         Frozen::new(
+    ///             MyDatabaseType {
+    ///                 runtime: self.runtime.fork(self),
+    ///                 other_field: self.other_field.clone(),
+    ///             }
+    ///         )
+    ///     }
+    /// }
+    /// ```
+    ///
     /// # Deadlock warning
     ///
     /// This second handle is intended to be used from a separate
     /// thread. Using two database handles from the **same thread**
     /// can lead to deadlock.
-    fn fork(&self) -> Frozen<Self> {
-        Frozen::new(self)
-    }
+    fn fork(&self) -> Frozen<Self>;
+}
 
-    /// Creates another handle to this database destined for another
-    /// thread. You are meant to implement this by cloning a second
-    /// handle to all all the state in the database; to clone the
-    /// salsa runtime, use the [`Runtime::fork_mut`] method.
-    ///
-    /// Note to users: you only need this method if you plan to be
-    /// setting inputs on the other thread. Otherwise, it is preferred
-    /// to use [`fork`], which will given back a frozen database fixed
-    /// at the current revision.
-    ///
-    /// # Deadlock warning
-    ///
-    /// This second handle is intended to be used from a
-    /// separate thread. Using two database handles from the **same
-    /// thread** can lead to deadlock.
-    ///
-    /// [`Runtime::fork_mut`]: https://docs.rs/salsa/0.7.0/salsa/struct.Runtime.html#method.fork_mut
-    /// [`fork`]: trait.ParallelDatabase.html#tymethod.fork
-    fn fork_mut(&self) -> Self;
+/// Simple wrapper struct that takes ownership of a database `DB`
+/// and only gives `&self` access to it. See [the `fork` method][fm] for
+/// more details.
+///
+/// [fm]: trait.ParallelDatabase#method.fork
+pub struct Frozen<DB>
+where
+    DB: ParallelDatabase,
+{
+    db: DB,
+}
+
+impl<DB> Frozen<DB>
+where
+    DB: ParallelDatabase,
+{
+    pub fn new(db: DB) -> Self {
+        Frozen { db }
+    }
+}
+
+impl<DB> std::ops::Deref for Frozen<DB>
+where
+    DB: ParallelDatabase,
+{
+    type Target = DB;
+
+    fn deref(&self) -> &DB {
+        &self.db
+    }
 }
 
 pub trait Query<DB: Database>: Debug + Default + Sized + 'static {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,7 @@ pub trait ParallelDatabase: Database + Send {
     /// **Warning.** This second handle is intended to be used from a
     /// separate thread. Using two database handles from the **same
     /// thread** can lead to deadlock.
-    fn fork(&self) -> Self;
+    fn fork_mut(&self) -> Self;
 }
 
 pub trait Query<DB: Database>: Debug + Default + Sized + 'static {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -69,7 +69,7 @@ where
     /// **Warning.** This second handle is intended to be used from a
     /// separate thread. Using two database handles from the **same
     /// thread** can lead to deadlock.
-    pub fn fork(&self) -> Self {
+    pub fn fork_mut(&self) -> Self {
         Runtime {
             id: RuntimeId {
                 counter: self.shared_state.next_id.fetch_add(1, Ordering::SeqCst),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -629,7 +629,7 @@ where
 {
     fn drop(&mut self) {
         // Release our read-lock without using RAII. As documented in
-        // `Frozen::new` above, this requires the unsafe keyword.
+        // `Snapshot::new` above, this requires the unsafe keyword.
         unsafe {
             self.shared_state.query_lock.raw().unlock_shared();
         }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -130,26 +130,6 @@ where
         db.for_each_query(|query_storage| query_storage.sweep(db, strategy));
     }
 
-    /// Indicates that a derived query has begun to execute; if this is the
-    /// first derived query on this thread, then acquires a read-lock on the
-    /// runtime to prevent us from moving to a new revision until that query
-    /// completes.
-    ///
-    /// (However, if other threads invoke `increment_revision`, then
-    /// the current revision may be considered cancelled, which can be
-    /// observed through `is_current_revision_canceled`.)
-    pub(crate) fn start_query(&self) -> Option<QueryGuard<'_, DB>> {
-        let mut local_state = self.local_state.borrow_mut();
-        if !local_state.query_in_progress {
-            local_state.query_in_progress = true;
-            let guard = self.shared_state.query_lock.read();
-
-            Some(QueryGuard::new(self, guard))
-        } else {
-            None
-        }
-    }
-
     /// The unique identifier attached to this `SalsaRuntime`. Each
     /// forked runtime has a distinct identifier.
     #[inline]

--- a/tests/panic_safely.rs
+++ b/tests/panic_safely.rs
@@ -30,9 +30,9 @@ impl salsa::Database for DatabaseStruct {
 }
 
 impl salsa::ParallelDatabase for DatabaseStruct {
-    fn fork(&self) -> Frozen<Self> {
+    fn snapshot(&self) -> Frozen<Self> {
         Frozen::new(DatabaseStruct {
-            runtime: self.runtime.fork(self),
+            runtime: self.runtime.snapshot(self),
         })
     }
 }
@@ -53,7 +53,7 @@ fn should_panic_safely() {
     // Invoke `db.panic_safely() without having set `db.one`. `db.one` will
     // default to 0 and we should catch the panic.
     let result = panic::catch_unwind(AssertUnwindSafe({
-        let db = db.fork();
+        let db = db.snapshot();
         move || db.panic_safely()
     }));
     assert!(result.is_err());

--- a/tests/panic_safely.rs
+++ b/tests/panic_safely.rs
@@ -1,4 +1,4 @@
-use salsa::{Database, Frozen, ParallelDatabase};
+use salsa::{Database, ParallelDatabase, Snapshot};
 use std::panic::{self, AssertUnwindSafe};
 
 salsa::query_group! {
@@ -30,8 +30,8 @@ impl salsa::Database for DatabaseStruct {
 }
 
 impl salsa::ParallelDatabase for DatabaseStruct {
-    fn snapshot(&self) -> Frozen<Self> {
-        Frozen::new(DatabaseStruct {
+    fn snapshot(&self) -> Snapshot<Self> {
+        Snapshot::new(DatabaseStruct {
             runtime: self.runtime.snapshot(self),
         })
     }

--- a/tests/parallel/cancellation.rs
+++ b/tests/parallel/cancellation.rs
@@ -14,7 +14,7 @@ fn in_par_get_set_cancellation() {
     db.query(Input).set('d', 0);
 
     let thread1 = std::thread::spawn({
-        let db = db.fork();
+        let db = db.fork_mut();
         move || {
             let v1 = db.knobs().sum_signal_on_entry.with_value(1, || {
                 db.knobs()
@@ -38,7 +38,7 @@ fn in_par_get_set_cancellation() {
     });
 
     let thread2 = std::thread::spawn({
-        let db = db.fork();
+        let db = db.fork_mut();
         move || {
             // Wait until we have entered `sum` in the other thread.
             db.wait_for(1);
@@ -68,7 +68,7 @@ fn in_par_get_set_transitive_cancellation() {
     db.query(Input).set('d', 0);
 
     let thread1 = std::thread::spawn({
-        let db = db.fork();
+        let db = db.fork_mut();
         move || {
             let v1 = db.knobs().sum_signal_on_entry.with_value(1, || {
                 db.knobs()
@@ -92,7 +92,7 @@ fn in_par_get_set_transitive_cancellation() {
     });
 
     let thread2 = std::thread::spawn({
-        let db = db.fork();
+        let db = db.fork_mut();
         move || {
             // Wait until we have entered `sum` in the other thread.
             db.wait_for(1);

--- a/tests/parallel/cancellation.rs
+++ b/tests/parallel/cancellation.rs
@@ -14,7 +14,7 @@ fn in_par_get_set_cancellation_immediate() {
     db.query(Input).set('d', 0);
 
     let thread1 = std::thread::spawn({
-        let db = db.fork();
+        let db = db.snapshot();
         move || {
             // This will not return until it sees cancellation is
             // signaled.
@@ -34,7 +34,7 @@ fn in_par_get_set_cancellation_immediate() {
 
     // This should re-compute the value (even though no input has changed).
     let thread2 = std::thread::spawn({
-        let db = db.fork();
+        let db = db.snapshot();
         move || db.sum("abc")
     });
 
@@ -55,7 +55,7 @@ fn in_par_get_set_cancellation_transitive() {
     db.query(Input).set('d', 0);
 
     let thread1 = std::thread::spawn({
-        let db = db.fork();
+        let db = db.snapshot();
         move || {
             // This will not return until it sees cancellation is
             // signaled.
@@ -75,7 +75,7 @@ fn in_par_get_set_cancellation_transitive() {
 
     // This should re-compute the value (even though no input has changed).
     let thread2 = std::thread::spawn({
-        let db = db.fork();
+        let db = db.snapshot();
         move || db.sum2("abc")
     });
 

--- a/tests/parallel/cancellation.rs
+++ b/tests/parallel/cancellation.rs
@@ -5,7 +5,7 @@ use salsa::{Database, ParallelDatabase};
 /// write. Check that we recompute the result in next revision, even
 /// though none of the inputs have changed.
 #[test]
-fn in_par_get_set_cancellation() {
+fn in_par_get_set_cancellation_immediate() {
     let db = ParDatabaseImpl::default();
 
     db.query(Input).set('a', 100);
@@ -14,52 +14,39 @@ fn in_par_get_set_cancellation() {
     db.query(Input).set('d', 0);
 
     let thread1 = std::thread::spawn({
-        let db = db.fork_mut();
+        let db = db.fork();
         move || {
-            let v1 = db.knobs().sum_signal_on_entry.with_value(1, || {
+            // This will not return until it sees cancellation is
+            // signaled.
+            db.knobs().sum_signal_on_entry.with_value(1, || {
                 db.knobs()
                     .sum_wait_for_cancellation
                     .with_value(true, || db.sum("abc"))
-            });
-
-            // check that we observed cancellation
-            assert_eq!(v1, std::usize::MAX);
-
-            // at this point, we have observed cancellation, so let's
-            // wait until the `set` is known to have occurred.
-            db.wait_for(2);
-
-            // Now when we read we should get the correct sums. Note
-            // in particular that we re-compute the sum of `"abc"`
-            // even though none of our inputs have changed.
-            let v2 = db.sum("abc");
-            (v1, v2)
+            })
         }
     });
 
+    // Wait until we have entered `sum` in the other thread.
+    db.wait_for(1);
+
+    // Try to set the input. This will signal cancellation.
+    db.query(Input).set('d', 1000);
+
+    // This should re-compute the value (even though no input has changed).
     let thread2 = std::thread::spawn({
-        let db = db.fork_mut();
-        move || {
-            // Wait until we have entered `sum` in the other thread.
-            db.wait_for(1);
-
-            db.query(Input).set('d', 1000);
-
-            // Signal that we have *set* `d`
-            db.signal(2);
-
-            db.sum("d")
-        }
+        let db = db.fork();
+        move || db.sum("abc")
     });
 
-    assert_eq!(thread1.join().unwrap(), (std::usize::MAX, 111));
-    assert_eq!(thread2.join().unwrap(), 1000);
+    assert_eq!(db.sum("d"), 1000);
+    assert_eq!(thread1.join().unwrap(), std::usize::MAX);
+    assert_eq!(thread2.join().unwrap(), 111);
 }
 
 /// Here, we check that `sum`'s cancellation is propagated
 /// to `sum2` properly.
 #[test]
-fn in_par_get_set_transitive_cancellation() {
+fn in_par_get_set_cancellation_transitive() {
     let db = ParDatabaseImpl::default();
 
     db.query(Input).set('a', 100);
@@ -68,44 +55,31 @@ fn in_par_get_set_transitive_cancellation() {
     db.query(Input).set('d', 0);
 
     let thread1 = std::thread::spawn({
-        let db = db.fork_mut();
+        let db = db.fork();
         move || {
-            let v1 = db.knobs().sum_signal_on_entry.with_value(1, || {
+            // This will not return until it sees cancellation is
+            // signaled.
+            db.knobs().sum_signal_on_entry.with_value(1, || {
                 db.knobs()
                     .sum_wait_for_cancellation
                     .with_value(true, || db.sum2("abc"))
-            });
-
-            // check that we observed cancellation
-            assert_eq!(v1, std::usize::MAX);
-
-            // at this point, we have observed cancellation, so let's
-            // wait until the `set` is known to have occurred.
-            db.wait_for(2);
-
-            // Now when we read we should get the correct sums. Note
-            // in particular that we re-compute the sum of `"abc"`
-            // even though none of our inputs have changed.
-            let v2 = db.sum2("abc");
-            (v1, v2)
+            })
         }
     });
 
+    // Wait until we have entered `sum` in the other thread.
+    db.wait_for(1);
+
+    // Try to set the input. This will signal cancellation.
+    db.query(Input).set('d', 1000);
+
+    // This should re-compute the value (even though no input has changed).
     let thread2 = std::thread::spawn({
-        let db = db.fork_mut();
-        move || {
-            // Wait until we have entered `sum` in the other thread.
-            db.wait_for(1);
-
-            db.query(Input).set('d', 1000);
-
-            // Signal that we have *set* `d`
-            db.signal(2);
-
-            db.sum("d")
-        }
+        let db = db.fork();
+        move || db.sum2("abc")
     });
 
-    assert_eq!(thread1.join().unwrap(), (std::usize::MAX, 111));
-    assert_eq!(thread2.join().unwrap(), 1000);
+    assert_eq!(db.sum2("d"), 1000);
+    assert_eq!(thread1.join().unwrap(), std::usize::MAX);
+    assert_eq!(thread2.join().unwrap(), 111);
 }

--- a/tests/parallel/fork_from_query.rs
+++ b/tests/parallel/fork_from_query.rs
@@ -1,0 +1,8 @@
+use crate::setup::{ParDatabase, ParDatabaseImpl};
+
+#[test]
+#[should_panic]
+fn fork_from_query() {
+    let db = ParDatabaseImpl::default();
+    db.fork_me();
+}

--- a/tests/parallel/fork_from_query.rs
+++ b/tests/parallel/fork_from_query.rs
@@ -2,7 +2,7 @@ use crate::setup::{ParDatabase, ParDatabaseImpl};
 
 #[test]
 #[should_panic]
-fn fork_from_query() {
+fn snapshot_from_query() {
     let db = ParDatabaseImpl::default();
-    db.fork_me();
+    db.snapshot_me();
 }

--- a/tests/parallel/frozen.rs
+++ b/tests/parallel/frozen.rs
@@ -43,7 +43,6 @@ fn in_par_get_set_cancellation() {
     });
 
     let thread2 = std::thread::spawn({
-        let db = db.fork_mut();
         let signal = signal.clone();
         move || {
             // Wait until thread 1 has asserted that they are not cancelled

--- a/tests/parallel/frozen.rs
+++ b/tests/parallel/frozen.rs
@@ -15,7 +15,7 @@ fn in_par_get_set_cancellation() {
     let signal = Arc::new(Signal::default());
 
     let thread1 = std::thread::spawn({
-        let db = db.fork();
+        let db = db.snapshot();
         let signal = signal.clone();
         move || {
             // Check that cancellation flag is not yet set, because
@@ -34,7 +34,7 @@ fn in_par_get_set_cancellation() {
             // see 1 here.
             let v = db.input('a');
 
-            // Since this is a forked database, we are in a consistent
+            // Since this is a snapshotted database, we are in a consistent
             // revision, so this must yield the same value.
             let w = db.input('a');
 

--- a/tests/parallel/independent.rs
+++ b/tests/parallel/independent.rs
@@ -5,19 +5,24 @@ use salsa::{Database, ParallelDatabase};
 /// threads. Really just a test that `fork` etc compiles.
 #[test]
 fn in_par_two_independent_queries() {
-    let db1 = ParDatabaseImpl::default();
-    let db2 = db1.fork_mut();
+    let db = ParDatabaseImpl::default();
 
-    db1.query(Input).set('a', 100);
-    db1.query(Input).set('b', 010);
-    db1.query(Input).set('c', 001);
-    db1.query(Input).set('d', 200);
-    db1.query(Input).set('e', 020);
-    db1.query(Input).set('f', 002);
+    db.query(Input).set('a', 100);
+    db.query(Input).set('b', 010);
+    db.query(Input).set('c', 001);
+    db.query(Input).set('d', 200);
+    db.query(Input).set('e', 020);
+    db.query(Input).set('f', 002);
 
-    let thread1 = std::thread::spawn(move || db1.sum("abc"));
+    let thread1 = std::thread::spawn({
+        let db = db.fork();
+        move || db.sum("abc")
+    });
 
-    let thread2 = std::thread::spawn(move || db2.sum("def"));
+    let thread2 = std::thread::spawn({
+        let db = db.fork();
+        move || db.sum("def")
+    });;
 
     assert_eq!(thread1.join().unwrap(), 111);
     assert_eq!(thread2.join().unwrap(), 222);

--- a/tests/parallel/independent.rs
+++ b/tests/parallel/independent.rs
@@ -2,7 +2,7 @@ use crate::setup::{Input, ParDatabase, ParDatabaseImpl};
 use salsa::{Database, ParallelDatabase};
 
 /// Test two `sum` queries (on distinct keys) executing in different
-/// threads. Really just a test that `fork` etc compiles.
+/// threads. Really just a test that `snapshot` etc compiles.
 #[test]
 fn in_par_two_independent_queries() {
     let db = ParDatabaseImpl::default();
@@ -15,12 +15,12 @@ fn in_par_two_independent_queries() {
     db.query(Input).set('f', 002);
 
     let thread1 = std::thread::spawn({
-        let db = db.fork();
+        let db = db.snapshot();
         move || db.sum("abc")
     });
 
     let thread2 = std::thread::spawn({
-        let db = db.fork();
+        let db = db.snapshot();
         move || db.sum("def")
     });;
 

--- a/tests/parallel/independent.rs
+++ b/tests/parallel/independent.rs
@@ -6,7 +6,7 @@ use salsa::{Database, ParallelDatabase};
 #[test]
 fn in_par_two_independent_queries() {
     let db1 = ParDatabaseImpl::default();
-    let db2 = db1.fork();
+    let db2 = db1.fork_mut();
 
     db1.query(Input).set('a', 100);
     db1.query(Input).set('b', 010);

--- a/tests/parallel/main.rs
+++ b/tests/parallel/main.rs
@@ -1,6 +1,7 @@
 mod setup;
 
 mod cancellation;
+mod fork_from_query;
 mod frozen;
 mod independent;
 mod race;

--- a/tests/parallel/main.rs
+++ b/tests/parallel/main.rs
@@ -1,9 +1,9 @@
 mod setup;
 
 mod cancellation;
+mod frozen;
 mod independent;
 mod race;
-mod revision_lock;
 mod signal;
-mod true_parallel;
 mod stress;
+mod true_parallel;

--- a/tests/parallel/race.rs
+++ b/tests/parallel/race.rs
@@ -6,7 +6,7 @@ use salsa::{Database, ParallelDatabase};
 #[test]
 fn in_par_get_set_race() {
     let db1 = ParDatabaseImpl::default();
-    let db2 = db1.fork();
+    let db2 = db1.fork_mut();
 
     db1.query(Input).set('a', 100);
     db1.query(Input).set('b', 010);

--- a/tests/parallel/race.rs
+++ b/tests/parallel/race.rs
@@ -12,7 +12,7 @@ fn in_par_get_set_race() {
     db.query(Input).set('c', 001);
 
     let thread1 = std::thread::spawn({
-        let db = db.fork();
+        let db = db.snapshot();
         move || {
             let v = db.sum("abc");
             v

--- a/tests/parallel/race.rs
+++ b/tests/parallel/race.rs
@@ -5,21 +5,23 @@ use salsa::{Database, ParallelDatabase};
 /// Should be atomic.
 #[test]
 fn in_par_get_set_race() {
-    let db1 = ParDatabaseImpl::default();
-    let db2 = db1.fork_mut();
+    let db = ParDatabaseImpl::default();
 
-    db1.query(Input).set('a', 100);
-    db1.query(Input).set('b', 010);
-    db1.query(Input).set('c', 001);
+    db.query(Input).set('a', 100);
+    db.query(Input).set('b', 010);
+    db.query(Input).set('c', 001);
 
-    let thread1 = std::thread::spawn(move || {
-        let v = db1.sum("abc");
-        v
+    let thread1 = std::thread::spawn({
+        let db = db.fork();
+        move || {
+            let v = db.sum("abc");
+            v
+        }
     });
 
     let thread2 = std::thread::spawn(move || {
-        db2.query(Input).set('a', 1000);
-        db2.sum("a")
+        db.query(Input).set('a', 1000);
+        db.sum("a")
     });
 
     // If the 1st thread runs first, you get 111, otherwise you get

--- a/tests/parallel/revision_lock.rs
+++ b/tests/parallel/revision_lock.rs
@@ -16,7 +16,7 @@ fn in_par_get_set_cancellation() {
 
     let lock = db.salsa_runtime().lock_revision();
     let thread1 = std::thread::spawn({
-        let db = db.fork();
+        let db = db.fork_mut();
         let signal = signal.clone();
         move || {
             // Check that cancellation flag is not yet set, because
@@ -47,7 +47,7 @@ fn in_par_get_set_cancellation() {
     });
 
     let thread2 = std::thread::spawn({
-        let db = db.fork();
+        let db = db.fork_mut();
         let signal = signal.clone();
         move || {
             // Wait until thread 1 has asserted that they are not cancelled

--- a/tests/parallel/setup.rs
+++ b/tests/parallel/setup.rs
@@ -20,8 +20,8 @@ salsa::query_group! {
             type Sum2;
         }
 
-        fn fork_me() -> () {
-            type ForkMe;
+        fn snapshot_me() -> () {
+            type SnapshotMe;
         }
     }
 }
@@ -112,9 +112,9 @@ fn sum2(db: &impl ParDatabase, key: &'static str) -> usize {
     db.sum(key)
 }
 
-fn fork_me(db: &impl ParDatabase) {
+fn snapshot_me(db: &impl ParDatabase) {
     // this should panic
-    db.fork();
+    db.snapshot();
 }
 
 #[derive(Default)]
@@ -141,9 +141,9 @@ impl Database for ParDatabaseImpl {
 }
 
 impl ParallelDatabase for ParDatabaseImpl {
-    fn fork(&self) -> Frozen<Self> {
+    fn snapshot(&self) -> Frozen<Self> {
         Frozen::new(ParDatabaseImpl {
-            runtime: self.runtime.fork(self),
+            runtime: self.runtime.snapshot(self),
             knobs: self.knobs.clone(),
         })
     }
@@ -169,7 +169,7 @@ salsa::database_storage! {
             fn input() for Input;
             fn sum() for Sum;
             fn sum2() for Sum2;
-            fn fork_me() for ForkMe;
+            fn snapshot_me() for SnapshotMe;
         }
     }
 }

--- a/tests/parallel/setup.rs
+++ b/tests/parallel/setup.rs
@@ -1,5 +1,6 @@
 use crate::signal::Signal;
 use salsa::Database;
+use salsa::Frozen;
 use salsa::ParallelDatabase;
 use std::cell::Cell;
 use std::sync::Arc;
@@ -104,7 +105,7 @@ fn sum(db: &impl ParDatabase, key: &'static str) -> usize {
 }
 
 fn sum2(db: &impl ParDatabase, key: &'static str) -> usize {
-    sum(db, key)
+    db.sum(key)
 }
 
 #[derive(Default)]
@@ -131,11 +132,11 @@ impl Database for ParDatabaseImpl {
 }
 
 impl ParallelDatabase for ParDatabaseImpl {
-    fn fork_mut(&self) -> Self {
-        ParDatabaseImpl {
-            runtime: self.runtime.fork_mut(),
+    fn fork(&self) -> Frozen<Self> {
+        Frozen::new(ParDatabaseImpl {
+            runtime: self.runtime.fork(self),
             knobs: self.knobs.clone(),
-        }
+        })
     }
 }
 

--- a/tests/parallel/setup.rs
+++ b/tests/parallel/setup.rs
@@ -131,9 +131,9 @@ impl Database for ParDatabaseImpl {
 }
 
 impl ParallelDatabase for ParDatabaseImpl {
-    fn fork(&self) -> Self {
+    fn fork_mut(&self) -> Self {
         ParDatabaseImpl {
-            runtime: self.runtime.fork(),
+            runtime: self.runtime.fork_mut(),
             knobs: self.knobs.clone(),
         }
     }

--- a/tests/parallel/setup.rs
+++ b/tests/parallel/setup.rs
@@ -1,7 +1,7 @@
 use crate::signal::Signal;
 use salsa::Database;
-use salsa::Frozen;
 use salsa::ParallelDatabase;
+use salsa::Snapshot;
 use std::cell::Cell;
 use std::sync::Arc;
 
@@ -141,8 +141,8 @@ impl Database for ParDatabaseImpl {
 }
 
 impl ParallelDatabase for ParDatabaseImpl {
-    fn snapshot(&self) -> Frozen<Self> {
-        Frozen::new(ParDatabaseImpl {
+    fn snapshot(&self) -> Snapshot<Self> {
+        Snapshot::new(ParDatabaseImpl {
             runtime: self.runtime.snapshot(self),
             knobs: self.knobs.clone(),
         })

--- a/tests/parallel/setup.rs
+++ b/tests/parallel/setup.rs
@@ -6,7 +6,7 @@ use std::cell::Cell;
 use std::sync::Arc;
 
 salsa::query_group! {
-    pub(crate) trait ParDatabase: Knobs + salsa::Database {
+    pub(crate) trait ParDatabase: Knobs + salsa::ParallelDatabase {
         fn input(key: char) -> usize {
             type Input;
             storage input;
@@ -18,6 +18,10 @@ salsa::query_group! {
 
         fn sum2(key: &'static str) -> usize {
             type Sum2;
+        }
+
+        fn fork_me() -> () {
+            type ForkMe;
         }
     }
 }
@@ -108,6 +112,11 @@ fn sum2(db: &impl ParDatabase, key: &'static str) -> usize {
     db.sum(key)
 }
 
+fn fork_me(db: &impl ParDatabase) {
+    // this should panic
+    db.fork();
+}
+
 #[derive(Default)]
 pub struct ParDatabaseImpl {
     runtime: salsa::Runtime<ParDatabaseImpl>,
@@ -160,6 +169,7 @@ salsa::database_storage! {
             fn input() for Input;
             fn sum() for Sum;
             fn sum2() for Sum2;
+            fn fork_me() for ForkMe;
         }
     }
 }

--- a/tests/parallel/stress.rs
+++ b/tests/parallel/stress.rs
@@ -52,9 +52,9 @@ impl salsa::Database for StressDatabaseImpl {
 }
 
 impl salsa::ParallelDatabase for StressDatabaseImpl {
-    fn fork(&self) -> Frozen<StressDatabaseImpl> {
+    fn snapshot(&self) -> Frozen<StressDatabaseImpl> {
         Frozen::new(StressDatabaseImpl {
-            runtime: self.runtime.fork(self),
+            runtime: self.runtime.snapshot(self),
         })
     }
 }
@@ -207,7 +207,7 @@ fn stress_test() {
     // generate the ops that the mutator thread will perform
     let write_ops: Vec<MutatorOp> = (0..N_MUTATOR_OPS).map(|_| rng.gen()).collect();
 
-    // execute the "main thread", which sometimes forks off other threads
+    // execute the "main thread", which sometimes snapshots off other threads
     let mut all_threads = vec![];
     for op in write_ops {
         match op {
@@ -216,7 +216,7 @@ fn stress_test() {
                 ops,
                 check_cancellation,
             } => all_threads.push(std::thread::spawn({
-                let db = db.fork();
+                let db = db.snapshot();
                 move || db_reader_thread(&db, ops, check_cancellation)
             })),
         }

--- a/tests/parallel/stress.rs
+++ b/tests/parallel/stress.rs
@@ -1,7 +1,7 @@
 use rand::Rng;
 use salsa::Database;
-use salsa::Frozen;
 use salsa::ParallelDatabase;
+use salsa::Snapshot;
 use salsa::SweepStrategy;
 
 // Number of operations a reader performs
@@ -52,8 +52,8 @@ impl salsa::Database for StressDatabaseImpl {
 }
 
 impl salsa::ParallelDatabase for StressDatabaseImpl {
-    fn snapshot(&self) -> Frozen<StressDatabaseImpl> {
-        Frozen::new(StressDatabaseImpl {
+    fn snapshot(&self) -> Snapshot<StressDatabaseImpl> {
+        Snapshot::new(StressDatabaseImpl {
             runtime: self.runtime.snapshot(self),
         })
     }

--- a/tests/parallel/true_parallel.rs
+++ b/tests/parallel/true_parallel.rs
@@ -1,5 +1,6 @@
 use crate::setup::{Input, Knobs, ParDatabase, ParDatabaseImpl, WithValue};
-use salsa::{Database, ParallelDatabase};
+use salsa::Database;
+use salsa::ParallelDatabase;
 
 /// Test where two threads are executing sum. We show that they can
 /// both be executing sum in parallel by having thread1 wait for
@@ -15,7 +16,7 @@ fn true_parallel_different_keys() {
 
     // Thread 1 will signal stage 1 when it enters and wait for stage 2.
     let thread1 = std::thread::spawn({
-        let db = db.fork_mut();
+        let db = db.fork();
         move || {
             let v = db.knobs().sum_signal_on_entry.with_value(1, || {
                 db.knobs()
@@ -29,7 +30,7 @@ fn true_parallel_different_keys() {
     // Thread 2 will wait_for stage 1 when it enters and signal stage 2
     // when it leaves.
     let thread2 = std::thread::spawn({
-        let db = db.fork_mut();
+        let db = db.fork();
         move || {
             let v = db.knobs().sum_wait_for_on_entry.with_value(1, || {
                 db.knobs().sum_signal_on_exit.with_value(2, || db.sum("b"))
@@ -55,7 +56,7 @@ fn true_parallel_same_keys() {
 
     // Thread 1 will wait_for a barrier in the start of `sum`
     let thread1 = std::thread::spawn({
-        let db = db.fork_mut();
+        let db = db.fork();
         move || {
             let v = db.knobs().sum_signal_on_entry.with_value(1, || {
                 db.knobs()
@@ -71,7 +72,7 @@ fn true_parallel_same_keys() {
     // continue. This way, we test out the mechanism of one thread
     // blocking on another.
     let thread2 = std::thread::spawn({
-        let db = db.fork_mut();
+        let db = db.fork();
         move || {
             db.knobs().signal.wait_for(1);
             db.knobs().signal_on_will_block.set(2);

--- a/tests/parallel/true_parallel.rs
+++ b/tests/parallel/true_parallel.rs
@@ -16,7 +16,7 @@ fn true_parallel_different_keys() {
 
     // Thread 1 will signal stage 1 when it enters and wait for stage 2.
     let thread1 = std::thread::spawn({
-        let db = db.fork();
+        let db = db.snapshot();
         move || {
             let v = db.knobs().sum_signal_on_entry.with_value(1, || {
                 db.knobs()
@@ -30,7 +30,7 @@ fn true_parallel_different_keys() {
     // Thread 2 will wait_for stage 1 when it enters and signal stage 2
     // when it leaves.
     let thread2 = std::thread::spawn({
-        let db = db.fork();
+        let db = db.snapshot();
         move || {
             let v = db.knobs().sum_wait_for_on_entry.with_value(1, || {
                 db.knobs().sum_signal_on_exit.with_value(2, || db.sum("b"))
@@ -56,7 +56,7 @@ fn true_parallel_same_keys() {
 
     // Thread 1 will wait_for a barrier in the start of `sum`
     let thread1 = std::thread::spawn({
-        let db = db.fork();
+        let db = db.snapshot();
         move || {
             let v = db.knobs().sum_signal_on_entry.with_value(1, || {
                 db.knobs()
@@ -72,7 +72,7 @@ fn true_parallel_same_keys() {
     // continue. This way, we test out the mechanism of one thread
     // blocking on another.
     let thread2 = std::thread::spawn({
-        let db = db.fork();
+        let db = db.snapshot();
         move || {
             db.knobs().signal.wait_for(1);
             db.knobs().signal_on_will_block.set(2);

--- a/tests/parallel/true_parallel.rs
+++ b/tests/parallel/true_parallel.rs
@@ -15,7 +15,7 @@ fn true_parallel_different_keys() {
 
     // Thread 1 will signal stage 1 when it enters and wait for stage 2.
     let thread1 = std::thread::spawn({
-        let db = db.fork();
+        let db = db.fork_mut();
         move || {
             let v = db.knobs().sum_signal_on_entry.with_value(1, || {
                 db.knobs()
@@ -29,7 +29,7 @@ fn true_parallel_different_keys() {
     // Thread 2 will wait_for stage 1 when it enters and signal stage 2
     // when it leaves.
     let thread2 = std::thread::spawn({
-        let db = db.fork();
+        let db = db.fork_mut();
         move || {
             let v = db.knobs().sum_wait_for_on_entry.with_value(1, || {
                 db.knobs().sum_signal_on_exit.with_value(2, || db.sum("b"))
@@ -55,7 +55,7 @@ fn true_parallel_same_keys() {
 
     // Thread 1 will wait_for a barrier in the start of `sum`
     let thread1 = std::thread::spawn({
-        let db = db.fork();
+        let db = db.fork_mut();
         move || {
             let v = db.knobs().sum_signal_on_entry.with_value(1, || {
                 db.knobs()
@@ -71,7 +71,7 @@ fn true_parallel_same_keys() {
     // continue. This way, we test out the mechanism of one thread
     // blocking on another.
     let thread2 = std::thread::spawn({
-        let db = db.fork();
+        let db = db.fork_mut();
         move || {
             db.knobs().signal.wait_for(1);
             db.knobs().signal_on_will_block.set(2);


### PR DESCRIPTION
This is the first step towards the "fewer footguns" API.

Opening for discussion.

Some to do items:

- [x] Move `set` to a `query_mut` method that requires `&mut self` (https://github.com/salsa-rs/salsa/issues/79)
- [x] Add tests for the "recursive read lock" case; I think i understand well enough now to be able to trigger the deadlock deterministically (and show that we are avoiding it)