### PR TITLE
allow to peek at values via debug query interface

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -22,11 +22,6 @@ pub trait DebugQueryTable {
     /// values the inputs take on from this point.
     fn is_constant(&self, key: Self::Key) -> bool;
 
-    /// Get the (current) set of the keys in the query table.
-    fn keys<C>(&self) -> C
-    where
-        C: FromIterator<Self::Key>;
-
     /// Get the (current) set of the entries in the query table.
     fn entries<C>(&self) -> C
     where
@@ -34,6 +29,7 @@ pub trait DebugQueryTable {
 }
 
 /// An entry from a query table, for debugging and inspecting the table state.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TableEntry<K, V> {
     /// key of the query
     pub key: K,
@@ -62,13 +58,6 @@ where
 
     fn is_constant(&self, key: Q::Key) -> bool {
         self.storage.is_constant(self.db, &key)
-    }
-
-    fn keys<C>(&self) -> C
-    where
-        C: FromIterator<Q::Key>,
-    {
-        self.storage.keys(self.db)
     }
 
     fn entries<C>(&self) -> C

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -902,14 +902,6 @@ where
         }
     }
 
-    fn keys<C>(&self, _db: &DB) -> C
-    where
-        C: std::iter::FromIterator<Q::Key>,
-    {
-        let map = self.map.read();
-        map.keys().cloned().collect()
-    }
-
     fn entries<C>(&self, _db: &DB) -> C
     where
         C: std::iter::FromIterator<TableEntry<Q::Key, Q::Value>>,

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -1,3 +1,4 @@
+use crate::debug::TableEntry;
 use crate::plumbing::CycleDetected;
 use crate::plumbing::QueryDescriptor;
 use crate::plumbing::QueryFunction;
@@ -160,6 +161,13 @@ where
         QueryState::InProgress {
             id,
             waiting: Default::default(),
+        }
+    }
+
+    fn value(&self) -> Option<Q::Value> {
+        match self {
+            QueryState::InProgress { .. } => None,
+            QueryState::Memoized(memo) => memo.value.clone(),
         }
     }
 }
@@ -900,6 +908,16 @@ where
     {
         let map = self.map.read();
         map.keys().cloned().collect()
+    }
+
+    fn entries<C>(&self, _db: &DB) -> C
+    where
+        C: std::iter::FromIterator<TableEntry<Q::Key, Q::Value>>,
+    {
+        let map = self.map.read();
+        map.iter()
+            .map(|(key, query_state)| TableEntry::new(key.clone(), query_state.value()))
+            .collect()
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,3 +1,4 @@
+use crate::debug::TableEntry;
 use crate::plumbing::CycleDetected;
 use crate::plumbing::InputQueryStorageOps;
 use crate::plumbing::QueryStorageMassOps;
@@ -199,6 +200,18 @@ where
     {
         let map = self.map.read();
         map.keys().cloned().collect()
+    }
+
+    fn entries<C>(&self, _db: &DB) -> C
+    where
+        C: std::iter::FromIterator<TableEntry<Q::Key, Q::Value>>,
+    {
+        let map = self.map.read();
+        map.iter()
+            .map(|(key, stamped_value)| {
+                TableEntry::new(key.clone(), Some(stamped_value.value.clone()))
+            })
+            .collect()
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -194,14 +194,6 @@ where
             .unwrap_or(false)
     }
 
-    fn keys<C>(&self, _db: &DB) -> C
-    where
-        C: std::iter::FromIterator<Q::Key>,
-    {
-        let map = self.map.read();
-        map.keys().cloned().collect()
-    }
-
     fn entries<C>(&self, _db: &DB) -> C
     where
         C: std::iter::FromIterator<TableEntry<Q::Key, Q::Value>>,

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -130,11 +130,6 @@ where
     /// Check if `key` is (currently) believed to be a constant.
     fn is_constant(&self, db: &DB, key: &Q::Key) -> bool;
 
-    /// Get the (current) set of the keys in the query storage
-    fn keys<C>(&self, db: &DB) -> C
-    where
-        C: std::iter::FromIterator<Q::Key>;
-
     /// Get the (current) set of the entries in the query storage
     fn entries<C>(&self, db: &DB) -> C
     where

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -1,5 +1,6 @@
 #![allow(missing_docs)]
 
+use crate::debug::TableEntry;
 use crate::Database;
 use crate::Query;
 use crate::QueryTable;
@@ -133,6 +134,11 @@ where
     fn keys<C>(&self, db: &DB) -> C
     where
         C: std::iter::FromIterator<Q::Key>;
+
+    /// Get the (current) set of the entries in the query storage
+    fn entries<C>(&self, db: &DB) -> C
+    where
+        C: std::iter::FromIterator<TableEntry<Q::Key, Q::Value>>;
 }
 
 /// An optional trait that is implemented for "user mutable" storage:

--- a/tests/gc/derived_tests.rs
+++ b/tests/gc/derived_tests.rs
@@ -3,16 +3,6 @@ use crate::group::*;
 use salsa::debug::DebugQueryTable;
 use salsa::{Database, SweepStrategy};
 
