### PR TITLE
WIP: Make GC API more orthogonal and flexible

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -3,7 +3,6 @@
 
 use crate::plumbing;
 use crate::plumbing::QueryStorageOps;
-use crate::Database;
 use crate::Query;
 use crate::QueryTable;
 use std::iter::FromIterator;

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -877,12 +877,15 @@ where
                     // revision, since we are holding the write lock
                     // when we read `revision_now`.
                     assert!(memo.verified_at <= revision_now);
+                    if strategy.keep_used && memo.verified_at == revision_now {
+                        return true;
+                    }
 
                     if !strategy.keep_values {
                         memo.value = None;
                     }
 
-                    memo.verified_at == revision_now
+                    strategy.keep_deps
                 }
             }
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,6 +205,8 @@ impl<DB: Database> fmt::Debug for EventKind<DB> {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct SweepStrategy {
     keep_values: bool,
+    keep_deps: bool,
+    keep_used: bool,
 }
 
 impl SweepStrategy {
@@ -218,11 +220,31 @@ impl SweepStrategy {
             ..self
         }
     }
+    /// Causes us to discard both memoized *values* and *dependencies*.
+    pub fn discard_deps(self) -> SweepStrategy {
+        SweepStrategy {
+            keep_deps: false,
+            ..self
+        }
+    }
+
+    /// Causes us to collect all keys (by default, only keys not used in the
+    /// current revision are collected)
+    pub fn discard_used(self) -> SweepStrategy {
+        SweepStrategy {
+            keep_used: false,
+            ..self
+        }
+    }
 }
 
 impl Default for SweepStrategy {
     fn default() -> Self {
-        SweepStrategy { keep_values: true }
+        SweepStrategy {
+            keep_values: true,
+            keep_deps: true,
+            keep_used: true,
+         }
     }
 }
 


### PR DESCRIPTION
WIP: will add tests later.

The idea here is to make gc API more explicit and orthogonal (you need to explicitly say what you are collecting, by default gc is a no-op), as well as more flexible (we can now collect all keys, not only "unused" ones). Does this sound reasonable? :)