### PR TITLE
Remove mention of unsupported '&mut self' in a query group panic

### DIFF
--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -87,7 +87,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
                 match iter.next() {
                     Some(FnArg::SelfRef(sr)) if sr.mutability.is_none() => (),
                     _ => panic!(
-                        "first argument of query `{}` must be `&self` or `&mut self`",
+                        "first argument of query `{}` must be `&self`",
                         method.sig.ident
                     ),
                 }


### PR DESCRIPTION
Closes #161

I am not sure if this is entirely correct only because the code doesn't "read right" to me.

If the `SelfRef`'s `mutability` is `None` (so it is `&self`, I _assume_) panic saying you must use `&self`.

Is this correct?