### PR TITLE
Issue 66 transitive cancelation

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -276,6 +276,10 @@ where
 
             local_state.query_stack.pop().unwrap()
         };
+        // Transitively propagete untracked.
+        if subqueries.is_none() {
+            self.report_untracked_read()
+        }
 
         ComputedQueryResult {
             value,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -414,7 +414,10 @@ where
         fmt.debug_struct("SharedState")
             .field("query_lock", &query_lock)
             .field("revision", &self.revision)
-            .field("pending_revision_increments", &self.pending_revision_increments)
+            .field(
+                "pending_revision_increments",
+                &self.pending_revision_increments,
+            )
             .finish()
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -276,10 +276,6 @@ where
 
             local_state.query_stack.pop().unwrap()
         };
-        // Transitively propagete untracked.
-        if subqueries.is_none() {
-            self.report_untracked_read()
-        }
 
         ComputedQueryResult {
             value,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -159,6 +159,14 @@ where
         }
     }
 
+    /// Read current value of the revision counter.
+    #[inline]
+    fn pending_revision(&self) -> Revision {
+        Revision {
+            generation: self.shared_state.pending_revision.load(Ordering::SeqCst) as u64,
+        }
+    }
+
     /// Check if the current revision is canceled. If this method ever
     /// returns true, the currently executing query is also marked as
     /// having an *untracked read* -- this means that, in the next
@@ -169,14 +177,48 @@ where
     /// whatever it likes.
     #[inline]
     pub fn is_current_revision_canceled(&self) -> bool {
-        let pending_revision_increments = self
-            .shared_state
-            .pending_revision_increments
-            .load(Ordering::SeqCst);
-        if pending_revision_increments > 0 {
+        let current_revision = self.current_revision();
+        let pending_revision = self.pending_revision();
+        debug!(
+            "is_current_revision_canceled: current_revision={:?}, pending_revision={:?}",
+            current_revision, pending_revision
+        );
+        if pending_revision > current_revision {
             self.report_untracked_read();
             true
         } else {
+            // Subtle: If the current revision is not canceled, we
+            // still report an **anonymous** read, which will bump up
+            // the revision number to be at least the last
+            // non-canceled revision. This is needed to ensure
+            // deterministic reads and avoid salsa-rs/salsa#66. The
+            // specific scenario we are trying to avoid is tested by
+            // `no_back_dating_in_cancellation`; it works like
+            // this. Imagine we have 3 queries, where Query3 invokes
+            // Query2 which invokes Query1. Then:
+            //
+            // - In Revision R1:
+            //   - Query1: Observes cancelation and returns sentinel S.
+            //     - Recorded inputs: Untracked, because we observed cancelation.
+            //   - Query2: Reads Query1 and propagates sentinel S.
+            //     - Recorded inputs: Query1, changed-at=R1
+            //   - Query3: Reads Query2 and propagates sentinel S. (Inputs = Query2, ChangedAt R1)
+            //     - Recorded inputs: Query2, changed-at=R1
+            // - In Revision R2:
+            //   - Query1: Observes no cancelation. All of its inputs last changed in R0,
+            //     so it returns a valid value with "changed at" of R0.
+            //     - Recorded inputs: ..., changed-at=R0
+            //   - Query2: Recomputes its value and returns correct result.
+            //     - Recorded inputs: Query1, changed-at=R0 <-- key problem!
+            //   - Query3: sees that Query2's result last changed in R0, so it thinks it
+            //     can re-use its value from R1 (which is the sentinel value).
+            //
+            // The anonymous read here prevents that scenario: Query1
+            // winds up with a changed-at setting of R2, which is the
+            // "pending revision", and hence Query2 and Query3
+            // are recomputed.
+            assert_eq!(pending_revision, current_revision);
+            self.report_anon_read(pending_revision);
             false
         }
     }
@@ -190,6 +232,10 @@ where
     /// method will also increment `pending_revision_increments`, thus
     /// signalling to queries that their results are "canceled" and
     /// they should abort as expeditiously as possible.
+    ///
+    /// Note that, given our writer model, we can assume that only one
+    /// thread is attempting to increment the global revision at a
+    /// time.
     pub(crate) fn with_incremented_revision<R>(&self, op: impl FnOnce(Revision) -> R) -> R {
         log::debug!("increment_revision()");
 
@@ -197,36 +243,24 @@ where
             panic!("increment_revision invoked during a query computation");
         }
 
-        // Signal that we have a pending increment so that workers can
-        // start to cancel work.
-        let old_pending_revision_increments = self
+        // Set the `pending_revision` field so that people
+        // know current revision is canceled.
+        let current_revision = self
             .shared_state
-            .pending_revision_increments
+            .pending_revision
             .fetch_add(1, Ordering::SeqCst);
-        assert!(
-            old_pending_revision_increments != usize::max_value(),
-            "pending increment overflow"
-        );
+        assert!(current_revision != usize::max_value(), "revision overflow");
 
         // To modify the revision, we need the lock.
         let _lock = self.shared_state.query_lock.write();
 
-        // *Before* updating the revision number, decrement the
-        // `pending_revision_increments` counter. This way, if anybody
-        // should happen to invoke `is_current_revision_canceled`
-        // before we update the number, and they read 0, they don't
-        // get an incorrect result -- once they acquire the query
-        // lock, we'll be in the new revision.
-        self.shared_state
-            .pending_revision_increments
-            .fetch_sub(1, Ordering::SeqCst);
-
         let old_revision = self.shared_state.revision.fetch_add(1, Ordering::SeqCst);
-        assert!(old_revision != usize::max_value(), "revision overflow");
+        assert_eq!(current_revision, old_revision);
 
         let new_revision = Revision {
-            generation: 1 + old_revision as u64,
+            generation: (current_revision + 1) as u64,
         };
+
         debug!("increment_revision: incremented to {:?}", new_revision);
 
         op(new_revision)
@@ -308,6 +342,20 @@ where
         }
     }
 