-macro_rules! assert_keys {
-    ($db:expr, $($query:expr => ($($key:expr),*),)*) => {
-        $(
-            let mut keys = $db.query($query).keys::<Vec<_>>();
-            keys.sort();
-            assert_eq!(keys, vec![$($key),*], "query {:?} had wrong keys", $query);
-        )*
-    };
-}
-
 #[test]
 fn compute_one() {
     let mut db = db::DatabaseImpl::default();

--- a/tests/gc/discard_values.rs
+++ b/tests/gc/discard_values.rs
@@ -9,7 +9,7 @@ fn sweep_default() {
 
     db.fibonacci(5);
 
-    let k: Vec<_> = db.query(FibonacciQuery).keys();
+    let k: Vec<_> = db.query(FibonacciQuery).entries();
     assert_eq!(k.len(), 6);
 
     db.salsa_runtime().next_revision();
@@ -20,9 +20,10 @@ fn sweep_default() {
     // fibonacci is a constant, so it will not be invalidated,
     // hence we keep 3 and 5 but remove the rest.
     db.sweep_all(SweepStrategy::default());
-    let mut k: Vec<_> = db.query(FibonacciQuery).keys();
-    k.sort();
-    assert_eq!(k, vec![3, 5]);
+    assert_keys! {
+        db,
+        FibonacciQuery => (3, 5),
+    }
 
     // Even though we ran the sweep, 5 is still in cache
     db.clear_log();
@@ -31,9 +32,11 @@ fn sweep_default() {
 
     // Same but we discard values this time.
     db.sweep_all(SweepStrategy::default().discard_values());
-    let mut k: Vec<_> = db.query(FibonacciQuery).keys();
-    k.sort();
-    assert_eq!(k, vec![3, 5]);
+    db.sweep_all(SweepStrategy::default());
+    assert_keys! {
+        db,
+        FibonacciQuery => (3, 5),
+    }
 
     // Now we have to recompute
     db.clear_log();

--- a/tests/gc/main.rs
+++ b/tests/gc/main.rs
@@ -1,3 +1,14 @@
+macro_rules! assert_keys {
+    ($db:expr, $($query:expr => ($($key:expr),*),)*) => {
+        $(
+            let entries = $db.query($query).entries::<Vec<_>>();
+            let mut keys = entries.into_iter().map(|e| e.key).collect::<Vec<_>>();
+            keys.sort();
+            assert_eq!(keys, vec![$($key),*], "query {:?} had wrong keys", $query);
+        )*
+    };
+}
+
 mod db;
 mod derived_tests;
 mod discard_values;

--- a/tests/gc/shallow_constant_tests.rs
+++ b/tests/gc/shallow_constant_tests.rs
@@ -13,7 +13,7 @@ fn one_rev() {
 
     db.fibonacci(5);
 
-    let k: Vec<_> = db.query(FibonacciQuery).keys();
+    let k: Vec<_> = db.query(FibonacciQuery).entries();
     assert_eq!(k.len(), 6);
 
     // Everything was used in this revision, so
@@ -28,7 +28,7 @@ fn two_rev_nothing() {
 
     db.fibonacci(5);
 
-    let k: Vec<_> = db.query(FibonacciQuery).keys();
+    let k: Vec<_> = db.query(FibonacciQuery).entries();
     assert_eq!(k.len(), 6);
 
     db.salsa_runtime().next_revision();
@@ -37,7 +37,7 @@ fn two_rev_nothing() {
     // everything gets collected.
     db.sweep_all(SweepStrategy::default());
 
-    let k: Vec<_> = db.query(FibonacciQuery).keys();
+    let k: Vec<_> = db.query(FibonacciQuery).entries();
     assert_eq!(k.len(), 0);
 }
 
@@ -47,7 +47,7 @@ fn two_rev_one_use() {
 
     db.fibonacci(5);
 
-    let k: Vec<_> = db.query(FibonacciQuery).keys();
+    let k: Vec<_> = db.query(FibonacciQuery).entries();
     assert_eq!(k.len(), 6);
 
     db.salsa_runtime().next_revision();
@@ -58,8 +58,10 @@ fn two_rev_one_use() {
     // hence we keep `fibonacci(5)` but remove 0..=4.
     db.sweep_all(SweepStrategy::default());
 
-    let k: Vec<_> = db.query(FibonacciQuery).keys();
-    assert_eq!(k, vec![5]);
+    assert_keys! {
+        db,
+        FibonacciQuery => (5),
+    }
 }
 
 #[test]
@@ -68,7 +70,7 @@ fn two_rev_two_uses() {
 
     db.fibonacci(5);
 
-    let k: Vec<_> = db.query(FibonacciQuery).keys();
+    let k: Vec<_> = db.query(FibonacciQuery).entries();
     assert_eq!(k.len(), 6);
 
     db.salsa_runtime().next_revision();
@@ -80,7 +82,8 @@ fn two_rev_two_uses() {
     // hence we keep 3 and 5 but remove the rest.
     db.sweep_all(SweepStrategy::default());
 
-    let mut k: Vec<_> = db.query(FibonacciQuery).keys();
-    k.sort();
-    assert_eq!(k, vec![3, 5]);
+    assert_keys! {
+        db,
+        FibonacciQuery => (3, 5),
+    }
 }


### PR DESCRIPTION
I'd love to answer the question "how much syntax trees are retained in the salsa database", and for that, peeking at values seems useful. 