### PR TITLE
adopt `salsa::database` attribute macro

### DIFF
--- a/components/salsa-macros/src/lib.rs
+++ b/components/salsa-macros/src/lib.rs
@@ -126,31 +126,26 @@ pub fn query_group(args: TokenStream, input: TokenStream) -> TokenStream {
     query_group::query_group(args, input)
 }
 
-/// This macro generates the "query storage" that goes into your
-/// database.  It requires you to list all of the query groups that
-/// you need. The format looks like so:
+/// This attribute is placed on your database struct. It takes a list of the
+/// query groups that your database supports. The format looks like so:
 ///
 /// ```rust,ignore
-/// salsa::database_storage! {
-///     $v MyDatabase {
-///         impl MyQueryGroup;
-///         // ... other query groups go here ...
-///     }
+/// #[salsa::database(MyQueryGroup1, MyQueryGroup2)]
+/// struct MyDatabase {
+///     runtime: salsa::Runtime<MyDatabase>, // <-- your database will need this field, too
 /// }
 /// ```
 ///
-/// Here, `MyDatabase` should be the name of your database type, and
-/// `$v` should be the "visibility" of that struct (e.g., `pub`,
-/// `pub(crate)`, or just nothing). The macro will then generate a
-/// struct named `MyDatabaseStorage` that is used by the
-/// [`salsa::Runtime`]. `MyQueryGroup` should be the name of your
-/// query group.
+/// Here, the struct `MyDatabase` would support the two query groups
+/// `MyQueryGroup1` and `MyQueryGroup2`. In addition to the `database`
+/// attribute, the struct needs to have a `runtime` field (of type
+/// [`salsa::Runtime`]) and to implement the `salsa::Database` trait.
 ///
 /// See [the `hello_world` example][hw] for more details.
 ///
 /// [`salsa::Runtime`]: struct.Runtime.html
 /// [hw]: https://github.com/salsa-rs/salsa/tree/master/examples/hello_world