+    /// An "anonymous" read is a read that doesn't come from executing
+    /// a query, but from some other internal operation. It just
+    /// modifies the "changed at" to be at least the given revision.
+    /// (It also does not disqualify a query from being considered
+    /// constant, since it is used for queries that don't give back
+    /// actual *data*.)
+    ///
+    /// This is used when queries check if they have been canceled.
+    fn report_anon_read(&self, revision: Revision) {
+        if let Some(top_query) = self.local_state.borrow_mut().query_stack.last_mut() {
+            top_query.add_anon_read(revision);
+        }
+    }
+
     /// Obviously, this should be user configurable at some point.
     pub(crate) fn report_unexpected_cycle(&self, descriptor: DB::QueryDescriptor) -> ! {
         debug!("report_unexpected_cycle(descriptor={:?})", descriptor);
@@ -374,12 +422,10 @@ struct SharedState<DB: Database> {
     /// (Ideally, this should be `AtomicU64`, but that is currently unstable.)
     revision: AtomicUsize,
 
-    /// Counts the number of pending increments to the revision
-    /// counter. If this is non-zero, it means that the current
-    /// revision is out of date, and hence queries are free to
-    /// "short-circuit" their results if they learn that. See
-    /// `is_current_revision_canceled` for more information.
-    pending_revision_increments: AtomicUsize,
+    /// This is typically equal to `revision` -- set to `revision+1`
+    /// when a new revision is pending (which implies that the current
+    /// revision is canceled).
+    pending_revision: AtomicUsize,
 
     /// The dependency graph tracks which runtimes are blocked on one
     /// another, waiting for queries to terminate.
@@ -393,8 +439,8 @@ impl<DB: Database> Default for SharedState<DB> {
             storage: Default::default(),
             query_lock: Default::default(),
             revision: Default::default(),
+            pending_revision: Default::default(),
             dependency_graph: Default::default(),
-            pending_revision_increments: Default::default(),
         }
     }
 }
@@ -414,10 +460,7 @@ where
         fmt.debug_struct("SharedState")
             .field("query_lock", &query_lock)
             .field("revision", &self.revision)
-            .field(
-                "pending_revision_increments",
-                &self.pending_revision_increments,
-            )
+            .field("pending_revision", &self.pending_revision)
             .finish()
     }
 }
@@ -504,6 +547,10 @@ impl<DB: Database> ActiveQuery<DB> {
         self.changed_at.is_constant = false;
         self.changed_at.revision = changed_at;
     }
+
+    fn add_anon_read(&mut self, changed_at: Revision) {
+        self.changed_at.revision = self.changed_at.revision.max(changed_at);
+    }
 }
 
 /// A unique identifier for a particular runtime. Each time you create
