### PR TITLE
prevent untracked queries from moving brackwards in time

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -276,6 +276,10 @@ where
 
             local_state.query_stack.pop().unwrap()
         };
+        // Transitively propagete untracked.
+        if subqueries.is_none() {
+            self.report_untracked_read()
+        }
 
         ComputedQueryResult {
             value,

--- a/tests/incremental/memoized_volatile.rs
+++ b/tests/incremental/memoized_volatile.rs
@@ -66,10 +66,8 @@ fn revalidate() {
     // Second generation: volatile will change (to 1) but memoized1
     // will not (still 0, as 1/2 = 0)
     query.salsa_runtime().next_revision();
-
     query.memoized2();
-    query.assert_log(&["Memoized1 invoked", "Volatile invoked"]);
-
+    query.assert_log(&["Memoized2 invoked", "Memoized1 invoked", "Volatile invoked"]);
     query.memoized2();
     query.assert_log(&[]);
 
@@ -79,7 +77,7 @@ fn revalidate() {
     query.salsa_runtime().next_revision();
 
     query.memoized2();
-    query.assert_log(&["Memoized1 invoked", "Volatile invoked", "Memoized2 invoked"]);
+    query.assert_log(&["Memoized2 invoked", "Memoized1 invoked", "Volatile invoked"]);
 
     query.memoized2();
     query.assert_log(&[]);

--- a/tests/parallel/cancellation.rs
+++ b/tests/parallel/cancellation.rs
@@ -83,3 +83,33 @@ fn in_par_get_set_cancellation_transitive() {
     assert_eq!(thread1.join().unwrap(), std::usize::MAX);
     assert_eq!(thread2.join().unwrap(), 111);
 }
+
+/// https://github.com/salsa-rs/salsa/issues/66
+#[test]
+fn no_back_dating_in_cancellation() {
+    let mut db = ParDatabaseImpl::default();
+
+    db.query_mut(Input).set('a', 1);
+    let thread1 = std::thread::spawn({
+        let db = db.snapshot();
+        move || {
+            // Here we compute a long-chain of queries,
+            // but the last one gets cancelled.
+            db.knobs().sum_signal_on_entry.with_value(1, || {
+                db.knobs()
+                    .sum_wait_for_cancellation
+                    .with_value(true, || db.sum3("a"))
+            })
+        }
+    });
+
+    db.wait_for(1);
+    // Set unrelated input to bump revision.
+    db.query_mut(Input).set('b', 2);
+
+    // Here we should recompute the whole chain again, clearing the cancellation
+    // state. If we get `usize::max()` here, it is a bug!
+    assert_eq!(db.sum3("a"), 1);
+
+    assert_eq!(thread1.join().unwrap(), std::usize::MAX);
+}

--- a/tests/parallel/setup.rs
+++ b/tests/parallel/setup.rs
@@ -20,6 +20,10 @@ salsa::query_group! {
             type Sum2;
         }
 
+        fn sum3(key: &'static str) -> usize {
+            type Sum3;
+        }
+
         fn snapshot_me() -> () {
             type SnapshotMe;
         }
@@ -119,6 +123,10 @@ fn sum2(db: &impl ParDatabase, key: &'static str) -> usize {
     db.sum(key)
 }
 
+fn sum3(db: &impl ParDatabase, key: &'static str) -> usize {
+    db.sum2(key)
+}
+
 fn snapshot_me(db: &impl ParDatabase) {
     // this should panic
     db.snapshot();
@@ -176,6 +184,7 @@ salsa::database_storage! {
             fn input() for Input;
             fn sum() for Sum;
             fn sum2() for Sum2;
+            fn sum3() for Sum3;
             fn snapshot_me() for SnapshotMe;
         }
     }


### PR DESCRIPTION
If a query observes an untracked read, it gets changed_at equal to the
current revision. When we re-validate the query later, if it doesn't
do an untracked read this time, it gets changed_at equal to the
maximum of the dependencies. Crucially, this new changed_at may
be **older** then the previous value of changed_at. That is, we break
the rule that `changed_at` monotonically increases.

This can lead to missed re-executions down the line (see the added
test).

closes #66