### PR TITLE
adopt raw-id for interned keys

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 mod derived;
 mod input;
 mod interned;
+mod raw_id;
 mod runtime;
 
 pub mod debug;
@@ -28,6 +29,7 @@ use std::fmt::{self, Debug};
 use std::hash::Hash;
 
 pub use crate::interned::InternKey;
+pub use crate::raw_id::RawId;
 pub use crate::runtime::Runtime;
 pub use crate::runtime::RuntimeId;
 

--- a/src/raw_id.rs
+++ b/src/raw_id.rs
@@ -1,0 +1,103 @@
+use std::fmt;
+
+/// The "raw-id" is used for interned keys in salsa. Typically, it is
+/// wrapped in a type of your own devising. For more information about
+/// interned keys, see [the interned key RFC][rfc].
+///
+/// # Creating a `RawId`
+//
+/// RawId values can be constructed using the `From` impls,
+/// which are implemented for `u32` and `usize`:
+///
+/// ```
+/// # use salsa::RawId;
+/// let raw_id = RawId::from(22_u32);
+/// ```
+///
+/// You can then convert back to a `u32` like so:
+///
+/// ```
+/// # use salsa::RawId;
+/// # let raw_id = RawId::from(22_u32);
+/// let value = u32::from(raw_id);
+/// assert_eq!(value, 22);
+/// ```
+///
+/// ## Illegal values
+///
+/// Be warned, however, that `RawId` values cannot be created from
+/// *arbitrary* values -- in particular large values greater than
+/// `RawId::MAX` will panic. Those large values are reserved so that
+/// the Rust compiler can use them as sentinel values, which means
+/// that (for example) `Option<RawId>` is represented in a single
+/// word.
+///
+/// ```should_panic
+/// # use salsa::RawId;
+/// RawId::from(RawId::MAX);
+/// ```
+///
+/// [rfc]: https://github.com/salsa-rs/salsa-rfcs/pull/2
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RawId {
+    value: u32,
+}
+
+impl RawId {
+    /// The maximum allowed `RawId`. This value can grow between
+    /// releases without affecting semver.
+    pub const MAX: u32 = 0xFFFF_FF00;
+
+    unsafe fn new_unchecked(value: u32) -> Self {
+        debug_assert!(value < RawId::MAX);
+        RawId { value }
+    }
+
+    /// Convert this raw-id into a u32 value.
+    pub fn as_u32(self) -> u32 {
+        self.value
+    }
+
+    /// Convert this raw-id into a usize value.
+    pub fn as_usize(self) -> usize {
+        self.value as usize
+    }
+}
+
+impl From<RawId> for u32 {
+    fn from(raw: RawId) -> u32 {
+        raw.value
+    }
+}
+
+impl From<RawId> for usize {
+    fn from(raw: RawId) -> usize {
+        raw.value as usize
+    }
+}
+
+impl From<u32> for RawId {
+    fn from(id: u32) -> RawId {
+        assert!(id < RawId::MAX);
+        unsafe { RawId::new_unchecked(id) }
+    }
+}
+
+impl From<usize> for RawId {
+    fn from(id: usize) -> RawId {
+        assert!(id < (RawId::MAX as usize));
+        unsafe { RawId::new_unchecked(id as u32) }
+    }
+}
+
+impl fmt::Debug for RawId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.value.fmt(f)
+    }
+}
+
+impl fmt::Display for RawId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.value.fmt(f)
+    }
+}

--- a/src/raw_id.rs
+++ b/src/raw_id.rs
@@ -2,8 +2,8 @@ use std::fmt;
 use std::num::NonZeroU32;
 
 /// The "raw-id" is used for interned keys in salsa -- it is basically
-/// a newtype'd integer. Typically, it is wrapped in a type of your
-/// own devising. For more information about interned keys, see [the
+/// a newtype'd u32. Typically, it is wrapped in a type of your own
+/// devising. For more information about interned keys, see [the
 /// interned key RFC][rfc].
 ///
 /// # Creating a `RawId`
@@ -18,23 +18,16 @@ use std::num::NonZeroU32;
 /// assert_eq!(raw_id1, raw_id2);
 /// ```
 ///
-/// # Converting to a usize
+/// # Converting to a u32 or usize
 ///
 /// Normally, there should be no need to access the underlying integer
 /// in a `RawId`. But if you do need to do so, you can convert to a
-/// `usize` using the `as_usize` method or the `From` impl.
+/// `usize` using the `as_u32` or `as_usize` methods or the `From` impls.
 ///
 /// ```
 /// # use salsa::RawId;
 /// let raw_id = RawId::from(22_u32);
-/// let value = raw_id.as_usize();
-/// assert_eq!(value, 22);
-/// ```
-///
-/// ```
-/// # use salsa::RawId;
-/// let raw_id = RawId::from(22_u32);
-/// let value = usize::from(raw_id);
+/// let value = u32::from(raw_id);
 /// assert_eq!(value, 22);
 /// ```
 ///
@@ -72,9 +65,34 @@ impl RawId {
         }
     }
 
+    /// Convert this raw-id into a u32 value.
+    ///
+    /// ```
+    /// # use salsa::RawId;
+    /// let raw_id = RawId::from(22_u32);
+    /// let value = raw_id.as_usize();
+    /// assert_eq!(value, 22);
+    /// ```
+    pub fn as_u32(self) -> u32 {
+        self.value.get() - 1
+    }
+
     /// Convert this raw-id into a usize value.