@@ -526,6 +573,17 @@ pub struct Revision {
 
 impl Revision {
     pub(crate) const ZERO: Self = Revision { generation: 0 };
+
+    fn next(self) -> Revision {
+        Revision {
+            generation: self.generation + 1,
+        }
+    }
+
+    fn as_usize(self) -> usize {
+        assert!(self.generation < (std::usize::MAX as u64));
+        self.generation as usize
+    }
 }
 
 impl std::fmt::Debug for Revision {

--- a/tests/incremental/memoized_volatile.rs
+++ b/tests/incremental/memoized_volatile.rs
@@ -67,7 +67,7 @@ fn revalidate() {
     // will not (still 0, as 1/2 = 0)
     query.salsa_runtime().next_revision();
     query.memoized2();
-    query.assert_log(&["Memoized2 invoked", "Memoized1 invoked", "Volatile invoked"]);
+    query.assert_log(&["Memoized1 invoked", "Volatile invoked"]);
     query.memoized2();
     query.assert_log(&[]);
 
@@ -77,7 +77,7 @@ fn revalidate() {
     query.salsa_runtime().next_revision();
 
     query.memoized2();
-    query.assert_log(&["Memoized2 invoked", "Memoized1 invoked", "Volatile invoked"]);
+    query.assert_log(&["Memoized1 invoked", "Volatile invoked", "Memoized2 invoked"]);
 
     query.memoized2();
     query.assert_log(&[]);

--- a/tests/incremental/memoized_volatile.rs
+++ b/tests/incremental/memoized_volatile.rs
@@ -66,10 +66,8 @@ fn revalidate() {
     // Second generation: volatile will change (to 1) but memoized1
     // will not (still 0, as 1/2 = 0)
     query.salsa_runtime().next_revision();
-
     query.memoized2();
-    query.assert_log(&["Memoized1 invoked", "Volatile invoked"]);
-
+    query.assert_log(&["Memoized2 invoked", "Memoized1 invoked", "Volatile invoked"]);
     query.memoized2();
     query.assert_log(&[]);
 
@@ -79,7 +77,7 @@ fn revalidate() {
     query.salsa_runtime().next_revision();
 
     query.memoized2();
-    query.assert_log(&["Memoized1 invoked", "Volatile invoked", "Memoized2 invoked"]);
+    query.assert_log(&["Memoized2 invoked", "Memoized1 invoked", "Volatile invoked"]);
 
     query.memoized2();
     query.assert_log(&[]);

--- a/tests/parallel/cancellation.rs
+++ b/tests/parallel/cancellation.rs
@@ -104,7 +104,8 @@ fn no_back_dating_in_cancellation() {
     });
 
     db.wait_for(1);
-    // Set unrelated input to bumpision rev
+
+    // Set unrelated input to bump revision
     db.query_mut(Input).set('b', 2);
 
     // Here we should recompuet the whole chain again, clearing the cancellation
@@ -112,4 +113,8 @@ fn no_back_dating_in_cancellation() {
     assert_eq!(db.sum3("a"), 1);
 
     assert_eq!(thread1.join().unwrap(), std::usize::MAX);
+
+    db.query_mut(Input).set('a', 3);
+    db.query_mut(Input).set('a', 4);
+    assert_eq!(db.sum3("ab"), 6);
 }

--- a/tests/parallel/cancellation.rs
+++ b/tests/parallel/cancellation.rs
@@ -118,3 +118,40 @@ fn no_back_dating_in_cancellation() {
     db.query_mut(Input).set('a', 4);
     assert_eq!(db.sum3("ab"), 6);
 }
+
+/// Here, we compute `sum3_drop_sum` and -- in the process -- observe
+/// a cancellation. As a result, we have to recompute `sum` when we
+/// reinvoke `sum3_drop_sum` and we have to re-execute
+/// `sum2_drop_sum`.  But the result of `sum2_drop_sum` doesn't
+/// change, so we don't have to re-execute `sum3_drop_sum`.
+#[test]
+fn transitive_cancellation() {
+    let mut db = ParDatabaseImpl::default();
+
+    db.query_mut(Input).set('a', 1);
+    let thread1 = std::thread::spawn({
+        let db = db.snapshot();
+        move || {
+            // Here we compute a long-chain of queries,
+            // but the last one gets cancelled.
+            db.knobs().sum_signal_on_entry.with_value(1, || {
+                db.knobs()
+                    .sum_wait_for_cancellation
+                    .with_value(true, || db.sum3_drop_sum("a"))
+            })
+        }
+    });
+
+    db.wait_for(1);
+
+    db.query_mut(Input).set('b', 2);
+
+    // Check that when we call `sum3_drop_sum` we don't wind up having
+    // to actually re-execute it, because the result of `sum2` winds
+    // up not changing.
+    db.knobs().sum3_drop_sum_should_panic.with_value(true, || {
+        assert_eq!(db.sum3_drop_sum("a"), 22);
+    });
+
+    assert_eq!(thread1.join().unwrap(), 22);
+}

--- a/tests/parallel/race.rs
+++ b/tests/parallel/race.rs
@@ -25,9 +25,14 @@ fn in_par_get_set_race() {
     });
 
     // If the 1st thread runs first, you get 111, otherwise you get
-    // 1011.
+    // 1011; if they run concurrently and the 1st thread observes the
+    // cancelation, you get back usize::max.
     let value1 = thread1.join().unwrap();
-    assert!(value1 == 111 || value1 == 1011, "illegal result {}", value1);
+    assert!(
+        value1 == 111 || value1 == 1011 || value1 == std::usize::MAX,
+        "illegal result {}",
+        value1
+    );
 
     assert_eq!(thread2.join().unwrap(), 1000);
 }

--- a/tests/parallel/setup.rs
+++ b/tests/parallel/setup.rs
@@ -20,6 +20,10 @@ salsa::query_group! {
             type Sum2;
         }
 
+        fn sum3(key: &'static str) -> usize {
+            type Sum3;
+        }
+
         fn snapshot_me() -> () {
             type SnapshotMe;
         }
@@ -119,6 +123,10 @@ fn sum2(db: &impl ParDatabase, key: &'static str) -> usize {
     db.sum(key)
 }
 
+fn sum3(db: &impl ParDatabase, key: &'static str) -> usize {
+    db.sum2(key)
+}
+
 fn snapshot_me(db: &impl ParDatabase) {
     // this should panic
     db.snapshot();
@@ -176,6 +184,7 @@ salsa::database_storage! {
             fn input() for Input;
             fn sum() for Sum;
             fn sum2() for Sum2;
+            fn sum3() for Sum3;
             fn snapshot_me() for SnapshotMe;
         }
     }

--- a/tests/parallel/setup.rs
+++ b/tests/parallel/setup.rs
@@ -109,6 +109,17 @@ fn sum(db: &impl ParDatabase, key: &'static str) -> usize {
             std::thread::yield_now();
         }
         log::debug!("cancellation observed");
+    }
+
+    // Check for cancelation and return MAX if so. Note that we check
+    // for cancelation *deterministically* -- but if
+    // `sum_wait_for_cancellation` is set, we will block
+    // beforehand. Deterministic execution is a requirement for valid
+    // salsa user code. It's also important to some tests that `sum`
+    // *attempts* to invoke `is_current_revision_canceled` even if we
+    // know it will not be canceled, because that helps us keep the
+    // accounting up to date.
+    if db.salsa_runtime().is_current_revision_canceled() {
         return std::usize::MAX; // when we are cancelled, we return usize::MAX.
     }
 


### PR DESCRIPTION
An alternate approach to fix #66. The basic problem is that `is_current_revision_canceled` was treated as observing *nothing* when it returned false, but that is only valid if there has never been a value of *true* observed. This PR revises how we track cancellation, which can actually be somewhat simpler since we no longer have multiple active writers to the database. We now track the revisions where cancellation occurs -- so, if revision R2 was canceled, then when you get back `false` from `is_current_revision_canceled`, that is treated as a read from R3.

Essentially, the 'next uncanceled revision' acts like an ordinary input -- it records the last time it was changed, and when you read from it, you see the corresponding dependency. There are however two differences between this and an ordinary input:

- It can change value asynchronously.
- We don't record a full dependency: so if you observed false in R1, and then R2 is canceled, and then R3 checks your value, you are not considered invalidated, as you would be with a regular input (since that input would've changed in R2).

r? @matklad 

Fixes #66