### PR TITLE
remove the need to list individual queries in group storage struct

### DIFF
--- a/components/salsa-macros/Cargo.toml
+++ b/components/salsa-macros/Cargo.toml
@@ -16,3 +16,4 @@ heck = "0.3"
 proc-macro2 = "0.4"
 quote = "0.6"
 syn = { version = "0.15", features = ["full", "extra-traits"] }
+

--- a/components/salsa-macros/src/database_storage.rs
+++ b/components/salsa-macros/src/database_storage.rs
@@ -1,4 +1,3 @@
-use crate::parenthesized::Parenthesized;
 use heck::SnakeCase;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
@@ -11,12 +10,7 @@ use syn::{Attribute, Ident, Path, Token, Visibility};
 ///
 /// ```ignore
 ///  salsa::database_storage! {
-///     struct DatabaseStorage for DatabaseStruct {
-///         impl HelloWorldDatabase {
-///             fn input_string() for InputString;
-///             fn length() for LengthQuery;
-///         }
-///     }
+///     $vis DatabaseStruct { impl HelloWorldDatabase; }
 /// }
 /// ```
 ///
@@ -246,19 +240,10 @@ impl QueryGroup {
     }
 }
 
-#[allow(dead_code)]
-struct Query {
-    query_name: Ident,
-    query_type: Path,
-}
-
 impl Parse for DatabaseStorage {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let attributes = input.call(Attribute::parse_outer)?;
         let visibility = input.parse()?;
-        let _struct_token: Token![struct ] = input.parse()?;
-        let _storage_struct_name: Ident = input.parse()?;
-        let _for_token: Token![for ] = input.parse()?;
         let database_name: Path = input.parse()?;
         let content;
         syn::braced!(content in input);
@@ -274,36 +259,13 @@ impl Parse for DatabaseStorage {
 
 impl Parse for QueryGroup {
     /// ```ignore
-    ///         impl HelloWorldDatabase {
-    ///             fn input_string() for InputString;
-    ///             fn length() for LengthQuery;
-    ///         }
+    ///         impl HelloWorldDatabase;
     /// ```
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        let _fn_token: Token![impl ] = input.parse()?;
+        let _: Token![impl ] = input.parse()?;
         let query_group: Path = input.parse()?;
-        let content;
-        syn::braced!(content in input);
-        let _queries: Vec<Query> = parse_while(Token![fn ], &content)?;
+        let _: Token![;] = input.parse()?;
         Ok(QueryGroup { query_group })
-    }
-}
-
-impl Parse for Query {
-    /// ```ignore
-    ///             fn input_string() for InputString;
-    /// ```
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        let _fn_token: Token![fn ] = input.parse()?;
-        let query_name: Ident = input.parse()?;
-        let _unit: Parenthesized<Nothing> = input.parse()?;
-        let _for_token: Token![for ] = input.parse()?;
-        let query_type: Path = input.parse()?;
-        let _for_token: Token![;] = input.parse()?;
-        Ok(Query {
-            query_name,
-            query_type,
-        })
     }
 }
 

