### PR TITLE
don't backdate canceled queries

### DIFF
--- a/src/derived.rs
+++ b/src/derived.rs
@@ -358,8 +358,13 @@ where
         if let Some(old_memo) = &old_memo {
             if let Some(old_value) = &old_memo.value {
                 if MP::memoized_value_eq(&old_value, &result.value) {
-                    assert!(old_memo.changed_at <= result.changed_at.revision);
-                    result.changed_at.revision = old_memo.changed_at;
+                    match (&old_memo.inputs, &result.subqueries) {
+                        (MemoInputs::Untracked, _) | (_, None) => (),
+                        _ => {
+                            assert!(old_memo.changed_at <= result.changed_at.revision);
+                            result.changed_at.revision = old_memo.changed_at;
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
closes #66, maybe :) 

So I was debugging #66 for a long time now. The user-visible symptom is that some query gets cancelled, and **is not** recomputed after revision is bumped, effectively poisoning the database.

Unfortunately, this happens only in "stress-test" situations (lots of concurrent queries) and in general is hard to reproduce, so I was unable to pin-point the actual bug. Here's [the most complete log](https://github.com/salsa-rs/salsa/issues/66#issuecomment-4501762780) I have. It's not illuminating. 

So, I've decided that I'd just read the code carefully, and I've fond this suspicious bit. If I read this right, here we can backdate the query with untracked inputs to the date *before* the current one, with the following sequence of events:

* we start computing the query **Q**
* we cancel the query **Q**, so it's memoized as `Untracked` with some special-value output
* we start computing **Q** in the new revision
* we cancel **Q** again
* we compare **Q**'s value (again, *the* special value) against the old one, and they are equal. So, we back-date **Q** to the first revision.

I am not sure if this actually causes any problems, however with this patched applied I don't observe poisonous cancellations any more :-) So, looks like this indeed fixes the issue, and we just need to figure out the test backwards from the fix :D