### PR TITLE
release 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"

--- a/examples/hello_world/README.md
+++ b/examples/hello_world/README.md
@@ -163,11 +163,11 @@ start using it:
 
 ```rust
 fn main() {
-    let db = DatabaseStruct::default();
+    let mut db = DatabaseStruct::default();
 
     println!("Initially, the length is {}.", db.length().get(()));
 
-    db.query(InputString)
+    db.query_mut(InputString)
         .set((), Arc::new(format!("Hello, world")));
 
     println!("Now, the length is {}.", db.length().get(()));
@@ -177,16 +177,16 @@ fn main() {
 One thing to notice here is how we set the value for an input query:
 
 ```rust
-    db.query(InputString)
+    db.query_mut(InputString)
         .set((), Arc::new(format!("Hello, world")));
 ```
 
-The `db.query(Foo)` method takes as argument the query type that
-characterizes your query. It gives back a "query table" type, which
-offers you more advanced methods beyond simply executing the query
-(for example, for input queries, you can invoke `set`). In fact, the
-standard call `db.query_name(key)` to access a query is just a
-shorthand for `db.query(QueryType).get(key)`.
+The `db.query_mut(Foo)` method takes as argument the query type that
+characterizes your query. It gives back a "mutable query table" type,
+which lets you invoke `set` to set the value of an input query. There
+is also a `query` method that gives access to other advanced methods
+in fact, the standard call `db.query_name(key)` to access a query is
+just a shorthand for `db.query(QueryType).get(key)`.
 
 Finally, if we run this code:
 


### PR DESCRIPTION
release 0.8.0

- major refactoring to the database APIs for safer parallel
  processing (#78, #82):
  - To set an input, you now write `db.query_mut(Query).set(...)`,
    and you must declare your database as `mut`.
  - To fork a thread, you now write `db.snapshot()`, which acquires
    a read-lock that is only released when the snapshot is dropped
    (note that this read-lock blocks `set` from occuring on the main
    thread).
  - Therefore, there can only be one mutable handle to the
    database; all other handles are snapshots. This eliminates a variety
    of complex and error-prone usage patterns.
- introduced the `salsa_event` callback that can be used for logging
  and introspection (#63)