### PR TITLE
Unwinding-based cancelation via panic hook

### DIFF
--- a/src/derived.rs
+++ b/src/derived.rs
@@ -480,7 +480,7 @@ where
                             },
                         });
 
-                        let value = rx.recv().unwrap();
+                        let value = rx.recv().unwrap_or_else(|_| db.on_propagated_panic());
                         ProbeState::UpToDate(Ok(value))
                     }
 
@@ -731,7 +731,7 @@ where
                         // can complete.
                         std::mem::drop(map);
 
-                        let value = rx.recv().unwrap();
+                        let value = rx.recv().unwrap_or_else(|_| db.on_propagated_panic());
                         return value.changed_at.changed_since(revision);
                     }
 

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -48,6 +48,16 @@ where
     policy: PhantomData<MP>,
 }
 
+impl<DB, Q, MP> std::panic::RefUnwindSafe for DerivedStorage<DB, Q, MP>
+where
+    Q: QueryFunction<DB>,
+    DB: Database,
+    MP: MemoizationPolicy<DB, Q>,
+    Q::Key: std::panic::RefUnwindSafe,
+    Q::Value: std::panic::RefUnwindSafe,
+{
+}
+
 pub trait MemoizationPolicy<DB, Q>
 where
     Q: QueryFunction<DB>,

--- a/src/input.rs
+++ b/src/input.rs
@@ -27,6 +27,15 @@ where
     map: RwLock<FxHashMap<Q::Key, StampedValue<Q::Value>>>,
 }
 
+impl<DB, Q> std::panic::RefUnwindSafe for InputStorage<DB, Q>
+where
+    Q: Query<DB>,
+    DB: Database,
+    Q::Key: std::panic::RefUnwindSafe,
+    Q::Value: std::panic::RefUnwindSafe,
+{
+}
+
 impl<DB, Q> Default for InputStorage<DB, Q>
 where
     Q: Query<DB>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,12 @@ pub trait Database: plumbing::DatabaseStorageTypes + plumbing::DatabaseOps {
     fn salsa_event(&self, event_fn: impl Fn() -> Event<Self>) {
         #![allow(unused_variables)]
     }
+
+    /// This function is invoked when a depndent query is being computed by the
+    /// other thread, and that thread panics.
+    fn on_propagated_panic(&self) -> ! {
+        panic!("concurrent salsa query paniced")
+    }
 }
 
 /// The `Event` struct identifies various notable things that can

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,10 +105,10 @@ pub trait Database: plumbing::DatabaseStorageTypes + plumbing::DatabaseOps {
         #![allow(unused_variables)]
     }
 
-    /// This function is invoked when a depndent query is being computed by the
+    /// This function is invoked when a dependent query is being computed by the
     /// other thread, and that thread panics.
     fn on_propagated_panic(&self) -> ! {
-        panic!("concurrent salsa query paniced")
+        panic!("concurrent salsa query panicked")
     }
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -35,6 +35,8 @@ pub struct Runtime<DB: Database> {
     shared_state: Arc<SharedState<DB>>,
 }
 
+impl<DB> std::panic::RefUnwindSafe for Runtime<DB> where DB: Database {}
+
 impl<DB> Default for Runtime<DB>
 where
     DB: Database,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -230,16 +230,6 @@ where
         }
     }
 
-    /// Calls the callback if the current revision is cancelled.
-    ///
-    /// Observing cancellation may lead to inconsistencies in database storage,
-    /// so the callback must panic.
-    pub fn if_current_revision_is_canceled(&self, cb: fn() -> !) {
-        if self.pending_revision() > self.current_revision() {
-            cb()
-        }
-    }
-
     /// Acquires the **global query write lock** (ensuring that no
     /// queries are executing) and then increments the current
     /// revision counter; invokes `op` with the global query write

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -35,7 +35,12 @@ pub struct Runtime<DB: Database> {
     shared_state: Arc<SharedState<DB>>,
 }
 
-impl<DB> std::panic::RefUnwindSafe for Runtime<DB> where DB: Database {}
+impl<DB> std::panic::RefUnwindSafe for Runtime<DB>
+where
+    DB: Database,
+    DB::DatabaseStorage: std::panic::RefUnwindSafe,
+{
+}
 
 impl<DB> Default for Runtime<DB>
 where

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -223,6 +223,16 @@ where
         }
     }
 
