### PR TITLE
release 0.9.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
- Introduces the `propagated_panic` hook and specify that the
  salsa storage types are unwind safe (#107).