### PR TITLE
release 0.10.0-alpha2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa"
-version = "0.10.0-alpha1"
+version = "0.10.0-alpha2"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
- You now write `#[salsa::database(query_groups...)]` instead of
  `database_storage!`, and you don't ned to list individual
  queries (#123, #124, #125)
- We now generate `set_foo` methods for inputs (#126)
- We can now peek at values using debug query interface (#122)
- Local handles recover from unwinds better (#114)
- We don't issue docs for `__SalsaQueryDescriptor` (#116)
- The unwind safety impls were moved about (internal refactoring, #115)

Contributors (since I've not been citing these in the past, this
includes all contributors to salsa to date):

- @cormacrelf
- @fabianschuiki
- @jrmuizel
- @kleimkuhler
- @matklad
- @memoryruins
- @nikomatsakis