### PR TITLE
move the RefUnwindSafe impls to shared/local state structs

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -37,13 +37,6 @@ pub struct Runtime<DB: Database> {
     shared_state: Arc<SharedState<DB>>,
 }
 
-impl<DB> std::panic::RefUnwindSafe for Runtime<DB>
-where
-    DB: Database,
-    DB::DatabaseStorage: std::panic::RefUnwindSafe,
-{
-}
-
 impl<DB> Default for Runtime<DB>
 where
     DB: Database,
@@ -445,6 +438,8 @@ struct SharedState<DB: Database> {
     /// another, waiting for queries to terminate.
     dependency_graph: Mutex<DependencyGraph<DB>>,
 }
+
+impl<DB> std::panic::RefUnwindSafe for SharedState<DB> where DB: Database {}
 
 impl<DB: Database> Default for SharedState<DB> {
     fn default() -> Self {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -439,7 +439,12 @@ struct SharedState<DB: Database> {
     dependency_graph: Mutex<DependencyGraph<DB>>,
 }
 
-impl<DB> std::panic::RefUnwindSafe for SharedState<DB> where DB: Database {}
+impl<DB> std::panic::RefUnwindSafe for SharedState<DB>
+where
+    DB: Database,
+    DB::DatabaseStorage: std::panic::RefUnwindSafe,
+{
+}
 
 impl<DB: Database> Default for SharedState<DB> {
     fn default() -> Self {

--- a/src/runtime/local_state.rs
+++ b/src/runtime/local_state.rs
@@ -80,6 +80,8 @@ impl<DB: Database> LocalState<DB> {
     }
 }
 
+impl<DB> std::panic::RefUnwindSafe for LocalState<DB> where DB: Database {}
+
 /// When a query is pushed onto the `active_query` stack, this guard
 /// is returned to represent its slot. The guard can be used to pop
 /// the query from the stack -- in the case of unwinding, the guard's


### PR DESCRIPTION
in general, the more narrowly we can make the claim, the easier it is to verify