### PR TITLE
Clear query stack on panic

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -320,7 +320,7 @@ where
         });
 
         // Push the active query onto the stack.
-        let push_len = self.local_state.push_query(descriptor);
+        let active_query = self.local_state.push_query(descriptor);
 
         // Execute user's code, accumulating inputs etc.
         let value = execute();
@@ -330,7 +330,7 @@ where
             subqueries,
             changed_at,
             ..
-        } = self.local_state.pop_query(push_len);
+        } = active_query.complete();
 
         ComputedQueryResult {
             value,

--- a/src/runtime/local_state.rs
+++ b/src/runtime/local_state.rs
@@ -109,3 +109,12 @@ where
         query
     }
 }
+
+impl<'me, DB> Drop for ActiveQueryGuard<'me, DB>
+where
+    DB: Database,
+{
+    fn drop(&mut self) {
+        self.pop_helper();
+    }
+}

--- a/src/runtime/local_state.rs
+++ b/src/runtime/local_state.rs
@@ -1,0 +1,87 @@
+use crate::runtime::ActiveQuery;
+use crate::runtime::ChangedAt;
+use crate::runtime::Revision;
+use crate::Database;
+use std::cell::Ref;
+use std::cell::RefCell;
+
+/// State that is specific to a single execution thread.
+///
+/// Internally, this type uses ref-cells.
+///
+/// **Note also that all mutations to the database handle (and hence
+/// to the local-state) must be undone during unwinding.**
+pub(super) struct LocalState<DB: Database> {
+    /// Vector of active queries.
+    ///
+    /// Unwinding note: pushes onto this vector must be popped -- even
+    /// during unwinding.
+    query_stack: RefCell<Vec<ActiveQuery<DB>>>,
+}
+
+impl<DB: Database> Default for LocalState<DB> {
+    fn default() -> Self {
+        LocalState {
+            query_stack: Default::default(),
+        }
+    }
+}
+
+impl<DB: Database> LocalState<DB> {
+    pub(super) fn push_query(&self, descriptor: &DB::QueryDescriptor) -> usize {
+        let mut query_stack = self.query_stack.borrow_mut();
+        query_stack.push(ActiveQuery::new(descriptor.clone()));
+        query_stack.len()
+    }
+
+    pub(super) fn pop_query(&self, push_len: usize) -> ActiveQuery<DB> {
+        let mut query_stack = self.query_stack.borrow_mut();
+
+        // Sanity check: pushes and pops should be balanced.
+        assert_eq!(query_stack.len(), push_len);
+
+        query_stack.pop().unwrap()
+    }
+
+    /// Returns a reference to the active query stack.
+    ///
+    /// **Warning:** Because this reference holds the ref-cell lock,
+    /// you should not use any mutating methods of `LocalState` while
+    /// reading from it.
+    pub(super) fn borrow_query_stack(&self) -> Ref<'_, Vec<ActiveQuery<DB>>> {
+        self.query_stack.borrow()
+    }
+
+    pub(super) fn query_in_progress(&self) -> bool {
+        !self.query_stack.borrow().is_empty()
+    }
+
+    pub(super) fn active_query(&self) -> Option<DB::QueryDescriptor> {
+        self.query_stack
+            .borrow()
+            .last()
+            .map(|active_query| active_query.descriptor.clone())
+    }
+
+    pub(super) fn report_query_read(
+        &self,
+        descriptor: &DB::QueryDescriptor,
+        changed_at: ChangedAt,
+    ) {
+        if let Some(top_query) = self.query_stack.borrow_mut().last_mut() {
+            top_query.add_read(descriptor, changed_at);
+        }
+    }
+
+    pub(super) fn report_untracked_read(&self, current_revision: Revision) {
+        if let Some(top_query) = self.query_stack.borrow_mut().last_mut() {
+            top_query.add_untracked_read(current_revision);
+        }
+    }
+
+    pub(super) fn report_anon_read(&self, revision: Revision) {
+        if let Some(top_query) = self.query_stack.borrow_mut().last_mut() {
+            top_query.add_anon_read(revision);
+        }
+    }
+}

--- a/tests/panic_safely.rs
+++ b/tests/panic_safely.rs
@@ -64,3 +64,17 @@ fn storages_are_unwind_safe() {
     fn check_unwind_safe<T: std::panic::UnwindSafe>() {}
     check_unwind_safe::<&DatabaseStruct>();
 }
+
+#[test]
+fn panics_clear_query_stack() {
+    let db = DatabaseStruct::default();
+
+    // Invoke `db.panic_if_not_one() without having set `db.input`. `db.input`
+    // will default to 0 and we should catch the panic.
+    let result = panic::catch_unwind(AssertUnwindSafe(|| db.panic_safely()));
+    assert!(result.is_err());
+
+    // The database has been poisoned and any attempt to increment the
+    // revision should panic.
+    assert_eq!(db.salsa_runtime().active_query(), None);
+}


### PR DESCRIPTION
Previously, the local query stack was not recovered if there was a panic. Fix that.

cc @kleimkuhler 