### PR TITLE
introduce `query_mut` which you must use to get `set` methods

### DIFF
--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -93,11 +93,11 @@ salsa::database_storage! {
 
 // This shows how to use a query.
 fn main() {
-    let db = DatabaseStruct::default();
+    let mut db = DatabaseStruct::default();
 
     println!("Initially, the length is {}.", db.length(()));
 
-    db.query(InputString)
+    db.query_mut(InputString)
         .set((), Arc::new(format!("Hello, world")));
 
     println!("Now, the length is {}.", db.length(()));

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -7,7 +7,11 @@ use crate::Query;
 use crate::QueryTable;
 use std::iter::FromIterator;
 
+/// Additional methods on queries that can be used to "peek into"
+/// their current state. These methods are meant for debugging and
+/// observing the effects of garbage collection etc.
 pub trait DebugQueryTable {
+    /// Key of this query.
     type Key;
 
     /// True if salsa thinks that the value for `key` is a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,17 +44,6 @@ pub trait Database: plumbing::DatabaseStorageTypes + plumbing::DatabaseOps {
     /// consume are marked as used.  You then invoke this method to
     /// remove other values that were not needed for your main query
     /// results.
-    ///
-    /// **A note on atomicity.** Since `sweep_all` removes data that
-    /// hasn't been actively used since the last revision, executing
-    /// `sweep_all` concurrently with `set` operations is not
-    /// recommended.  It won't do any *harm* -- but it may cause more
-    /// data to be discarded then you expect, leading to more
-    /// re-computation. You can use the [`lock_revision`][] method to
-    /// guarantee atomicity (or execute `sweep_all` from the same
-    /// threads that would be performing a `set`).
-    ///
-    /// [`lock_revision`]: struct.Runtime.html#method.lock_revision
     fn sweep_all(&self, strategy: SweepStrategy) {
         self.salsa_runtime().sweep_all(self, strategy);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,6 +261,21 @@ pub trait ParallelDatabase: Database + Send {
     ///
     /// [`is_current_revision_canceled`]: struct.Runtime.html#method.is_current_revision_canceled
     ///
+    /// # Panics
+    ///
+    /// It is not permitted to create a snapshot from inside of a
+    /// query. Attepting to do so will panic.
+    ///
+    /// # Deadlock warning
+    ///
+    /// The intended pattern for snapshots is that, once created, they
+    /// are sent to another thread and used from there. As such, the
+    /// `snapshot` acquires a "read lock" on the database --
+    /// therefore, so long as the `snapshot` is not dropped, any
+    /// attempt to `set` a value in the database will block. If the
+    /// `snapshot` is owned by the same thread that is attempting to
+    /// `set`, this will cause a problem.
+    ///
     /// # How to implement this
     ///
     /// Typically, this method will create a second copy of your
@@ -287,21 +302,6 @@ pub trait ParallelDatabase: Database + Send {
     ///     }
     /// }
     /// ```
-    ///
-    /// # Panics
-    ///
-    /// It is not permitted to create a snapshot from inside of a
-    /// query. Attepting to do so will panic.
-    ///
-    /// # Deadlock warning
-    ///
-    /// The intended pattern for snapshots is that, once created, they
-    /// are sent to another thread and used from there. As such, the
-    /// `snapshot` acquires a "read lock" on the database --
-    /// therefore, so long as the `snapshot` is not dropped, any
-    /// attempt to `set` a value in the database will block. If the
-    /// `snapshot` is owned by the same thread that is attempting to
-    /// `set`, this will cause a problem.
     fn snapshot(&self) -> Snapshot<Self>;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,11 +288,20 @@ pub trait ParallelDatabase: Database + Send {
     /// }
     /// ```
     ///
+    /// # Panics
+    ///
+    /// It is not permitted to create a snapshot from inside of a
+    /// query. Attepting to do so will panic.
+    ///
     /// # Deadlock warning
     ///
-    /// This second handle is intended to be used from a separate
-    /// thread. Using two database handles from the **same thread**
-    /// can lead to deadlock.
+    /// The intended pattern for snapshots is that, once created, they
+    /// are sent to another thread and used from there. As such, the
+    /// `snapshot` acquires a "read lock" on the database --
+    /// therefore, so long as the `snapshot` is not dropped, any
+    /// attempt to `set` a value in the database will block. If the
+    /// `snapshot` is owned by the same thread that is attempting to
+    /// `set`, this will cause a problem.
     fn snapshot(&self) -> Snapshot<Self>;
 }
 

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use crate::Database;
 use crate::Query;
 use crate::QueryTable;

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -1,6 +1,7 @@
 use crate::Database;
 use crate::Query;
 use crate::QueryTable;
+use crate::QueryTableMut;
 use crate::SweepStrategy;
 use std::fmt::Debug;
 use std::hash::Hash;
@@ -57,6 +58,8 @@ pub trait QueryFunction<DB: Database>: Query<DB> {
 
 pub trait GetQueryTable<Q: Query<Self>>: Database {
     fn get_query_table(db: &Self) -> QueryTable<'_, Self, Q>;
+
+    fn get_query_table_mut(db: &mut Self) -> QueryTableMut<'_, Self, Q>;
 }
 
 pub trait QueryStorageOps<DB, Q>: Default

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -65,6 +65,8 @@ impl<DB> Runtime<DB>
 where
     DB: Database,
 {
+    /// Create a new runtime; equivalent to `Self::default`. This is
+    /// used when creating a new database.
     pub fn new() -> Self {
         Self::default()
     }
@@ -480,11 +482,19 @@ impl<DB: Database> ActiveQuery<DB> {
     }
 }
 
+/// A unique identifier for a particular runtime. Each time you create
+/// a snapshot, a fresh `RuntimeId` is generated. Once a snapshot is
+/// complete, its `RuntimeId` may potentially be re-used.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct RuntimeId {
     counter: usize,
 }
 
+/// A unique identifier for the current version of the database; each
+/// time an input is changed, the revision number is incremented.
+/// `Revision` is used internally to track which values may need to be
+/// recomputed, but not something you should have to interact with
+/// directly as a user of salsa.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Revision {
     generation: u64,

--- a/tests/gc/derived_tests.rs
+++ b/tests/gc/derived_tests.rs
@@ -15,10 +15,10 @@ macro_rules! assert_keys {
 
 #[test]
 fn compute_one() {
-    let db = db::DatabaseImpl::default();
+    let mut db = db::DatabaseImpl::default();
 
     // Will compute fibonacci(5)
-    db.query(UseTriangular).set(5, false);
+    db.query_mut(UseTriangular).set(5, false);
     db.compute(5);
 
     db.salsa_runtime().next_revision();
@@ -50,14 +50,14 @@ fn compute_one() {
 
 #[test]
 fn compute_switch() {
-    let db = db::DatabaseImpl::default();
+    let mut db = db::DatabaseImpl::default();
 
     // Will compute fibonacci(5)
-    db.query(UseTriangular).set(5, false);
+    db.query_mut(UseTriangular).set(5, false);
     assert_eq!(db.compute(5), 5);
 
     // Change to triangular mode
-    db.query(UseTriangular).set(5, true);
+    db.query_mut(UseTriangular).set(5, true);
 
     // Now computes triangular(5)
     assert_eq!(db.compute(5), 15);
@@ -107,14 +107,14 @@ fn compute_switch() {
 /// Test a query with multiple layers of keys.
 #[test]
 fn compute_all() {
-    let db = db::DatabaseImpl::default();
+    let mut db = db::DatabaseImpl::default();
 
     for i in 0..6 {
-        db.query(UseTriangular).set(i, (i % 2) != 0);
+        db.query_mut(UseTriangular).set(i, (i % 2) != 0);
     }
 
-    db.query(Min).set((), 0);
-    db.query(Max).set((), 6);
+    db.query_mut(Min).set((), 0);
+    db.query_mut(Max).set((), 6);
 
     db.compute_all();
     db.salsa_runtime().next_revision();
@@ -133,7 +133,7 @@ fn compute_all() {
     }
 
     // Reduce the range to exclude index 5.
-    db.query(Max).set((), 5);
+    db.query_mut(Max).set((), 5);
     db.compute_all();
 
     assert_keys! {

--- a/tests/incremental/constants.rs
+++ b/tests/incremental/constants.rs
@@ -23,24 +23,24 @@ fn constants_add(db: &impl ConstantsDatabase, (key1, key2): (char, char)) -> usi
 #[test]
 #[should_panic]
 fn invalidate_constant() {
-    let db = &TestContextImpl::default();
-    db.query(ConstantsInput).set_constant('a', 44);
-    db.query(ConstantsInput).set_constant('a', 66);
+    let db = &mut TestContextImpl::default();
+    db.query_mut(ConstantsInput).set_constant('a', 44);
+    db.query_mut(ConstantsInput).set_constant('a', 66);
 }
 
 #[test]
 #[should_panic]
 fn invalidate_constant_1() {
-    let db = &TestContextImpl::default();
+    let db = &mut TestContextImpl::default();
 
     // Not constant:
-    db.query(ConstantsInput).set('a', 44);
+    db.query_mut(ConstantsInput).set('a', 44);
 
     // Becomes constant:
-    db.query(ConstantsInput).set_constant('a', 44);
+    db.query_mut(ConstantsInput).set_constant('a', 44);
 
     // Invalidates:
-    db.query(ConstantsInput).set_constant('a', 66);
+    db.query_mut(ConstantsInput).set_constant('a', 66);
 }
 
 /// Test that invoking `set` on a constant is an error, even if you
@@ -48,55 +48,55 @@ fn invalidate_constant_1() {
 #[test]
 #[should_panic]
 fn set_after_constant_same_value() {
-    let db = &TestContextImpl::default();
-    db.query(ConstantsInput).set_constant('a', 44);
-    db.query(ConstantsInput).set('a', 44);
+    let db = &mut TestContextImpl::default();
+    db.query_mut(ConstantsInput).set_constant('a', 44);
+    db.query_mut(ConstantsInput).set('a', 44);
 }
 
 #[test]
 fn not_constant() {
-    let db = &TestContextImpl::default();
+    let db = &mut TestContextImpl::default();
 
-    db.query(ConstantsInput).set('a', 22);
-    db.query(ConstantsInput).set('b', 44);
+    db.query_mut(ConstantsInput).set('a', 22);
+    db.query_mut(ConstantsInput).set('b', 44);
     assert_eq!(db.constants_add(('a', 'b')), 66);
     assert!(!db.query(ConstantsAdd).is_constant(('a', 'b')));
 }
 
 #[test]
 fn is_constant() {
-    let db = &TestContextImpl::default();
+    let db = &mut TestContextImpl::default();
 
-    db.query(ConstantsInput).set_constant('a', 22);
-    db.query(ConstantsInput).set_constant('b', 44);
+    db.query_mut(ConstantsInput).set_constant('a', 22);
+    db.query_mut(ConstantsInput).set_constant('b', 44);
     assert_eq!(db.constants_add(('a', 'b')), 66);
     assert!(db.query(ConstantsAdd).is_constant(('a', 'b')));
 }
 
 #[test]
 fn mixed_constant() {
-    let db = &TestContextImpl::default();
+    let db = &mut TestContextImpl::default();
 
-    db.query(ConstantsInput).set_constant('a', 22);
-    db.query(ConstantsInput).set('b', 44);
+    db.query_mut(ConstantsInput).set_constant('a', 22);
+    db.query_mut(ConstantsInput).set('b', 44);
     assert_eq!(db.constants_add(('a', 'b')), 66);
     assert!(!db.query(ConstantsAdd).is_constant(('a', 'b')));
 }
 
 #[test]
 fn becomes_constant_with_change() {
-    let db = &TestContextImpl::default();
+    let db = &mut TestContextImpl::default();
 
-    db.query(ConstantsInput).set('a', 22);
-    db.query(ConstantsInput).set('b', 44);
+    db.query_mut(ConstantsInput).set('a', 22);
+    db.query_mut(ConstantsInput).set('b', 44);
     assert_eq!(db.constants_add(('a', 'b')), 66);
     assert!(!db.query(ConstantsAdd).is_constant(('a', 'b')));
 
-    db.query(ConstantsInput).set_constant('a', 23);
+    db.query_mut(ConstantsInput).set_constant('a', 23);
     assert_eq!(db.constants_add(('a', 'b')), 67);
     assert!(!db.query(ConstantsAdd).is_constant(('a', 'b')));
 
-    db.query(ConstantsInput).set_constant('b', 45);
+    db.query_mut(ConstantsInput).set_constant('b', 45);
     assert_eq!(db.constants_add(('a', 'b')), 68);
     assert!(db.query(ConstantsAdd).is_constant(('a', 'b')));
 }

--- a/tests/incremental/memoized_dep_inputs.rs
+++ b/tests/incremental/memoized_dep_inputs.rs
@@ -41,9 +41,9 @@ fn dep_derived1(db: &impl MemoizedDepInputsContext) -> usize {
 
 #[test]
 fn revalidate() {
-    let db = &TestContextImpl::default();
+    let db = &mut TestContextImpl::default();
 
-    db.query(Input1).set((), 0);
+    db.query_mut(Input1).set((), 0);
 
     // Initial run starts from Memoized2:
     let v = db.dep_memoized2();
@@ -53,19 +53,19 @@ fn revalidate() {
     // After that, we first try to validate Memoized1 but wind up
     // running Memoized2. Note that we don't try to validate
     // Derived1, so it is invoked by Memoized1.
-    db.query(Input1).set((), 44);
+    db.query_mut(Input1).set((), 44);
     let v = db.dep_memoized2();
     assert_eq!(v, 44);
     db.assert_log(&["Memoized1 invoked", "Derived1 invoked", "Memoized2 invoked"]);
 
     // Here validation of Memoized1 succeeds so Memoized2 never runs.
-    db.query(Input1).set((), 45);
+    db.query_mut(Input1).set((), 45);
     let v = db.dep_memoized2();
     assert_eq!(v, 44);
     db.assert_log(&["Memoized1 invoked", "Derived1 invoked"]);
 
     // Here, a change to input2 doesn't affect us, so nothing runs.
-    db.query(Input2).set((), 45);
+    db.query_mut(Input2).set((), 45);
     let v = db.dep_memoized2();
     assert_eq!(v, 44);
     db.assert_log(&[]);

--- a/tests/incremental/memoized_inputs.rs
+++ b/tests/incremental/memoized_inputs.rs
@@ -24,10 +24,10 @@ fn max(db: &impl MemoizedInputsContext) -> usize {
 
 #[test]
 fn revalidate() {
-    let db = &TestContextImpl::default();
+    let db = &mut TestContextImpl::default();
 
-    db.query(Input1).set((), 0);
-    db.query(Input2).set((), 0);
+    db.query_mut(Input1).set((), 0);
+    db.query_mut(Input2).set((), 0);
 
     let v = db.max();
     assert_eq!(v, 0);
@@ -37,7 +37,7 @@ fn revalidate() {
     assert_eq!(v, 0);
     db.assert_log(&[]);
 
-    db.query(Input1).set((), 44);
+    db.query_mut(Input1).set((), 44);
     db.assert_log(&[]);
 
     let v = db.max();
@@ -48,11 +48,11 @@ fn revalidate() {
     assert_eq!(v, 44);
     db.assert_log(&[]);
 
-    db.query(Input1).set((), 44);
+    db.query_mut(Input1).set((), 44);
     db.assert_log(&[]);
-    db.query(Input2).set((), 66);
+    db.query_mut(Input2).set((), 66);
     db.assert_log(&[]);
-    db.query(Input1).set((), 64);
+    db.query_mut(Input1).set((), 64);
     db.assert_log(&[]);
 
     let v = db.max();
@@ -68,16 +68,16 @@ fn revalidate() {
 /// triggers a new revision.
 #[test]
 fn set_after_no_change() {
-    let db = &TestContextImpl::default();
+    let db = &mut TestContextImpl::default();
 
-    db.query(Input2).set((), 0);
+    db.query_mut(Input2).set((), 0);
 
-    db.query(Input1).set((), 44);
+    db.query_mut(Input1).set((), 44);
     let v = db.max();
     assert_eq!(v, 44);
     db.assert_log(&["Max invoked"]);
 
-    db.query(Input1).set((), 44);
+    db.query_mut(Input1).set((), 44);
     let v = db.max();
     assert_eq!(v, 44);
     db.assert_log(&["Max invoked"]);

--- a/tests/panic_safely.rs
+++ b/tests/panic_safely.rs
@@ -48,7 +48,7 @@ salsa::database_storage! {
 
 #[test]
 fn should_panic_safely() {
-    let db = DatabaseStruct::default();
+    let mut db = DatabaseStruct::default();
 
     // Invoke `db.panic_safely() without having set `db.one`. `db.one` will
     // default to 0 and we should catch the panic.
@@ -59,7 +59,7 @@ fn should_panic_safely() {
     assert!(result.is_err());
 
     // Set `db.one` to 1 and assert ok
-    db.query(One).set((), 1);
+    db.query_mut(One).set((), 1);
     let result = panic::catch_unwind(AssertUnwindSafe(|| db.panic_safely()));
     assert!(result.is_ok())
 }

--- a/tests/parallel/cancellation.rs
+++ b/tests/parallel/cancellation.rs
@@ -6,12 +6,12 @@ use salsa::{Database, ParallelDatabase};
 /// though none of the inputs have changed.
 #[test]
 fn in_par_get_set_cancellation_immediate() {
-    let db = ParDatabaseImpl::default();
+    let mut db = ParDatabaseImpl::default();
 
-    db.query(Input).set('a', 100);
-    db.query(Input).set('b', 010);
-    db.query(Input).set('c', 001);
-    db.query(Input).set('d', 0);
+    db.query_mut(Input).set('a', 100);
+    db.query_mut(Input).set('b', 010);
+    db.query_mut(Input).set('c', 001);
+    db.query_mut(Input).set('d', 0);
 
     let thread1 = std::thread::spawn({
         let db = db.snapshot();
@@ -30,7 +30,7 @@ fn in_par_get_set_cancellation_immediate() {
     db.wait_for(1);
 
     // Try to set the input. This will signal cancellation.
-    db.query(Input).set('d', 1000);
+    db.query_mut(Input).set('d', 1000);
 
     // This should re-compute the value (even though no input has changed).
     let thread2 = std::thread::spawn({
@@ -47,12 +47,12 @@ fn in_par_get_set_cancellation_immediate() {
 /// to `sum2` properly.
 #[test]
 fn in_par_get_set_cancellation_transitive() {
-    let db = ParDatabaseImpl::default();
+    let mut db = ParDatabaseImpl::default();
 
-    db.query(Input).set('a', 100);
-    db.query(Input).set('b', 010);
-    db.query(Input).set('c', 001);
-    db.query(Input).set('d', 0);
+    db.query_mut(Input).set('a', 100);
+    db.query_mut(Input).set('b', 010);
+    db.query_mut(Input).set('c', 001);
+    db.query_mut(Input).set('d', 0);
 
     let thread1 = std::thread::spawn({
         let db = db.snapshot();
@@ -71,7 +71,7 @@ fn in_par_get_set_cancellation_transitive() {
     db.wait_for(1);
 
     // Try to set the input. This will signal cancellation.
-    db.query(Input).set('d', 1000);
+    db.query_mut(Input).set('d', 1000);
 
     // This should re-compute the value (even though no input has changed).
     let thread2 = std::thread::spawn({

--- a/tests/parallel/frozen.rs
+++ b/tests/parallel/frozen.rs
@@ -8,9 +8,9 @@ use std::sync::Arc;
 /// though none of the inputs have changed.
 #[test]
 fn in_par_get_set_cancellation() {
-    let db = ParDatabaseImpl::default();
+    let mut db = ParDatabaseImpl::default();
 
-    db.query(Input).set('a', 1);
+    db.query_mut(Input).set('a', 1);
 
     let signal = Arc::new(Signal::default());
 
@@ -50,7 +50,7 @@ fn in_par_get_set_cancellation() {
             signal.wait_for(1);
 
             // This will block until thread1 drops the revision lock.
-            db.query(Input).set('a', 2);
+            db.query_mut(Input).set('a', 2);
 
             db.input('a')
         }

--- a/tests/parallel/independent.rs
+++ b/tests/parallel/independent.rs
@@ -5,14 +5,14 @@ use salsa::{Database, ParallelDatabase};
 /// threads. Really just a test that `snapshot` etc compiles.
 #[test]
 fn in_par_two_independent_queries() {
-    let db = ParDatabaseImpl::default();
+    let mut db = ParDatabaseImpl::default();
 
-    db.query(Input).set('a', 100);
-    db.query(Input).set('b', 010);
-    db.query(Input).set('c', 001);
-    db.query(Input).set('d', 200);
-    db.query(Input).set('e', 020);
-    db.query(Input).set('f', 002);
+    db.query_mut(Input).set('a', 100);
+    db.query_mut(Input).set('b', 010);
+    db.query_mut(Input).set('c', 001);
+    db.query_mut(Input).set('d', 200);
+    db.query_mut(Input).set('e', 020);
+    db.query_mut(Input).set('f', 002);
 
     let thread1 = std::thread::spawn({
         let db = db.snapshot();

--- a/tests/parallel/race.rs
+++ b/tests/parallel/race.rs
@@ -5,11 +5,11 @@ use salsa::{Database, ParallelDatabase};
 /// Should be atomic.
 #[test]
 fn in_par_get_set_race() {
-    let db = ParDatabaseImpl::default();
+    let mut db = ParDatabaseImpl::default();
 
-    db.query(Input).set('a', 100);
-    db.query(Input).set('b', 010);
-    db.query(Input).set('c', 001);
+    db.query_mut(Input).set('a', 100);
+    db.query_mut(Input).set('b', 010);
+    db.query_mut(Input).set('c', 001);
 
     let thread1 = std::thread::spawn({
         let db = db.snapshot();
@@ -20,7 +20,7 @@ fn in_par_get_set_race() {
     });
 
     let thread2 = std::thread::spawn(move || {
-        db.query(Input).set('a', 1000);
+        db.query_mut(Input).set('a', 1000);
         db.sum("a")
     });
 

--- a/tests/parallel/stress.rs
+++ b/tests/parallel/stress.rs
@@ -157,7 +157,7 @@ impl WriteOp {
     fn execute(self, db: &mut StressDatabaseImpl) {
         match self {
             WriteOp::SetA(key, value) => {
-                db.query(A).set(key, value);
+                db.query_mut(A).set(key, value);
             }
         }
     }
@@ -199,7 +199,7 @@ impl ReadOp {
 fn stress_test() {
     let mut db = StressDatabaseImpl::default();
     for i in 0..10 {
-        db.query(A).set(i, i);
+        db.query_mut(A).set(i, i);
     }
 
     let mut rng = rand::thread_rng();

--- a/tests/parallel/true_parallel.rs
+++ b/tests/parallel/true_parallel.rs
@@ -8,11 +8,11 @@ use salsa::ParallelDatabase;
 /// waits for thread1 to send a signal before it enters).
 #[test]
 fn true_parallel_different_keys() {
-    let db = ParDatabaseImpl::default();
+    let mut db = ParDatabaseImpl::default();
 
-    db.query(Input).set('a', 100);
-    db.query(Input).set('b', 010);
-    db.query(Input).set('c', 001);
+    db.query_mut(Input).set('a', 100);
+    db.query_mut(Input).set('b', 010);
+    db.query_mut(Input).set('c', 001);
 
     // Thread 1 will signal stage 1 when it enters and wait for stage 2.
     let thread1 = std::thread::spawn({
@@ -48,11 +48,11 @@ fn true_parallel_different_keys() {
 /// therefore has to block.
 #[test]
 fn true_parallel_same_keys() {
-    let db = ParDatabaseImpl::default();
+    let mut db = ParDatabaseImpl::default();
 
-    db.query(Input).set('a', 100);
-    db.query(Input).set('b', 010);
-    db.query(Input).set('c', 001);
+    db.query_mut(Input).set('a', 100);
+    db.query_mut(Input).set('b', 010);
+    db.query_mut(Input).set('c', 001);
 
     // Thread 1 will wait_for a barrier in the start of `sum`
     let thread1 = std::thread::spawn({

--- a/tests/set_unchecked.rs
+++ b/tests/set_unchecked.rs
@@ -50,10 +50,10 @@ salsa::database_storage! {
 
 #[test]
 fn normal() {
-    let db = DatabaseStruct::default();
-    db.query(Input).set((), format!("Hello, world"));
+    let mut db = DatabaseStruct::default();
+    db.query_mut(Input).set((), format!("Hello, world"));
     assert_eq!(db.double_length(), 24);
-    db.query(Input).set((), format!("Hello, world!"));
+    db.query_mut(Input).set((), format!("Hello, world!"));
     assert_eq!(db.double_length(), 26);
 }
 
@@ -66,30 +66,32 @@ fn use_without_set() {
 
 #[test]
 fn using_set_unchecked_on_input() {
-    let db = DatabaseStruct::default();
-    db.query(Input).set_unchecked((), format!("Hello, world"));
+    let mut db = DatabaseStruct::default();
+    db.query_mut(Input)
+        .set_unchecked((), format!("Hello, world"));
     assert_eq!(db.double_length(), 24);
 }
 
 #[test]
 fn using_set_unchecked_on_input_after() {
-    let db = DatabaseStruct::default();
-    db.query(Input).set((), format!("Hello, world"));
+    let mut db = DatabaseStruct::default();
+    db.query_mut(Input).set((), format!("Hello, world"));
     assert_eq!(db.double_length(), 24);
 
     // If we use `set_unchecked`, we don't notice that `double_length`
     // is out of date. Oh well, don't do that.
-    db.query(Input).set_unchecked((), format!("Hello, world!"));
+    db.query_mut(Input)
+        .set_unchecked((), format!("Hello, world!"));
     assert_eq!(db.double_length(), 24);
 }
 
 #[test]
 fn using_set_unchecked() {
-    let db = DatabaseStruct::default();
+    let mut db = DatabaseStruct::default();
 
     // Use `set_unchecked` to intentionally set the wrong value,
     // demonstrating that the code never runs.
-    db.query(Length).set_unchecked((), 24);
+    db.query_mut(Length).set_unchecked((), 24);
 
     assert_eq!(db.double_length(), 48);
 }

--- a/tests/variadic.rs
+++ b/tests/variadic.rs
@@ -66,10 +66,10 @@ salsa::database_storage! {
 
 #[test]
 fn execute() {
-    let db = DatabaseStruct::default();
+    let mut db = DatabaseStruct::default();
 
     // test what happens with inputs:
-    db.query(Input).set((1, 2), 3);
+    db.query_mut(Input).set((1, 2), 3);
     assert_eq!(db.input(1, 2), 3);
 
     assert_eq!(db.none(), 22);


### PR DESCRIPTION
This makes it impossible to try and invoke `set` from a snapshot.

Interestingly, at least the way the library is currently setup, the `&mut` we acquire on the database is only "skin deep" -- this because the `QueryTable` needs to store both a `&Storage` (which is owned by the `db`) and a reference to the db itself. This means that users who "hack up something" against the plumbing APIs directly could -- if they *truly wanted* -- get themselves into deadlocks. I think they have no one to blame but themselves. It might (maybe?) be interesting to think about refactoring things to avoid this, but it doesn't seem very important. I guess the way we would do it using traits so that we only pass down the `&mut DB` but we can extract the storage or other things we need later (vs the current scheme, which creates a `QueryTableMut` containing all the pieces we are going to need in one place).

Fixes #79