--- a/components/salsa-macros/src/database_storage.rs
+++ b/components/salsa-macros/src/database_storage.rs
@@ -80,7 +80,7 @@ pub(crate) fn database_storage(input: TokenStream) -> TokenStream {
         // rewrite the last identifier (`MyGroup`, above) to
         // (e.g.) `MyGroupGroupStorage`.
         descriptor_impls.extend(quote! {
-            impl ::salsa::plumbing::FromQueryGroupDescriptor<#group_descriptor> for #database_name {
+            impl ::salsa::plumbing::GetDatabaseDescriptor<#group_descriptor> for #database_name {
                 fn from(descriptor: #group_descriptor) -> __SalsaQueryDescriptor {
                     __SalsaQueryDescriptor {
                         kind: __SalsaQueryDescriptorKind::#group_name(descriptor),
@@ -226,7 +226,7 @@ pub(crate) fn database_storage(input: TokenStream) -> TokenStream {
                     db: &Self,
                     key: <#query_type as ::salsa::Query<Self>>::Key,
                 ) -> <Self as ::salsa::plumbing::DatabaseStorageTypes>::QueryDescriptor {
-                    <Self as ::salsa::plumbing::FromQueryGroupDescriptor<_>>::from(#group_descriptor::#query_name(key))
+                    <Self as ::salsa::plumbing::GetDatabaseDescriptor<_>>::from(#group_descriptor::#query_name(key))
                 }
             }
         });

--- a/components/salsa-macros/src/database_storage.rs
+++ b/components/salsa-macros/src/database_storage.rs
@@ -128,11 +128,11 @@ pub(crate) fn database_storage(input: TokenStream) -> TokenStream {
 
     //
     let mut for_each_ops = proc_macro2::TokenStream::new();
-    for (query_group, Query { query_name, .. }) in each_query() {
+    for query_group in &query_groups {
         let group_storage = query_group.group_storage();
         for_each_ops.extend(quote! {
             let storage: &#group_storage<#database_name> = ::salsa::plumbing::GetQueryGroupStorage::from(self);
-            op(&storage.#query_name);
+            storage.for_each_query(self, &mut op);
         });
     }
     output.extend(quote! {

--- a/components/salsa-macros/src/lib.rs
+++ b/components/salsa-macros/src/lib.rs
@@ -126,26 +126,25 @@ pub fn query_group(args: TokenStream, input: TokenStream) -> TokenStream {
     query_group::query_group(args, input)
 }
 
-/// This macro generates the "query storage" that goes into your database.
-/// It requires you to list all of the query groups that you need as well
-/// as the queries within those groups. The format looks like so:
+/// This macro generates the "query storage" that goes into your
+/// database.  It requires you to list all of the query groups that
+/// you need. The format looks like so:
 ///
 /// ```rust,ignore
 /// salsa::database_storage! {
-///     struct MyDatabaseStorage for MyDatabase {
-///         impl MyQueryGroup {
-///             fn my_query1() for MyQuery1;
-///             fn my_query2() for MyQuery2;
-///         }
+///     $v MyDatabase {
+///         impl MyQueryGroup;
 ///         // ... other query groups go here ...
 ///     }
 /// }
 /// ```
 ///
-/// Here, `MyDatabase` should be the name of your database type.  The
-/// macro will then generate a struct named `MyDatabaseStorage` that
-/// is used by the [`salsa::Runtime`]. `MyQueryGroup` should be the
-/// name of your query group.
+/// Here, `MyDatabase` should be the name of your database type, and
+/// `$v` should be the "visibility" of that struct (e.g., `pub`,
+/// `pub(crate)`, or just nothing). The macro will then generate a
+/// struct named `MyDatabaseStorage` that is used by the
+/// [`salsa::Runtime`]. `MyQueryGroup` should be the name of your
+/// query group.
 ///
 /// See [the `hello_world` example][hw] for more details.
 ///

--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -215,6 +215,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
 
     // Emit the query types.
     for query in &queries {
+        let fn_name = &query.fn_name;
         let qt = &query.query_type;
         let storage = Ident::new(
             match query.storage {
@@ -240,6 +241,16 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
                 type Key = (#(#keys),*);
                 type Value = #value;
                 type Storage = salsa::plumbing::#storage<DB, Self>;
+                type GroupStorage = #group_storage<DB>;
+                type GroupDescriptor = #group_descriptor;
+
+                fn storage(group_storage: &Self::GroupStorage) -> &Self::Storage {
+                    &group_storage.#fn_name
+                }
+
+                fn descriptor(key: Self::Key) -> Self::GroupDescriptor {
+                    #group_descriptor::#fn_name(key)
+                }
             }
         });
 

--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -243,11 +243,11 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
                 type GroupStorage = #group_storage<DB>;
                 type GroupDescriptor = #group_descriptor;
 
-                fn storage(group_storage: &Self::GroupStorage) -> &Self::Storage {
+                fn group_storage(group_storage: &Self::GroupStorage) -> &Self::Storage {
                     &group_storage.#fn_name
                 }
 
-                fn descriptor(key: Self::Key) -> Self::GroupDescriptor {
+                fn group_descriptor(key: Self::Key) -> Self::GroupDescriptor {
                     #group_descriptor::#fn_name(key)
                 }
             }

--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -204,7 +204,9 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
         quote! {
             impl<T> #trait_name for T
             where
-                T: #(salsa::plumbing::GetQueryTable<#qts> +)* #bounds
+                T: #(salsa::plumbing::GetQueryTable<#qts> +)* #bounds,
+                T: ::salsa::plumbing::GetQueryGroupStorage<#group_storage<T>>,
+                T: ::salsa::plumbing::FromQueryGroupDescriptor<#group_descriptor>,
             {
                 #query_fn_definitions
             }

--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -206,7 +206,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
             where
                 T: #(salsa::plumbing::GetQueryTable<#qts> +)* #bounds,
                 T: ::salsa::plumbing::GetQueryGroupStorage<#group_storage<T>>,
-                T: ::salsa::plumbing::FromQueryGroupDescriptor<#group_descriptor>,
+                T: ::salsa::plumbing::GetDatabaseDescriptor<#group_descriptor>,
             {
                 #query_fn_definitions
             }

--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -188,11 +188,10 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
     // Emit the trait itself.
     let mut output = {
         let attrs = &input.attrs;
-        let qts = queries.iter().map(|q| &q.query_type);
         let bounds = &input.supertraits;
         quote! {
             #(#attrs)*
-            #trait_vis trait #trait_name : #(salsa::plumbing::GetQueryTable<#qts> +)* #bounds {
+            #trait_vis trait #trait_name : #bounds {
                 #query_fn_declarations
             }
         }

--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -199,12 +199,11 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
 
     // Emit an impl of the trait
     output.extend({
-        let qts = queries.iter().map(|q| &q.query_type);
         let bounds = &input.supertraits;
         quote! {
             impl<T> #trait_name for T
             where
-                T: #(salsa::plumbing::GetQueryTable<#qts> +)* #bounds,
+                T: #bounds,
                 T: ::salsa::plumbing::GetQueryGroupStorage<#group_storage<T>>,
                 T: ::salsa::plumbing::GetDatabaseDescriptor<#group_descriptor>,
             {

--- a/examples/compiler/implementation.rs
+++ b/examples/compiler/implementation.rs
@@ -37,12 +37,8 @@ impl salsa::Database for DatabaseImpl {
 /// storage and also generate impls for those traits, so that you
 /// `DatabaseImpl` type implements them.
 salsa::database_storage! {
-    pub struct DatabaseImplStorage for DatabaseImpl {
-        impl class_table::ClassTableDatabase {
-            fn all_classes() for class_table::AllClassesQuery;
-            fn all_fields() for class_table::AllFieldsQuery;
-            fn fields() for class_table::FieldsQuery;
-        }
+    pub DatabaseImpl {
+        impl class_table::ClassTableDatabase;
     }
 }
 

--- a/examples/hello_world/README.md
+++ b/examples/hello_world/README.md
@@ -133,23 +133,15 @@ impl salsa::Database for DatabaseStruct {
 }
 ```
 
-Next, you must use the `database_storage!` to define the "storage
-struct" for your type. This storage struct contains all the hashmaps
-and other things that salsa uses to store the values for your
-queries. You won't need to interact with it directly. To use the
-macro, you basically list out all the traits and each of the queries
-within those traits:
+Next, you must use the `database_storage!` to specify the set of query
+groups that your database stores. This macro generates the internal
+storage struct used to store your data. To use the macro, you
+basically list out all the traits:
 
 ```rust
 salsa::database_storage! {
-    struct DatabaseStorage for DatabaseStruct {
-    //     ^^^^^^^^^^^^^^^     --------------
-    //     name of the type    the name of your context type
-    //     we will make
-        impl HelloWorldDatabase {
-            fn input_string() for InputString;
-            fn length() for Length;
-        }
+    DatabaseStruct { // <-- name of your context type
+        impl HelloWorldDatabase;
     }
 }
 ```

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -68,16 +68,13 @@ impl salsa::Database for DatabaseStruct {
     }
 }
 
-// Define the full set of queries that your context needs. This would
+// Define the full set of query groups that your context needs. This would
 // in general combine (and implement) all the database traits in
 // your application into one place, allocating storage for all of
-// them.
+// them. But here we have only one.
 salsa::database_storage! {
-    struct DatabaseStorage for DatabaseStruct {
-        impl HelloWorldDatabase {
-            fn input_string() for InputString;
-            fn length() for LengthQuery;
-        }
+    DatabaseStruct {
+        impl HelloWorldDatabase;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,12 +141,12 @@ pub enum EventKind<DB: Database> {
     ///
     /// Executes before the "re-used" value is returned.
     DidValidateMemoizedValue {
-        /// The descriptor for the affected value. Implements `Debug`.
-        descriptor: DB::QueryDescriptor,
+        /// The database-key for the affected value. Implements `Debug`.
+        database_key: DB::DatabaseKey,
     },
 
     /// Indicates that another thread (with id `other_runtime_id`) is processing the
-    /// given query (`descriptor`), so we will block until they
+    /// given query (`database_key`), so we will block until they
     /// finish.
     ///
     /// Executes after we have registered with the other thread but
@@ -158,48 +158,48 @@ pub enum EventKind<DB: Database> {
         /// The id of the runtime we will block on.
         other_runtime_id: RuntimeId,
 
-        /// The descriptor for the affected value. Implements `Debug`.
-        descriptor: DB::QueryDescriptor,
+        /// The database-key for the affected value. Implements `Debug`.
+        database_key: DB::DatabaseKey,
     },
 
     /// Indicates that the input value will change after this
     /// callback, e.g. due to a call to `set`.
     WillChangeInputValue {
-        /// The descriptor for the affected value. Implements `Debug`.
-        descriptor: DB::QueryDescriptor,
+        /// The database-key for the affected value. Implements `Debug`.
+        database_key: DB::DatabaseKey,
     },
 
     /// Indicates that the function for this query will be executed.
     /// This is either because it has never executed before or because
     /// its inputs may be out of date.
     WillExecute {
-        /// The descriptor for the affected value. Implements `Debug`.
-        descriptor: DB::QueryDescriptor,
+        /// The database-key for the affected value. Implements `Debug`.
+        database_key: DB::DatabaseKey,
     },
 }
 
 impl<DB: Database> fmt::Debug for EventKind<DB> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            EventKind::DidValidateMemoizedValue { descriptor } => fmt
+            EventKind::DidValidateMemoizedValue { database_key } => fmt
                 .debug_struct("DidValidateMemoizedValue")
-                .field("descriptor", descriptor)
+                .field("database_key", database_key)
                 .finish(),
             EventKind::WillBlockOn {
                 other_runtime_id,
-                descriptor,
+                database_key,
             } => fmt
                 .debug_struct("WillBlockOn")
                 .field("other_runtime_id", other_runtime_id)
-                .field("descriptor", descriptor)
+                .field("database_key", database_key)
                 .finish(),
-            EventKind::WillChangeInputValue { descriptor } => fmt
+            EventKind::WillChangeInputValue { database_key } => fmt
                 .debug_struct("WillChangeInputValue")
-                .field("descriptor", descriptor)
+                .field("database_key", database_key)
                 .finish(),
-            EventKind::WillExecute { descriptor } => fmt
+            EventKind::WillExecute { database_key } => fmt
                 .debug_struct("WillExecute")
-                .field("descriptor", descriptor)
+                .field("database_key", database_key)
                 .finish(),
         }
     }
@@ -352,14 +352,14 @@ pub trait Query<DB: Database>: Debug + Default + Sized + 'static {
     /// Generated struct that contains storage for all queries in a group.
     type GroupStorage;
 
-    /// Generated descriptor for all queries in a group.
-    type GroupDescriptor;
+    /// Type that identifies a particular query within the group + its key.
+    type GroupKey;
 
     /// Extact storage for this query from the storage for its group.
     fn group_storage(group_storage: &Self::GroupStorage) -> &Self::Storage;
 
-    /// Create group descriptor for this query.
-    fn group_descriptor(key: Self::Key) -> Self::GroupDescriptor;
+    /// Create group key for this query.
+    fn group_key(key: Self::Key) -> Self::GroupKey;
 }
 
 /// Return value from [the `query` method] on `Database`.
@@ -386,11 +386,13 @@ where
     /// queries (those with no inputs, or those with more than one
     /// input) the key will be a tuple.
     pub fn get(&self, key: Q::Key) -> Q::Value {
-        let descriptor = self.descriptor(&key);
+        let database_key = self.database_key(&key);
         self.storage
-            .try_fetch(self.db, &key, &descriptor)
+            .try_fetch(self.db, &key, &database_key)
             .unwrap_or_else(|CycleDetected| {
-                self.db.salsa_runtime().report_unexpected_cycle(descriptor)
+                self.db
+                    .salsa_runtime()
+                    .report_unexpected_cycle(database_key)
             })
     }
 
@@ -403,8 +405,8 @@ where
         self.storage.sweep(self.db, strategy);
     }
 
-    fn descriptor(&self, key: &Q::Key) -> DB::QueryDescriptor {
-        <DB as plumbing::GetQueryTable<Q>>::descriptor(&self.db, key.clone())
+    fn database_key(&self, key: &Q::Key) -> DB::DatabaseKey {
+        <DB as plumbing::GetQueryTable<Q>>::database_key(&self.db, key.clone())
     }
 }
 
@@ -428,8 +430,8 @@ where
     DB: plumbing::GetQueryTable<Q>,
     Q: Query<DB>,
 {
-    fn descriptor(&self, key: &Q::Key) -> DB::QueryDescriptor {
-        <DB as plumbing::GetQueryTable<Q>>::descriptor(&self.db, key.clone())
+    fn database_key(&self, key: &Q::Key) -> DB::DatabaseKey {
+        <DB as plumbing::GetQueryTable<Q>>::database_key(&self.db, key.clone())
     }
 
     /// Assign a value to an "input query". Must be used outside of
@@ -444,7 +446,7 @@ where
         Q::Storage: plumbing::InputQueryStorageOps<DB, Q>,
     {
         self.storage
-            .set(self.db, &key, &self.descriptor(&key), value);
+            .set(self.db, &key, &self.database_key(&key), value);
     }
 
     /// Assign a value to an "input query", with the additional
@@ -460,7 +462,7 @@ where
         Q::Storage: plumbing::InputQueryStorageOps<DB, Q>,
     {
         self.storage
-            .set_constant(self.db, &key, &self.descriptor(&key), value);
+            .set_constant(self.db, &key, &self.database_key(&key), value);
     }
 
     /// Assigns a value to the query **bypassing the normal

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,10 +356,10 @@ pub trait Query<DB: Database>: Debug + Default + Sized + 'static {
     type GroupDescriptor;
 
     /// Extact storage for this query from the storage for its group.
-    fn storage(group_storage: &Self::GroupStorage) -> &Self::Storage;
+    fn group_storage(group_storage: &Self::GroupStorage) -> &Self::Storage;
 
     /// Create group descriptor for this query.
-    fn descriptor(key: Self::Key) -> Self::GroupDescriptor;
+    fn group_descriptor(key: Self::Key) -> Self::GroupDescriptor;
 }
 
 /// Return value from [the `query` method] on `Database`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,6 +348,18 @@ pub trait Query<DB: Database>: Debug + Default + Sized + 'static {
 
     /// Internal struct storing the values for the query.
     type Storage: plumbing::QueryStorageOps<DB, Self> + Send + Sync;
+
+    /// Generated struct that contains storage for all queries in a group.
+    type GroupStorage;
+
+    /// Generated descriptor for all queries in a group.
+    type GroupDescriptor;
+
+    /// Extact storage for this query from the storage for its group.
+    fn storage(group_storage: &Self::GroupStorage) -> &Self::Storage;
+
+    /// Create group descriptor for this query.
+    fn descriptor(key: Self::Key) -> Self::GroupDescriptor;
 }
 
 /// Return value from [the `query` method] on `Database`.

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -87,6 +87,7 @@ pub trait GetQueryGroupStorage<S>: Database {
 
 pub trait QueryStorageOps<DB, Q>: Default
 where
+    Self: QueryStorageMassOps<DB>,
     DB: Database,
     Q: Query<DB>,
 {

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -90,14 +90,14 @@ where
 {
     fn get_query_table(db: &DB) -> QueryTable<'_, DB, Q> {
         let group_storage: &Q::GroupStorage = GetQueryGroupStorage::from(db);
-        let query_storage = Q::storage(group_storage);
+        let query_storage = Q::group_storage(group_storage);
         QueryTable::new(db, query_storage)
     }
 
     fn get_query_table_mut(db: &mut DB) -> QueryTableMut<'_, DB, Q> {
         let db = &*db;
         let group_storage: &Q::GroupStorage = GetQueryGroupStorage::from(db);
-        let query_storage = Q::storage(group_storage);
+        let query_storage = Q::group_storage(group_storage);
         QueryTableMut::new(db, query_storage)
     }
 
@@ -105,7 +105,7 @@ where
         _db: &DB,
         key: <Q as Query<DB>>::Key,
     ) -> <DB as DatabaseStorageTypes>::QueryDescriptor {
-        let group_descriptor = Q::descriptor(key);
+        let group_descriptor = Q::group_descriptor(key);
         <DB as GetDatabaseDescriptor<_>>::from(group_descriptor)
     }
 }

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -85,6 +85,10 @@ pub trait GetQueryGroupStorage<S>: Database {
     fn from(db: &Self) -> &S;
 }
 
+pub trait FromQueryGroupDescriptor<D>: Database {
+    fn from(descriptor: D) -> Self::QueryDescriptor;
+}
+
 pub trait QueryStorageOps<DB, Q>: Default
 where
     Self: QueryStorageMassOps<DB>,

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -81,6 +81,10 @@ pub trait GetQueryTable<Q: Query<Self>>: Database {
     fn descriptor(db: &Self, key: Q::Key) -> Self::QueryDescriptor;
 }
 
+pub trait GetQueryGroupStorage<S>: Database {
+    fn from(db: &Self) -> &S;
+}
+
 pub trait QueryStorageOps<DB, Q>: Default
 where
     DB: Database,

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -81,11 +81,20 @@ pub trait GetQueryTable<Q: Query<Self>>: Database {
     fn descriptor(db: &Self, key: Q::Key) -> Self::QueryDescriptor;
 }
 
+/// Access the "group storage" with type `S` from the database.
+///
+/// This basically moves from the full context of the database to the context
+/// of one query group.
 pub trait GetQueryGroupStorage<S>: Database {
     fn from(db: &Self) -> &S;
 }
 
-pub trait FromQueryGroupDescriptor<D>: Database {
+/// Given a group descriptor of type `D`, convert it to a full
+/// database query descriptor.
+///
+/// This basically moves a descriptor from the context of the query
+/// group into the full context of the database.
+pub trait GetDatabaseDescriptor<D>: Database {
     fn from(descriptor: D) -> Self::QueryDescriptor;
 }
 

--- a/tests/cycles.rs
+++ b/tests/cycles.rs
@@ -10,13 +10,8 @@ impl salsa::Database for DatabaseImpl {
 }
 
 salsa::database_storage! {
-    struct DatabaseImplStorage for DatabaseImpl {
-        impl Database {
-            fn memoized_a() for MemoizedAQuery;
-            fn memoized_b() for MemoizedBQuery;
-            fn volatile_a() for VolatileAQuery;
-            fn volatile_b() for VolatileBQuery;
-        }
+    DatabaseImpl {
+        impl Database;
     }
 }
 

--- a/tests/gc/db.rs
+++ b/tests/gc/db.rs
@@ -14,16 +14,8 @@ impl salsa::Database for DatabaseImpl {
 }
 
 salsa::database_storage! {
-    pub(crate) struct DatabaseImplStorage for DatabaseImpl {
-        impl group::GcDatabase {
-            fn min() for group::MinQuery;
-            fn max() for group::MaxQuery;
-            fn use_triangular() for group::UseTriangularQuery;
-            fn fibonacci() for group::FibonacciQuery;
-            fn triangular() for group::TriangularQuery;
-            fn compute() for group::ComputeQuery;
-            fn compute_all() for group::ComputeAllQuery;
-        }
+    pub(crate) DatabaseImpl {
+        impl group::GcDatabase;
     }
 }
 

--- a/tests/incremental/implementation.rs
+++ b/tests/incremental/implementation.rs
@@ -39,31 +39,14 @@ impl TestContextImpl {
 }
 
 salsa::database_storage! {
-    pub(crate) struct TestContextImplStorage for TestContextImpl {
-        impl constants::ConstantsDatabase {
-            fn constants_input() for constants::ConstantsInputQuery;
-            fn constants_add() for constants::ConstantsAddQuery;
-        }
+    pub(crate) TestContextImpl {
+        impl constants::ConstantsDatabase;
 
-        impl memoized_dep_inputs::MemoizedDepInputsContext {
-            fn dep_memoized2() for memoized_dep_inputs::DepMemoized2Query;
-            fn dep_memoized1() for memoized_dep_inputs::DepMemoized1Query;
-            fn dep_derived1() for memoized_dep_inputs::DepDerived1Query;
-            fn dep_input1() for memoized_dep_inputs::DepInput1Query;
-            fn dep_input2() for memoized_dep_inputs::DepInput2Query;
-        }
+        impl memoized_dep_inputs::MemoizedDepInputsContext;
 
-        impl memoized_inputs::MemoizedInputsContext {
-            fn max() for memoized_inputs::MaxQuery;
-            fn input1() for memoized_inputs::Input1Query;
-            fn input2() for memoized_inputs::Input2Query;
-        }
+        impl memoized_inputs::MemoizedInputsContext;
 
-        impl memoized_volatile::MemoizedVolatileContext {
-            fn memoized2() for memoized_volatile::Memoized2Query;
-            fn memoized1() for memoized_volatile::Memoized1Query;
-            fn volatile() for memoized_volatile::VolatileQuery;
-        }
+        impl memoized_volatile::MemoizedVolatileContext;
     }
 }
 

--- a/tests/panic_safely.rs
+++ b/tests/panic_safely.rs
@@ -33,11 +33,8 @@ impl salsa::ParallelDatabase for DatabaseStruct {
 }
 
 salsa::database_storage! {
-    struct DatabaseStorage for DatabaseStruct {
-        impl PanicSafelyDatabase {
-            fn one() for OneQuery;
-            fn panic_safely() for PanicSafelyQuery;
-        }
+    DatabaseStruct {
+        impl PanicSafelyDatabase;
     }
 }
 

--- a/tests/parallel/setup.rs
+++ b/tests/parallel/setup.rs
@@ -235,15 +235,7 @@ impl Knobs for ParDatabaseImpl {
 }
 
 salsa::database_storage! {
-    pub(crate) struct DatabaseImplStorage for ParDatabaseImpl {
-        impl ParDatabase {
-            fn input() for InputQuery;
-            fn sum() for SumQuery;
-            fn sum2() for Sum2Query;
-            fn sum2_drop_sum() for Sum2DropSumQuery;
-            fn sum3() for Sum3Query;
-            fn sum3_drop_sum() for Sum3DropSumQuery;
-            fn snapshot_me() for SnapshotMeQuery;
-        }
+    pub(crate) ParDatabaseImpl {
+        impl ParDatabase;
     }
 }

--- a/tests/parallel/stress.rs
+++ b/tests/parallel/stress.rs
@@ -53,12 +53,8 @@ impl salsa::ParallelDatabase for StressDatabaseImpl {
 }
 
 salsa::database_storage! {
-    pub struct DatabaseImplStorage for StressDatabaseImpl {
-        impl StressDatabase {
-            fn a() for AQuery;
-            fn b() for BQuery;
-            fn c() for CQuery;
-        }
+    pub StressDatabaseImpl {
+        impl StressDatabase;
     }
 }
 

--- a/tests/set_unchecked.rs
+++ b/tests/set_unchecked.rs
@@ -32,12 +32,8 @@ impl salsa::Database for DatabaseStruct {
 }
 
 salsa::database_storage! {
-    struct DatabaseStorage for DatabaseStruct {
-        impl HelloWorldDatabase {
-            fn input() for InputQuery;
-            fn length() for LengthQuery;
-            fn double_length() for DoubleLengthQuery;
-        }
+    DatabaseStruct {
+        impl HelloWorldDatabase;
     }
 }
 

--- a/tests/storage_varieties/implementation.rs
+++ b/tests/storage_varieties/implementation.rs
@@ -8,11 +8,8 @@ pub(crate) struct DatabaseImpl {
 }
 
 salsa::database_storage! {
-    pub(crate) struct DatabaseImplStorage for DatabaseImpl {
-        impl queries::Database {
-            fn memoized() for queries::MemoizedQuery;
-            fn volatile() for queries::VolatileQuery;
-        }
+    pub(crate) DatabaseImpl {
+        impl queries::Database;
     }
 }
 

--- a/tests/variadic.rs
+++ b/tests/variadic.rs
@@ -42,14 +42,8 @@ impl salsa::Database for DatabaseStruct {
 }
 
 salsa::database_storage! {
-    struct DatabaseStorage for DatabaseStruct {
-        impl HelloWorldDatabase {
-            fn input() for InputQuery;
-            fn none() for NoneQuery;
-            fn one() for OneQuery;
-            fn two() for TwoQuery;
-            fn trailing() for TrailingQuery;
-        }
+    DatabaseStruct {
+        impl HelloWorldDatabase;
     }
 }
 


### PR DESCRIPTION
By the end of this PR, the `database_storage` macro format just lists out the query group *traits*, not the queries within:

```rust
salsa::database_storage! {
    pub MyDatabaseStruct {
        impl MyQueryGroup;
    }
}
```

I would like to move to a `#[salsa::database(...)]` annotation on the struct itself but that is left for a future PR. =) (Other bits of future work include generating the `set_foo` methods and so forth and (hopefully) removing the `query` and `query_mut` methods in the `Database` trait).

I had to do things just a *hair* differently than anticipated, so I need to update the RFC. The salsa `Query` trait grew "group storage" and "group descriptor" associated types and so forth. I think that trait really ought to wind up in `plumbing`.

cc #120 