### PR TITLE
Allow lifetime annotations in `database_storage!` and `query_group!`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -641,8 +641,14 @@ macro_rules! query_group {
         }
 
         $(
-            #[derive(Default, Debug)]
+            #[derive(Default)]
             $v struct $QueryType<$lt>(std::marker::PhantomData<&$lt ()>);
+
+            impl std::fmt::Debug for $QueryType<'_> {
+                fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                    write!(f, "{}", stringify!($QueryType))
+                }
+            }
 
             impl<$lt, DB> $crate::Query<DB> for $QueryType<$lt>
             where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,7 +332,7 @@ where
 
 /// Trait implements by all of the "special types" associated with
 /// each of your queries.
-pub trait Query<DB: Database>: Debug + Default + Sized + 'static {
+pub trait Query<DB: Database>: Debug + Default + Sized {
     /// Type that you you give as a parameter -- for queries with zero
     /// or more than one input, this will be a tuple.
     type Key: Clone + Debug + Hash + Eq;

--- a/tests/refs.rs
+++ b/tests/refs.rs
@@ -1,0 +1,77 @@
+#![cfg(test)]
+
+pub struct DatabaseImpl<'a> {
+    runtime: salsa::Runtime<DatabaseImpl<'a>>,
+    input: &'a str,
+}
+
+impl<'a> DatabaseImpl<'a> {
+    pub fn new(input: &'a str) -> DatabaseImpl<'a> {
+        DatabaseImpl {
+            runtime: Default::default(),
+            input,
+        }
+    }
+}
+
+pub trait DatabaseWithInput<'a>: salsa::Database {
+    fn input(&self) -> &'a str;
+}
+
+impl<'a> salsa::Database for DatabaseImpl<'a> {
+    fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseImpl<'a>> {
+        &self.runtime
+    }
+}
+
+impl<'a> DatabaseWithInput<'a> for DatabaseImpl<'a> {
+    fn input(&self) -> &'a str {
+        self.input
+    }
+}
+
+salsa::database_storage! {
+    pub struct DatabaseImplStorage<'a> for DatabaseImpl<'a> {
+        impl Database<'a> {
+            fn unmodified() for Unmodified<'a>;
+            fn uppercase() for Uppercase<'a>;
+        }
+    }
+}
+
+salsa::query_group! {
+    trait Database<'a>: DatabaseWithInput<'a> {
+        fn unmodified() -> &'a str {
+            type Unmodified;
+            storage volatile;
+        }
+
+        fn uppercase() -> String {
+            type Uppercase;
+        }
+    }
+}
+
+fn unmodified<'a>(db: &impl Database<'a>) -> &'a str {
+    db.input()
+}
+
+fn uppercase<'a>(db: &impl Database<'a>) -> String {
+    db.unmodified().to_uppercase()
+}
+
+#[test]
+fn static_ref() {
+    let input: &'static str = "Hello Salsa";
+    let db = DatabaseImpl::new(input);
+    assert_eq!(db.unmodified(), "Hello Salsa");
+    assert_eq!(db.uppercase(), "HELLO SALSA");
+}
+
+#[test]
+fn local_ref() {
+    let input = String::from("Hello Salsa");
+    let db = DatabaseImpl::new(&input);
+    assert_eq!(db.unmodified(), "Hello Salsa");
+    assert_eq!(db.uppercase(), "HELLO SALSA");
+}


### PR DESCRIPTION
Extend the `database_storage!` macro such that it allows for lifetimes to be added to the generated struct. This is necessary if the database itself has lifetime parameters that need to be threaded through to the queries being invoked.

The main goal is to allow arena allocation to be used in your database struct, and to pass those references around as query inputs and outputs.

Not sure this is the best solution -- I'd love to hear your thoughts.