### PR TITLE
apply `non_camel_case_types` to the enum variant

### DIFF
--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -342,6 +342,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
     // Emit query group descriptor
     output.extend(quote! {
         #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+        #[allow(non_camel_case_types)]
         #trait_vis enum #group_key {
             #query_descriptor_variants
         }


### PR DESCRIPTION
Not sure why this isn't signaling warnings all over the place, but I see them in other projects.