### PR TITLE
Improve doc comments generation

### DIFF
--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -208,24 +208,33 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
             let set_constant_fn_name =
                 Ident::new(&format!("set_constant_{}", fn_name), fn_name.span());
 
+            let set_fn_docs = format!("
+                Set the value of the `{fn_name}` input.
+
+                See `{fn_name}` for details.
+
+                *Note:* Setting values will trigger cancellation
+                of any ongoing queries; this method blocks until
+                those queries have been cancelled.
+            ", fn_name = fn_name);
+
+            let set_constant_fn_docs = format!("
+                Set the value of the `{fn_name}` input and promise
+                that its value will never change again.
+
+                See `{fn_name}` for details.
+
+                *Note:* Setting values will trigger cancellation
+                of any ongoing queries; this method blocks until
+                those queries have been cancelled.
+            ", fn_name = fn_name);
+
             query_fn_declarations.extend(quote! {
-                /// Set the value of the `#fn_name` input.
-                ///
-                /// See [`#fn_name()`][] for details.
-                ///
-                /// *Note:* Setting values will trigger cancellation
-                /// of any ongoing queries; this method blocks until
-                /// those queries have been cancelled.
+                # [doc = #set_fn_docs]
                 fn #set_fn_name(&mut self, #(#key_names: #keys,)* value__: #value);
 
-                /// Set the value of the `#fn_name` input and promise
-                /// that its value will never change again.
-                ///
-                /// See [`#fn_name()`][] for details.
-                ///
-                /// *Note:* Setting values will trigger cancellation
-                /// of any ongoing queries; this method blocks until
-                /// those queries have been cancelled.
+
+                # [doc = #set_constant_fn_docs]
                 fn #set_constant_fn_name(&mut self, #(#key_names: #keys,)* value__: #value);
             });
 


### PR DESCRIPTION
This is just a silly detail but I noticed that the auto-generated documentation for `salsa::query_group` does not interpolate the method names correctly. It's a bit unfortunate to deal with string formatting though :disappointed: 

I could generate a more precise markdown link to `fn_name` but I feel it'd a bit fragile?

<details>
<summary>Before</summary>

![before](https://user-images.githubusercontent.com/1636604/55669541-d129ad00-5878-11e9-9b9f-b5acfeec4e11.png)

</details>

<details>
<summary>After</summary>

![after](https://user-images.githubusercontent.com/1636604/55669544-d555ca80-5878-11e9-93d4-db7f7f2273c4.png)

</details>
