### PR TITLE
release 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
- Panic safety improvements (#81)
- We build on stable now (#94)
- Removed use of dynamic dispatch for constructing query
  descriptors (#95)
  - Technically a breaking change, though unlikely to affect clients
- Removed use of upgradable reads to avoid Amanieu/parking-lot#101 (#75)
- Upgraded parking lot (#100)
- Improved Debug output (#98)
- Snapshot implements Debug (#85)