### PR TITLE
convert tests to use generated set methods

### DIFF
--- a/tests/gc/derived_tests.rs
+++ b/tests/gc/derived_tests.rs
@@ -103,8 +103,8 @@ fn compute_all() {
         db.set_use_triangular(i, (i % 2) != 0);
     }
 
-    db.query_mut(MinQuery).set((), 0);
-    db.query_mut(MaxQuery).set((), 6);
+    db.set_min(0);
+    db.set_max(6);
 
     db.compute_all();
     db.salsa_runtime().next_revision();
@@ -123,7 +123,7 @@ fn compute_all() {
     }
 
     // Reduce the range to exclude index 5.
-    db.query_mut(MaxQuery).set((), 5);
+    db.set_max(5);
     db.compute_all();
 
     assert_keys! {

--- a/tests/incremental/memoized_inputs.rs
+++ b/tests/incremental/memoized_inputs.rs
@@ -1,5 +1,4 @@
 use crate::implementation::{TestContext, TestContextImpl};
-use salsa::Database;
 
 #[salsa::query_group(MemoizedInputs)]
 pub(crate) trait MemoizedInputsContext: TestContext {
@@ -19,8 +18,8 @@ fn max(db: &impl MemoizedInputsContext) -> usize {
 fn revalidate() {
     let db = &mut TestContextImpl::default();
 
-    db.query_mut(Input1Query).set((), 0);
-    db.query_mut(Input2Query).set((), 0);
+    db.set_input1(0);
+    db.set_input2(0);
 
     let v = db.max();
     assert_eq!(v, 0);
@@ -30,7 +29,7 @@ fn revalidate() {
     assert_eq!(v, 0);
     db.assert_log(&[]);
 
-    db.query_mut(Input1Query).set((), 44);
+    db.set_input1(44);
     db.assert_log(&[]);
 
     let v = db.max();
@@ -41,11 +40,11 @@ fn revalidate() {
     assert_eq!(v, 44);
     db.assert_log(&[]);
 
-    db.query_mut(Input1Query).set((), 44);
+    db.set_input1(44);
     db.assert_log(&[]);
-    db.query_mut(Input2Query).set((), 66);
+    db.set_input2(66);
     db.assert_log(&[]);
-    db.query_mut(Input1Query).set((), 64);
+    db.set_input1(64);
     db.assert_log(&[]);
 
     let v = db.max();
@@ -63,14 +62,14 @@ fn revalidate() {
 fn set_after_no_change() {
     let db = &mut TestContextImpl::default();
 
-    db.query_mut(Input2Query).set((), 0);
+    db.set_input2(0);
 
-    db.query_mut(Input1Query).set((), 44);
+    db.set_input1(44);
     let v = db.max();
     assert_eq!(v, 44);
     db.assert_log(&["Max invoked"]);
 
-    db.query_mut(Input1Query).set((), 44);
+    db.set_input1(44);
     let v = db.max();
     assert_eq!(v, 44);
     db.assert_log(&["Max invoked"]);

--- a/tests/panic_safely.rs
+++ b/tests/panic_safely.rs
@@ -46,7 +46,7 @@ fn should_panic_safely() {
     assert!(result.is_err());
 
     // Set `db.one` to 1 and assert ok
-    db.query_mut(OneQuery).set((), 1);
+    db.set_one(1);
     let result = panic::catch_unwind(AssertUnwindSafe(|| db.panic_safely()));
     assert!(result.is_ok())
 }

--- a/tests/parallel/cancellation.rs
+++ b/tests/parallel/cancellation.rs
@@ -1,7 +1,7 @@
 use crate::setup::{
-    CancelationFlag, Canceled, InputQuery, Knobs, ParDatabase, ParDatabaseImpl, WithValue,
+    CancelationFlag, Canceled, Knobs, ParDatabase, ParDatabaseImpl, WithValue,
 };
-use salsa::{Database, ParallelDatabase};
+use salsa::ParallelDatabase;
 
 macro_rules! assert_canceled {
     ($flag:expr, $thread:expr) => {
@@ -34,10 +34,10 @@ fn in_par_get_set_cancellation_immediate() {
     check_cancelation(|flag| {
         let mut db = ParDatabaseImpl::default();
 
-        db.query_mut(InputQuery).set('a', 100);
-        db.query_mut(InputQuery).set('b', 010);
-        db.query_mut(InputQuery).set('c', 001);
-        db.query_mut(InputQuery).set('d', 0);
+        db.set_input('a', 100);
+        db.set_input('b', 010);
+        db.set_input('c', 001);
+        db.set_input('d', 0);
 
         let thread1 = std::thread::spawn({
             let db = db.snapshot();
@@ -56,7 +56,7 @@ fn in_par_get_set_cancellation_immediate() {
         db.wait_for(1);
 
         // Try to set the input. This will signal cancellation.
-        db.query_mut(InputQuery).set('d', 1000);
+        db.set_input('d', 1000);
 
         // This should re-compute the value (even though no input has changed).
         let thread2 = std::thread::spawn({
@@ -77,10 +77,10 @@ fn in_par_get_set_cancellation_transitive() {
     check_cancelation(|flag| {
         let mut db = ParDatabaseImpl::default();
 
-        db.query_mut(InputQuery).set('a', 100);
-        db.query_mut(InputQuery).set('b', 010);
-        db.query_mut(InputQuery).set('c', 001);
-        db.query_mut(InputQuery).set('d', 0);
+        db.set_input('a', 100);
+        db.set_input('b', 010);
+        db.set_input('c', 001);
+        db.set_input('d', 0);
 
         let thread1 = std::thread::spawn({
             let db = db.snapshot();
@@ -99,7 +99,7 @@ fn in_par_get_set_cancellation_transitive() {
         db.wait_for(1);
 
         // Try to set the input. This will signal cancellation.
-        db.query_mut(InputQuery).set('d', 1000);
+        db.set_input('d', 1000);
 
         // This should re-compute the value (even though no input has changed).
         let thread2 = std::thread::spawn({
@@ -119,7 +119,7 @@ fn no_back_dating_in_cancellation() {
     check_cancelation(|flag| {
         let mut db = ParDatabaseImpl::default();
 
-        db.query_mut(InputQuery).set('a', 1);
+        db.set_input('a', 1);
         let thread1 = std::thread::spawn({
             let db = db.snapshot();
             move || {
@@ -136,7 +136,7 @@ fn no_back_dating_in_cancellation() {
         db.wait_for(1);
 
         // Set unrelated input to bump revision
-        db.query_mut(InputQuery).set('b', 2);
+        db.set_input('b', 2);
 
         // Here we should recompuet the whole chain again, clearing the cancellation
         // state. If we get `usize::max()` here, it is a bug!
@@ -144,8 +144,8 @@ fn no_back_dating_in_cancellation() {
 
         assert_canceled!(flag, thread1);
 
-        db.query_mut(InputQuery).set('a', 3);
-        db.query_mut(InputQuery).set('a', 4);
+        db.set_input('a', 3);
+        db.set_input('a', 4);
         assert_eq!(db.sum3("ab"), 6);
     })
 }
@@ -160,7 +160,7 @@ fn no_back_dating_in_cancellation() {
 fn transitive_cancellation() {
     let mut db = ParDatabaseImpl::default();
 
-    db.query_mut(InputQuery).set('a', 1);
+    db.set_input('a', 1);
     let thread1 = std::thread::spawn({
         let db = db.snapshot();
         move || {
@@ -176,7 +176,7 @@ fn transitive_cancellation() {
 
     db.wait_for(1);
 
-    db.query_mut(InputQuery).set('b', 2);
+    db.set_input('b', 2);
 
     // Check that when we call `sum3_drop_sum` we don't wind up having
     // to actually re-execute it, because the result of `sum2` winds

--- a/tests/parallel/frozen.rs
+++ b/tests/parallel/frozen.rs
@@ -1,4 +1,4 @@
-use crate::setup::{InputQuery, ParDatabase, ParDatabaseImpl};
+use crate::setup::{ParDatabase, ParDatabaseImpl};
 use crate::signal::Signal;
 use salsa::{Database, ParallelDatabase};
 use std::sync::Arc;
@@ -10,7 +10,7 @@ use std::sync::Arc;
 fn in_par_get_set_cancellation() {
     let mut db = ParDatabaseImpl::default();
 
-    db.query_mut(InputQuery).set('a', 1);
+    db.set_input('a', 1);
 
     let signal = Arc::new(Signal::default());
 
@@ -50,7 +50,7 @@ fn in_par_get_set_cancellation() {
             signal.wait_for(1);
 
             // This will block until thread1 drops the revision lock.
-            db.query_mut(InputQuery).set('a', 2);
+            db.set_input('a', 2);
 
             db.input('a')
         }

--- a/tests/parallel/independent.rs
+++ b/tests/parallel/independent.rs
@@ -1,5 +1,5 @@
-use crate::setup::{InputQuery, ParDatabase, ParDatabaseImpl};
-use salsa::{Database, ParallelDatabase};
+use crate::setup::{ParDatabase, ParDatabaseImpl};
+use salsa::ParallelDatabase;
 
 /// Test two `sum` queries (on distinct keys) executing in different
 /// threads. Really just a test that `snapshot` etc compiles.
@@ -7,12 +7,12 @@ use salsa::{Database, ParallelDatabase};
 fn in_par_two_independent_queries() {
     let mut db = ParDatabaseImpl::default();
 
-    db.query_mut(InputQuery).set('a', 100);
-    db.query_mut(InputQuery).set('b', 010);
-    db.query_mut(InputQuery).set('c', 001);
-    db.query_mut(InputQuery).set('d', 200);
-    db.query_mut(InputQuery).set('e', 020);
-    db.query_mut(InputQuery).set('f', 002);
+    db.set_input('a', 100);
+    db.set_input('b', 010);
+    db.set_input('c', 001);
+    db.set_input('d', 200);
+    db.set_input('e', 020);
+    db.set_input('f', 002);
 
     let thread1 = std::thread::spawn({
         let db = db.snapshot();

--- a/tests/parallel/race.rs
+++ b/tests/parallel/race.rs
@@ -1,5 +1,5 @@
-use crate::setup::{InputQuery, ParDatabase, ParDatabaseImpl};
-use salsa::{Database, ParallelDatabase};
+use crate::setup::{ParDatabase, ParDatabaseImpl};
+use salsa::ParallelDatabase;
 
 /// Test where a read and a set are racing with one another.
 /// Should be atomic.
@@ -7,9 +7,9 @@ use salsa::{Database, ParallelDatabase};
 fn in_par_get_set_race() {
     let mut db = ParDatabaseImpl::default();
 
-    db.query_mut(InputQuery).set('a', 100);
-    db.query_mut(InputQuery).set('b', 010);
-    db.query_mut(InputQuery).set('c', 001);
+    db.set_input('a', 100);
+    db.set_input('b', 010);
+    db.set_input('c', 001);
 
     let thread1 = std::thread::spawn({
         let db = db.snapshot();
@@ -20,7 +20,7 @@ fn in_par_get_set_race() {
     });
 
     let thread2 = std::thread::spawn(move || {
-        db.query_mut(InputQuery).set('a', 1000);
+        db.set_input('a', 1000);
         db.sum("a")
     });
 

--- a/tests/parallel/stress.rs
+++ b/tests/parallel/stress.rs
@@ -141,7 +141,7 @@ impl WriteOp {
     fn execute(self, db: &mut StressDatabaseImpl) {
         match self {
             WriteOp::SetA(key, value) => {
-                db.query_mut(AQuery).set(key, value);
+                db.set_a(key, value);
             }
         }
     }
@@ -183,7 +183,7 @@ impl ReadOp {
 fn stress_test() {
     let mut db = StressDatabaseImpl::default();
     for i in 0..10 {
-        db.query_mut(AQuery).set(i, i);
+        db.set_a(i, i);
     }
 
     let mut rng = rand::thread_rng();

--- a/tests/parallel/true_parallel.rs
+++ b/tests/parallel/true_parallel.rs
@@ -1,5 +1,5 @@
-use crate::setup::{InputQuery, Knobs, ParDatabase, ParDatabaseImpl, WithValue};
-use salsa::{Database, ParallelDatabase};
+use crate::setup::{Knobs, ParDatabase, ParDatabaseImpl, WithValue};
+use salsa::ParallelDatabase;
 use std::panic::{self, AssertUnwindSafe};
 
 /// Test where two threads are executing sum. We show that they can
@@ -10,9 +10,9 @@ use std::panic::{self, AssertUnwindSafe};
 fn true_parallel_different_keys() {
     let mut db = ParDatabaseImpl::default();
 
-    db.query_mut(InputQuery).set('a', 100);
-    db.query_mut(InputQuery).set('b', 010);
-    db.query_mut(InputQuery).set('c', 001);
+    db.set_input('a', 100);
+    db.set_input('b', 010);
+    db.set_input('c', 001);
 
     // Thread 1 will signal stage 1 when it enters and wait for stage 2.
     let thread1 = std::thread::spawn({
@@ -50,9 +50,9 @@ fn true_parallel_different_keys() {
 fn true_parallel_same_keys() {
     let mut db = ParDatabaseImpl::default();
 
-    db.query_mut(InputQuery).set('a', 100);
-    db.query_mut(InputQuery).set('b', 010);
-    db.query_mut(InputQuery).set('c', 001);
+    db.set_input('a', 100);
+    db.set_input('b', 010);
+    db.set_input('c', 001);
 
     // Thread 1 will wait_for a barrier in the start of `sum`
     let thread1 = std::thread::spawn({
@@ -91,7 +91,7 @@ fn true_parallel_same_keys() {
 fn true_parallel_propagate_panic() {
     let mut db = ParDatabaseImpl::default();
 
-    db.query_mut(InputQuery).set('a', 1);
+    db.set_input('a', 1);
 
     // `thread1` will wait_for a barrier in the start of `sum`. Once it can
     // continue, it will panic.

--- a/tests/variadic.rs
+++ b/tests/variadic.rs
@@ -1,5 +1,3 @@
-use salsa::Database;
-
 #[salsa::query_group(HelloWorld)]
 trait HelloWorldDatabase: salsa::Database {
     #[salsa::input]
@@ -47,7 +45,7 @@ fn execute() {
     let mut db = DatabaseStruct::default();
 
     // test what happens with inputs:
-    db.query_mut(InputQuery).set((1, 2), 3);
+    db.set_input(1, 2, 3);
     assert_eq!(db.input(1, 2), 3);
 
     assert_eq!(db.none(), 22);


### PR DESCRIPTION
Closes #128
Converts tests to use `set_foo` now that set methods are generated for inputs.