+    /// Calls the callback if the current revision is cancelled.
+    ///
+    /// Observing cancellation may lead to inconsistencies in database storage,
+    /// so the callback must panic.
+    pub fn if_current_revision_is_canceled(&self, cb: fn() -> !) {
+        if self.pending_revision() > self.current_revision() {
+            cb()
+        }
+    }
+
     /// Acquires the **global query write lock** (ensuring that no
     /// queries are executing) and then increments the current
     /// revision counter; invokes `op` with the global query write

--- a/tests/panic_safely.rs
+++ b/tests/panic_safely.rs
@@ -63,3 +63,9 @@ fn should_panic_safely() {
     let result = panic::catch_unwind(AssertUnwindSafe(|| db.panic_safely()));
     assert!(result.is_ok())
 }
+
+#[test]
+fn storages_are_unwind_safe() {
+    fn check_unwind_safe<T: std::panic::UnwindSafe>() {}
+    check_unwind_safe::<&DatabaseStruct>();
+}

--- a/tests/parallel/cancellation.rs
+++ b/tests/parallel/cancellation.rs
@@ -4,15 +4,26 @@ use crate::setup::{
 use salsa::{Database, ParallelDatabase};
 
 macro_rules! assert_canceled {
-    ($thread:expr) => {
-        match $thread.join() {
-            Ok(value) => panic!("expected cancelation, got {:?}", value),
-            Err(payload) => match payload.downcast::<Canceled>() {
-                Ok(_) => {}
-                Err(payload) => ::std::panic::resume_unwind(payload),
-            },
+    ($flag:expr, $thread:expr) => {
+        if $flag == CancelationFlag::Panic {
+            match $thread.join() {
+                Ok(value) => panic!("expected cancelation, got {:?}", value),
+                Err(payload) => match payload.downcast::<Canceled>() {
+                    Ok(_) => {}
+                    Err(payload) => ::std::panic::resume_unwind(payload),
+                },
+            }
+        } else {
+            assert_eq!($thread.join().unwrap(), usize::max_value());
         }
     };
+}
+
+/// We have to falvors of cancellation: based on unwindig and based on anon
+/// reads. This checks both,
+fn check_cancelation(f: impl Fn(CancelationFlag)) {
+    f(CancelationFlag::Panic);
+    f(CancelationFlag::SpecialValue);
 }
 
 /// Add test where a call to `sum` is cancelled by a simultaneous
@@ -20,117 +31,123 @@ macro_rules! assert_canceled {
 /// though none of the inputs have changed.
 #[test]
 fn in_par_get_set_cancellation_immediate() {
-    let mut db = ParDatabaseImpl::default();
+    check_cancelation(|flag| {
+        let mut db = ParDatabaseImpl::default();
 
-    db.query_mut(Input).set('a', 100);
-    db.query_mut(Input).set('b', 010);
-    db.query_mut(Input).set('c', 001);
-    db.query_mut(Input).set('d', 0);
+        db.query_mut(Input).set('a', 100);
+        db.query_mut(Input).set('b', 010);
+        db.query_mut(Input).set('c', 001);
+        db.query_mut(Input).set('d', 0);
 
-    let thread1 = std::thread::spawn({
-        let db = db.snapshot();
-        move || {
-            // This will not return until it sees cancellation is
-            // signaled.
-            db.knobs().sum_signal_on_entry.with_value(1, || {
-                db.knobs()
-                    .sum_wait_for_cancellation
-                    .with_value(CancelationFlag::Panic, || db.sum("abc"))
-            })
-        }
-    });
+        let thread1 = std::thread::spawn({
+            let db = db.snapshot();
+            move || {
+                // This will not return until it sees cancellation is
+                // signaled.
+                db.knobs().sum_signal_on_entry.with_value(1, || {
+                    db.knobs()
+                        .sum_wait_for_cancellation
+                        .with_value(flag, || db.sum("abc"))
+                })
+            }
+        });
 
-    // Wait until we have entered `sum` in the other thread.
-    db.wait_for(1);
+        // Wait until we have entered `sum` in the other thread.
+        db.wait_for(1);
 
-    // Try to set the input. This will signal cancellation.
-    db.query_mut(Input).set('d', 1000);
+        // Try to set the input. This will signal cancellation.
+        db.query_mut(Input).set('d', 1000);
 
-    // This should re-compute the value (even though no input has changed).
-    let thread2 = std::thread::spawn({
-        let db = db.snapshot();
-        move || db.sum("abc")
-    });
+        // This should re-compute the value (even though no input has changed).
+        let thread2 = std::thread::spawn({
+            let db = db.snapshot();
+            move || db.sum("abc")
+        });
 
-    assert_eq!(db.sum("d"), 1000);
-    assert_canceled!(thread1);
-    assert_eq!(thread2.join().unwrap(), 111);
+        assert_eq!(db.sum("d"), 1000);
+        assert_canceled!(flag, thread1);
+        assert_eq!(thread2.join().unwrap(), 111);
+    })
 }
 
 /// Here, we check that `sum`'s cancellation is propagated
 /// to `sum2` properly.
 #[test]
 fn in_par_get_set_cancellation_transitive() {
-    let mut db = ParDatabaseImpl::default();
+    check_cancelation(|flag| {
+        let mut db = ParDatabaseImpl::default();
 
-    db.query_mut(Input).set('a', 100);
-    db.query_mut(Input).set('b', 010);
-    db.query_mut(Input).set('c', 001);
-    db.query_mut(Input).set('d', 0);
+        db.query_mut(Input).set('a', 100);
+        db.query_mut(Input).set('b', 010);
+        db.query_mut(Input).set('c', 001);
+        db.query_mut(Input).set('d', 0);
 
-    let thread1 = std::thread::spawn({
-        let db = db.snapshot();
-        move || {
-            // This will not return until it sees cancellation is
-            // signaled.
-            db.knobs().sum_signal_on_entry.with_value(1, || {
-                db.knobs()
-                    .sum_wait_for_cancellation
-                    .with_value(CancelationFlag::Panic, || db.sum2("abc"))
-            })
-        }
-    });
+        let thread1 = std::thread::spawn({
+            let db = db.snapshot();
+            move || {
+                // This will not return until it sees cancellation is
+                // signaled.
+                db.knobs().sum_signal_on_entry.with_value(1, || {
+                    db.knobs()
+                        .sum_wait_for_cancellation
+                        .with_value(flag, || db.sum2("abc"))
+                })
+            }
+        });
 
-    // Wait until we have entered `sum` in the other thread.
-    db.wait_for(1);
+        // Wait until we have entered `sum` in the other thread.
+        db.wait_for(1);
 
-    // Try to set the input. This will signal cancellation.
-    db.query_mut(Input).set('d', 1000);
+        // Try to set the input. This will signal cancellation.
+        db.query_mut(Input).set('d', 1000);
 
-    // This should re-compute the value (even though no input has changed).
-    let thread2 = std::thread::spawn({
-        let db = db.snapshot();
-        move || db.sum2("abc")
-    });
+        // This should re-compute the value (even though no input has changed).
+        let thread2 = std::thread::spawn({
+            let db = db.snapshot();
+            move || db.sum2("abc")
+        });
 
-    assert_eq!(db.sum2("d"), 1000);
-    assert_canceled!(thread1);
-    assert_eq!(thread2.join().unwrap(), 111);
+        assert_eq!(db.sum2("d"), 1000);
+        assert_canceled!(flag, thread1);
+        assert_eq!(thread2.join().unwrap(), 111);
+    })
 }
 
 /// https://github.com/salsa-rs/salsa/issues/66
 #[test]
 fn no_back_dating_in_cancellation() {
-    let mut db = ParDatabaseImpl::default();
+    check_cancelation(|flag| {
+        let mut db = ParDatabaseImpl::default();
 
-    db.query_mut(Input).set('a', 1);
-    let thread1 = std::thread::spawn({
-        let db = db.snapshot();
-        move || {
-            // Here we compute a long-chain of queries,
-            // but the last one gets cancelled.
-            db.knobs().sum_signal_on_entry.with_value(1, || {
-                db.knobs()
-                    .sum_wait_for_cancellation
-                    .with_value(CancelationFlag::Panic, || db.sum3("a"))
-            })
-        }
-    });
+        db.query_mut(Input).set('a', 1);
+        let thread1 = std::thread::spawn({
+            let db = db.snapshot();
+            move || {
+                // Here we compute a long-chain of queries,
+                // but the last one gets cancelled.
+                db.knobs().sum_signal_on_entry.with_value(1, || {
+                    db.knobs()
+                        .sum_wait_for_cancellation
+                        .with_value(flag, || db.sum3("a"))
+                })
+            }
+        });
 
-    db.wait_for(1);
+        db.wait_for(1);
 
-    // Set unrelated input to bump revision
-    db.query_mut(Input).set('b', 2);
+        // Set unrelated input to bump revision
+        db.query_mut(Input).set('b', 2);
 
-    // Here we should recompuet the whole chain again, clearing the cancellation
-    // state. If we get `usize::max()` here, it is a bug!
-    assert_eq!(db.sum3("a"), 1);
+        // Here we should recompuet the whole chain again, clearing the cancellation
+        // state. If we get `usize::max()` here, it is a bug!
+        assert_eq!(db.sum3("a"), 1);
 
-    assert_canceled!(thread1);
+        assert_canceled!(flag, thread1);
 
-    db.query_mut(Input).set('a', 3);
-    db.query_mut(Input).set('a', 4);
-    assert_eq!(db.sum3("ab"), 6);
+        db.query_mut(Input).set('a', 3);
+        db.query_mut(Input).set('a', 4);
+        assert_eq!(db.sum3("ab"), 6);
+    })
 }
 
 /// Here, we compute `sum3_drop_sum` and -- in the process -- observe
@@ -138,6 +155,7 @@ fn no_back_dating_in_cancellation() {
 /// reinvoke `sum3_drop_sum` and we have to re-execute
 /// `sum2_drop_sum`.  But the result of `sum2_drop_sum` doesn't
 /// change, so we don't have to re-execute `sum3_drop_sum`.
+/// This only works with SpecialValue cancellation strategy.
 #[test]
 fn transitive_cancellation() {
     let mut db = ParDatabaseImpl::default();

--- a/tests/parallel/setup.rs
+++ b/tests/parallel/setup.rs
@@ -42,6 +42,16 @@ salsa::query_group! {
     }
 }
 
+#[derive(PartialEq, Eq)]
+pub(crate) struct Canceled;
+
+impl Canceled {
+    fn throw() -> ! {
+        // Don't print backtrace
+        std::panic::resume_unwind(Box::new(Canceled));
+    }
+}
+
 /// Various "knobs" and utilities used by tests to force
 /// a certain behavior.
 pub(crate) trait Knobs {
@@ -68,6 +78,19 @@ impl<T> WithValue<T> for Cell<T> {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CancelationFlag {
+    Down,
+    Panic,
+    SpecialValue,
+}
+
+impl Default for CancelationFlag {
+    fn default() -> CancelationFlag {
+        CancelationFlag::Down
+    }
+}
+
 /// Various "knobs" that can be used to customize how the queries
 /// behave on one specific thread. Note that this state is
 /// intentionally thread-local (apart from `signal`).
@@ -91,7 +114,7 @@ pub(crate) struct KnobsStruct {
 
     /// If true, invocations of `sum` will wait for cancellation before
     /// they exit.
-    pub(crate) sum_wait_for_cancellation: Cell<bool>,
+    pub(crate) sum_wait_for_cancellation: Cell<CancelationFlag>,
 
     /// Invocations of `sum` will wait for this stage prior to exiting.
     pub(crate) sum_wait_for_on_exit: Cell<usize>,
@@ -118,12 +141,25 @@ fn sum(db: &impl ParDatabase, key: &'static str) -> usize {
         sum += db.input(ch);
     }
 
-    if db.knobs().sum_wait_for_cancellation.get() {
-        log::debug!("waiting for cancellation");
-        while !db.salsa_runtime().is_current_revision_canceled() {
-            std::thread::yield_now();
+    match db.knobs().sum_wait_for_cancellation.get() {
+        CancelationFlag::Down => (),
+        CancelationFlag::SpecialValue => {
+            log::debug!("waiting for cancellation");
+            while !db.salsa_runtime().is_current_revision_canceled() {
+                std::thread::yield_now();
+            }
+            log::debug!("observed cancelation");
         }
-        log::debug!("cancellation observed");
+        CancelationFlag::Panic => {
+            log::debug!("waiting for cancellation");
+            loop {
+                db.salsa_runtime().if_current_revision_is_canceled(|| {
+                    log::debug!("observed cancelation");
+                    Canceled::throw()
+                });
+                std::thread::yield_now();
+            }
+        }
     }
 
     // Check for cancelation and return MAX if so. Note that we check
@@ -190,6 +226,10 @@ impl Database for ParDatabaseImpl {
 
             _ => {}
         }
+    }
+
+    fn on_propagated_panic(&self) -> ! {
+        Canceled::throw()
     }
 }
 


### PR DESCRIPTION
This adds unwinding based cancellation (user is responsible for both panicking and catching). The current `anon_read` infrastructure is not deleted yet. We probably should tear it down though?

Tests are rewritten to use panics, except for the one which does not make sense with panicking. This test still uses the old-style cancelation.

Future work:

* either remove anon-read, or make sure we test both anon-reads and unwinding
* improve PanicGuard such that it restores old value, thus achieving strong exception safety guarantee. 