### PR TITLE
Add transparent query type

### DIFF
--- a/tests/transparent.rs
+++ b/tests/transparent.rs
@@ -1,0 +1,44 @@
+//! Test that transparent (uncached) queries work
+
+#[salsa::query_group(QueryGroupStorage)]
+trait QueryGroup {
+    #[salsa::input]
+    fn input(&self, x: u32) -> u32;
+    #[salsa::transparent]
+    fn wrap(&self, x: u32) -> u32;
+    fn get(&self, x: u32) -> u32;
+}
+
+fn wrap(db: &impl QueryGroup, x: u32) -> u32 {
+    db.input(x)
+}
+
+fn get(db: &impl QueryGroup, x: u32) -> u32 {
+    db.wrap(x)
+}
+
+
+#[salsa::database(QueryGroupStorage)]
+#[derive(Default)]
+struct Database {
+    runtime: salsa::Runtime<Database>,
+}
+
+impl salsa::Database for Database {
+    fn salsa_runtime(&self) -> &salsa::Runtime<Database> {
+        &self.runtime
+    }
+}
+
+#[test]
+fn transparent_queries_work() {
+    let mut db = Database::default();
+
+    db.set_input(1, 10);
+    assert_eq!(db.get(1), 10);
+    assert_eq!(db.get(1), 10);
+
+    db.set_input(1, 92);
+    assert_eq!(db.get(1), 92);
+    assert_eq!(db.get(1), 92);
+}


### PR DESCRIPTION
Transparent queries are not really queries: they are just plain
uncached functions without any backing storage.

Making a query transparent can be useful to figure out if caching it
at all is a win.

Context:

I need this in rust-analyzer. I want to change the input to the system from files with `String` contents to a roughly pair of `(String, Mutex<Option<CachedSyntaxTree>>)`, such that I can implement LRU eviction of syntax trees outside of salsa. Currently `parse(FIleId) -> SyntaxTree` is a query, and I'd love to preserve this API. However, if `parse` will be caching trees in any way, that would completely undo any eviction I implement :-) 