### PR TITLE
generate an impl of the trait from procedural macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -590,8 +590,6 @@ macro_rules! database_storage {
         }
 
         $(
-            impl $TraitName for $Database { }
-
             $(
                 impl $crate::plumbing::GetQueryTable<$QueryType> for $Database {
                     fn get_query_table(


### PR DESCRIPTION
Instead of generating

```rust
trait Query: GetQueryTable<Foo> {
    fn foo() { .. }
}
```

generate

```rust
trait Query {
}

impl<T> Query for T
where
    T: GetQueryTable<Foo>,
{
    fn foo() { .. }
}
```