### PR TITLE
add interned keys to salsa

### DIFF
--- a/components/salsa-macros/Cargo.toml
+++ b/components/salsa-macros/Cargo.toml
@@ -15,5 +15,5 @@ proc-macro = true
 heck = "0.3"
 proc-macro2 = "0.4"
 quote = "0.6"
-syn = { version = "0.15", features = ["full", "extra-traits"] }
+syn = { version = "0.15.29", features = ["full", "extra-traits"] }
 

--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -3,7 +3,7 @@ use heck::CamelCase;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::ToTokens;
-use syn::{parse_macro_input, FnArg, Ident, ItemTrait, ReturnType, TraitItem};
+use syn::{parse_macro_input, parse_quote, FnArg, Ident, ItemTrait, ReturnType, TraitItem, Type};
 
 /// Implementation for `[salsa::query_group]` decorator.
 pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream {
@@ -110,15 +110,56 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
                     ),
                 };
 
+                // For `#[salsa::interned]` keys, we create a "lookup key" automatically.
+                //
+                // For a query like:
+                //
+                //     fn foo(&self, x: Key1, y: Key2) -> u32
+                //
+                // we would create
+                //
+                //     fn lookup_foo(&self, x: u32) -> (Key1, Key2)
+                let lookup_query = if let QueryStorage::Interned = storage {
+                    let lookup_query_type = Ident::new(
+                        &format!(
+                            "{}LookupQuery",
+                            method.sig.ident.to_string().to_camel_case()
+                        ),
+                        Span::call_site(),
+                    );
+                    let lookup_fn_name = Ident::new(
+                        &format!("lookup_{}", method.sig.ident.to_string()),
+                        method.sig.ident.span(),
+                    );
+                    let keys = &keys;
+                    let lookup_value: Type = parse_quote!((#(#keys),*));
+                    let lookup_keys = vec![value.clone()];
+                    Some(Query {
+                        query_type: lookup_query_type,
+                        fn_name: lookup_fn_name,
+                        attrs: vec![], // FIXME -- some automatically generated docs on this method?
+                        storage: QueryStorage::InternedLookup {
+                            intern_query_type: query_type.clone(),
+                        },
+                        keys: lookup_keys,
+                        value: lookup_value,
+                        invoke: None,
+                    })
+                } else {
+                    None
+                };
+
                 queries.push(Query {
                     query_type,
-                    fn_name: method.sig.ident.clone(),
+                    fn_name: method.sig.ident,
                     attrs,
                     storage,
                     keys,
                     value,
                     invoke,
                 });
+
+                queries.extend(lookup_query);
             }
             _ => (),
         }
@@ -199,23 +240,6 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
             });
         }
 
