### PR TITLE
feat: Allow queries to avoid panics on cycles

### DIFF
--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -360,9 +360,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
             QueryStorage::Dependencies => quote!(salsa::plumbing::DependencyStorage<#db, Self>),
             QueryStorage::Input => quote!(salsa::plumbing::InputStorage<#db, Self>),
             QueryStorage::Interned => quote!(salsa::plumbing::InternedStorage<#db, Self>),
-            QueryStorage::InternedLookup { intern_query_type } => {
-                quote!(salsa::plumbing::LookupInternedStorage<#db, Self, #intern_query_type>)
-            }
+            QueryStorage::InternedLookup { intern_query_type } => quote!(salsa::plumbing::LookupInternedStorage<#db, Self, #intern_query_type>),
             QueryStorage::Transparent => continue,
         };
         let keys = &query.keys;

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -1,14 +1,13 @@
 use crate::debug::TableEntry;
 use crate::durability::Durability;
 use crate::lru::Lru;
-use crate::plumbing::CycleDetected;
 use crate::plumbing::HasQueryGroup;
 use crate::plumbing::LruQueryStorageOps;
 use crate::plumbing::QueryFunction;
 use crate::plumbing::QueryStorageMassOps;
 use crate::plumbing::QueryStorageOps;
 use crate::runtime::StampedValue;
-use crate::{Database, SweepStrategy};
+use crate::{CycleError, Database, SweepStrategy};
 use parking_lot::RwLock;
 use rustc_hash::FxHashMap;
 use std::marker::PhantomData;
@@ -131,7 +130,7 @@ where
     DB: Database + HasQueryGroup<Q::Group>,
     MP: MemoizationPolicy<DB, Q>,
 {
-    fn try_fetch(&self, db: &DB, key: &Q::Key) -> Result<Q::Value, CycleDetected> {
+    fn try_fetch(&self, db: &DB, key: &Q::Key) -> Result<Q::Value, CycleError<DB::DatabaseKey>> {
         let slot = self.slot(key);
         let StampedValue {
             value,

--- a/src/doctest.rs
+++ b/src/doctest.rs
@@ -45,6 +45,7 @@ fn test_key_not_send_db_not_send() {}
 ///
 /// ```compile_fail,E0277
 /// use std::rc::Rc;
+/// use std::cell::Cell;
 ///
 /// #[salsa::query_group(NoSendSyncStorage)]
 /// trait NoSendSyncDatabase: salsa::Database {

--- a/src/input.rs
+++ b/src/input.rs
@@ -75,9 +75,9 @@ where
     DB: Database,
 {
     fn try_fetch(&self, db: &DB, key: &Q::Key) -> Result<Q::Value, CycleError<DB::DatabaseKey>> {
-        let slot = self.slot(key).unwrap_or_else(|| {
-            panic!("no value set for {:?}({:?})", Q::default(), key)
-        });
+        let slot = self
+            .slot(key)
+            .unwrap_or_else(|| panic!("no value set for {:?}({:?})", Q::default(), key));
 
         let StampedValue {
             value,
@@ -95,7 +95,7 @@ where
         match self.slot(key) {
             Some(slot) => slot.stamped_value.read().durability,
             None => panic!("no value set for {:?}({:?})", Q::default(), key),
-    }
+        }
     }
 
     fn entries<C>(&self, _db: &DB) -> C
@@ -184,7 +184,7 @@ where
                     let mut slot_stamped_value = entry.get().stamped_value.write();
                     guard.mark_durability_as_changed(slot_stamped_value.durability);
                     *slot_stamped_value = stamped_value;
-    }
+                }
 
                 Entry::Vacant(entry) => {
                     entry.insert(Arc::new(Slot {

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -1,8 +1,8 @@
 #![allow(missing_docs)]
 
 use crate::debug::TableEntry;
-use crate::CycleError;
 use crate::durability::Durability;
+use crate::CycleError;
 use crate::Database;
 use crate::Query;
 use crate::QueryTable;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -644,6 +644,7 @@ struct ActiveQuery<DB: Database> {
     /// there was an untracked the read.
     dependencies: Option<FxIndexSet<Dependency<DB>>>,
 
+    /// Stores the entire cycle, if one is found and this query is part of it.
     cycle: Vec<DB::DatabaseKey>,
 }
 

--- a/src/runtime/local_state.rs
+++ b/src/runtime/local_state.rs
@@ -3,8 +3,7 @@ use crate::durability::Durability;
 use crate::runtime::ActiveQuery;
 use crate::runtime::Revision;
 use crate::Database;
-use std::cell::Ref;
-use std::cell::RefCell;
+use std::cell::{Ref, RefCell, RefMut};
 
 /// State that is specific to a single execution thread.
 ///
@@ -49,6 +48,10 @@ impl<DB: Database> LocalState<DB> {
     /// reading from it.
     pub(super) fn borrow_query_stack(&self) -> Ref<'_, Vec<ActiveQuery<DB>>> {
         self.query_stack.borrow()
+    }
+
+    pub(super) fn borrow_query_stack_mut(&self) -> RefMut<'_, Vec<ActiveQuery<DB>>> {
+        self.query_stack.borrow_mut()
     }
 
     pub(super) fn query_in_progress(&self) -> bool {

--- a/tests/parallel/cancellation.rs
+++ b/tests/parallel/cancellation.rs
@@ -1,6 +1,4 @@
-use crate::setup::{
-    CancelationFlag, Canceled, Knobs, ParDatabase, ParDatabaseImpl, WithValue,
-};
+use crate::setup::{CancelationFlag, Canceled, Knobs, ParDatabase, ParDatabaseImpl, WithValue};
 use salsa::ParallelDatabase;
 
 macro_rules! assert_canceled {

--- a/tests/parallel/independent.rs
+++ b/tests/parallel/independent.rs
@@ -22,7 +22,7 @@ fn in_par_two_independent_queries() {
     let thread2 = std::thread::spawn({
         let db = db.snapshot();
         move || db.sum("def")
-    });;
+    });
 
     assert_eq!(thread1.join().unwrap(), 111);
     assert_eq!(thread2.join().unwrap(), 222);

--- a/tests/requires.rs
+++ b/tests/requires.rs
@@ -1,7 +1,6 @@
 //! Test `salsa::requires` attribute for private query dependencies
 //! https://github.com/salsa-rs/salsa-rfcs/pull/3
 
-
 mod queries {
     #[salsa::query_group(InputGroupStorage)]
     pub trait InputGroup {
@@ -14,7 +13,7 @@ mod queries {
         fn private_a(&self, x: u32) -> u32;
     }
 
-    fn private_a(db: &impl PrivGroupA, x: u32) -> u32{
+    fn private_a(db: &impl PrivGroupA, x: u32) -> u32 {
         db.input(x)
     }
 
@@ -23,7 +22,7 @@ mod queries {
         fn private_b(&self, x: u32) -> u32;
     }
 
-    fn private_b(db: &impl PrivGroupB, x: u32) -> u32{
+    fn private_b(db: &impl PrivGroupB, x: u32) -> u32 {
         db.input(x)
     }
 
@@ -34,7 +33,6 @@ mod queries {
         fn public(&self, x: u32) -> u32;
     }
 
-
     fn public(db: &(impl PubGroup + PrivGroupA + PrivGroupB), x: u32) -> u32 {
         db.private_a(x) + db.private_b(x)
     }
@@ -44,7 +42,7 @@ mod queries {
     queries::InputGroupStorage,
     queries::PrivGroupAStorage,
     queries::PrivGroupBStorage,
-    queries::PubGroupStorage,
+    queries::PubGroupStorage
 )]
 #[derive(Default)]
 struct Database {

--- a/tests/transparent.rs
+++ b/tests/transparent.rs
@@ -17,7 +17,6 @@ fn get(db: &impl QueryGroup, x: u32) -> u32 {
     db.wrap(x)
 }
 
-
 #[salsa::database(QueryGroupStorage)]
 #[derive(Default)]
 struct Database {


### PR DESCRIPTION
The default behavior when salsa detects a cycle is to panic. This is fine behavior when the cycle occurs as a programmer error but in some instances cycles can be expected to occur. To allow this case while still keeping "programmer error" as the default assumption on cycles a `salsa::cycle` is added which can be attached to any function which could naturally appear in a cycle.

The `salsa::cycle` takes a function which takes the keys of the query as well as description of all the queries that were part of the cycle (currently a slice of `Debug` formatted strings for simplicity's sake). When a cycle is detected salsa invokes the cycle function to produce the result for the query instead of panicking. Furthermore, every other query in the cycle will discard whatever value they produced normally and invoke their own cycle function (if a function in the cycle lacks the attribute salsa will panic as usual). All values produced from a cycle function is memoized in the same way as if the query executed normally.

This has been tested to work well in gluon's import system which needs to error if modules import each other in a cycle (a programmer error for the one writing gluon programs, but not in the salsa query usage in gluon) https://github.com/gluon-lang/gluon/pull/683 . The only nasty part is that the cycle information needs to be parsed out of the `Debug` formatted string but currently I don't have a good abstraction for solving that.

cc #6