-#[proc_macro]
-pub fn database_storage(input: TokenStream) -> TokenStream {
-    database_storage::database_storage(input)
+#[proc_macro_attribute]
+pub fn database(args: TokenStream, input: TokenStream) -> TokenStream {
+    database_storage::database(args, input)
 }

--- a/examples/compiler/implementation.rs
+++ b/examples/compiler/implementation.rs
@@ -13,6 +13,7 @@ use crate::compiler::{CompilerDatabase, Interner};
 /// to your context (e.g., a shared counter or some such thing). If
 /// mutations to that shared state affect the results of your queries,
 /// that's going to mess up the incremental results.
+#[salsa::database(class_table::ClassTableDatabase)]
 #[derive(Default)]
 pub struct DatabaseImpl {
     runtime: salsa::Runtime<DatabaseImpl>,
@@ -28,17 +29,6 @@ pub struct DatabaseImpl {
 impl salsa::Database for DatabaseImpl {
     fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseImpl> {
         &self.runtime
-    }
-}
-
-/// Declares the "query storage" for your context. Here, you list out
-/// all of the query traits from your application that you wish to
-/// provide storage for. This macro will generate the appropriate
-/// storage and also generate impls for those traits, so that you
-/// `DatabaseImpl` type implements them.
-salsa::database_storage! {
-    pub DatabaseImpl {
-        impl class_table::ClassTableDatabase;
     }
 }
 

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -56,6 +56,7 @@ fn length(db: &impl HelloWorldDatabase, (): ()) -> usize {
 
 // Define the actual database struct. This must contain a salsa
 // runtime but can also contain anything else you need.
+#[salsa::database(HelloWorldDatabase)]
 #[derive(Default)]
 struct DatabaseStruct {
     runtime: salsa::Runtime<DatabaseStruct>,
@@ -65,16 +66,6 @@ struct DatabaseStruct {
 impl salsa::Database for DatabaseStruct {
     fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseStruct> {
         &self.runtime
-    }
-}
-
-// Define the full set of query groups that your context needs. This would
-// in general combine (and implement) all the database traits in
-// your application into one place, allocating storage for all of
-// them. But here we have only one.
-salsa::database_storage! {
-    DatabaseStruct {
-        impl HelloWorldDatabase;
     }
 }
 

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -54,8 +54,14 @@ fn length(db: &impl HelloWorldDatabase, (): ()) -> usize {
 ///////////////////////////////////////////////////////////////////////////
 // Step 3. Define the database struct
 
-// Define the actual database struct. This must contain a salsa
-// runtime but can also contain anything else you need.
+// Define the actual database struct. This struct needs to be
+// annotated with `#[salsa::database(..)]`, which contains a list of
+// query groups that this database supports. This attribute macro will generate
+// the necessary impls so that the database implements all of those traits.
+//
+// The database struct can contain basically anything you need, but it
+// must have a `runtime` field as shown, and you must implement the
+// `salsa::Database` trait (as shown below).
 #[salsa::database(HelloWorldDatabase)]
 #[derive(Default)]
 struct DatabaseStruct {

--- a/tests/cycles.rs
+++ b/tests/cycles.rs
@@ -1,3 +1,4 @@
+#[salsa::database(Database)]
 #[derive(Default)]
 struct DatabaseImpl {
     runtime: salsa::Runtime<DatabaseImpl>,
@@ -6,12 +7,6 @@ struct DatabaseImpl {
 impl salsa::Database for DatabaseImpl {
     fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseImpl> {
         &self.runtime
-    }
-}
-
-salsa::database_storage! {
-    DatabaseImpl {
-        impl Database;
     }
 }
 

--- a/tests/gc/db.rs
+++ b/tests/gc/db.rs
@@ -1,6 +1,7 @@
 use crate::group;
 use crate::log::{HasLog, Log};
 
+#[salsa::database(group::GcDatabase)]
 #[derive(Default)]
 pub(crate) struct DatabaseImpl {
     runtime: salsa::Runtime<DatabaseImpl>,
@@ -10,12 +11,6 @@ pub(crate) struct DatabaseImpl {
 impl salsa::Database for DatabaseImpl {
     fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseImpl> {
         &self.runtime
-    }
-}
-
-salsa::database_storage! {
-    pub(crate) DatabaseImpl {
-        impl group::GcDatabase;
     }
 }
 

--- a/tests/incremental/implementation.rs
+++ b/tests/incremental/implementation.rs
@@ -10,6 +10,12 @@ pub(crate) trait TestContext: salsa::Database {
     fn log(&self) -> &Log;
 }
 
+#[salsa::database(
+    constants::ConstantsDatabase,
+    memoized_dep_inputs::MemoizedDepInputsContext,
+    memoized_inputs::MemoizedInputsContext,
+    memoized_volatile::MemoizedVolatileContext
+)]
 #[derive(Default)]
 pub(crate) struct TestContextImpl {
     runtime: salsa::Runtime<TestContextImpl>,
@@ -35,18 +41,6 @@ impl TestContextImpl {
         }
 
         panic!("incorrect log results");
-    }
-}
-
-salsa::database_storage! {
-    pub(crate) TestContextImpl {
-        impl constants::ConstantsDatabase;
-
-        impl memoized_dep_inputs::MemoizedDepInputsContext;
-
-        impl memoized_inputs::MemoizedInputsContext;
-
-        impl memoized_volatile::MemoizedVolatileContext;
     }
 }
 

--- a/tests/panic_safely.rs
+++ b/tests/panic_safely.rs
@@ -13,6 +13,7 @@ fn panic_safely(db: &impl PanicSafelyDatabase) -> () {
     assert_eq!(db.one(), 1);
 }
 
+#[salsa::database(PanicSafelyDatabase)]
 #[derive(Default)]
 struct DatabaseStruct {
     runtime: salsa::Runtime<DatabaseStruct>,
@@ -29,12 +30,6 @@ impl salsa::ParallelDatabase for DatabaseStruct {
         Snapshot::new(DatabaseStruct {
             runtime: self.runtime.snapshot(self),
         })
-    }
-}
-
-salsa::database_storage! {
-    DatabaseStruct {
-        impl PanicSafelyDatabase;
     }
 }
 

--- a/tests/parallel/setup.rs
+++ b/tests/parallel/setup.rs
@@ -184,6 +184,7 @@ fn snapshot_me(db: &impl ParDatabase) {
     db.snapshot();
 }
 
+#[salsa::database(ParDatabase)]
 #[derive(Default)]
 pub(crate) struct ParDatabaseImpl {
     runtime: salsa::Runtime<ParDatabaseImpl>,
@@ -231,11 +232,5 @@ impl Knobs for ParDatabaseImpl {
 
     fn wait_for(&self, stage: usize) {
         self.knobs.signal.wait_for(stage);
-    }
-}
-
-salsa::database_storage! {
-    pub(crate) ParDatabaseImpl {
-        impl ParDatabase;
     }
 }

--- a/tests/parallel/stress.rs
+++ b/tests/parallel/stress.rs
@@ -33,6 +33,7 @@ fn c(db: &impl StressDatabase, key: usize) -> Cancelable<usize> {
     db.b(key)
 }
 
+#[salsa::database(StressDatabase)]
 #[derive(Default)]
 struct StressDatabaseImpl {
     runtime: salsa::Runtime<StressDatabaseImpl>,
@@ -49,12 +50,6 @@ impl salsa::ParallelDatabase for StressDatabaseImpl {
         Snapshot::new(StressDatabaseImpl {
             runtime: self.runtime.snapshot(self),
         })
-    }
-}
-
-salsa::database_storage! {
-    pub StressDatabaseImpl {
-        impl StressDatabase;
     }
 }
 

--- a/tests/set_unchecked.rs
+++ b/tests/set_unchecked.rs
@@ -20,6 +20,7 @@ fn double_length(db: &impl HelloWorldDatabase) -> usize {
     db.length() * 2
 }
 
+#[salsa::database(HelloWorldDatabase)]
 #[derive(Default)]
 struct DatabaseStruct {
     runtime: salsa::Runtime<DatabaseStruct>,
@@ -28,12 +29,6 @@ struct DatabaseStruct {
 impl salsa::Database for DatabaseStruct {
     fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseStruct> {
         &self.runtime
-    }
-}
-
-salsa::database_storage! {
-    DatabaseStruct {
-        impl HelloWorldDatabase;
     }
 }
 

--- a/tests/storage_varieties/implementation.rs
+++ b/tests/storage_varieties/implementation.rs
@@ -1,16 +1,11 @@
 use crate::queries;
 use std::cell::Cell;
 
+#[salsa::database(queries::Database)]
 #[derive(Default)]
 pub(crate) struct DatabaseImpl {
     runtime: salsa::Runtime<DatabaseImpl>,
     counter: Cell<usize>,
-}
-
-salsa::database_storage! {
-    pub(crate) DatabaseImpl {
-        impl queries::Database;
-    }
 }
 
 impl queries::Counter for DatabaseImpl {

--- a/tests/variadic.rs
+++ b/tests/variadic.rs
@@ -30,6 +30,7 @@ fn trailing(_db: &impl HelloWorldDatabase, a: u32, b: u32) -> u32 {
     a - b
 }
 
+#[salsa::database(HelloWorldDatabase)]
 #[derive(Default)]
 struct DatabaseStruct {
     runtime: salsa::Runtime<DatabaseStruct>,
@@ -38,12 +39,6 @@ struct DatabaseStruct {
 impl salsa::Database for DatabaseStruct {
     fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseStruct> {
         &self.runtime
-    }
-}
-
-salsa::database_storage! {
-    DatabaseStruct {
-        impl HelloWorldDatabase;
     }
 }
 


### PR DESCRIPTION
With this change, you write

```rust
#[salsa::database(QueryGroup1, QueryGroup2)]
struct MyDatabase { .. }
```

instead of `salsa::database_storage! { ... }`.

cc https://github.com/salsa-rs/salsa/issues/120