-        // For interned queries, we need `lookup_foo`
-        if let QueryStorage::Interned = query.storage {
-            let lookup_fn_name = Ident::new(&format!("lookup_{}", fn_name), fn_name.span());
-
-            query_fn_declarations.extend(quote! {
-                /// Lookup the value(s) interned with a specific key.
-                fn #lookup_fn_name(&mut self, value: #value) -> (#(#keys),*);
-            });
-
-            query_fn_definitions.extend(quote! {
-                fn #lookup_fn_name(&mut self, value: #value) -> (#(#keys),*) {
-                    <Self as salsa::plumbing::GetQueryTable<#qt>>::get_query_table(self)
-                        .lookup(value)
-                }
-            });
-        }
-
         // A variant for the group descriptor below
         query_descriptor_variants.extend(quote! {
             #fn_name((#(#keys),*)),
@@ -266,6 +290,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
         impl<DB__> salsa::plumbing::QueryGroup<DB__> for #group_struct
         where
             DB__: #trait_name,
+            DB__: salsa::plumbing::HasQueryGroup<#group_struct>,
             DB__: salsa::Database,
         {
             type GroupStorage = #group_storage<DB__>;
@@ -291,16 +316,19 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
     for query in &queries {
         let fn_name = &query.fn_name;
         let qt = &query.query_type;
-        let storage = Ident::new(
-            match query.storage {
-                QueryStorage::Memoized => "MemoizedStorage",
-                QueryStorage::Volatile => "VolatileStorage",
-                QueryStorage::Dependencies => "DependencyStorage",
-                QueryStorage::Input => "InputStorage",
-                QueryStorage::Interned => "InternedStorage",
-            },
-            Span::call_site(),
-        );
+
+        let db = quote! {DB};
+
+        let storage = match &query.storage {
+            QueryStorage::Memoized => quote!(salsa::plumbing::MemoizedStorage<#db, Self>),
+            QueryStorage::Volatile => quote!(salsa::plumbing::VolatileStorage<#db, Self>),
+            QueryStorage::Dependencies => quote!(salsa::plumbing::DependencyStorage<#db, Self>),
+            QueryStorage::Input => quote!(salsa::plumbing::InputStorage<#db, Self>),
+            QueryStorage::Interned => quote!(salsa::plumbing::InternedStorage<#db, Self>),
+            QueryStorage::InternedLookup { intern_query_type } => {
+                quote!(salsa::plumbing::LookupInternedStorage<#db, Self, #intern_query_type>)
+            }
+        };
         let keys = &query.keys;
         let value = &query.value;
 
@@ -309,16 +337,17 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
             #[derive(Default, Debug)]
             #trait_vis struct #qt;
 
-            impl<DB> salsa::Query<DB> for #qt
+            impl<#db> salsa::Query<#db> for #qt
             where
                 DB: #trait_name,
+                DB: salsa::plumbing::HasQueryGroup<#group_struct>,
                 DB: salsa::Database,
             {
                 type Key = (#(#keys),*);
                 type Value = #value;
-                type Storage = salsa::plumbing::#storage<DB, Self>;
+                type Storage = #storage;
                 type Group = #group_struct;
-                type GroupStorage = #group_storage<DB>;
+                type GroupStorage = #group_storage<#db>;
                 type GroupKey = #group_key;
 
                 fn query_storage(group_storage: &Self::GroupStorage) -> &Self::Storage {
@@ -331,7 +360,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
             }
         });
 
-        // Implement the QueryFunction trait for all queries except inputs.
+        // Implement the QueryFunction trait for queries which need it.
         if query.storage.needs_query_function() {
             let span = query.fn_name.span();
             let key_names: &Vec<_> = &(0..query.keys.len())
@@ -401,6 +430,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
         #trait_vis struct #group_storage<DB__>
         where
             DB__: #trait_name,
+            DB__: salsa::plumbing::HasQueryGroup<#group_struct>,
             DB__: salsa::Database,
         {
             #storage_fields
@@ -409,6 +439,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
         impl<DB__> Default for #group_storage<DB__>
         where
             DB__: #trait_name,
+            DB__: salsa::plumbing::HasQueryGroup<#group_struct>,
             DB__: salsa::Database,
         {
             #[inline]
@@ -462,19 +493,22 @@ struct Query {
     invoke: Option<syn::Path>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum QueryStorage {
     Memoized,
     Volatile,
     Dependencies,
     Input,
     Interned,
+    InternedLookup { intern_query_type: Ident },
 }
 
 impl QueryStorage {
-    fn needs_query_function(self) -> bool {
+    fn needs_query_function(&self) -> bool {
         match self {
-            QueryStorage::Input | QueryStorage::Interned => false,
+            QueryStorage::Input | QueryStorage::Interned | QueryStorage::InternedLookup { .. } => {
+                false
+            }
             QueryStorage::Memoized | QueryStorage::Volatile | QueryStorage::Dependencies => true,
         }
     }

--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -379,6 +379,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
                 impl<DB> salsa::plumbing::QueryFunction<DB> for #qt
                 where
                     DB: #trait_name,
+                    DB: salsa::plumbing::HasQueryGroup<#group_struct>,
                     DB: salsa::Database,
                 {
                     fn execute(db: &DB, #key_pattern: <Self as salsa::Query<DB>>::Key)

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -846,7 +846,7 @@ where
         let maybe_changed = inputs
             .iter()
             .flat_map(|inputs| inputs.iter())
-            .take_while(|input| input.maybe_changed_since(db, revision))
+            .filter(|input| input.maybe_changed_since(db, revision))
             .inspect(|input| {
                 debug!(
                     "{:?}({:?}): input `{:?}` may have changed",
@@ -1042,7 +1042,7 @@ where
             MemoInputs::Tracked { inputs } => {
                 let changed_input = inputs
                     .iter()
-                    .take_while(|input| input.maybe_changed_since(db, verified_at))
+                    .filter(|input| input.maybe_changed_since(db, verified_at))
                     .next();
 
                 if let Some(input) = changed_input {

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -846,7 +846,7 @@ where
         let maybe_changed = inputs
             .iter()
             .flat_map(|inputs| inputs.iter())
-            .filter(|input| input.maybe_changed_since(db, revision))
+            .take_while(|input| input.maybe_changed_since(db, revision))
             .inspect(|input| {
                 debug!(
                     "{:?}({:?}): input `{:?}` may have changed",
@@ -947,7 +947,7 @@ where
                 debug!("sweep({:?}): clearing the table", Q::default());
                 map_write.clear();
                 return;
-            },
+            }
             (DiscardIf::Never, _) | (_, DiscardWhat::Nothing) => return,
             _ => {}
         }
@@ -1042,7 +1042,7 @@ where
             MemoInputs::Tracked { inputs } => {
                 let changed_input = inputs
                     .iter()
-                    .filter(|input| input.maybe_changed_since(db, verified_at))
+                    .take_while(|input| input.maybe_changed_since(db, verified_at))
                     .next();
 
                 if let Some(input) = changed_input {

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -1,0 +1,448 @@
+use crate::debug::TableEntry;
+use crate::plumbing::CycleDetected;
+use crate::plumbing::InternedQueryStorageOps;
+use crate::plumbing::QueryStorageMassOps;
+use crate::plumbing::QueryStorageOps;
+use crate::runtime::ChangedAt;
+use crate::runtime::Revision;
+use crate::runtime::StampedValue;
+use crate::Query;
+use crate::{Database, DiscardIf, SweepStrategy};
+use parking_lot::RwLock;
+use rustc_hash::FxHashMap;
+use std::collections::hash_map::Entry;
+use std::convert::From;
+use std::hash::Hash;
+
+/// Handles storage where the value is 'derived' by executing a
+/// function (in contrast to "inputs").
+pub struct InternedStorage<DB, Q>
+where
+    Q: Query<DB>,
+    Q::Value: From<u32>,
+    Q::Value: Into<u32>,
+    DB: Database,
+{
+    tables: RwLock<InternTables<Q::Key>>,
+}
+
+struct InternTables<K> {
+    /// Map from the key to the corresponding intern-index.
+    map: FxHashMap<K, InternIndex>,
+
+    /// For each valid intern-index, stores the interned value. When
+    /// an interned value is GC'd, the entry is set to
+    /// `InternValue::Free` with the next free item.
+    values: Vec<InternValue<K>>,
+
+    /// Index of the first free intern-index, if any.
+    first_free: Option<InternIndex>,
+}
+
+/// Newtype indicating an index into the intern table.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+struct InternIndex {
+    index: u32,
+}
+
+impl InternIndex {
+    fn index(self) -> usize {
+        self.index as usize
+    }
+}
+
+impl From<usize> for InternIndex {
+    fn from(v: usize) -> Self {
+        assert!(v < (std::u32::MAX as usize));
+        InternIndex { index: v as u32 }
+    }
+}
+
+enum InternValue<K> {
+    /// The value has not been gc'd.
+    Present {
+        value: K,
+
+        /// When was this intern'd?
+        ///
+        /// (This informs the "changed-at" result)
+        interned_at: Revision,
+
+        /// When was it accessed?
+        ///
+        /// (This informs the garbage collector)
+        accessed_at: Revision,
+    },
+
+    /// Free-list -- the index is the next
+    Free { next: Option<InternIndex> },
+}
+
+impl<DB, Q> std::panic::RefUnwindSafe for InternedStorage<DB, Q>
+where
+    Q: Query<DB>,
+    DB: Database,
+    Q::Key: std::panic::RefUnwindSafe,
+    Q::Value: From<u32>,
+    Q::Value: Into<u32>,
+    Q::Value: std::panic::RefUnwindSafe,
+{
+}
+
+impl<DB, Q> Default for InternedStorage<DB, Q>
+where
+    Q: Query<DB>,
+    Q::Key: Eq + Hash,
+    Q::Value: From<u32>,
+    Q::Value: Into<u32>,
+    DB: Database,
+{
+    fn default() -> Self {
+        InternedStorage {
+            tables: RwLock::new(InternTables::default()),
+        }
+    }
+}
+
+impl<K> Default for InternTables<K>
+where
+    K: Eq + Hash,
+{
+    fn default() -> Self {
+        Self {
+            map: Default::default(),
+            values: Default::default(),
+            first_free: Default::default(),
+        }
+    }
+}
+
+impl<DB, Q> InternedStorage<DB, Q>
+where
+    Q: Query<DB>,
+    Q::Key: Eq + Hash + Clone,
+    Q::Value: From<u32>,
+    Q::Value: Into<u32>,
+    DB: Database,
+{
+    fn intern_index(&self, db: &DB, key: &Q::Key) -> StampedValue<InternIndex> {
+        if let Some(i) = self.intern_check(db, key) {
+            return i;
+        }
+
+        let owned_key1 = key.to_owned();
+        let owned_key2 = owned_key1.clone();
+        let revision_now = db.salsa_runtime().current_revision();
+
+        let mut tables = self.tables.write();
+        let tables = &mut *tables;
+        let entry = match tables.map.entry(owned_key1) {
+            Entry::Vacant(entry) => entry,
+            Entry::Occupied(entry) => {
+                // Somebody inserted this key while we were waiting
+                // for the write lock.
+                let index = *entry.get();
+                match &tables.values[index.index()] {
+                    InternValue::Present {
+                        value,
+                        interned_at,
+                        accessed_at,
+                    } => {
+                        debug_assert_eq!(owned_key2, *value);
+                        debug_assert_eq!(*accessed_at, revision_now);
+                        return StampedValue {
+                            value: index,
+                            changed_at: ChangedAt {
+                                is_constant: false,
+                                revision: *interned_at,
+                            },
+                        };
+                    }
+
+                    InternValue::Free { .. } => {
+                        panic!("key {:?} should be present but is not", key,);
+                    }
+                }
+            }
+        };
+
+        let index = match tables.first_free {
+            None => {
+                let index = InternIndex::from(tables.values.len());
+                tables.values.push(InternValue::Present {
+                    value: owned_key2,
+                    interned_at: revision_now,
+                    accessed_at: revision_now,
+                });
+                index
+            }
+
+            Some(i) => {
+                let next_free = match &tables.values[i.index()] {
+                    InternValue::Free { next } => *next,
+                    InternValue::Present { value, .. } => {
+                        panic!(
+                            "index {:?} was supposed to be free but contains {:?}",
+                            i, value
+                        );
+                    }
+                };
+
+                tables.values[i.index()] = InternValue::Present {
+                    value: owned_key2,
+                    interned_at: revision_now,
+                    accessed_at: revision_now,
+                };
+                tables.first_free = next_free;
+                i
+            }
+        };
+
+        entry.insert(index);
+
+        StampedValue {
+            value: index,
+            changed_at: ChangedAt {
+                is_constant: false,
+                revision: revision_now,
+            },
+        }
+    }
+
+    fn intern_check(&self, db: &DB, key: &Q::Key) -> Option<StampedValue<InternIndex>> {
+        let revision_now = db.salsa_runtime().current_revision();
+
+        // First,
+        {
+            let tables = self.tables.read();
+            let &index = tables.map.get(key)?;
+            match &tables.values[index.index()] {
+                InternValue::Present {
+                    interned_at,
+                    accessed_at,
+                    ..
+                } => {
+                    if *accessed_at == revision_now {
+                        return Some(StampedValue {
+                            value: index,
+                            changed_at: ChangedAt {
+                                is_constant: false,
+                                revision: *interned_at,
+                            },
+                        });
+                    }
+                }
+
+                InternValue::Free { .. } => {
+                    panic!(
+                        "key {:?} maps to index {:?} is free but should not be",
+                        key, index
+                    );
+                }
+            }
+        }
+
+        // Next,
+        let mut tables = self.tables.write();
+        let &index = tables.map.get(key)?;
+        match &mut tables.values[index.index()] {
+            InternValue::Present {
+                interned_at,
+                accessed_at,
+                ..
+            } => {
+                *accessed_at = revision_now;
+
+                return Some(StampedValue {
+                    value: index,
+                    changed_at: ChangedAt {
+                        is_constant: false,
+                        revision: *interned_at,
+                    },
+                });
+            }
+
+            InternValue::Free { .. } => {
+                panic!(
+                    "key {:?} maps to index {:?} is free but should not be",
+                    key, index
+                );
+            }
+        }
+    }
+
+    /// Given an index, lookup and clone its value, updating the
+    /// `accessed_at` time if necessary.
+    fn lookup_value(&self, db: &DB, index: u32) -> StampedValue<Q::Key> {
+        let index = index as usize;
+        let revision_now = db.salsa_runtime().current_revision();
+
+        {
+            let tables = self.tables.read();
+            match &tables.values[index] {
+                InternValue::Present {
+                    accessed_at,
+                    interned_at,
+                    value,
+                } => {
+                    if *accessed_at == revision_now {
+                        return StampedValue {
+                            value: value.clone(),
+                            changed_at: ChangedAt {
+                                is_constant: false,
+                                revision: *interned_at,
+                            },
+                        };
+                    }
+                }
+
+                InternValue::Free { .. } => panic!("lookup of index {:?} found a free slot", index),
+            }
+        }
+
+        let mut tables = self.tables.write();
+        match &mut tables.values[index] {
+            InternValue::Present {
+                accessed_at,
+                interned_at,
+                value,
+            } => {
+                *accessed_at = revision_now;
+
+                return StampedValue {
+                    value: value.clone(),
+                    changed_at: ChangedAt {
+                        is_constant: false,
+                        revision: *interned_at,
+                    },
+                };
+            }
+
+            InternValue::Free { .. } => panic!("lookup of index {:?} found a free slot", index),
+        }
+    }
+}
+
+impl<DB, Q> QueryStorageOps<DB, Q> for InternedStorage<DB, Q>
+where
+    Q: Query<DB>,
+    Q::Key: ToOwned,
+    <Q::Key as ToOwned>::Owned: Eq + Hash + Clone,
+    Q::Value: From<u32>,
+    Q::Value: Into<u32>,
+    DB: Database,
+{
+    fn try_fetch(
+        &self,
+        db: &DB,
+        key: &Q::Key,
+        database_key: &DB::DatabaseKey,
+    ) -> Result<Q::Value, CycleDetected> {
+        let StampedValue { value, changed_at } = self.intern_index(db, key);
+
+        db.salsa_runtime()
+            .report_query_read(database_key, changed_at);
+
+        Ok(<Q::Value>::from(value.index))
+    }
+
+    fn maybe_changed_since(
+        &self,
+        db: &DB,
+        revision: Revision,
+        key: &Q::Key,
+        _database_key: &DB::DatabaseKey,
+    ) -> bool {
+        match self.intern_check(db, key) {
+            Some(StampedValue {
+                value: _,
+                changed_at,
+            }) => changed_at.changed_since(revision),
+            None => true,
+        }
+    }
+
+    fn is_constant(&self, _db: &DB, _key: &Q::Key) -> bool {
+        false
+    }
+
+    fn entries<C>(&self, _db: &DB) -> C
+    where
+        C: std::iter::FromIterator<TableEntry<Q::Key, Q::Value>>,
+    {
+        let tables = self.tables.read();
+        tables
+            .map
+            .iter()
+            .map(|(key, index)| TableEntry::new(key.clone(), Some(<Q::Value>::from(index.index))))
+            .collect()
+    }
+}
+
+impl<DB, Q> InternedQueryStorageOps<DB, Q> for InternedStorage<DB, Q>
+where
+    Q: Query<DB>,
+    Q::Key: ToOwned,
+    <Q::Key as ToOwned>::Owned: Eq + Hash + Clone,
+    Q::Value: From<u32>,
+    Q::Value: Into<u32>,
+    DB: Database,
+{
+    fn lookup(&self, db: &DB, value: Q::Value) -> Q::Key {
+        let index: u32 = value.into();
+        let StampedValue {
+            value,
+            changed_at: _,
+        } = self.lookup_value(db, index);
+
+        // XXX -- this setup is wrong, we can't report the read. We
+        // should create a *second* query that is linked to this query
+        // somehow. Or, at least, we need a distinct entry in the
+        // group key so that we can implement the "maybe changed" and
+        // all that stuff.
+
+        value
+    }
+}
+
+impl<DB, Q> QueryStorageMassOps<DB> for InternedStorage<DB, Q>
+where
+    Q: Query<DB>,
+    Q::Key: ToOwned,
+    Q::Value: From<u32>,
+    Q::Value: Into<u32>,
+    DB: Database,
+{
+    fn sweep(&self, db: &DB, strategy: SweepStrategy) {
+        let mut tables = self.tables.write();
+        let revision_now = db.salsa_runtime().current_revision();
+        let InternTables {
+            map,
+            values,
+            first_free,
+        } = &mut *tables;
+        map.retain(|key, intern_index| {
+            let discard = match strategy.discard_if {
+                DiscardIf::Never => false,
+                DiscardIf::Outdated => match values[intern_index.index()] {
+                    InternValue::Present { accessed_at, .. } => accessed_at < revision_now,
+
+                    InternValue::Free { .. } => {
+                        panic!(
+                            "key {:?} maps to index {:?} which is free",
+                            key, intern_index
+                        );
+                    }
+                },
+                DiscardIf::Always => false,
+            };
+
+            if discard {
+                values[intern_index.index()] = InternValue::Free { next: *first_free };
+                *first_free = Some(*intern_index);
+            }
+
+            !discard
+        });
+    }
+}

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -479,7 +479,7 @@ where
                         );
                     }
                 },
-                DiscardIf::Always => false,
+                DiscardIf::Always => true,
             };
 
             if discard {

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -84,7 +84,7 @@ impl InternKey for usize {
     }
 
     fn as_u32(&self) -> u32 {
-        assert!(*self < (std::u32::MAX as usize));
+        assert!(*self <= (std::u32::MAX as usize));
         *self as u32
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,7 +409,7 @@ pub trait Query<DB: Database>: Debug + Default + Sized + 'static {
     type Value: Clone + Debug;
 
     /// Internal struct storing the values for the query.
-    type Storage: plumbing::QueryStorageOps<DB, Self> + Send + Sync;
+    type Storage: plumbing::QueryStorageOps<DB, Self>;
 
     /// Associate query group struct.
     type Group: plumbing::QueryGroup<

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@ pub mod plumbing;
 
 use crate::plumbing::CycleDetected;
 use crate::plumbing::InputQueryStorageOps;
-use crate::plumbing::InternedQueryStorageOps;
 use crate::plumbing::QueryStorageMassOps;
 use crate::plumbing::QueryStorageOps;
 use derive_new::new;
@@ -463,17 +462,6 @@ where
                     .salsa_runtime()
                     .report_unexpected_cycle(database_key)
             })
-    }
-
-    /// For `#[salsa::interned]` queries only, does a reverse lookup
-    /// from the interned value (which must be some newtype'd integer)
-    /// to get the key that was interned.
-    pub fn lookup(&self, value: Q::Value) -> Q::Key
-    where
-        Q::Storage: plumbing::InternedQueryStorageOps<DB, Q>,
-        Q::Value: InternKey,
-    {
-        self.storage.lookup(self.db, value)
     }
 
     /// Remove all values for this query that have not been used in

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ use derive_new::new;
 use std::fmt::{self, Debug};
 use std::hash::Hash;
 
+pub use crate::interned::InternKey;
 pub use crate::runtime::Runtime;
 pub use crate::runtime::RuntimeId;
 
@@ -470,7 +471,7 @@ where
     pub fn lookup(&self, value: Q::Value) -> Q::Key
     where
         Q::Storage: plumbing::InternedQueryStorageOps<DB, Q>,
-        Q::Value: Into<u32>,
+        Q::Value: InternKey,
     {
         self.storage.lookup(self.db, value)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 
 mod derived;
 mod input;
+mod interned;
 mod runtime;
 
 pub mod debug;
@@ -20,6 +21,7 @@ pub mod plumbing;
 
 use crate::plumbing::CycleDetected;
 use crate::plumbing::InputQueryStorageOps;
+use crate::plumbing::InternedQueryStorageOps;
 use crate::plumbing::QueryStorageMassOps;
 use crate::plumbing::QueryStorageOps;
 use derive_new::new;
@@ -460,6 +462,17 @@ where
                     .salsa_runtime()
                     .report_unexpected_cycle(database_key)
             })
+    }
+
+    /// For `#[salsa::interned]` queries only, does a reverse lookup
+    /// from the interned value (which must be some newtype'd integer)
+    /// to get the key that was interned.
+    pub fn lookup(&self, value: Q::Value) -> Q::Key
+    where
+        Q::Storage: plumbing::InternedQueryStorageOps<DB, Q>,
+        Q::Value: Into<u32>,
+    {
+        self.storage.lookup(self.db, value)
     }
 
     /// Remove all values for this query that have not been used in

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -189,7 +189,6 @@ pub trait InternedQueryStorageOps<DB, Q>: Default
 where
     DB: Database,
     Q: Query<DB>,
-    Q::Value: Into<u32>,
 {
     fn lookup(&self, db: &DB, value: Q::Value) -> Q::Key;
 }

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -14,6 +14,7 @@ pub use crate::derived::MemoizedStorage;
 pub use crate::derived::VolatileStorage;
 pub use crate::input::InputStorage;
 pub use crate::interned::InternedStorage;
+pub use crate::interned::LookupInternedStorage;
 pub use crate::runtime::Revision;
 
 pub struct CycleDetected;
@@ -182,15 +183,6 @@ where
     fn entries<C>(&self, db: &DB) -> C
     where
         C: std::iter::FromIterator<TableEntry<Q::Key, Q::Value>>;
-}
-
-/// An optional trait that is implemented for "interned" storage.
-pub trait InternedQueryStorageOps<DB, Q>: Default
-where
-    DB: Database,
-    Q: Query<DB>,
-{
-    fn lookup(&self, db: &DB, value: Q::Value) -> Q::Key;
 }
 
 /// An optional trait that is implemented for "user mutable" storage:

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -13,6 +13,7 @@ pub use crate::derived::DependencyStorage;
 pub use crate::derived::MemoizedStorage;
 pub use crate::derived::VolatileStorage;
 pub use crate::input::InputStorage;
+pub use crate::interned::InternedStorage;
 pub use crate::runtime::Revision;
 
 pub struct CycleDetected;
@@ -181,6 +182,16 @@ where
     fn entries<C>(&self, db: &DB) -> C
     where
         C: std::iter::FromIterator<TableEntry<Q::Key, Q::Value>>;
+}
+
+/// An optional trait that is implemented for "interned" storage.
+pub trait InternedQueryStorageOps<DB, Q>: Default
+where
+    DB: Database,
+    Q: Query<DB>,
+    Q::Value: Into<u32>,
+{
+    fn lookup(&self, db: &DB, value: Q::Value) -> Q::Key;
 }
 
 /// An optional trait that is implemented for "user mutable" storage:

--- a/tests/gc/db.rs
+++ b/tests/gc/db.rs
@@ -1,8 +1,9 @@
 use crate::group;
 use crate::interned;
 use crate::log::{HasLog, Log};
+use crate::volatile_tests;
 
-#[salsa::database(group::Gc, interned::Intern)]
+#[salsa::database(group::Gc, interned::Intern, volatile_tests::Volatile)]
 #[derive(Default)]
 pub(crate) struct DatabaseImpl {
     runtime: salsa::Runtime<DatabaseImpl>,

--- a/tests/gc/db.rs
+++ b/tests/gc/db.rs
@@ -1,7 +1,8 @@
 use crate::group;
+use crate::interned;
 use crate::log::{HasLog, Log};
 
-#[salsa::database(group::Gc)]
+#[salsa::database(group::Gc, interned::Intern)]
 #[derive(Default)]
 pub(crate) struct DatabaseImpl {
     runtime: salsa::Runtime<DatabaseImpl>,

--- a/tests/gc/interned.rs
+++ b/tests/gc/interned.rs
@@ -1,0 +1,57 @@
+use crate::db;
+use salsa::{Database, SweepStrategy};
+
+#[salsa::query_group(Intern)]
+pub(crate) trait InternDatabase {
+    #[salsa::interned]
+    fn intern_str(&self, x: &'static str) -> u32;
+
+    fn repeat_intern1(&self, x: &'static str) -> u32;
+
+    fn repeat_intern2(&self, x: &'static str) -> u32;
+}
+
+fn repeat_intern1(db: &impl InternDatabase, x: &'static str) -> u32 {
+    db.intern_str(x)
+}
+
+fn repeat_intern2(db: &impl InternDatabase, x: &'static str) -> u32 {
+    db.intern_str(x)
+}
+
+/// This test highlights the difference between *interned queries* and
+/// other non-input queries -- in particular, their results are not
+/// *deterministic*.  Therefore, we cannot GC values that were created
+/// in the current revision; that might cause us to re-execute the
+/// query twice on the same key during the same revision, which could
+/// yield different results each time, wreaking havoc. This test
+/// exercises precisely that scenario.
+#[test]
+fn discard_during_same_revision() {
+    let db = db::DatabaseImpl::default();
+
+    // This will assign index 0 for "foo".
+    let foo1a = db.repeat_intern1("foo");
+
+    // If we are not careful, this would remove the interned key for
+    // "foo".
+    db.query(InternStrQuery).sweep(
+        SweepStrategy::default()
+            .discard_everything()
+            .sweep_all_revisions(),
+    );
+
+    // This would then reuse index 0 for "bar".
+    let bar1 = db.intern_str("bar");
+
+    // And here we would assign index *1* to "foo".
+    let foo2 = db.repeat_intern2("foo");
+
+    // But we would still have a cached result, *from the same
+    // revision*, with the value 0. So that's inconsistent.
+    let foo1b = db.repeat_intern1("foo");
+
+    assert_ne!(foo2, bar1);
+    assert_eq!(foo1a, foo1b);
+    assert_eq!(foo1b, foo2);
+}

--- a/tests/gc/interned.rs
+++ b/tests/gc/interned.rs
@@ -105,4 +105,8 @@ fn discard_outdated() {
     assert_ne!(foo_from_rev0, foo_from_rev1);
     assert_ne!(foo_from_rev1, bar_from_rev1);
     assert_ne!(foo_from_rev1, baz_from_rev1);
+
+    assert_eq!(db.lookup_intern_str(foo_from_rev1), "foo");
+    assert_eq!(db.lookup_intern_str(bar_from_rev1), "bar");
+    assert_eq!(db.lookup_intern_str(baz_from_rev1), "baz");
 }

--- a/tests/gc/interned.rs
+++ b/tests/gc/interned.rs
@@ -1,13 +1,21 @@
 use crate::db;
 use salsa::{Database, SweepStrategy};
 
+/// Query group for tests for how interned keys interact with GC.
 #[salsa::query_group(Intern)]
 pub(crate) trait InternDatabase {
+    /// A dummy input that can be used to trigger a new revision.
+    #[salsa::input]
+    fn dummy(&self) -> ();
+
+    /// Underlying interning query.
     #[salsa::interned]
     fn intern_str(&self, x: &'static str) -> u32;
 
+    /// This just executes the intern query and returns the result.
     fn repeat_intern1(&self, x: &'static str) -> u32;
 
+    /// Same as `repeat_intern1`. =)
     fn repeat_intern2(&self, x: &'static str) -> u32;
 }
 
@@ -54,4 +62,47 @@ fn discard_during_same_revision() {
     assert_ne!(foo2, bar1);
     assert_eq!(foo1a, foo1b);
     assert_eq!(foo1b, foo2);
+}
+
+/// This test highlights the difference between *interned queries* and
+/// other non-input queries -- in particular, their results are not
+/// *deterministic*.  Therefore, we cannot GC values that were created
+/// in the current revision; that might cause us to re-execute the
+/// query twice on the same key during the same revision, which could
+/// yield different results each time, wreaking havoc. This test
+/// exercises precisely that scenario.
+#[test]
+fn discard_outdated() {
+    let mut db = db::DatabaseImpl::default();
+
+    let foo_from_rev0 = db.repeat_intern1("foo");
+    let bar_from_rev0 = db.repeat_intern1("bar");
+
+    // Trigger a new revision.
+    db.set_dummy(());
+
+    // In this revision, we use "bar".
+    let bar_from_rev1 = db.repeat_intern1("bar");
+
+    // This should collect "foo".
+    db.sweep_all(SweepStrategy::discard_outdated());
+
+    // This should be the same as before the GC, as bar
+    // is not outdated.
+    let bar2_from_rev1 = db.repeat_intern1("bar");
+
+    // This should re-use the index of "foo".
+    let baz_from_rev1 = db.repeat_intern1("baz");
+
+    // This should assign the next index to "foo".
+    let foo_from_rev1 = db.repeat_intern1("foo");
+
+    assert_eq!(bar_from_rev0, bar_from_rev1);
+    assert_eq!(bar_from_rev0, bar2_from_rev1);
+
+    assert_eq!(foo_from_rev0, baz_from_rev1);
+
+    assert_ne!(foo_from_rev0, foo_from_rev1);
+    assert_ne!(foo_from_rev1, bar_from_rev1);
+    assert_ne!(foo_from_rev1, baz_from_rev1);
 }

--- a/tests/gc/main.rs
+++ b/tests/gc/main.rs
@@ -16,3 +16,4 @@ mod group;
 mod interned;
 mod log;
 mod shallow_constant_tests;
+mod volatile_tests;

--- a/tests/gc/main.rs
+++ b/tests/gc/main.rs
@@ -13,5 +13,6 @@ mod db;
 mod derived_tests;
 mod discard_values;
 mod group;
+mod interned;
 mod log;
 mod shallow_constant_tests;

--- a/tests/gc/volatile_tests.rs
+++ b/tests/gc/volatile_tests.rs
@@ -1,0 +1,72 @@
+use crate::db;
+use salsa::{Database, SweepStrategy};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+
+/// Query group for tests for how interned keys interact with GC.
+#[salsa::query_group(Volatile)]
+pub(crate) trait VolatileDatabase {
+    #[salsa::input]
+    fn atomic_cell(&self) -> Arc<AtomicU32>;
+
+    /// Underlying volatile query.
+    #[salsa::volatile]
+    fn volatile(&self) -> u32;
+
+    /// This just executes the intern query and returns the result.
+    fn repeat1(&self) -> u32;
+
+    /// Same as `repeat_intern1`. =)
+    fn repeat2(&self) -> u32;
+}
+
+fn volatile(db: &impl VolatileDatabase) -> u32 {
+    db.atomic_cell().load(Ordering::SeqCst)
+}
+
+fn repeat1(db: &impl VolatileDatabase) -> u32 {
+    db.volatile()
+}
+
+fn repeat2(db: &impl VolatileDatabase) -> u32 {
+    db.volatile()
+}
+
+#[test]
+fn consistency_no_gc() {
+    let mut db = db::DatabaseImpl::default();
+
+    let cell = Arc::new(AtomicU32::new(22));
+
+    db.set_atomic_cell(cell.clone());
+
+    let v1 = db.repeat1();
+
+    cell.store(23, Ordering::SeqCst);
+
+    let v2 = db.repeat2();
+
+    assert_eq!(v1, v2);
+}
+
+#[test]
+fn consistency_with_gc() {
+    let mut db = db::DatabaseImpl::default();
+
+    let cell = Arc::new(AtomicU32::new(22));
+
+    db.set_atomic_cell(cell.clone());
+
+    let v1 = db.repeat1();
+
+    cell.store(23, Ordering::SeqCst);
+    db.query(VolatileQuery).sweep(
+        SweepStrategy::default()
+            .discard_everything()
+            .sweep_all_revisions(),
+    );
+
+    let v2 = db.repeat2();
+
+    assert_eq!(v1, v2);
+}

--- a/tests/gc/volatile_tests.rs
+++ b/tests/gc/volatile_tests.rs
@@ -1,34 +1,34 @@
 use crate::db;
 use salsa::{Database, SweepStrategy};
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 /// Query group for tests for how interned keys interact with GC.
 #[salsa::query_group(Volatile)]
 pub(crate) trait VolatileDatabase {
     #[salsa::input]
-    fn atomic_cell(&self) -> Arc<AtomicU32>;
+    fn atomic_cell(&self) -> Arc<AtomicUsize>;
 
     /// Underlying volatile query.
     #[salsa::volatile]
-    fn volatile(&self) -> u32;
+    fn volatile(&self) -> usize;
 
     /// This just executes the intern query and returns the result.
-    fn repeat1(&self) -> u32;
+    fn repeat1(&self) -> usize;
 
     /// Same as `repeat_intern1`. =)
-    fn repeat2(&self) -> u32;
+    fn repeat2(&self) -> usize;
 }
 
-fn volatile(db: &impl VolatileDatabase) -> u32 {
+fn volatile(db: &impl VolatileDatabase) -> usize {
     db.atomic_cell().load(Ordering::SeqCst)
 }
 
-fn repeat1(db: &impl VolatileDatabase) -> u32 {
+fn repeat1(db: &impl VolatileDatabase) -> usize {
     db.volatile()
 }
 
-fn repeat2(db: &impl VolatileDatabase) -> u32 {
+fn repeat2(db: &impl VolatileDatabase) -> usize {
     db.volatile()
 }
 
@@ -36,7 +36,7 @@ fn repeat2(db: &impl VolatileDatabase) -> u32 {
 fn consistency_no_gc() {
     let mut db = db::DatabaseImpl::default();
 
-    let cell = Arc::new(AtomicU32::new(22));
+    let cell = Arc::new(AtomicUsize::new(22));
 
     db.set_atomic_cell(cell.clone());
 
@@ -53,7 +53,7 @@ fn consistency_no_gc() {
 fn consistency_with_gc() {
     let mut db = db::DatabaseImpl::default();
 
-    let cell = Arc::new(AtomicU32::new(22));
+    let cell = Arc::new(AtomicUsize::new(22));
 
     db.set_atomic_cell(cell.clone());
 

--- a/tests/interned.rs
+++ b/tests/interned.rs
@@ -39,7 +39,7 @@ impl salsa::InternKey for InternKey {
 
 #[test]
 fn test_intern1() {
-    let mut db = Database::default();
+    let db = Database::default();
     let foo0 = db.intern1(format!("foo"));
     let bar0 = db.intern1(format!("bar"));
     let foo1 = db.intern1(format!("foo"));
@@ -55,7 +55,7 @@ fn test_intern1() {
 
 #[test]
 fn test_intern2() {
-    let mut db = Database::default();
+    let db = Database::default();
     let foo0 = db.intern2(format!("x"), format!("foo"));
     let bar0 = db.intern2(format!("x"), format!("bar"));
     let foo1 = db.intern2(format!("x"), format!("foo"));
@@ -71,7 +71,7 @@ fn test_intern2() {
 
 #[test]
 fn test_intern_key() {
-    let mut db = Database::default();
+    let db = Database::default();
     let foo0 = db.intern_key(format!("foo"));
     let bar0 = db.intern_key(format!("bar"));
     let foo1 = db.intern_key(format!("foo"));

--- a/tests/interned.rs
+++ b/tests/interned.rs
@@ -1,0 +1,88 @@
+//! Test that you can implement a query using a `dyn Trait` setup.
+
+#[salsa::database(InternStorage)]
+#[derive(Default)]
+struct Database {
+    runtime: salsa::Runtime<Database>,
+}
+
+impl salsa::Database for Database {
+    fn salsa_runtime(&self) -> &salsa::Runtime<Database> {
+        &self.runtime
+    }
+}
+
+#[salsa::query_group(InternStorage)]
+trait Intern {
+    #[salsa::interned]
+    fn intern1(&self, x: String) -> u32;
+
+    #[salsa::interned]
+    fn intern2(&self, x: String, y: String) -> u32;
+
+    #[salsa::interned]
+    fn intern_key(&self, x: String) -> InternKey;
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct InternKey(u32);
+
+impl From<u32> for InternKey {
+    fn from(v: u32) -> Self {
+        InternKey(v)
+    }
+}
+
+impl Into<u32> for InternKey {
+    fn into(self) -> u32 {
+        self.0
+    }
+}
+
+#[test]
+fn test_intern1() {
+    let mut db = Database::default();
+    let foo0 = db.intern1(format!("foo"));
+    let bar0 = db.intern1(format!("bar"));
+    let foo1 = db.intern1(format!("foo"));
+    let bar1 = db.intern1(format!("bar"));
+
+    assert_eq!(foo0, foo1);
+    assert_eq!(bar0, bar1);
+    assert_ne!(foo0, bar0);
+
+    assert_eq!(format!("foo"), db.lookup_intern1(foo0));
+    assert_eq!(format!("bar"), db.lookup_intern1(bar0));
+}
+
+#[test]
+fn test_intern2() {
+    let mut db = Database::default();
+    let foo0 = db.intern2(format!("x"), format!("foo"));
+    let bar0 = db.intern2(format!("x"), format!("bar"));
+    let foo1 = db.intern2(format!("x"), format!("foo"));
+    let bar1 = db.intern2(format!("x"), format!("bar"));
+
+    assert_eq!(foo0, foo1);
+    assert_eq!(bar0, bar1);
+    assert_ne!(foo0, bar0);
+
+    assert_eq!((format!("x"), format!("foo")), db.lookup_intern2(foo0));
+    assert_eq!((format!("x"), format!("bar")), db.lookup_intern2(bar0));
+}
+
+#[test]
+fn test_intern_key() {
+    let mut db = Database::default();
+    let foo0 = db.intern_key(format!("foo"));
+    let bar0 = db.intern_key(format!("bar"));
+    let foo1 = db.intern_key(format!("foo"));
+    let bar1 = db.intern_key(format!("bar"));
+
+    assert_eq!(foo0, foo1);
+    assert_eq!(bar0, bar1);
+    assert_ne!(foo0, bar0);
+
+    assert_eq!(format!("foo"), db.lookup_intern_key(foo0));
+    assert_eq!(format!("bar"), db.lookup_intern_key(bar0));
+}

--- a/tests/interned.rs
+++ b/tests/interned.rs
@@ -27,14 +27,12 @@ trait Intern {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct InternKey(u32);
 
-impl From<u32> for InternKey {
-    fn from(v: u32) -> Self {
+impl salsa::InternKey for InternKey {
+    fn from_u32(v: u32) -> Self {
         InternKey(v)
     }
-}
 
-impl Into<u32> for InternKey {
-    fn into(self) -> u32 {
+    fn as_u32(&self) -> u32 {
         self.0
     }
 }


### PR DESCRIPTION
This is a WIP PR. It adds a new kind of salsa key, `#[salsa::interned]`. This uses an internal storage that maps key values to an integral value. So the query might look like:

```rust
    #[salsa::interned]
    fn intern1(&self, x: String) -> u32;
```

For every interned key, there will automatically be a `lookup_intern1` method added as well. Also, the return type does not have to be `u32`, it can be any newtype of `u32` so long as it implements the `salsa::InternKey` trait. So you can do something like this:

```rust
    #[salsa::interned]
    fn intern_key(&self, x: String) -> InternKeyType;
```

where `InternKeyType` implements `salsa::InternKey`. The `InternKey` trait is very simple:

```rust
/// Trait implemented for the "key" that results from a
/// `#[salsa::intern]` query.  This is basically meant to be a
/// "newtype"'d `u32`.
pub trait InternKey {
    /// Create an instance of the intern-key from a `u32` value.
    fn from_u32(v: u32) -> Self;

    /// Extract the `u32` with which the intern-key was created.
    fn as_u32(&self) -> u32;
}
```

These interned keys are fully integrated into the salsa change tracking in the usual way. That means, for example, that they inter-operate with the garbage collector, so we can cleanup keys that are no longer used -- or, alternatively, you can clear the set of interned keys and we will figure out all the things that may have referenced them and recompute those things.

There is some slight overhead over top of a standard interning scheme. In particular, we have to track the revision where a given key was interned and accessed in order to interoperate smoothly with GC. We might be able to be clever here, I've not thought about that in some time. (Also, to be honest, I wrote this code mostly during the Rust All Hands, and there may be some FIXMEs or something.)

The motivation behind this is that it turns out to be pretty common for salsa-like schemes to require interning, and this makes it very easy and convenient to do. (And lets us optimize at the same time.)