### PR TITLE
publish v0.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"
@@ -16,7 +16,7 @@ lock_api = "0.1.4"
 indexmap = "1.0.1"
 log = "0.4.5"
 smallvec = "0.6.5"
-salsa-macros = { version = "0.11.1", path = "components/salsa-macros" }
+salsa-macros = { version = "0.12.0", path = "components/salsa-macros" }
 
 [dev-dependencies]
 diff = "0.1.0"

--- a/components/salsa-macros/Cargo.toml
+++ b/components/salsa-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa-macros"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
- Introduce `InternId` as the basis for interned keys, replacing
  `u32` (#157, #158)
- Support keys/values that are not `Send/Sync` (#153)