### PR TITLE
remove `UncheckedMutQueryStorageOps` trait

### DIFF
--- a/src/derived.rs
+++ b/src/derived.rs
@@ -4,7 +4,6 @@ use crate::plumbing::DatabaseKey;
 use crate::plumbing::QueryFunction;
 use crate::plumbing::QueryStorageMassOps;
 use crate::plumbing::QueryStorageOps;
-use crate::plumbing::UncheckedMutQueryStorageOps;
 use crate::runtime::ChangedAt;
 use crate::runtime::FxIndexSet;
 use crate::runtime::Revision;
@@ -980,31 +979,6 @@ where
                 }
             }
         });
-    }
-}
-
-impl<DB, Q, MP> UncheckedMutQueryStorageOps<DB, Q> for DerivedStorage<DB, Q, MP>
-where
-    Q: QueryFunction<DB>,
-    DB: Database,
-    MP: MemoizationPolicy<DB, Q>,
-{
-    fn set_unchecked(&self, db: &DB, key: &Q::Key, value: Q::Value) {
-        let key = key.clone();
-
-        let mut map_write = self.map.write();
-        let current_revision = db.salsa_runtime().current_revision();
-        map_write.insert(
-            key,
-            QueryState::Memoized(Memo {
-                value: Some(value),
-                changed_at: current_revision,
-                verified_at: current_revision,
-                inputs: MemoInputs::Tracked {
-                    inputs: Default::default(),
-                },
-            }),
-        );
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -3,7 +3,6 @@ use crate::plumbing::CycleDetected;
 use crate::plumbing::InputQueryStorageOps;
 use crate::plumbing::QueryStorageMassOps;
 use crate::plumbing::QueryStorageOps;
-use crate::plumbing::UncheckedMutQueryStorageOps;
 use crate::runtime::ChangedAt;
 use crate::runtime::Revision;
 use crate::runtime::StampedValue;
@@ -231,26 +230,5 @@ where
         log::debug!("{:?}({:?}) = {:?}", Q::default(), key, value);
 
         self.set_common(db, key, database_key, value, IsConstant(true))
-    }
-}
-
-impl<DB, Q> UncheckedMutQueryStorageOps<DB, Q> for InputStorage<DB, Q>
-where
-    Q: Query<DB>,
-    DB: Database,
-{
-    fn set_unchecked(&self, db: &DB, key: &Q::Key, value: Q::Value) {
-        let key = key.clone();
-
-        let mut map_write = self.map.write();
-
-        // Unlike with `set`, here we use the **current revision** and
-        // do not create a new one.
-        let changed_at = ChangedAt {
-            is_constant: false,
-            revision: db.salsa_runtime().current_revision(),
-        };
-
-        map_write.insert(key, StampedValue { value, changed_at });
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@ use crate::plumbing::CycleDetected;
 use crate::plumbing::InputQueryStorageOps;
 use crate::plumbing::QueryStorageMassOps;
 use crate::plumbing::QueryStorageOps;
-use crate::plumbing::UncheckedMutQueryStorageOps;
 use derive_new::new;
 use std::fmt::{self, Debug};
 use std::hash::Hash;

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -201,14 +201,3 @@ where
         new_value: Q::Value,
     );
 }
-
-/// An optional trait that is implemented for "user mutable" storage:
-/// that is, storage whose value is not derived from other storage but
-/// is set independently.
-pub trait UncheckedMutQueryStorageOps<DB, Q>: Default
-where
-    DB: Database,
-    Q: Query<DB>,
-{
-    fn set_unchecked(&self, db: &DB, key: &Q::Key, new_value: Q::Value);
-}


### PR DESCRIPTION
Follow-up of #140. Removes the trait from plumbing and the implementations. 