+    ///
+    /// ```
+    /// # use salsa::RawId;
+    /// let raw_id = RawId::from(22_u32);
+    /// let value = raw_id.as_usize();
+    /// assert_eq!(value, 22);
+    /// ```
     pub fn as_usize(self) -> usize {
-        (self.value.get() - 1) as usize
+        self.as_u32() as usize
+    }
+}
+
+impl From<RawId> for u32 {
+    fn from(raw: RawId) -> u32 {
+        raw.as_u32()
     }
 }
 

--- a/src/raw_id.rs
+++ b/src/raw_id.rs
@@ -1,8 +1,9 @@
 use std::fmt;
 
-/// The "raw-id" is used for interned keys in salsa. Typically, it is
-/// wrapped in a type of your own devising. For more information about
-/// interned keys, see [the interned key RFC][rfc].
+/// The "raw-id" is used for interned keys in salsa -- it is basically
+/// a newtype'd integer. Typically, it is wrapped in a type of your
+/// own devising. For more information about interned keys, see [the
+/// interned key RFC][rfc].
 ///
 /// # Creating a `RawId`
 //
@@ -11,15 +12,28 @@ use std::fmt;
 ///
 /// ```
 /// # use salsa::RawId;
-/// let raw_id = RawId::from(22_u32);
+/// let raw_id1 = RawId::from(22_u32);
+/// let raw_id2 = RawId::from(22_usize);
+/// assert_eq!(raw_id1, raw_id2);
 /// ```
 ///
-/// You can then convert back to a `u32` like so:
+/// # Converting to a usize
+///
+/// Normally, there should be no need to access the underlying integer
+/// in a `RawId`. But if you do need to do so, you can convert to a
+/// `usize` using the `as_usize` method or the `From` impl.
 ///
 /// ```
 /// # use salsa::RawId;
-/// # let raw_id = RawId::from(22_u32);
-/// let value = u32::from(raw_id);
+/// let raw_id = RawId::from(22_u32);
+/// let value = raw_id.as_usize();
+/// assert_eq!(value, 22);
+/// ```
+///
+/// ```
+/// # use salsa::RawId;
+/// let raw_id = RawId::from(22_u32);
+/// let value = usize::from(raw_id);
 /// assert_eq!(value, 22);
 /// ```
 ///
@@ -53,20 +67,9 @@ impl RawId {
         RawId { value }
     }
 
-    /// Convert this raw-id into a u32 value.
-    pub fn as_u32(self) -> u32 {
-        self.value
-    }
-
     /// Convert this raw-id into a usize value.
     pub fn as_usize(self) -> usize {
         self.value as usize
-    }
-}
-
-impl From<RawId> for u32 {
-    fn from(raw: RawId) -> u32 {
-        raw.value
     }
 }
 

--- a/tests/gc/interned.rs
+++ b/tests/gc/interned.rs
@@ -1,5 +1,5 @@
 use crate::db;
-use salsa::{Database, SweepStrategy};
+use salsa::{Database, RawId, SweepStrategy};
 
 /// Query group for tests for how interned keys interact with GC.
 #[salsa::query_group(Intern)]
@@ -10,20 +10,20 @@ pub(crate) trait InternDatabase {
 
     /// Underlying interning query.
     #[salsa::interned]
-    fn intern_str(&self, x: &'static str) -> u32;
+    fn intern_str(&self, x: &'static str) -> RawId;
 
     /// This just executes the intern query and returns the result.
-    fn repeat_intern1(&self, x: &'static str) -> u32;
+    fn repeat_intern1(&self, x: &'static str) -> RawId;
 
     /// Same as `repeat_intern1`. =)
-    fn repeat_intern2(&self, x: &'static str) -> u32;
+    fn repeat_intern2(&self, x: &'static str) -> RawId;
 }
 
-fn repeat_intern1(db: &impl InternDatabase, x: &'static str) -> u32 {
+fn repeat_intern1(db: &impl InternDatabase, x: &'static str) -> RawId {
     db.intern_str(x)
 }
 
-fn repeat_intern2(db: &impl InternDatabase, x: &'static str) -> u32 {
+fn repeat_intern2(db: &impl InternDatabase, x: &'static str) -> RawId {
     db.intern_str(x)
 }
 

--- a/tests/interned.rs
+++ b/tests/interned.rs
@@ -1,5 +1,7 @@
 //! Test that you can implement a query using a `dyn Trait` setup.
 
+use salsa::RawId;
+
 #[salsa::database(InternStorage)]
 #[derive(Default)]
 struct Database {
@@ -23,24 +25,24 @@ impl salsa::ParallelDatabase for Database {
 #[salsa::query_group(InternStorage)]
 trait Intern {
     #[salsa::interned]
-    fn intern1(&self, x: String) -> u32;
+    fn intern1(&self, x: String) -> RawId;
 
     #[salsa::interned]
-    fn intern2(&self, x: String, y: String) -> u32;
+    fn intern2(&self, x: String, y: String) -> RawId;
 
     #[salsa::interned]
     fn intern_key(&self, x: String) -> InternKey;
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct InternKey(u32);
+pub struct InternKey(RawId);
 
 impl salsa::InternKey for InternKey {
-    fn from_u32(v: u32) -> Self {
+    fn from_raw_id(v: RawId) -> Self {
         InternKey(v)
     }
 
-    fn as_u32(&self) -> u32 {
+    fn as_raw_id(&self) -> RawId {
         self.0
     }
 }


### PR DESCRIPTION
Per @matklad's suggestion, create a `RawId` type and use it in place of `u32` for interned keys.