### PR TITLE
Introduce "query group struct"

### DIFF
--- a/components/salsa-macros/src/database_storage.rs
+++ b/components/salsa-macros/src/database_storage.rs
@@ -62,9 +62,9 @@ pub(crate) fn database(args: TokenStream, input: TokenStream) -> TokenStream {
             #group_name_snake: #group_storage,
         });
         has_group_impls.extend(quote! {
-            impl ::salsa::plumbing::HasQueryGroup<#group_path> for #database_name {
+            impl salsa::plumbing::HasQueryGroup<#group_path> for #database_name {
                 fn group_storage(db: &Self) -> &#group_storage {
-                    let runtime = ::salsa::Database::salsa_runtime(db);
+                    let runtime = salsa::Database::salsa_runtime(db);
                     &runtime.storage().#group_name_snake
                 }
 
@@ -98,7 +98,7 @@ pub(crate) fn database(args: TokenStream, input: TokenStream) -> TokenStream {
     // For each query `fn foo() for FooType` create
     //
     // ```
-    // foo(<FooType as ::salsa::Query<#database_name>>::Key),
+    // foo(<FooType as salsa::Query<#database_name>>::Key),
     // ```
     let mut variants = proc_macro2::TokenStream::new();
     for (query_group, group_key) in query_groups.iter().zip(&query_group_key_names) {
@@ -116,7 +116,7 @@ pub(crate) fn database(args: TokenStream, input: TokenStream) -> TokenStream {
 
     //
     output.extend(quote! {
-        impl ::salsa::plumbing::DatabaseStorageTypes for #database_name {
+        impl salsa::plumbing::DatabaseStorageTypes for #database_name {
             type DatabaseKey = __SalsaDatabaseKey;
             type DatabaseStorage = __SalsaDatabaseStorage;
         }
@@ -134,10 +134,10 @@ pub(crate) fn database(args: TokenStream, input: TokenStream) -> TokenStream {
         });
     }
     output.extend(quote! {
-        impl ::salsa::plumbing::DatabaseOps for #database_name {
+        impl salsa::plumbing::DatabaseOps for #database_name {
             fn for_each_query(
                 &self,
-                mut op: impl FnMut(&dyn ::salsa::plumbing::QueryStorageMassOps<Self>),
+                mut op: impl FnMut(&dyn salsa::plumbing::QueryStorageMassOps<Self>),
             ) {
                 #for_each_ops
             }
@@ -157,11 +157,11 @@ pub(crate) fn database(args: TokenStream, input: TokenStream) -> TokenStream {
     }
 
     output.extend(quote! {
-        impl ::salsa::plumbing::DatabaseKey<#database_name> for __SalsaDatabaseKey {
+        impl salsa::plumbing::DatabaseKey<#database_name> for __SalsaDatabaseKey {
             fn maybe_changed_since(
                 &self,
                 db: &#database_name,
-                revision: ::salsa::plumbing::Revision,
+                revision: salsa::plumbing::Revision,
             ) -> bool {
                 match &self.kind {
                     #for_each_query_desc

--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -152,7 +152,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
 
         query_fn_definitions.extend(quote! {
             fn #fn_name(&self, #(#key_names: #keys),*) -> #value {
-                <Self as ::salsa::plumbing::GetQueryTable<#qt>>::get_query_table(self).get((#(#key_names),*))
+                <Self as salsa::plumbing::GetQueryTable<#qt>>::get_query_table(self).get((#(#key_names),*))
             }
         });
 
@@ -185,11 +185,11 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
 
             query_fn_definitions.extend(quote! {
                 fn #set_fn_name(&mut self, #(#key_names: #keys,)* value__: #value) {
-                    <Self as ::salsa::plumbing::GetQueryTable<#qt>>::get_query_table_mut(self).set((#(#key_names),*), value__)
+                    <Self as salsa::plumbing::GetQueryTable<#qt>>::get_query_table_mut(self).set((#(#key_names),*), value__)
                 }
 
                 fn #set_constant_fn_name(&mut self, #(#key_names: #keys,)* value__: #value) {
-                    <Self as ::salsa::plumbing::GetQueryTable<#qt>>::get_query_table_mut(self).set_constant((#(#key_names),*), value__)
+                    <Self as salsa::plumbing::GetQueryTable<#qt>>::get_query_table_mut(self).set_constant((#(#key_names),*), value__)
                 }
             });
         }
@@ -202,10 +202,10 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
         // A variant for the group descriptor below
         query_descriptor_maybe_change.extend(quote! {
             #group_key::#fn_name(key) => {
-                let group_storage: &#group_storage<DB__> = ::salsa::plumbing::HasQueryGroup::group_storage(db);
+                let group_storage: &#group_storage<DB__> = salsa::plumbing::HasQueryGroup::group_storage(db);
                 let storage = &group_storage.#fn_name;
 
-                <_ as ::salsa::plumbing::QueryStorageOps<DB__, #qt>>::maybe_changed_since(
+                <_ as salsa::plumbing::QueryStorageOps<DB__, #qt>>::maybe_changed_since(
                     storage,
                     db,
                     revision,
@@ -219,7 +219,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
         //
         // FIXME(#120): the pub should not be necessary once we complete the transition
         storage_fields.extend(quote! {
-            pub #fn_name: <#qt as ::salsa::Query<DB__>>::Storage,
+            pub #fn_name: <#qt as salsa::Query<DB__>>::Storage,
         });
     }
 
@@ -255,7 +255,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
             impl<T> #trait_name for T
             where
                 T: #bounds,
-                T: ::salsa::plumbing::HasQueryGroup<#group_struct>
+                T: salsa::plumbing::HasQueryGroup<#group_struct>
             {
                 #query_fn_definitions
             }
@@ -344,12 +344,12 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
             #trait_vis fn maybe_changed_since<DB__>(
                 &self,
                 db: &DB__,
-                db_descriptor: &<DB__ as ::salsa::plumbing::DatabaseStorageTypes>::DatabaseKey,
-                revision: ::salsa::plumbing::Revision,
+                db_descriptor: &<DB__ as salsa::plumbing::DatabaseStorageTypes>::DatabaseKey,
+                revision: salsa::plumbing::Revision,
             ) -> bool
             where
                 DB__: #trait_name,
-                DB__: ::salsa::plumbing::HasQueryGroup<#group_struct>,
+                DB__: salsa::plumbing::HasQueryGroup<#group_struct>,
             {
                 match self {
                     #query_descriptor_maybe_change
@@ -375,12 +375,12 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
         impl<DB__> #group_storage<DB__>
         where
             DB__: #trait_name,
-            DB__: ::salsa::plumbing::HasQueryGroup<#group_struct>,
+            DB__: salsa::plumbing::HasQueryGroup<#group_struct>,
         {
             #trait_vis fn for_each_query(
                 &self,
                 db: &DB__,
-                mut op: &mut dyn FnMut(&dyn ::salsa::plumbing::QueryStorageMassOps<DB__>),
+                mut op: &mut dyn FnMut(&dyn salsa::plumbing::QueryStorageMassOps<DB__>),
             ) {
                 #for_each_ops
             }

--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -202,7 +202,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
         // A variant for the group descriptor below
         query_descriptor_maybe_change.extend(quote! {
             #group_key::#fn_name(key) => {
-                let group_storage: &#group_storage<DB__> = ::salsa::plumbing::GetQueryGroupStorage::from(db);
+                let group_storage: &#group_storage<DB__> = ::salsa::plumbing::HasQueryGroup::group_storage(db);
                 let storage = &group_storage.#fn_name;
 
                 <_ as ::salsa::plumbing::QueryStorageOps<DB__, #qt>>::maybe_changed_since(
@@ -242,8 +242,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
             impl<T> #trait_name for T
             where
                 T: #bounds,
-                T: ::salsa::plumbing::GetQueryGroupStorage<#group_storage<T>>,
-                T: ::salsa::plumbing::GetDatabaseKey<#group_key>,
+                T: ::salsa::plumbing::HasQueryGroup<#group_storage<T>, #group_key>,
             {
                 #query_fn_definitions
             }
@@ -336,7 +335,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
             ) -> bool
             where
                 DB__: #trait_name,
-                DB__: ::salsa::plumbing::GetQueryGroupStorage<#group_storage<DB__>>,
+                DB__: ::salsa::plumbing::HasQueryGroup<#group_storage<DB__>, #group_key>,
             {
                 match self {
                     #query_descriptor_maybe_change
@@ -362,7 +361,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
         impl<DB__> #group_storage<DB__>
         where
             DB__: #trait_name,
-            DB__: ::salsa::plumbing::GetQueryGroupStorage<#group_storage<DB__>>,
+            DB__: ::salsa::plumbing::HasQueryGroup<#group_storage<DB__>, #group_key>,
         {
             #trait_vis fn for_each_query(
                 &self,

--- a/examples/compiler/class_table.rs
+++ b/examples/compiler/class_table.rs
@@ -1,7 +1,7 @@
 use crate::compiler;
 use std::sync::Arc;
 
-#[salsa::query_group]
+#[salsa::query_group(ClassTable)]
 pub trait ClassTableDatabase: compiler::CompilerDatabase {
     /// Get the fields.
     fn fields(&self, class: DefId) -> Arc<Vec<DefId>>;

--- a/examples/compiler/implementation.rs
+++ b/examples/compiler/implementation.rs
@@ -13,7 +13,7 @@ use crate::compiler::{CompilerDatabase, Interner};
 /// to your context (e.g., a shared counter or some such thing). If
 /// mutations to that shared state affect the results of your queries,
 /// that's going to mess up the incremental results.
-#[salsa::database(class_table::ClassTableDatabase)]
+#[salsa::database(class_table::ClassTable)]
 #[derive(Default)]
 pub struct DatabaseImpl {
     runtime: salsa::Runtime<DatabaseImpl>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,6 +349,13 @@ pub trait Query<DB: Database>: Debug + Default + Sized + 'static {
     /// Internal struct storing the values for the query.
     type Storage: plumbing::QueryStorageOps<DB, Self> + Send + Sync;
 
+    /// Associate query group struct.
+    type Group: plumbing::QueryGroup<
+        DB,
+        GroupStorage = Self::GroupStorage,
+        GroupKey = Self::GroupKey,
+    >;
+
     /// Generated struct that contains storage for all queries in a group.
     type GroupStorage;
 

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -86,18 +86,17 @@ impl<DB, Q> GetQueryTable<Q> for DB
 where
     DB: Database,
     Q: Query<DB>,
-    DB: GetQueryGroupStorage<Q::GroupStorage>,
-    DB: GetDatabaseKey<Q::GroupKey>,
+    DB: HasQueryGroup<Q::GroupStorage, Q::GroupKey>,
 {
     fn get_query_table(db: &DB) -> QueryTable<'_, DB, Q> {
-        let group_storage: &Q::GroupStorage = GetQueryGroupStorage::from(db);
+        let group_storage: &Q::GroupStorage = HasQueryGroup::group_storage(db);
         let query_storage = Q::group_storage(group_storage);
         QueryTable::new(db, query_storage)
     }
 
     fn get_query_table_mut(db: &mut DB) -> QueryTableMut<'_, DB, Q> {
         let db = &*db;
-        let group_storage: &Q::GroupStorage = GetQueryGroupStorage::from(db);
+        let group_storage: &Q::GroupStorage = HasQueryGroup::group_storage(db);
         let query_storage = Q::group_storage(group_storage);
         QueryTableMut::new(db, query_storage)
     }
@@ -107,25 +106,18 @@ where
         key: <Q as Query<DB>>::Key,
     ) -> <DB as DatabaseStorageTypes>::DatabaseKey {
         let group_key = Q::group_key(key);
-        <DB as GetDatabaseKey<_>>::from(group_key)
+        <DB as HasQueryGroup<_, _>>::database_key(group_key)
     }
 }
 
-/// Access the "group storage" with type `S` from the database.
-///
-/// This basically moves from the full context of the database to the context
-/// of one query group.
-pub trait GetQueryGroupStorage<S>: Database {
-    fn from(db: &Self) -> &S;
-}
+/// Trait implemented by a database for each group that it supports.
+/// `S` and `K` are the types for *group storage* and *group key*, respectively.
+pub trait HasQueryGroup<S, K>: Database {
+    /// Access the group storage struct from the database.
+    fn group_storage(db: &Self) -> &S;
 
-/// Given a group descriptor of type `D`, convert it to a full
-/// database query descriptor.
-///
-/// This basically moves a descriptor from the context of the query
-/// group into the full context of the database.
-pub trait GetDatabaseKey<D>: Database {
-    fn from(group_key: D) -> Self::DatabaseKey;
+    /// "Upcast" a group key into a database key.
+    fn database_key(group_key: K) -> Self::DatabaseKey;
 }
 
 pub trait QueryStorageOps<DB, Q>: Default

--- a/tests/cycles.rs
+++ b/tests/cycles.rs
@@ -1,4 +1,4 @@
-#[salsa::database(Database)]
+#[salsa::database(GroupStruct)]
 #[derive(Default)]
 struct DatabaseImpl {
     runtime: salsa::Runtime<DatabaseImpl>,
@@ -10,7 +10,7 @@ impl salsa::Database for DatabaseImpl {
     }
 }
 
-#[salsa::query_group]
+#[salsa::query_group(GroupStruct)]
 trait Database: salsa::Database {
     // `a` and `b` depend on each other and form a cycle
     fn memoized_a(&self) -> ();

--- a/tests/gc/db.rs
+++ b/tests/gc/db.rs
@@ -1,7 +1,7 @@
 use crate::group;
 use crate::log::{HasLog, Log};
 
-#[salsa::database(group::GcDatabase)]
+#[salsa::database(group::Gc)]
 #[derive(Default)]
 pub(crate) struct DatabaseImpl {
     runtime: salsa::Runtime<DatabaseImpl>,

--- a/tests/gc/group.rs
+++ b/tests/gc/group.rs
@@ -1,6 +1,6 @@
 use crate::log::HasLog;
 
-#[salsa::query_group]
+#[salsa::query_group(Gc)]
 pub(crate) trait GcDatabase: salsa::Database + HasLog {
     #[salsa::input]
     fn min(&self) -> usize;

--- a/tests/incremental/constants.rs
+++ b/tests/incremental/constants.rs
@@ -2,7 +2,7 @@ use crate::implementation::{TestContext, TestContextImpl};
 use salsa::debug::DebugQueryTable;
 use salsa::Database;
 
-#[salsa::query_group]
+#[salsa::query_group(Constants)]
 pub(crate) trait ConstantsDatabase: TestContext {
     #[salsa::input]
     fn input(&self, key: char) -> usize;

--- a/tests/incremental/implementation.rs
+++ b/tests/incremental/implementation.rs
@@ -11,10 +11,10 @@ pub(crate) trait TestContext: salsa::Database {
 }
 
 #[salsa::database(
-    constants::ConstantsDatabase,
-    memoized_dep_inputs::MemoizedDepInputsContext,
-    memoized_inputs::MemoizedInputsContext,
-    memoized_volatile::MemoizedVolatileContext
+    constants::Constants,
+    memoized_dep_inputs::MemoizedDepInputs,
+    memoized_inputs::MemoizedInputs,
+    memoized_volatile::MemoizedVolatile
 )]
 #[derive(Default)]
 pub(crate) struct TestContextImpl {

--- a/tests/incremental/memoized_dep_inputs.rs
+++ b/tests/incremental/memoized_dep_inputs.rs
@@ -1,7 +1,7 @@
 use crate::implementation::{TestContext, TestContextImpl};
 use salsa::Database;
 
-#[salsa::query_group]
+#[salsa::query_group(MemoizedDepInputs)]
 pub(crate) trait MemoizedDepInputsContext: TestContext {
     fn dep_memoized2(&self) -> usize;
     fn dep_memoized1(&self) -> usize;

--- a/tests/incremental/memoized_inputs.rs
+++ b/tests/incremental/memoized_inputs.rs
@@ -1,7 +1,7 @@
 use crate::implementation::{TestContext, TestContextImpl};
 use salsa::Database;
 
-#[salsa::query_group]
+#[salsa::query_group(MemoizedInputs)]
 pub(crate) trait MemoizedInputsContext: TestContext {
     fn max(&self) -> usize;
     #[salsa::input]

--- a/tests/incremental/memoized_volatile.rs
+++ b/tests/incremental/memoized_volatile.rs
@@ -1,7 +1,7 @@
 use crate::implementation::{TestContext, TestContextImpl};
 use salsa::Database;
 
-#[salsa::query_group]
+#[salsa::query_group(MemoizedVolatile)]
 pub(crate) trait MemoizedVolatileContext: TestContext {
     // Queries for testing a "volatile" value wrapped by
     // memoization.

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -1,4 +1,4 @@
-#[salsa::query_group]
+#[salsa::query_group(MyStruct)]
 trait MyDatabase: salsa::Database {
     #[salsa::invoke(another_module::another_name)]
     fn my_query(&self, key: ()) -> ();

--- a/tests/panic_safely.rs
+++ b/tests/panic_safely.rs
@@ -1,7 +1,7 @@
 use salsa::{Database, ParallelDatabase, Snapshot};
 use std::panic::{self, AssertUnwindSafe};
 
-#[salsa::query_group]
+#[salsa::query_group(PanicSafelyStruct)]
 trait PanicSafelyDatabase: salsa::Database {
     #[salsa::input]
     fn one(&self) -> usize;
@@ -13,7 +13,7 @@ fn panic_safely(db: &impl PanicSafelyDatabase) -> () {
     assert_eq!(db.one(), 1);
 }
 
-#[salsa::database(PanicSafelyDatabase)]
+#[salsa::database(PanicSafelyStruct)]
 #[derive(Default)]
 struct DatabaseStruct {
     runtime: salsa::Runtime<DatabaseStruct>,

--- a/tests/parallel/setup.rs
+++ b/tests/parallel/setup.rs
@@ -5,7 +5,7 @@ use salsa::Snapshot;
 use std::cell::Cell;
 use std::sync::Arc;
 
-#[salsa::query_group]
+#[salsa::query_group(Par)]
 pub(crate) trait ParDatabase: Knobs + salsa::ParallelDatabase {
     #[salsa::input]
     fn input(&self, key: char) -> usize;
@@ -184,7 +184,7 @@ fn snapshot_me(db: &impl ParDatabase) {
     db.snapshot();
 }
 
-#[salsa::database(ParDatabase)]
+#[salsa::database(Par)]
 #[derive(Default)]
 pub(crate) struct ParDatabaseImpl {
     runtime: salsa::Runtime<ParDatabaseImpl>,

--- a/tests/parallel/stress.rs
+++ b/tests/parallel/stress.rs
@@ -12,7 +12,7 @@ const N_READER_OPS: usize = 100;
 struct Canceled;
 type Cancelable<T> = Result<T, Canceled>;
 
-#[salsa::query_group]
+#[salsa::query_group(Stress)]
 trait StressDatabase: salsa::Database {
     #[salsa::input]
     fn a(&self, key: usize) -> usize;
@@ -33,7 +33,7 @@ fn c(db: &impl StressDatabase, key: usize) -> Cancelable<usize> {
     db.b(key)
 }
 
-#[salsa::database(StressDatabase)]
+#[salsa::database(Stress)]
 #[derive(Default)]
 struct StressDatabaseImpl {
     runtime: salsa::Runtime<StressDatabaseImpl>,

--- a/tests/set_unchecked.rs
+++ b/tests/set_unchecked.rs
@@ -1,6 +1,6 @@
 use salsa::Database;
 
-#[salsa::query_group]
+#[salsa::query_group(HelloWorldStruct)]
 trait HelloWorldDatabase: salsa::Database {
     #[salsa::input]
     fn input(&self) -> String;
@@ -20,7 +20,7 @@ fn double_length(db: &impl HelloWorldDatabase) -> usize {
     db.length() * 2
 }
 
-#[salsa::database(HelloWorldDatabase)]
+#[salsa::database(HelloWorldStruct)]
 #[derive(Default)]
 struct DatabaseStruct {
     runtime: salsa::Runtime<DatabaseStruct>,

--- a/tests/storage_varieties/implementation.rs
+++ b/tests/storage_varieties/implementation.rs
@@ -1,7 +1,7 @@
 use crate::queries;
 use std::cell::Cell;
 
-#[salsa::database(queries::Database)]
+#[salsa::database(queries::GroupStruct)]
 #[derive(Default)]
 pub(crate) struct DatabaseImpl {
     runtime: salsa::Runtime<DatabaseImpl>,

--- a/tests/storage_varieties/queries.rs
+++ b/tests/storage_varieties/queries.rs
@@ -2,7 +2,7 @@ pub(crate) trait Counter: salsa::Database {
     fn increment(&self) -> usize;
 }
 
-#[salsa::query_group]
+#[salsa::query_group(GroupStruct)]
 pub(crate) trait Database: Counter {
     fn memoized(&self) -> usize;
     #[salsa::volatile]

--- a/tests/variadic.rs
+++ b/tests/variadic.rs
@@ -1,6 +1,6 @@
 use salsa::Database;
 
-#[salsa::query_group]
+#[salsa::query_group(HelloWorld)]
 trait HelloWorldDatabase: salsa::Database {
     #[salsa::input]
     fn input(&self, a: u32, b: u32) -> u32;
@@ -30,7 +30,7 @@ fn trailing(_db: &impl HelloWorldDatabase, a: u32, b: u32) -> u32 {
     a - b
 }
 
-#[salsa::database(HelloWorldDatabase)]
+#[salsa::database(HelloWorld)]
 #[derive(Default)]
 struct DatabaseStruct {
     runtime: salsa::Runtime<DatabaseStruct>,


### PR DESCRIPTION
As @matklad noted, having the `#[salsa::database]` macro find the associated group storage / group key structs by manipulating the path proved to be too fragile, thus making the salsa abstraction more leaky than we might like. To fix this, we introduce the idea of a **query group struct** -- this struct now defines the query group, rather than the trait. You specify the struct name in the `#[salsa::query_group]` attribute macro:

```rust
#[salsa::query_group(MyQueryGroup)]
trait MyQueryGroupDatabase {
    ...
}
```

As you can see, by convention the name of the struct is the name of the query group (`MyQueryGroup`) and the trait has the word `Database` attached to it (i.e., it is implemented by the database which supports this query group).

Now, the `#[salsa::database]` struct refers to the *query group struct*, not the trait:

```rust
#[salsa::database(MyQueryGroup)]
```

This does require a bit more boilerplate, but it's probably better than relying on the terrible string munging we were doing.