### PR TITLE
Removed remaining stray bounds for `Send + Sync` that still survived PR #42 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -406,7 +406,7 @@ pub trait Query<DB: Database>: Debug + Default + Sized + 'static {
     type Value: Clone + Debug;
 
     /// Internal struct storing the values for the query.
-    type Storage: plumbing::QueryStorageOps<DB, Self> + Send + Sync;
+    type Storage: plumbing::QueryStorageOps<DB, Self>;
 
     /// Associate query group struct.
     type Group: plumbing::QueryGroup<

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -49,7 +49,7 @@ pub trait QueryStorageMassOps<DB: Database> {
     fn sweep(&self, db: &DB, strategy: SweepStrategy);
 }
 
-pub trait DatabaseKey<DB>: Clone + Debug + Eq + Hash + Send + Sync {
+pub trait DatabaseKey<DB>: Clone + Debug + Eq + Hash {
     /// Returns true if the value of this query may have changed since
     /// the given revision.
     fn maybe_changed_since(&self, db: &DB, revision: Revision) -> bool;

--- a/tests/no_send_sync.rs
+++ b/tests/no_send_sync.rs
@@ -1,0 +1,35 @@
+#[macro_use]
+extern crate salsa;
+
+use std::rc::Rc;
+
+// #[derive(Clone, PartialEq, Eq, Debug)]
+// struct Dummy;
+
+#[salsa::query_group(NoSendStorage)]
+trait NoSendDatabase: salsa::Database {
+    fn query(&self, key: ()) -> Rc<bool>;
+}
+
+fn query(db: &impl NoSendDatabase, (): ()) -> Rc<bool> {
+    Rc::new(true)
+}
+
+#[salsa::database(NoSendStorage)]
+#[derive(Default)]
+struct DatabaseImpl {
+    runtime: salsa::Runtime<DatabaseImpl>,
+}
+
+impl salsa::Database for DatabaseImpl {
+    fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseImpl> {
+        &self.runtime
+    }
+}
+
+#[test]
+fn no_send_sync() {
+    let mut db = DatabaseImpl::default();
+
+    db.query(());
+}


### PR DESCRIPTION
This removes the last remaining uses of `: Send + Sync`, fixing https://github.com/salsa-rs/salsa/issues/152.