### PR TITLE
release 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa"
-version = "0.10.0-alpha5"
+version = "0.10.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"
@@ -16,7 +16,7 @@ lock_api = "0.1.4"
 indexmap = "1.0.1"
 log = "0.4.5"
 smallvec = "0.6.5"
-salsa-macros = { version = "0.10.0-alpha5", path = "components/salsa-macros" }
+salsa-macros = { version = "0.10.0", path = "components/salsa-macros" }
 
 [dev-dependencies]
 diff = "0.1.0"

--- a/components/salsa-macros/Cargo.toml
+++ b/components/salsa-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa-macros"
-version = "0.10.0-alpha5"
+version = "0.10.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
- GC API now more orthogonal + flexible (#138)
- Removed `set_unchecked` testing mechanism (#141)
- Generated enums now squelch `non_camel_case_types` lint (#135)
- Tests now using `set_foo` (#139)
- `Query::group_storage` now called `Query::query_storage` (#142)

Contributors to this release:

- @matklad
- @memoryruins
- @nikomatsakis