### PR TITLE
introduce slots

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ description = "A generic framework for on-demand, incrementalized computation (e
 readme = "README.md"
 
 [dependencies]
+crossbeam = "0.7.1"
 derive-new = "0.5.5"
 indexmap = "1.0.1"
 lock_api = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,16 @@ description = "A generic framework for on-demand, incrementalized computation (e
 readme = "README.md"
 
 [dependencies]
+arc-swap = "0.3"
 derive-new = "0.5.5"
-rustc-hash = "1.0"
-parking_lot = "0.8.0"
-lock_api = "0.2.0"
 indexmap = "1.0.1"
+linked-hash-map = "0.5.2"
+lock_api = "0.2.0"
 log = "0.4.5"
+parking_lot = "0.8.0"
+rustc-hash = "1.0"
 smallvec = "0.6.5"
 salsa-macros = { version = "0.13.0", path = "components/salsa-macros" }
-linked-hash-map = "0.5.2"
 
 [dev-dependencies]
 diff = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,20 +9,19 @@ description = "A generic framework for on-demand, incrementalized computation (e
 readme = "README.md"
 
 [dependencies]
-arc-swap = "0.3"
 derive-new = "0.5.5"
 indexmap = "1.0.1"
-linked-hash-map = "0.5.2"
 lock_api = "0.2.0"
 log = "0.4.5"
 parking_lot = "0.8.0"
 rustc-hash = "1.0"
 smallvec = "0.6.5"
 salsa-macros = { version = "0.13.0", path = "components/salsa-macros" }
+rand = "0.6"
 
 [dev-dependencies]
 diff = "0.1.0"
 env_logger = "0.5.13"
-rand = "0.5.5"
+linked-hash-map = "0.5.2"
 
 [workspace]

--- a/components/salsa-macros/src/database_storage.rs
+++ b/components/salsa-macros/src/database_storage.rs
@@ -144,29 +144,8 @@ pub(crate) fn database(args: TokenStream, input: TokenStream) -> TokenStream {
         }
     });
 
-    let mut for_each_query_desc = proc_macro2::TokenStream::new();
-    for query_group in query_groups {
-        let group_name = query_group.name();
-        for_each_query_desc.extend(quote! {
-            __SalsaDatabaseKeyKind::#group_name(database_key) => database_key.maybe_changed_since(
-                db,
-                self,
-                revision,
-            ),
-        });
-    }
-
     output.extend(quote! {
         impl salsa::plumbing::DatabaseKey<#database_name> for __SalsaDatabaseKey {
-            fn maybe_changed_since(
-                &self,
-                db: &#database_name,
-                revision: salsa::plumbing::Revision,
-            ) -> bool {
-                match &self.kind {
-                    #for_each_query_desc
-                }
-            }
         }
     });
 

--- a/components/salsa-macros/src/database_storage.rs
+++ b/components/salsa-macros/src/database_storage.rs
@@ -114,11 +114,20 @@ pub(crate) fn database(args: TokenStream, input: TokenStream) -> TokenStream {
         }
     });
 
+    // Create a tuple (D1, D2, ...) where Di is the data for a given query group.
+    let mut database_data = vec![];
+    for QueryGroup { group_path } in query_groups {
+        database_data.push(quote! {
+            <#group_path as salsa::plumbing::QueryGroup<#database_name>>::GroupData
+        });
+    }
+
     //
     output.extend(quote! {
         impl salsa::plumbing::DatabaseStorageTypes for #database_name {
             type DatabaseKey = __SalsaDatabaseKey;
             type DatabaseStorage = __SalsaDatabaseStorage;
+            type DatabaseData = (#(#database_data),*);
         }
     });
 

--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -184,6 +184,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
     let mut query_fn_declarations = proc_macro2::TokenStream::new();
     let mut query_fn_definitions = proc_macro2::TokenStream::new();
     let mut query_descriptor_variants = proc_macro2::TokenStream::new();
+    let mut group_data_elements = vec![];
     let mut storage_fields = proc_macro2::TokenStream::new();
     let mut storage_defaults = proc_macro2::TokenStream::new();
     for query in &queries {
@@ -277,6 +278,11 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
             #fn_name((#(#keys),*)),
         });
 
+        // Entry for the query group data tuple
+        group_data_elements.push(quote! {
+            (#(#keys,)* #value)
+        });
+
         // A field for the storage struct
         //
         // FIXME(#120): the pub should not be necessary once we complete the transition
@@ -310,6 +316,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
         {
             type GroupStorage = #group_storage<DB__>;
             type GroupKey = #group_key;
+            type GroupData = (#(#group_data_elements),*);
         }
     });
 

--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -367,7 +367,9 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
             #[derive(Default, Debug)]
             #trait_vis struct #qt;
 
-            impl<#db> salsa::Query<#db> for #qt
+            // Unsafe proof obligation: that our key/value are a part
+            // of the `GroupData`.
+            unsafe impl<#db> salsa::Query<#db> for #qt
             where
                 DB: #trait_name + #requires,
                 DB: salsa::plumbing::HasQueryGroup<#group_struct>,

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -57,8 +57,7 @@ where
     type Value = Q::Value;
 
     fn is_constant(&self, key: Q::Key) -> bool {
-        let database_key = DB::database_key(self.db, key.clone());
-        self.storage.is_constant(self.db, &key, &database_key)
+        self.storage.is_constant(self.db, &key)
     }
 
     fn entries<C>(&self) -> C

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -57,7 +57,8 @@ where
     type Value = Q::Value;
 
     fn is_constant(&self, key: Q::Key) -> bool {
-        self.storage.is_constant(self.db, &key)
+        let database_key = DB::database_key(self.db, key.clone());
+        self.storage.is_constant(self.db, &key, &database_key)
     }
 
     fn entries<C>(&self) -> C

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -1,0 +1,58 @@
+use crate::runtime::Revision;
+use crate::Database;
+use std::fmt::Debug;
+use std::hash::Hasher;
+use std::sync::Arc;
+
+/// Each kind of query exports a "slot".
+pub(crate) trait DatabaseSlot<DB: Database>: Debug {
+    /// Returns true if the value of this query may have changed since
+    /// the given revision.
+    fn maybe_changed_since(&self, db: &DB, revision: Revision) -> bool;
+}
+
+pub(crate) struct Dependency<DB: Database> {
+    slot: Arc<dyn DatabaseSlot<DB> + Send + Sync>,
+}
+
+impl<DB: Database> Dependency<DB> {
+    pub(crate) fn new(slot: Arc<dyn DatabaseSlot<DB> + '_>) -> Self {
+        // Forgive me for I am a horrible monster and pray for death:
+        //
+        // Hiding these bounds behind a trait object is a total hack
+        // but I just want to see how well this works. -nikomatsakis
+        let slot: Arc<dyn DatabaseSlot<DB> + Send + Sync> = unsafe { std::mem::transmute(slot) };
+        Self { slot }
+    }
+
+    fn raw_slot(&self) -> *const dyn DatabaseSlot<DB> {
+        &*self.slot
+    }
+
+    pub(crate) fn maybe_changed_since(&self, db: &DB, revision: Revision) -> bool {
+        self.slot.maybe_changed_since(db, revision)
+    }
+}
+
+impl<DB: Database> std::hash::Hash for Dependency<DB> {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.raw_slot().hash(state)
+    }
+}
+
+impl<DB: Database> std::cmp::PartialEq for Dependency<DB> {
+    fn eq(&self, other: &Self) -> bool {
+        self.raw_slot() == other.raw_slot()
+    }
+}
+
+impl<DB: Database> std::cmp::Eq for Dependency<DB> {}
+
+impl<DB: Database> std::fmt::Debug for Dependency<DB> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.slot.fmt(fmt)
+    }
+}

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -21,10 +21,9 @@ pub(crate) struct Dependency<DB: Database> {
 
 impl<DB: Database> Dependency<DB> {
     pub(crate) fn new(slot: Arc<dyn DatabaseSlot<DB> + '_>) -> Self {
-        // Forgive me for I am a horrible monster and pray for death:
-        //
-        // Hiding these bounds behind a trait object is a total hack
-        // but I just want to see how well this works. -nikomatsakis
+        // Unsafety note: It is safe to 'pretend' the trait object is
+        // Send+Sync+'static because the phantom-data will reflect the
+        // reality.
         let slot: Arc<dyn DatabaseSlot<DB> + Send + Sync> = unsafe { std::mem::transmute(slot) };
         Self {
             slot,

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -1,6 +1,7 @@
 use crate::debug::TableEntry;
 use crate::lru::Lru;
 use crate::plumbing::CycleDetected;
+use crate::plumbing::HasQueryGroup;
 use crate::plumbing::LruQueryStorageOps;
 use crate::plumbing::QueryFunction;
 use crate::plumbing::QueryStorageMassOps;
@@ -31,7 +32,7 @@ pub type DependencyStorage<DB, Q> = DerivedStorage<DB, Q, NeverMemoizeValue>;
 pub struct DerivedStorage<DB, Q, MP>
 where
     Q: QueryFunction<DB>,
-    DB: Database,
+    DB: Database + HasQueryGroup<Q::Group>,
     MP: MemoizationPolicy<DB, Q>,
 {
     lru_list: Lru<Slot<DB, Q, MP>>,
@@ -42,7 +43,7 @@ where
 impl<DB, Q, MP> std::panic::RefUnwindSafe for DerivedStorage<DB, Q, MP>
 where
     Q: QueryFunction<DB>,
-    DB: Database,
+    DB: Database + HasQueryGroup<Q::Group>,
     MP: MemoizationPolicy<DB, Q>,
     Q::Key: std::panic::RefUnwindSafe,
     Q::Value: std::panic::RefUnwindSafe,
@@ -93,7 +94,7 @@ where
 impl<DB, Q, MP> Default for DerivedStorage<DB, Q, MP>
 where
     Q: QueryFunction<DB>,
-    DB: Database,
+    DB: Database + HasQueryGroup<Q::Group>,
     MP: MemoizationPolicy<DB, Q>,
 {
     fn default() -> Self {
@@ -108,10 +109,10 @@ where
 impl<DB, Q, MP> DerivedStorage<DB, Q, MP>
 where
     Q: QueryFunction<DB>,
-    DB: Database,
+    DB: Database + HasQueryGroup<Q::Group>,
     MP: MemoizationPolicy<DB, Q>,
 {
-    fn slot(&self, key: &Q::Key, database_key: &DB::DatabaseKey) -> Arc<Slot<DB, Q, MP>> {
+    fn slot(&self, key: &Q::Key) -> Arc<Slot<DB, Q, MP>> {
         if let Some(v) = self.slot_map.read().get(key) {
             return v.clone();
         }
@@ -119,7 +120,7 @@ where
         let mut write = self.slot_map.write();
         write
             .entry(key.clone())
-            .or_insert_with(|| Arc::new(Slot::new(key.clone(), database_key.clone())))
+            .or_insert_with(|| Arc::new(Slot::new(key.clone())))
             .clone()
     }
 
@@ -129,7 +130,7 @@ where
 impl<DB, Q, MP> QueryStorageOps<DB, Q> for DerivedStorage<DB, Q, MP>
 where
     Q: QueryFunction<DB>,
-    DB: Database,
+    DB: Database + HasQueryGroup<Q::Group>,
     MP: MemoizationPolicy<DB, Q>,
 {
     fn try_fetch(
@@ -138,7 +139,7 @@ where
         key: &Q::Key,
         database_key: &DB::DatabaseKey,
     ) -> Result<Q::Value, CycleDetected> {
-        let slot = self.slot(key, database_key);
+        let slot = self.slot(key);
         let StampedValue { value, changed_at } = slot.read(db)?;
 
         if let Some(evicted) = self.lru_list.record_use(&slot) {
@@ -156,14 +157,13 @@ where
         db: &DB,
         revision: Revision,
         key: &Q::Key,
-        database_key: &DB::DatabaseKey,
+        _database_key: &DB::DatabaseKey,
     ) -> bool {
-        self.slot(key, database_key)
-            .maybe_changed_since(db, revision)
+        self.slot(key).maybe_changed_since(db, revision)
     }
 
-    fn is_constant(&self, db: &DB, key: &Q::Key, database_key: &DB::DatabaseKey) -> bool {
-        self.slot(key, &database_key).is_constant(db)
+    fn is_constant(&self, db: &DB, key: &Q::Key, _database_key: &DB::DatabaseKey) -> bool {
+        self.slot(key).is_constant(db)
     }
 
     fn entries<C>(&self, _db: &DB) -> C
@@ -181,7 +181,7 @@ where
 impl<DB, Q, MP> QueryStorageMassOps<DB> for DerivedStorage<DB, Q, MP>
 where
     Q: QueryFunction<DB>,
-    DB: Database,
+    DB: Database + HasQueryGroup<Q::Group>,
     MP: MemoizationPolicy<DB, Q>,
 {
     fn sweep(&self, db: &DB, strategy: SweepStrategy) {
@@ -196,7 +196,7 @@ where
 impl<DB, Q, MP> LruQueryStorageOps for DerivedStorage<DB, Q, MP>
 where
     Q: QueryFunction<DB>,
-    DB: Database,
+    DB: Database + HasQueryGroup<Q::Group>,
     MP: MemoizationPolicy<DB, Q>,
 {
     fn set_lru_capacity(&self, new_capacity: usize) {

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -1,29 +1,22 @@
 use crate::debug::TableEntry;
 use crate::plumbing::CycleDetected;
-use crate::plumbing::DatabaseKey;
 use crate::plumbing::LruQueryStorageOps;
 use crate::plumbing::QueryFunction;
 use crate::plumbing::QueryStorageMassOps;
 use crate::plumbing::QueryStorageOps;
-use crate::runtime::ChangedAt;
-use crate::runtime::FxIndexSet;
 use crate::runtime::Revision;
-use crate::runtime::Runtime;
-use crate::runtime::RuntimeId;
 use crate::runtime::StampedValue;
-use crate::{Database, DiscardIf, DiscardWhat, Event, EventKind, SweepStrategy};
+use crate::{Database, SweepStrategy};
 use linked_hash_map::LinkedHashMap;
-use log::{debug, info};
-use parking_lot::Mutex;
 use parking_lot::RwLock;
 use rustc_hash::{FxHashMap, FxHasher};
-use smallvec::SmallVec;
 use std::hash::BuildHasherDefault;
 use std::marker::PhantomData;
-use std::ops::Deref;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::Arc;
+
+mod slot;
+use slot::Slot;
 
 /// Memoized queries store the result plus a list of the other queries
 /// that they invoked. This means we can avoid recomputing them when
@@ -46,7 +39,7 @@ where
     // `lru_cap` logically belongs to `QueryMap`, but we store it outside, so
     // that we can read it without aquiring the lock.
     lru_cap: AtomicUsize,
-    map: RwLock<QueryMap<DB, Q>>,
+    slot_map: RwLock<FxHashMap<Q::Key, Arc<Slot<DB, Q, MP>>>>,
     policy: PhantomData<MP>,
 }
 
@@ -101,164 +94,7 @@ where
     }
 }
 
-/// Defines the "current state" of query's memoized results.
-enum QueryState<DB, Q>
-where
-    Q: QueryFunction<DB>,
-    DB: Database,
-{
-    /// The runtime with the given id is currently computing the
-    /// result of this query; if we see this value in the table, it
-    /// indeeds a cycle.
-    InProgress {
-        id: RuntimeId,
-        waiting: Mutex<SmallVec<[Sender<StampedValue<Q::Value>>; 2]>>,
-    },
-
-    /// We have computed the query already, and here is the result.
-    Memoized(Memo<DB, Q>),
-}
-
-impl<DB, Q> QueryState<DB, Q>
-where
-    Q: QueryFunction<DB>,
-    DB: Database,
-{
-    fn in_progress(id: RuntimeId) -> Self {
-        QueryState::InProgress {
-            id,
-            waiting: Default::default(),
-        }
-    }
-
-    fn value(&self) -> Option<Q::Value> {
-        match self {
-            QueryState::InProgress { .. } => None,
-            QueryState::Memoized(memo) => memo.value.clone(),
-        }
-    }
-}
-
-struct Memo<DB, Q>
-where
-    Q: QueryFunction<DB>,
-    DB: Database,
-{
-    /// The result of the query, if we decide to memoize it.
-    value: Option<Q::Value>,
-
-    /// Last revision when this memo was verified (if there are
-    /// untracked inputs, this will also be when the memo was
-    /// created).
-    verified_at: Revision,
-
-    /// Last revision when the memoized value was observed to change.
-    changed_at: Revision,
-
-    /// The inputs that went into our query, if we are tracking them.
-    inputs: MemoInputs<DB>,
-}
-
-/// An insertion-order-preserving set of queries. Used to track the
-/// inputs accessed during query execution.
-pub(crate) enum MemoInputs<DB: Database> {
-    // No inputs
-    Constant,
-
-    // Non-empty set of inputs fully known
-    Tracked {
-        inputs: Arc<FxIndexSet<DB::DatabaseKey>>,
-    },
-
-    // Unknown quantity of inputs
-    Untracked,
-}
-
-impl<DB: Database> MemoInputs<DB> {
-    fn is_constant(&self) -> bool {
-        if let MemoInputs::Constant = self {
-            true
-        } else {
-            false
-        }
-    }
-}
-
-impl<DB: Database> std::fmt::Debug for MemoInputs<DB> {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            MemoInputs::Constant => fmt.debug_struct("Constant").finish(),
-            MemoInputs::Tracked { inputs } => {
-                fmt.debug_struct("Tracked").field("inputs", inputs).finish()
-            }
-            MemoInputs::Untracked => fmt.debug_struct("Untracked").finish(),
-        }
-    }
-}
-
 type LinkedHashSet<T> = LinkedHashMap<T, (), BuildHasherDefault<FxHasher>>;
-
-struct QueryMap<DB, Q>
-where
-    Q: QueryFunction<DB>,
-    DB: Database,
-{
-    lru_keys: LinkedHashSet<Q::Key>,
-    data: FxHashMap<Q::Key, QueryState<DB, Q>>,
-}
-
-impl<DB, Q> Default for QueryMap<DB, Q>
-where
-    Q: QueryFunction<DB>,
-    DB: Database,
-{
-    fn default() -> Self {
-        QueryMap {
-            lru_keys: Default::default(),
-            data: Default::default(),
-        }
-    }
-}
-
-impl<DB, Q> QueryMap<DB, Q>
-where
-    Q: QueryFunction<DB>,
-    DB: Database,
-{
-    fn set_lru_capacity(&mut self, new_capacity: usize) {
-        if new_capacity == 0 {
-            self.lru_keys.clear();
-        } else {
-            while self.lru_keys.len() > new_capacity {
-                self.remove_lru();
-            }
-            let additional_cap = new_capacity - self.lru_keys.len();
-            self.lru_keys.reserve(additional_cap);
-        }
-    }
-
-    fn record_use(&mut self, key: &Q::Key, lru_cap: usize) {
-        self.lru_keys.insert(key.clone(), ());
-        if self.lru_keys.len() > lru_cap {
-            self.remove_lru();
-        }
-    }
-
-    fn remove_lru(&mut self) {
-        if let Some((evicted, ())) = self.lru_keys.pop_front() {
-            if let Some(QueryState::Memoized(memo)) = self.data.get_mut(&evicted) {
-                // Similar to GC, evicting a value with an untracked input could
-                // lead to inconsistencies. Note that we can't check
-                // `has_untracked_input` when we add the value to the cache,
-                // because inputs can become untracked in the next revision.
-                if memo.has_untracked_input() {
-                    return;
-                }
-                memo.value = None;
-            }
-        }
-    }
-}
 
 impl<DB, Q, MP> Default for DerivedStorage<DB, Q, MP>
 where
@@ -269,16 +105,10 @@ where
     fn default() -> Self {
         DerivedStorage {
             lru_cap: AtomicUsize::new(0),
-            map: RwLock::new(QueryMap::default()),
+            slot_map: RwLock::new(FxHashMap::default()),
             policy: PhantomData,
         }
     }
-}
-
-/// Return value of `probe` helper.
-enum ProbeState<V, G> {
-    UpToDate(Result<V, CycleDetected>),
-    StaleOrAbsent(G),
 }
 
 impl<DB, Q, MP> DerivedStorage<DB, Q, MP>
@@ -287,433 +117,50 @@ where
     DB: Database,
     MP: MemoizationPolicy<DB, Q>,
 {
-    fn read(
-        &self,
-        db: &DB,
-        key: &Q::Key,
-        database_key: &DB::DatabaseKey,
-    ) -> Result<StampedValue<Q::Value>, CycleDetected> {
-        let runtime = db.salsa_runtime();
-
-        // NB: We don't need to worry about people modifying the
-        // revision out from under our feet. Either `db` is a frozen
-        // database, in which case there is a lock, or the mutator
-        // thread is the current thread, and it will be prevented from
-        // doing any `set` invocations while the query function runs.
-        let revision_now = runtime.current_revision();
-
-        info!(
-            "{:?}({:?}): invoked at {:?}",
-            Q::default(),
-            key,
-            revision_now,
-        );
-
-        // First, do a check with a read-lock.
-        match self.probe(
-            db,
-            self.map.read(),
-            runtime,
-            revision_now,
-            database_key,
-            key,
-        ) {
-            ProbeState::UpToDate(v) => return v,
-            ProbeState::StaleOrAbsent(_guard) => (),
+    fn slot(&self, key: &Q::Key, database_key: &DB::DatabaseKey) -> Arc<Slot<DB, Q, MP>> {
+        if let Some(v) = self.slot_map.read().get(key) {
+            return v.clone();
         }
 
-        self.read_upgrade(db, key, database_key, revision_now)
+        let mut write = self.slot_map.write();
+        write
+            .entry(key.clone())
+            .or_insert_with(|| Arc::new(Slot::new(key.clone(), database_key.clone())))
+            .clone()
     }
 
-    /// Second phase of a read operation: acquires an upgradable-read
-    /// and -- if needed -- validates whether inputs have changed,
-    /// recomputes value, etc. This is invoked after our initial probe
-    /// shows a potentially out of date value.
-    fn read_upgrade(
-        &self,
-        db: &DB,
-        key: &Q::Key,
-        database_key: &DB::DatabaseKey,
-        revision_now: Revision,
-    ) -> Result<StampedValue<Q::Value>, CycleDetected> {
-        let runtime = db.salsa_runtime();
-
-        debug!(
-            "{:?}({:?}): read_upgrade(revision_now={:?})",
-            Q::default(),
-            key,
-            revision_now,
-        );
-
-        // Check with an upgradable read to see if there is a value
-        // already. (This permits other readers but prevents anyone
-        // else from running `read_upgrade` at the same time.)
-        //
-        // FIXME(Amanieu/parking_lot#101) -- we are using a write-lock
-        // and not an upgradable read here because upgradable reads
-        // can sometimes encounter deadlocks.
-        let old_memo = match self.probe(
-            db,
-            self.map.write(),
-            runtime,
-            revision_now,
-            database_key,
-            key,
-        ) {
-            ProbeState::UpToDate(v) => return v,
-            ProbeState::StaleOrAbsent(mut map) => {
-                match map
-                    .data
-                    .insert(key.clone(), QueryState::in_progress(runtime.id()))
-                {
-                    Some(QueryState::Memoized(old_memo)) => Some(old_memo),
-                    Some(QueryState::InProgress { .. }) => unreachable!(),
-                    None => None,
-                }
-            }
-        };
-
-        let mut panic_guard = PanicGuard::new(&self.map, key, old_memo, database_key, runtime);
-
-        // If we have an old-value, it *may* now be stale, since there
-        // has been a new revision since the last time we checked. So,
-        // first things first, let's walk over each of our previous
-        // inputs and check whether they are out of date.
-        if let Some(memo) = &mut panic_guard.memo {
-            if let Some(value) = memo.validate_memoized_value(db, revision_now) {
-                info!(
-                    "{:?}({:?}): validated old memoized value",
-                    Q::default(),
-                    key
-                );
-
-                db.salsa_event(|| Event {
-                    runtime_id: runtime.id(),
-                    kind: EventKind::DidValidateMemoizedValue {
-                        database_key: database_key.clone(),
-                    },
-                });
-
-                panic_guard.proceed(&value);
-
-                return Ok(value);
-            }
-        }
-
-        // Query was not previously executed, or value is potentially
-        // stale, or value is absent. Let's execute!
-        let mut result = runtime.execute_query_implementation(db, database_key, || {
-            info!("{:?}({:?}): executing query", Q::default(), key);
-            Q::execute(db, key.clone())
-        });
-
-        // We assume that query is side-effect free -- that is, does
-        // not mutate the "inputs" to the query system. Sanity check
-        // that assumption here, at least to the best of our ability.
-        assert_eq!(
-            runtime.current_revision(),
-            revision_now,
-            "revision altered during query execution",
-        );
-
-        // If the new value is equal to the old one, then it didn't
-        // really change, even if some of its inputs have. So we can
-        // "backdate" its `changed_at` revision to be the same as the
-        // old value.
-        if let Some(old_memo) = &panic_guard.memo {
-            if let Some(old_value) = &old_memo.value {
-                if MP::memoized_value_eq(&old_value, &result.value) {
-                    debug!(
-                        "read_upgrade({:?}({:?})): value is equal, back-dating to {:?}",
-                        Q::default(),
-                        key,
-                        old_memo.changed_at,
-                    );
-
-                    assert!(old_memo.changed_at <= result.changed_at.revision);
-                    result.changed_at.revision = old_memo.changed_at;
-                }
-            }
-        }
-
-        let new_value = StampedValue {
-            value: result.value,
-            changed_at: result.changed_at,
-        };
-
-        let value = if self.should_memoize_value(key) {
-            Some(new_value.value.clone())
-        } else {
-            None
-        };
-
-        debug!(
-            "read_upgrade({:?}({:?})): result.changed_at={:?}, result.subqueries = {:#?}",
-            Q::default(),
-            key,
-            result.changed_at,
-            result.subqueries,
-        );
-
-        let inputs = match result.subqueries {
-            None => MemoInputs::Untracked,
-
-            Some(database_keys) => {
-                // If all things that we read were constants, then
-                // we don't need to track our inputs: our value
-                // can never be invalidated.
-                //
-                // If OTOH we read at least *some* non-constant
-                // inputs, then we do track our inputs (even the
-                // constants), so that if we run the GC, we know
-                // which constants we looked at.
-                if database_keys.is_empty() || result.changed_at.is_constant {
-                    MemoInputs::Constant
-                } else {
-                    MemoInputs::Tracked {
-                        inputs: Arc::new(database_keys),
-                    }
-                }
-            }
-        };
-        panic_guard.memo = Some(Memo {
-            value,
-            changed_at: result.changed_at.revision,
-            verified_at: revision_now,
-            inputs,
-        });
-
-        panic_guard.proceed(&new_value);
-
-        Ok(new_value)
+    fn set_lru_capacity(&mut self, _new_capacity: usize) {
+        //TODO        if new_capacity == 0 {
+        //TODO            self.lru_keys.clear();
+        //TODO        } else {
+        //TODO            while self.lru_keys.len() > new_capacity {
+        //TODO                self.remove_lru();
+        //TODO            }
+        //TODO            let additional_cap = new_capacity - self.lru_keys.len();
+        //TODO            self.lru_keys.reserve(additional_cap);
+        //TODO        }
     }
 
-    /// Helper for `read`:
-    ///
-    /// Invoked with the guard `map` of some lock on `self.map` (read
-    /// or write) as well as details about the key to look up.  Looks
-    /// in the map to see if we have an up-to-date value or a
-    /// cycle. Returns a suitable `ProbeState`:
-    ///
-    /// - `ProbeState::UpToDate(r)` if the table has an up-to-date
-    ///   value (or we blocked on another thread that produced such a value).
-    /// - `ProbeState::CycleDetected` if this thread is (directly or
-    ///   indirectly) already computing this value.
-    /// - `ProbeState::BlockedOnOtherThread` if some other thread
-    ///   (which does not depend on us) was already computing this
-    ///   value; caller should re-acquire the lock and try again.
-    /// - `ProbeState::StaleOrAbsent` if either (a) there is no memo
-    ///    for this key, (b) the memo has no value; or (c) the memo
-    ///    has not been verified at the current revision.
-    ///
-    /// Note that in all cases **except** for `StaleOrAbsent`, the lock on
-    /// `map` will have been released.
-    fn probe<MapGuard>(
-        &self,
-        db: &DB,
-        map: MapGuard,
-        runtime: &Runtime<DB>,
-        revision_now: Revision,
-        database_key: &DB::DatabaseKey,
-        key: &Q::Key,
-    ) -> ProbeState<StampedValue<Q::Value>, MapGuard>
-    where
-        MapGuard: Deref<Target = QueryMap<DB, Q>>,
-    {
-        match map.data.get(key) {
-            Some(QueryState::InProgress { id, waiting }) => {
-                let other_id = *id;
-                return match self.register_with_in_progress_thread(
-                    runtime,
-                    database_key,
-                    other_id,
-                    waiting,
-                ) {
-                    Ok(rx) => {
-                        // Release our lock on `self.map`, so other thread
-                        // can complete.
-                        std::mem::drop(map);
-
-                        db.salsa_event(|| Event {
-                            runtime_id: db.salsa_runtime().id(),
-                            kind: EventKind::WillBlockOn {
-                                other_runtime_id: other_id,
-                                database_key: database_key.clone(),
-                            },
-                        });
-
-                        let value = rx.recv().unwrap_or_else(|_| db.on_propagated_panic());
-                        ProbeState::UpToDate(Ok(value))
-                    }
-
-                    Err(CycleDetected) => ProbeState::UpToDate(Err(CycleDetected)),
-                };
-            }
-
-            Some(QueryState::Memoized(memo)) => {
-                debug!("{:?}({:?}): found memoized value", Q::default(), key);
-
-                if let Some(value) = memo.probe_memoized_value(revision_now) {
-                    info!(
-                        "{:?}({:?}): returning memoized value changed at {:?}",
-                        Q::default(),
-                        key,
-                        value.changed_at
-                    );
-
-                    return ProbeState::UpToDate(Ok(value));
-                }
-            }
-
-            None => {}
-        }
-
-        ProbeState::StaleOrAbsent(map)
+    fn record_use(&mut self, _key: &Q::Key, _lru_cap: usize) {
+        //TODO        self.lru_keys.insert(key.clone(), ());
+        //TODO        if self.lru_keys.len() > lru_cap {
+        //TODO            self.remove_lru();
+        //TODO        }
     }
 
-    /// Helper:
-    ///
-    /// When we encounter an `InProgress` indicator, we need to either
-    /// report a cycle or else register ourselves to be notified when
-    /// that work completes. This helper does that; it returns a port
-    /// where you can wait for the final value that wound up being
-    /// computed (but first drop the lock on the map).
-    fn register_with_in_progress_thread(
-        &self,
-        runtime: &Runtime<DB>,
-        database_key: &DB::DatabaseKey,
-        other_id: RuntimeId,
-        waiting: &Mutex<SmallVec<[Sender<StampedValue<Q::Value>>; 2]>>,
-    ) -> Result<Receiver<StampedValue<Q::Value>>, CycleDetected> {
-        if other_id == runtime.id() {
-            return Err(CycleDetected);
-        } else {
-            if !runtime.try_block_on(database_key, other_id) {
-                return Err(CycleDetected);
-            }
-
-            let (tx, rx) = mpsc::channel();
-
-            // The reader of this will have to acquire map
-            // lock, we don't need any particular ordering.
-            waiting.lock().push(tx);
-
-            Ok(rx)
-        }
-    }
-
-    fn should_memoize_value(&self, key: &Q::Key) -> bool {
-        MP::should_memoize_value(key)
-    }
-}
-
-struct PanicGuard<'db, DB, Q>
-where
-    DB: Database,
-    Q: QueryFunction<DB>,
-{
-    database_key: &'db DB::DatabaseKey,
-    key: &'db Q::Key,
-    memo: Option<Memo<DB, Q>>,
-    map: &'db RwLock<QueryMap<DB, Q>>,
-    runtime: &'db Runtime<DB>,
-}
-
-impl<'db, DB, Q> PanicGuard<'db, DB, Q>
-where
-    DB: Database + 'db,
-    Q: QueryFunction<DB>,
-{
-    fn new(
-        map: &'db RwLock<QueryMap<DB, Q>>,
-        key: &'db Q::Key,
-        memo: Option<Memo<DB, Q>>,
-        database_key: &'db DB::DatabaseKey,
-        runtime: &'db Runtime<DB>,
-    ) -> Self {
-        Self {
-            database_key,
-            key,
-            memo,
-            map,
-            runtime,
-        }
-    }
-
-    /// Proceed with our panic guard by overwriting the placeholder for `key`.
-    /// Once that completes, ensure that our deconstructor is not run once we
-    /// are out of scope.
-    fn proceed(mut self, new_value: &StampedValue<Q::Value>) {
-        self.overwrite_placeholder(Some(new_value));
-        std::mem::forget(self)
-    }
-
-    /// Overwrites the `InProgress` placeholder for `key` that we
-    /// inserted; if others were blocked, waiting for us to finish,
-    /// then notify them.
-    fn overwrite_placeholder(&mut self, new_value: Option<&StampedValue<Q::Value>>) {
-        let mut write = self.map.write();
-
-        let old_value = match self.memo.take() {
-            // Replace the `InProgress` marker that we installed with the new
-            // memo, thus releasing our unique access to this key.
-            Some(memo) => write
-                .data
-                .insert(self.key.clone(), QueryState::Memoized(memo)),
-
-            // We had installed an `InProgress` marker, but we panicked before
-            // it could be removed. At this point, we therefore "own" unique
-            // access to our slot, so we can just remove the key.
-            None => write.data.remove(self.key),
-        };
-
-        match old_value {
-            Some(QueryState::InProgress { id, waiting }) => {
-                assert_eq!(id, self.runtime.id());
-
-                self.runtime
-                    .unblock_queries_blocked_on_self(self.database_key);
-
-                match new_value {
-                    // If anybody has installed themselves in our "waiting"
-                    // list, notify them that the value is available.
-                    Some(new_value) => {
-                        for tx in waiting.into_inner() {
-                            tx.send(new_value.clone()).unwrap()
-                        }
-                    }
-
-                    // We have no value to send when we are panicking.
-                    // Therefore, we need to drop the sending half of the
-                    // channel so that our panic propagates to those waiting
-                    // on the receiving half.
-                    None => std::mem::drop(waiting),
-                }
-            }
-            _ => panic!(
-                "\
-Unexpected panic during query evaluation, aborting the process.
-
-Please report this bug to https://github.com/salsa-rs/salsa/issues."
-            ),
-        }
-    }
-}
-
-impl<'db, DB, Q> Drop for PanicGuard<'db, DB, Q>
-where
-    DB: Database + 'db,
-    Q: QueryFunction<DB>,
-{
-    fn drop(&mut self) {
-        if std::thread::panicking() {
-            // We panicked before we could proceed and need to remove `key`.
-            self.overwrite_placeholder(None)
-        } else {
-            // If no panic occurred, then panic guard ought to be
-            // "forgotten" and so this Drop code should never run.
-            panic!(".forget() was not called")
-        }
+    fn remove_lru(&mut self) {
+        //TODO        if let Some((evicted, ())) = self.lru_keys.pop_front() {
+        //TODO            if let Some(QueryState::Memoized(memo)) = self.data.get_mut(&evicted) {
+        //TODO                // Similar to GC, evicting a value with an untracked input could
+        //TODO                // lead to inconsistencies. Note that we can't check
+        //TODO                // `has_untracked_input` when we add the value to the cache,
+        //TODO                // because inputs can become untracked in the next revision.
+        //TODO                if memo.has_untracked_input() {
+        //TODO                    return;
+        //TODO                }
+        //TODO                memo.value = None;
+        //TODO            }
+        //TODO        }
     }
 }
 
@@ -729,12 +176,13 @@ where
         key: &Q::Key,
         database_key: &DB::DatabaseKey,
     ) -> Result<Q::Value, CycleDetected> {
-        let StampedValue { value, changed_at } = self.read(db, key, &database_key)?;
+        let slot = self.slot(key, database_key);
+        let StampedValue { value, changed_at } = slot.read(db)?;
 
-        let lru_cap = self.lru_cap.load(Ordering::Relaxed);
-        if lru_cap > 0 {
-            self.map.write().record_use(key, lru_cap);
-        }
+        let _lru_cap = self.lru_cap.load(Ordering::Relaxed);
+        //TODO if lru_cap > 0 {
+        //TODO     self.map.write().record_use(key, lru_cap);
+        //TODO }
 
         db.salsa_runtime()
             .report_query_read(database_key, changed_at);
@@ -749,218 +197,22 @@ where
         key: &Q::Key,
         database_key: &DB::DatabaseKey,
     ) -> bool {
-        let runtime = db.salsa_runtime();
-        let revision_now = runtime.current_revision();
-
-        debug!(
-            "maybe_changed_since({:?}({:?})) called with revision={:?}, revision_now={:?}",
-            Q::default(),
-            key,
-            revision,
-            revision_now,
-        );
-
-        // Acquire read lock to start. In some of the arms below, we
-        // drop this explicitly.
-        let map = self.map.read();
-
-        // Look for a memoized value.
-        let memo = match map.data.get(key) {
-            // If somebody depends on us, but we have no map
-            // entry, that must mean that it was found to be out
-            // of date and removed.
-            None => {
-                debug!(
-                    "maybe_changed_since({:?}({:?}): no value",
-                    Q::default(),
-                    key,
-                );
-                return true;
-            }
-
-            // This value is being actively recomputed. Wait for
-            // that thread to finish (assuming it's not dependent
-            // on us...) and check its associated revision.
-            Some(QueryState::InProgress { id, waiting }) => {
-                let other_id = *id;
-                debug!(
-                    "maybe_changed_since({:?}({:?}): blocking on thread `{:?}`",
-                    Q::default(),
-                    key,
-                    other_id,
-                );
-                match self.register_with_in_progress_thread(
-                    runtime,
-                    database_key,
-                    other_id,
-                    waiting,
-                ) {
-                    Ok(rx) => {
-                        // Release our lock on `self.map`, so other thread
-                        // can complete.
-                        std::mem::drop(map);
-
-                        let value = rx.recv().unwrap_or_else(|_| db.on_propagated_panic());
-                        return value.changed_at.changed_since(revision);
-                    }
-
-                    // Consider a cycle to have changed.
-                    Err(CycleDetected) => return true,
-                }
-            }
-
-            Some(QueryState::Memoized(memo)) => memo,
-        };
-
-        if memo.verified_at == revision_now {
-            debug!(
-                "maybe_changed_since({:?}({:?}): {:?} since up-to-date memo that changed at {:?}",
-                Q::default(),
-                key,
-                memo.changed_at > revision,
-                memo.changed_at,
-            );
-            return memo.changed_at > revision;
-        }
-
-        let inputs = match &memo.inputs {
-            MemoInputs::Untracked => {
-                // we don't know the full set of
-                // inputs, so if there is a new
-                // revision, we must assume it is
-                // dirty
-                debug!(
-                    "maybe_changed_since({:?}({:?}): true since untracked inputs",
-                    Q::default(),
-                    key,
-                );
-                return true;
-            }
-
-            MemoInputs::Constant => None,
-
-            MemoInputs::Tracked { inputs } => {
-                // At this point, the value may be dirty (we have
-                // to check the database-keys). If we have a cached
-                // value, we'll just fall back to invoking `read`,
-                // which will do that checking (and a bit more) --
-                // note that we skip the "pure read" part as we
-                // already know the result.
-                assert!(inputs.len() > 0);
-                if memo.value.is_some() {
-                    std::mem::drop(map);
-                    return match self.read_upgrade(db, key, database_key, revision_now) {
-                        Ok(v) => {
-                            debug!(
-                                "maybe_changed_since({:?}({:?}): {:?} since (recomputed) value changed at {:?}",
-                                Q::default(),
-                                key,
-                                v.changed_at.changed_since(revision),
-                                v.changed_at,
-                            );
-                            v.changed_at.changed_since(revision)
-                        }
-                        Err(CycleDetected) => true,
-                    };
-                }
-
-                Some(inputs.clone())
-            }
-        };
-
-        // We have a **tracked set of inputs**
-        // (found in `database_keys`) that need to
-        // be validated.
-        std::mem::drop(map);
-
-        // Iterate the inputs and see if any have maybe changed.
-        let maybe_changed = inputs
-            .iter()
-            .flat_map(|inputs| inputs.iter())
-            .filter(|input| input.maybe_changed_since(db, revision))
-            .inspect(|input| {
-                debug!(
-                    "{:?}({:?}): input `{:?}` may have changed",
-                    Q::default(),
-                    key,
-                    input
-                )
-            })
-            .next()
-            .is_some();
-
-        // Either way, we have to update our entry.
-        //
-        // Keep in mind, though, we only acquired a read lock so a lot
-        // could have happened in the interim. =) Therefore, we have
-        // to probe the current state of `key` and in some cases we
-        // ought to do nothing.
-        {
-            let mut map = self.map.write();
-            match map.data.get_mut(key) {
-                Some(QueryState::Memoized(memo)) => {
-                    if memo.verified_at == revision_now {
-                        // Since we started verifying inputs, somebody
-                        // else has come along and updated this value
-                        // (they may even have recomputed
-                        // it). Therefore, we should not touch this
-                        // memo.
-                        //
-                        // FIXME: Should we still return whatever
-                        // `maybe_changed` value we computed,
-                        // however..? It seems .. harmless to indicate
-                        // that the value has changed, but possibly
-                        // less efficient? (It may cause some
-                        // downstream value to be recomputed that
-                        // wouldn't otherwise have to be?)
-                    } else if maybe_changed {
-                        // We found this entry is out of date and
-                        // nobody touch it in the meantime. Just
-                        // remove it.
-                        map.data.remove(key);
-                    } else {
-                        // We found this entry is valid. Update the
-                        // `verified_at` to reflect the current
-                        // revision.
-                        memo.verified_at = revision_now;
-                    }
-                }
-
-                Some(QueryState::InProgress { .. }) => {
-                    // Since we started verifying inputs, somebody
-                    // else has come along and started updated this
-                    // value. Just leave their marker alone and return
-                    // whatever `maybe_changed` value we computed.
-                }
-
-                None => {
-                    // Since we started verifying inputs, somebody
-                    // else has come along and removed this value. The
-                    // GC can do this, for example. That's fine.
-                }
-            }
-        }
-
-        maybe_changed
+        self.slot(key, database_key)
+            .maybe_changed_since(db, revision)
     }
 
-    fn is_constant(&self, _db: &DB, key: &Q::Key) -> bool {
-        let map_read = self.map.read();
-        match map_read.data.get(key) {
-            None => false,
-            Some(QueryState::InProgress { .. }) => panic!("query in progress"),
-            Some(QueryState::Memoized(memo)) => memo.inputs.is_constant(),
-        }
+    fn is_constant(&self, db: &DB, key: &Q::Key, database_key: &DB::DatabaseKey) -> bool {
+        self.slot(key, &database_key).is_constant(db)
     }
 
     fn entries<C>(&self, _db: &DB) -> C
     where
         C: std::iter::FromIterator<TableEntry<Q::Key, Q::Value>>,
     {
-        let map = self.map.read();
-        map.data
-            .iter()
-            .map(|(key, query_state)| TableEntry::new(key.clone(), query_state.value()))
+        let slot_map = self.slot_map.read();
+        slot_map
+            .values()
+            .filter_map(|slot| slot.as_table_entry())
             .collect()
     }
 }
@@ -972,76 +224,11 @@ where
     MP: MemoizationPolicy<DB, Q>,
 {
     fn sweep(&self, db: &DB, strategy: SweepStrategy) {
-        let mut map_write = self.map.write();
+        let map_read = self.slot_map.read();
         let revision_now = db.salsa_runtime().current_revision();
-        map_write.data.retain(|key, query_state| {
-            match query_state {
-                // Leave stuff that is currently being computed -- the
-                // other thread doing that work has unique access to
-                // this slot and we should not interfere.
-                QueryState::InProgress { .. } => {
-                    debug!("sweep({:?}({:?})): in-progress", Q::default(), key);
-                    true
-                }
-
-                // Otherwise, drop only value or the whole memo accoring to the
-                // strategy.
-                QueryState::Memoized(memo) => {
-                    debug!(
-                        "sweep({:?}({:?})): last verified at {:?}, current revision {:?}",
-                        Q::default(),
-                        key,
-                        memo.verified_at,
-                        revision_now
-                    );
-
-                    // Check if this memo read something "untracked"
-                    // -- meaning non-deterministic.  In this case, we
-                    // can only collect "outdated" data that wasn't
-                    // used in the current revision. This is because
-                    // if we collected something from the current
-                    // revision, we might wind up re-executing the
-                    // query later in the revision and getting a
-                    // distinct result.
-                    let has_untracked_input = memo.has_untracked_input();
-
-                    // Since we don't acquire a query lock in this
-                    // method, it *is* possible for the revision to
-                    // change while we are executing. However, it is
-                    // *not* possible for any memos to have been
-                    // written into this table that reflect the new
-                    // revision, since we are holding the write lock
-                    // when we read `revision_now`.
-                    assert!(memo.verified_at <= revision_now);
-                    match strategy.discard_if {
-                        DiscardIf::Never => unreachable!(),
-
-                        // If we are only discarding outdated things,
-                        // and this is not outdated, keep it.
-                        DiscardIf::Outdated if memo.verified_at == revision_now => true,
-
-                        // As explained on the `has_untracked_input` variable
-                        // definition, if this is a volatile entry, we
-                        // can't discard it unless it is outdated.
-                        DiscardIf::Always
-                            if has_untracked_input && memo.verified_at == revision_now =>
-                        {
-                            true
-                        }
-
-                        // Otherwise, we can discard -- discard whatever the user requested.
-                        DiscardIf::Outdated | DiscardIf::Always => match strategy.discard_what {
-                            DiscardWhat::Nothing => unreachable!(),
-                            DiscardWhat::Values => {
-                                memo.value = None;
-                                true
-                            }
-                            DiscardWhat::Everything => false,
-                        },
-                    }
-                }
-            }
-        });
+        for slot in map_read.values() {
+            slot.sweep(revision_now, strategy);
+        }
     }
 }
 
@@ -1051,114 +238,8 @@ where
     DB: Database,
     MP: MemoizationPolicy<DB, Q>,
 {
-    fn set_lru_capacity(&self, new_capacity: usize) {
-        self.lru_cap.store(new_capacity, Ordering::SeqCst);
-        self.map.write().set_lru_capacity(new_capacity);
-    }
-}
-
-impl<DB, Q> Memo<DB, Q>
-where
-    Q: QueryFunction<DB>,
-    DB: Database,
-{
-    fn validate_memoized_value(
-        &mut self,
-        db: &DB,
-        revision_now: Revision,
-    ) -> Option<StampedValue<Q::Value>> {
-        // If we don't have a memoized value, nothing to validate.
-        let value = self.value.as_ref()?;
-
-        assert!(self.verified_at != revision_now);
-        let verified_at = self.verified_at;
-
-        debug!(
-            "validate_memoized_value({:?}): verified_at={:#?}",
-            Q::default(),
-            self.inputs,
-        );
-
-        let is_constant = match &mut self.inputs {
-            // We can't validate values that had untracked inputs; just have to
-            // re-execute.
-            MemoInputs::Untracked { .. } => {
-                return None;
-            }
-
-            // Constant: no changed input
-            MemoInputs::Constant => true,
-
-            // Check whether any of our inputs changed since the
-            // **last point where we were verified** (not since we
-            // last changed). This is important: if we have
-            // memoized values, then an input may have changed in
-            // revision R2, but we found that *our* value was the
-            // same regardless, so our change date is still
-            // R1. But our *verification* date will be R2, and we
-            // are only interested in finding out whether the
-            // input changed *again*.
-            MemoInputs::Tracked { inputs } => {
-                let changed_input = inputs
-                    .iter()
-                    .filter(|input| input.maybe_changed_since(db, verified_at))
-                    .next();
-
-                if let Some(input) = changed_input {
-                    debug!(
-                        "{:?}::validate_memoized_value: `{:?}` may have changed",
-                        Q::default(),
-                        input
-                    );
-
-                    return None;
-                }
-
-                false
-            }
-        };
-
-        self.verified_at = revision_now;
-        Some(StampedValue {
-            changed_at: ChangedAt {
-                is_constant,
-                revision: self.changed_at,
-            },
-            value: value.clone(),
-        })
-    }
-
-    /// Returns the memoized value *if* it is known to be update in the given revision.
-    fn probe_memoized_value(&self, revision_now: Revision) -> Option<StampedValue<Q::Value>> {
-        let value = self.value.as_ref()?;
-
-        debug!(
-            "probe_memoized_value(verified_at={:?}, changed_at={:?})",
-            self.verified_at, self.changed_at,
-        );
-
-        if self.verified_at == revision_now {
-            let is_constant = match self.inputs {
-                MemoInputs::Constant => true,
-                _ => false,
-            };
-
-            return Some(StampedValue {
-                changed_at: ChangedAt {
-                    is_constant,
-                    revision: self.changed_at,
-                },
-                value: value.clone(),
-            });
-        }
-
-        None
-    }
-
-    fn has_untracked_input(&self) -> bool {
-        match self.inputs {
-            MemoInputs::Untracked => true,
-            _ => false,
-        }
+    fn set_lru_capacity(&self, _new_capacity: usize) {
+        //TODO        self.lru_cap.store(new_capacity, Ordering::SeqCst);
+        //TODO        self.map.write().set_lru_capacity(new_capacity);
     }
 }

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -49,7 +49,7 @@ where
 {
 }
 
-pub trait MemoizationPolicy<DB, Q>
+pub trait MemoizationPolicy<DB, Q>: Send + Sync + 'static
 where
     Q: QueryFunction<DB>,
     DB: Database,

--- a/src/derived/slot.rs
+++ b/src/derived/slot.rs
@@ -1,0 +1,894 @@
+use crate::debug::TableEntry;
+use crate::derived::MemoizationPolicy;
+use crate::plumbing::CycleDetected;
+use crate::plumbing::DatabaseKey;
+use crate::plumbing::QueryFunction;
+use crate::runtime::ChangedAt;
+use crate::runtime::FxIndexSet;
+use crate::runtime::Revision;
+use crate::runtime::Runtime;
+use crate::runtime::RuntimeId;
+use crate::runtime::StampedValue;
+use crate::{Database, DiscardIf, DiscardWhat, Event, EventKind, SweepStrategy};
+use log::{debug, info};
+use parking_lot::Mutex;
+use parking_lot::RwLock;
+use smallvec::SmallVec;
+use std::marker::PhantomData;
+use std::ops::Deref;
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::Arc;
+
+pub(super) struct Slot<DB, Q, MP>
+where
+    Q: QueryFunction<DB>,
+    DB: Database,
+    MP: MemoizationPolicy<DB, Q>,
+{
+    key: Q::Key,
+
+    /// The "database key" version of key.
+    ///
+    /// FIXME -- it should be possible to synthesize this on demand,
+    /// but too lazy right now.
+    database_key: DB::DatabaseKey,
+    state: RwLock<QueryState<DB, Q>>,
+    policy: PhantomData<MP>,
+}
+
+/// Defines the "current state" of query's memoized results.
+enum QueryState<DB, Q>
+where
+    Q: QueryFunction<DB>,
+    DB: Database,
+{
+    NotComputed,
+
+    /// The runtime with the given id is currently computing the
+    /// result of this query; if we see this value in the table, it
+    /// indeeds a cycle.
+    InProgress {
+        id: RuntimeId,
+        waiting: Mutex<SmallVec<[Sender<StampedValue<Q::Value>>; 2]>>,
+    },
+
+    /// We have computed the query already, and here is the result.
+    Memoized(Memo<DB, Q>),
+}
+
+struct Memo<DB, Q>
+where
+    Q: QueryFunction<DB>,
+    DB: Database,
+{
+    /// The result of the query, if we decide to memoize it.
+    value: Option<Q::Value>,
+
+    /// Last revision when this memo was verified (if there are
+    /// untracked inputs, this will also be when the memo was
+    /// created).
+    verified_at: Revision,
+
+    /// Last revision when the memoized value was observed to change.
+    changed_at: Revision,
+
+    /// The inputs that went into our query, if we are tracking them.
+    inputs: MemoInputs<DB>,
+}
+
+/// An insertion-order-preserving set of queries. Used to track the
+/// inputs accessed during query execution.
+pub(super) enum MemoInputs<DB: Database> {
+    // No inputs
+    Constant,
+
+    // Non-empty set of inputs fully known
+    Tracked {
+        inputs: Arc<FxIndexSet<DB::DatabaseKey>>,
+    },
+
+    // Unknown quantity of inputs
+    Untracked,
+}
+
+/// Return value of `probe` helper.
+enum ProbeState<V, G> {
+    UpToDate(Result<V, CycleDetected>),
+    StaleOrAbsent(G),
+}
+
+impl<DB, Q, MP> Slot<DB, Q, MP>
+where
+    Q: QueryFunction<DB>,
+    DB: Database,
+    MP: MemoizationPolicy<DB, Q>,
+{
+    pub(super) fn new(key: Q::Key, database_key: DB::DatabaseKey) -> Self {
+        Self {
+            key,
+            database_key,
+            state: RwLock::new(QueryState::NotComputed),
+            policy: PhantomData,
+        }
+    }
+
+    pub(super) fn read(&self, db: &DB) -> Result<StampedValue<Q::Value>, CycleDetected> {
+        let runtime = db.salsa_runtime();
+
+        // NB: We don't need to worry about people modifying the
+        // revision out from under our feet. Either `db` is a frozen
+        // database, in which case there is a lock, or the mutator
+        // thread is the current thread, and it will be prevented from
+        // doing any `set` invocations while the query function runs.
+        let revision_now = runtime.current_revision();
+
+        info!("{:?}: invoked at {:?}", self, revision_now,);
+
+        // First, do a check with a read-lock.
+        match self.probe(db, self.state.read(), runtime, revision_now) {
+            ProbeState::UpToDate(v) => return v,
+            ProbeState::StaleOrAbsent(_guard) => (),
+        }
+
+        self.read_upgrade(db, revision_now)
+    }
+
+    /// Second phase of a read operation: acquires an upgradable-read
+    /// and -- if needed -- validates whether inputs have changed,
+    /// recomputes value, etc. This is invoked after our initial probe
+    /// shows a potentially out of date value.
+    fn read_upgrade(
+        &self,
+        db: &DB,
+        revision_now: Revision,
+    ) -> Result<StampedValue<Q::Value>, CycleDetected> {
+        let runtime = db.salsa_runtime();
+
+        debug!("{:?}: read_upgrade(revision_now={:?})", self, revision_now,);
+
+        // Check with an upgradable read to see if there is a value
+        // already. (This permits other readers but prevents anyone
+        // else from running `read_upgrade` at the same time.)
+        //
+        // FIXME(Amanieu/parking_lot#101) -- we are using a write-lock
+        // and not an upgradable read here because upgradable reads
+        // can sometimes encounter deadlocks.
+        let old_memo = match self.probe(db, self.state.write(), runtime, revision_now) {
+            ProbeState::UpToDate(v) => return v,
+            ProbeState::StaleOrAbsent(mut state) => {
+                match std::mem::replace(&mut *state, QueryState::in_progress(runtime.id())) {
+                    QueryState::Memoized(old_memo) => Some(old_memo),
+                    QueryState::InProgress { .. } => unreachable!(),
+                    QueryState::NotComputed => None,
+                }
+            }
+        };
+
+        let mut panic_guard = PanicGuard::new(self, old_memo, runtime);
+
+        // If we have an old-value, it *may* now be stale, since there
+        // has been a new revision since the last time we checked. So,
+        // first things first, let's walk over each of our previous
+        // inputs and check whether they are out of date.
+        if let Some(memo) = &mut panic_guard.memo {
+            if let Some(value) = memo.validate_memoized_value(db, revision_now) {
+                info!("{:?}: validated old memoized value", self,);
+
+                db.salsa_event(|| Event {
+                    runtime_id: runtime.id(),
+                    kind: EventKind::DidValidateMemoizedValue {
+                        database_key: self.database_key.clone(),
+                    },
+                });
+
+                panic_guard.proceed(&value);
+
+                return Ok(value);
+            }
+        }
+
+        // Query was not previously executed, or value is potentially
+        // stale, or value is absent. Let's execute!
+        let mut result = runtime.execute_query_implementation(db, &self.database_key, || {
+            info!("{:?}: executing query", self);
+
+            Q::execute(db, self.key.clone())
+        });
+
+        // We assume that query is side-effect free -- that is, does
+        // not mutate the "inputs" to the query system. Sanity check
+        // that assumption here, at least to the best of our ability.
+        assert_eq!(
+            runtime.current_revision(),
+            revision_now,
+            "revision altered during query execution",
+        );
+
+        // If the new value is equal to the old one, then it didn't
+        // really change, even if some of its inputs have. So we can
+        // "backdate" its `changed_at` revision to be the same as the
+        // old value.
+        if let Some(old_memo) = &panic_guard.memo {
+            if let Some(old_value) = &old_memo.value {
+                if MP::memoized_value_eq(&old_value, &result.value) {
+                    debug!(
+                        "read_upgrade({:?}): value is equal, back-dating to {:?}",
+                        self, old_memo.changed_at,
+                    );
+
+                    assert!(old_memo.changed_at <= result.changed_at.revision);
+                    result.changed_at.revision = old_memo.changed_at;
+                }
+            }
+        }
+
+        let new_value = StampedValue {
+            value: result.value,
+            changed_at: result.changed_at,
+        };
+
+        let value = if self.should_memoize_value(&self.key) {
+            Some(new_value.value.clone())
+        } else {
+            None
+        };
+
+        debug!(
+            "read_upgrade({:?}): result.changed_at={:?}, result.subqueries = {:#?}",
+            self, result.changed_at, result.subqueries,
+        );
+
+        let inputs = match result.subqueries {
+            None => MemoInputs::Untracked,
+
+            Some(database_keys) => {
+                // If all things that we read were constants, then
+                // we don't need to track our inputs: our value
+                // can never be invalidated.
+                //
+                // If OTOH we read at least *some* non-constant
+                // inputs, then we do track our inputs (even the
+                // constants), so that if we run the GC, we know
+                // which constants we looked at.
+                if database_keys.is_empty() || result.changed_at.is_constant {
+                    MemoInputs::Constant
+                } else {
+                    MemoInputs::Tracked {
+                        inputs: Arc::new(database_keys),
+                    }
+                }
+            }
+        };
+        panic_guard.memo = Some(Memo {
+            value,
+            changed_at: result.changed_at.revision,
+            verified_at: revision_now,
+            inputs,
+        });
+
+        panic_guard.proceed(&new_value);
+
+        Ok(new_value)
+    }
+
+    /// Helper for `read`:
+    ///
+    /// Invoked with the guard `map` of some lock on `self.map` (read
+    /// or write) as well as details about the key to look up.  Looks
+    /// in the map to see if we have an up-to-date value or a
+    /// cycle. Returns a suitable `ProbeState`:
+    ///
+    /// - `ProbeState::UpToDate(r)` if the table has an up-to-date
+    ///   value (or we blocked on another thread that produced such a value).
+    /// - `ProbeState::CycleDetected` if this thread is (directly or
+    ///   indirectly) already computing this value.
+    /// - `ProbeState::BlockedOnOtherThread` if some other thread
+    ///   (which does not depend on us) was already computing this
+    ///   value; caller should re-acquire the lock and try again.
+    /// - `ProbeState::StaleOrAbsent` if either (a) there is no memo
+    ///    for this key, (b) the memo has no value; or (c) the memo
+    ///    has not been verified at the current revision.
+    ///
+    /// Note that in all cases **except** for `StaleOrAbsent`, the lock on
+    /// `map` will have been released.
+    fn probe<StateGuard>(
+        &self,
+        db: &DB,
+        state: StateGuard,
+        runtime: &Runtime<DB>,
+        revision_now: Revision,
+    ) -> ProbeState<StampedValue<Q::Value>, StateGuard>
+    where
+        StateGuard: Deref<Target = QueryState<DB, Q>>,
+    {
+        match &*state {
+            QueryState::NotComputed => { /* fall through */ }
+
+            QueryState::InProgress { id, waiting } => {
+                let other_id = *id;
+                return match self.register_with_in_progress_thread(runtime, other_id, waiting) {
+                    Ok(rx) => {
+                        // Release our lock on `self.map`, so other thread
+                        // can complete.
+                        std::mem::drop(state);
+
+                        db.salsa_event(|| Event {
+                            runtime_id: db.salsa_runtime().id(),
+                            kind: EventKind::WillBlockOn {
+                                other_runtime_id: other_id,
+                                database_key: self.database_key.clone(),
+                            },
+                        });
+
+                        let value = rx.recv().unwrap_or_else(|_| db.on_propagated_panic());
+                        ProbeState::UpToDate(Ok(value))
+                    }
+
+                    Err(CycleDetected) => ProbeState::UpToDate(Err(CycleDetected)),
+                };
+            }
+
+            QueryState::Memoized(memo) => {
+                debug!("{:?}: found memoized value", self);
+
+                if let Some(value) = memo.probe_memoized_value(revision_now) {
+                    info!(
+                        "{:?}: returning memoized value changed at {:?}",
+                        self, value.changed_at
+                    );
+
+                    return ProbeState::UpToDate(Ok(value));
+                }
+            }
+        }
+
+        ProbeState::StaleOrAbsent(state)
+    }
+
+    pub(super) fn maybe_changed_since(&self, db: &DB, revision: Revision) -> bool {
+        let runtime = db.salsa_runtime();
+        let revision_now = runtime.current_revision();
+
+        debug!(
+            "maybe_changed_since({:?}) called with revision={:?}, revision_now={:?}",
+            self, revision, revision_now,
+        );
+
+        // Acquire read lock to start. In some of the arms below, we
+        // drop this explicitly.
+        let state = self.state.read();
+
+        // Look for a memoized value.
+        let memo = match &*state {
+            // If somebody depends on us, but we have no map
+            // entry, that must mean that it was found to be out
+            // of date and removed.
+            QueryState::NotComputed => {
+                debug!("maybe_changed_since({:?}: no value", self);
+                return true;
+            }
+
+            // This value is being actively recomputed. Wait for
+            // that thread to finish (assuming it's not dependent
+            // on us...) and check its associated revision.
+            QueryState::InProgress { id, waiting } => {
+                let other_id = *id;
+                debug!(
+                    "maybe_changed_since({:?}: blocking on thread `{:?}`",
+                    self, other_id,
+                );
+                match self.register_with_in_progress_thread(runtime, other_id, waiting) {
+                    Ok(rx) => {
+                        // Release our lock on `self.map`, so other thread
+                        // can complete.
+                        std::mem::drop(state);
+
+                        let value = rx.recv().unwrap_or_else(|_| db.on_propagated_panic());
+                        return value.changed_at.changed_since(revision);
+                    }
+
+                    // Consider a cycle to have changed.
+                    Err(CycleDetected) => return true,
+                }
+            }
+
+            QueryState::Memoized(memo) => memo,
+        };
+
+        if memo.verified_at == revision_now {
+            debug!(
+                "maybe_changed_since({:?}: {:?} since up-to-date memo that changed at {:?}",
+                self,
+                memo.changed_at > revision,
+                memo.changed_at,
+            );
+            return memo.changed_at > revision;
+        }
+
+        let inputs = match &memo.inputs {
+            MemoInputs::Untracked => {
+                // we don't know the full set of
+                // inputs, so if there is a new
+                // revision, we must assume it is
+                // dirty
+                debug!(
+                    "maybe_changed_since({:?}: true since untracked inputs",
+                    self,
+                );
+                return true;
+            }
+
+            MemoInputs::Constant => None,
+
+            MemoInputs::Tracked { inputs } => {
+                // At this point, the value may be dirty (we have
+                // to check the database-keys). If we have a cached
+                // value, we'll just fall back to invoking `read`,
+                // which will do that checking (and a bit more) --
+                // note that we skip the "pure read" part as we
+                // already know the result.
+                assert!(inputs.len() > 0);
+                if memo.value.is_some() {
+                    std::mem::drop(state);
+                    return match self.read_upgrade(db, revision_now) {
+                        Ok(v) => {
+                            debug!(
+                                "maybe_changed_since({:?}: {:?} since (recomputed) value changed at {:?}",
+                                self,
+                                v.changed_at.changed_since(revision),
+                                v.changed_at,
+                            );
+                            v.changed_at.changed_since(revision)
+                        }
+                        Err(CycleDetected) => true,
+                    };
+                }
+
+                Some(inputs.clone())
+            }
+        };
+
+        // We have a **tracked set of inputs**
+        // (found in `database_keys`) that need to
+        // be validated.
+        std::mem::drop(state);
+
+        // Iterate the inputs and see if any have maybe changed.
+        let maybe_changed = inputs
+            .iter()
+            .flat_map(|inputs| inputs.iter())
+            .filter(|input| input.maybe_changed_since(db, revision))
+            .inspect(|input| debug!("{:?}: input `{:?}` may have changed", self, input))
+            .next()
+            .is_some();
+
+        // Either way, we have to update our entry.
+        //
+        // Keep in mind, though, we only acquired a read lock so a lot
+        // could have happened in the interim. =) Therefore, we have
+        // to probe the current state of `key` and in some cases we
+        // ought to do nothing.
+        {
+            let mut state = self.state.write();
+            match &mut *state {
+                QueryState::Memoized(memo) => {
+                    if memo.verified_at == revision_now {
+                        // Since we started verifying inputs, somebody
+                        // else has come along and updated this value
+                        // (they may even have recomputed
+                        // it). Therefore, we should not touch this
+                        // memo.
+                        //
+                        // FIXME: Should we still return whatever
+                        // `maybe_changed` value we computed,
+                        // however..? It seems .. harmless to indicate
+                        // that the value has changed, but possibly
+                        // less efficient? (It may cause some
+                        // downstream value to be recomputed that
+                        // wouldn't otherwise have to be?)
+                    } else if maybe_changed {
+                        // We found this entry is out of date and
+                        // nobody touch it in the meantime. Just
+                        // remove it.
+                        *state = QueryState::NotComputed;
+                    } else {
+                        // We found this entry is valid. Update the
+                        // `verified_at` to reflect the current
+                        // revision.
+                        memo.verified_at = revision_now;
+                    }
+                }
+
+                QueryState::InProgress { .. } => {
+                    // Since we started verifying inputs, somebody
+                    // else has come along and started updated this
+                    // value. Just leave their marker alone and return
+                    // whatever `maybe_changed` value we computed.
+                }
+
+                QueryState::NotComputed => {
+                    // Since we started verifying inputs, somebody
+                    // else has come along and removed this value. The
+                    // GC can do this, for example. That's fine.
+                }
+            }
+        }
+
+        maybe_changed
+    }
+
+    pub(super) fn is_constant(&self, _db: &DB) -> bool {
+        match &*self.state.read() {
+            QueryState::NotComputed => false,
+            QueryState::InProgress { .. } => panic!("query in progress"),
+            QueryState::Memoized(memo) => memo.inputs.is_constant(),
+        }
+    }
+
+    pub(super) fn as_table_entry(&self) -> Option<TableEntry<Q::Key, Q::Value>> {
+        match &*self.state.read() {
+            QueryState::NotComputed => None,
+            QueryState::InProgress { .. } => Some(TableEntry::new(self.key.clone(), None)),
+            QueryState::Memoized(memo) => {
+                Some(TableEntry::new(self.key.clone(), memo.value.clone()))
+            }
+        }
+    }
+
+    pub(super) fn sweep(&self, revision_now: Revision, strategy: SweepStrategy) {
+        let mut state = self.state.write();
+        match &mut *state {
+            QueryState::NotComputed => (),
+
+            // Leave stuff that is currently being computed -- the
+            // other thread doing that work has unique access to
+            // this slot and we should not interfere.
+            QueryState::InProgress { .. } => {
+                debug!("sweep({:?}): in-progress", self);
+            }
+
+            // Otherwise, drop only value or the whole memo accoring to the
+            // strategy.
+            QueryState::Memoized(memo) => {
+                debug!(
+                    "sweep({:?}): last verified at {:?}, current revision {:?}",
+                    self, memo.verified_at, revision_now
+                );
+
+                // Check if this memo read something "untracked"
+                // -- meaning non-deterministic.  In this case, we
+                // can only collect "outdated" data that wasn't
+                // used in the current revision. This is because
+                // if we collected something from the current
+                // revision, we might wind up re-executing the
+                // query later in the revision and getting a
+                // distinct result.
+                let has_untracked_input = memo.has_untracked_input();
+
+                // Since we don't acquire a query lock in this
+                // method, it *is* possible for the revision to
+                // change while we are executing. However, it is
+                // *not* possible for any memos to have been
+                // written into this table that reflect the new
+                // revision, since we are holding the write lock
+                // when we read `revision_now`.
+                assert!(memo.verified_at <= revision_now);
+                match strategy.discard_if {
+                    DiscardIf::Never => unreachable!(),
+
+                    // If we are only discarding outdated things,
+                    // and this is not outdated, keep it.
+                    DiscardIf::Outdated if memo.verified_at == revision_now => (),
+
+                    // As explained on the `has_untracked_input` variable
+                    // definition, if this is a volatile entry, we
+                    // can't discard it unless it is outdated.
+                    DiscardIf::Always
+                        if has_untracked_input && memo.verified_at == revision_now => {}
+
+                    // Otherwise, we can discard -- discard whatever the user requested.
+                    DiscardIf::Outdated | DiscardIf::Always => match strategy.discard_what {
+                        DiscardWhat::Nothing => unreachable!(),
+                        DiscardWhat::Values => {
+                            memo.value = None;
+                        }
+                        DiscardWhat::Everything => {
+                            *state = QueryState::NotComputed;
+                        }
+                    },
+                }
+            }
+        }
+    }
+
+    /// Helper:
+    ///
+    /// When we encounter an `InProgress` indicator, we need to either
+    /// report a cycle or else register ourselves to be notified when
+    /// that work completes. This helper does that; it returns a port
+    /// where you can wait for the final value that wound up being
+    /// computed (but first drop the lock on the map).
+    fn register_with_in_progress_thread(
+        &self,
+        runtime: &Runtime<DB>,
+        other_id: RuntimeId,
+        waiting: &Mutex<SmallVec<[Sender<StampedValue<Q::Value>>; 2]>>,
+    ) -> Result<Receiver<StampedValue<Q::Value>>, CycleDetected> {
+        if other_id == runtime.id() {
+            return Err(CycleDetected);
+        } else {
+            if !runtime.try_block_on(&self.database_key, other_id) {
+                return Err(CycleDetected);
+            }
+
+            let (tx, rx) = mpsc::channel();
+
+            // The reader of this will have to acquire map
+            // lock, we don't need any particular ordering.
+            waiting.lock().push(tx);
+
+            Ok(rx)
+        }
+    }
+
+    fn should_memoize_value(&self, key: &Q::Key) -> bool {
+        MP::should_memoize_value(key)
+    }
+}
+
+impl<DB, Q> QueryState<DB, Q>
+where
+    Q: QueryFunction<DB>,
+    DB: Database,
+{
+    fn in_progress(id: RuntimeId) -> Self {
+        QueryState::InProgress {
+            id,
+            waiting: Default::default(),
+        }
+    }
+}
+
+struct PanicGuard<'me, DB, Q, MP>
+where
+    DB: Database,
+    Q: QueryFunction<DB>,
+    MP: MemoizationPolicy<DB, Q>,
+{
+    slot: &'me Slot<DB, Q, MP>,
+    memo: Option<Memo<DB, Q>>,
+    runtime: &'me Runtime<DB>,
+}
+
+impl<'me, DB, Q, MP> PanicGuard<'me, DB, Q, MP>
+where
+    DB: Database + 'me,
+    Q: QueryFunction<DB>,
+    MP: MemoizationPolicy<DB, Q>,
+{
+    fn new(
+        slot: &'me Slot<DB, Q, MP>,
+        memo: Option<Memo<DB, Q>>,
+        runtime: &'me Runtime<DB>,
+    ) -> Self {
+        Self {
+            slot,
+            memo,
+            runtime,
+        }
+    }
+
+    /// Proceed with our panic guard by overwriting the placeholder for `key`.
+    /// Once that completes, ensure that our deconstructor is not run once we
+    /// are out of scope.
+    fn proceed(mut self, new_value: &StampedValue<Q::Value>) {
+        self.overwrite_placeholder(Some(new_value));
+        std::mem::forget(self)
+    }
+
+    /// Overwrites the `InProgress` placeholder for `key` that we
+    /// inserted; if others were blocked, waiting for us to finish,
+    /// then notify them.
+    fn overwrite_placeholder(&mut self, new_value: Option<&StampedValue<Q::Value>>) {
+        let mut write = self.slot.state.write();
+
+        let old_value = match self.memo.take() {
+            // Replace the `InProgress` marker that we installed with the new
+            // memo, thus releasing our unique access to this key.
+            Some(memo) => std::mem::replace(&mut *write, QueryState::Memoized(memo)),
+
+            // We had installed an `InProgress` marker, but we panicked before
+            // it could be removed. At this point, we therefore "own" unique
+            // access to our slot, so we can just remove the key.
+            None => std::mem::replace(&mut *write, QueryState::NotComputed),
+        };
+
+        match old_value {
+            QueryState::InProgress { id, waiting } => {
+                assert_eq!(id, self.runtime.id());
+
+                self.runtime
+                    .unblock_queries_blocked_on_self(&self.slot.database_key);
+
+                match new_value {
+                    // If anybody has installed themselves in our "waiting"
+                    // list, notify them that the value is available.
+                    Some(new_value) => {
+                        for tx in waiting.into_inner() {
+                            tx.send(new_value.clone()).unwrap()
+                        }
+                    }
+
+                    // We have no value to send when we are panicking.
+                    // Therefore, we need to drop the sending half of the
+                    // channel so that our panic propagates to those waiting
+                    // on the receiving half.
+                    None => std::mem::drop(waiting),
+                }
+            }
+            _ => panic!(
+                "\
+Unexpected panic during query evaluation, aborting the process.
+
+Please report this bug to https://github.com/salsa-rs/salsa/issues."
+            ),
+        }
+    }
+}
+
+impl<'me, DB, Q, MP> Drop for PanicGuard<'me, DB, Q, MP>
+where
+    DB: Database + 'me,
+    Q: QueryFunction<DB>,
+    MP: MemoizationPolicy<DB, Q>,
+{
+    fn drop(&mut self) {
+        if std::thread::panicking() {
+            // We panicked before we could proceed and need to remove `key`.
+            self.overwrite_placeholder(None)
+        } else {
+            // If no panic occurred, then panic guard ought to be
+            // "forgotten" and so this Drop code should never run.
+            panic!(".forget() was not called")
+        }
+    }
+}
+
+impl<DB: Database> MemoInputs<DB> {
+    fn is_constant(&self) -> bool {
+        if let MemoInputs::Constant = self {
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl<DB, Q> Memo<DB, Q>
+where
+    Q: QueryFunction<DB>,
+    DB: Database,
+{
+    fn validate_memoized_value(
+        &mut self,
+        db: &DB,
+        revision_now: Revision,
+    ) -> Option<StampedValue<Q::Value>> {
+        // If we don't have a memoized value, nothing to validate.
+        let value = self.value.as_ref()?;
+
+        assert!(self.verified_at != revision_now);
+        let verified_at = self.verified_at;
+
+        debug!(
+            "validate_memoized_value({:?}): verified_at={:#?}",
+            Q::default(),
+            self.inputs,
+        );
+
+        let is_constant = match &mut self.inputs {
+            // We can't validate values that had untracked inputs; just have to
+            // re-execute.
+            MemoInputs::Untracked { .. } => {
+                return None;
+            }
+
+            // Constant: no changed input
+            MemoInputs::Constant => true,
+
+            // Check whether any of our inputs changed since the
+            // **last point where we were verified** (not since we
+            // last changed). This is important: if we have
+            // memoized values, then an input may have changed in
+            // revision R2, but we found that *our* value was the
+            // same regardless, so our change date is still
+            // R1. But our *verification* date will be R2, and we
+            // are only interested in finding out whether the
+            // input changed *again*.
+            MemoInputs::Tracked { inputs } => {
+                let changed_input = inputs
+                    .iter()
+                    .filter(|input| input.maybe_changed_since(db, verified_at))
+                    .next();
+
+                if let Some(input) = changed_input {
+                    debug!(
+                        "{:?}::validate_memoized_value: `{:?}` may have changed",
+                        Q::default(),
+                        input
+                    );
+
+                    return None;
+                }
+
+                false
+            }
+        };
+
+        self.verified_at = revision_now;
+        Some(StampedValue {
+            changed_at: ChangedAt {
+                is_constant,
+                revision: self.changed_at,
+            },
+            value: value.clone(),
+        })
+    }
+
+    /// Returns the memoized value *if* it is known to be update in the given revision.
+    fn probe_memoized_value(&self, revision_now: Revision) -> Option<StampedValue<Q::Value>> {
+        let value = self.value.as_ref()?;
+
+        debug!(
+            "probe_memoized_value(verified_at={:?}, changed_at={:?})",
+            self.verified_at, self.changed_at,
+        );
+
+        if self.verified_at == revision_now {
+            let is_constant = match self.inputs {
+                MemoInputs::Constant => true,
+                _ => false,
+            };
+
+            return Some(StampedValue {
+                changed_at: ChangedAt {
+                    is_constant,
+                    revision: self.changed_at,
+                },
+                value: value.clone(),
+            });
+        }
+
+        None
+    }
+
+    fn has_untracked_input(&self) -> bool {
+        match self.inputs {
+            MemoInputs::Untracked => true,
+            _ => false,
+        }
+    }
+}
+
+impl<DB, Q, MP> std::fmt::Debug for Slot<DB, Q, MP>
+where
+    Q: QueryFunction<DB>,
+    DB: Database,
+    MP: MemoizationPolicy<DB, Q>,
+{
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(fmt, "{:?}({:?})", Q::default(), self.key)
+    }
+}
+
+impl<DB: Database> std::fmt::Debug for MemoInputs<DB> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MemoInputs::Constant => fmt.debug_struct("Constant").finish(),
+            MemoInputs::Tracked { inputs } => {
+                fmt.debug_struct("Tracked").field("inputs", inputs).finish()
+            }
+            MemoInputs::Untracked => fmt.debug_struct("Untracked").finish(),
+        }
+    }
+}

--- a/src/derived/slot.rs
+++ b/src/derived/slot.rs
@@ -1,6 +1,6 @@
 use crate::debug::TableEntry;
 use crate::derived::MemoizationPolicy;
-use crate::lru::LruLinks;
+use crate::lru::LruIndex;
 use crate::lru::LruNode;
 use crate::plumbing::CycleDetected;
 use crate::plumbing::DatabaseKey;
@@ -36,7 +36,7 @@ where
     database_key: DB::DatabaseKey,
     state: RwLock<QueryState<DB, Q>>,
     policy: PhantomData<MP>,
-    lru_links: LruLinks<Self>,
+    lru_index: LruIndex,
 }
 
 /// Defines the "current state" of query's memoized results.
@@ -111,7 +111,7 @@ where
             key,
             database_key,
             state: RwLock::new(QueryState::NotComputed),
-            lru_links: LruLinks::default(),
+            lru_index: LruIndex::default(),
             policy: PhantomData,
         }
     }
@@ -917,7 +917,7 @@ where
     DB: Database,
     MP: MemoizationPolicy<DB, Q>,
 {
-    fn links(&self) -> &LruLinks<Self> {
-        &self.lru_links
+    fn lru_index(&self) -> &LruIndex {
+        &self.lru_index
     }
 }

--- a/src/doctest.rs
+++ b/src/doctest.rs
@@ -1,0 +1,121 @@
+#![allow(dead_code)]
+
+/// Test that a database with a key/value that is not `Send` will,
+/// indeed, not be `Send`.
+///
+/// ```compile_fail,E0277
+/// use std::rc::Rc;
+///
+/// #[salsa::query_group(NoSendSyncStorage)]
+/// trait NoSendSyncDatabase: salsa::Database {
+///     fn no_send_sync_value(&self, key: bool) -> Rc<bool>;
+///     fn no_send_sync_key(&self, key: Rc<bool>) -> bool;
+/// }
+///
+/// fn no_send_sync_value(_db: &impl NoSendSyncDatabase, key: bool) -> Rc<bool> {
+///     Rc::new(key)
+/// }
+///
+/// fn no_send_sync_key(_db: &impl NoSendSyncDatabase, key: Rc<bool>) -> bool {
+///     *key
+/// }
+///
+/// #[salsa::database(NoSendSyncStorage)]
+/// #[derive(Default)]
+/// struct DatabaseImpl {
+///     runtime: salsa::Runtime<DatabaseImpl>,
+/// }
+///
+/// impl salsa::Database for DatabaseImpl {
+///     fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseImpl> {
+///         &self.runtime
+///     }
+/// }
+///
+/// fn is_send<T: Send>(_: T) { }
+///
+/// fn assert_send() {
+///    is_send(DatabaseImpl::default());
+/// }
+/// ```
+fn test_key_not_send_db_not_send() {}
+
+/// Test that a database with a key/value that is not `Sync` will not
+/// be `Send`.
+///
+/// ```compile_fail,E0277
+/// use std::rc::Rc;
+///
+/// #[salsa::query_group(NoSendSyncStorage)]
+/// trait NoSendSyncDatabase: salsa::Database {
+///     fn no_send_sync_value(&self, key: bool) -> Cell<bool>;
+///     fn no_send_sync_key(&self, key: Cell<bool>) -> bool;
+/// }
+///
+/// fn no_send_sync_value(_db: &impl NoSendSyncDatabase, key: bool) -> Cell<bool> {
+///     Cell::new(key)
+/// }
+///
+/// fn no_send_sync_key(_db: &impl NoSendSyncDatabase, key: Cell<bool>) -> bool {
+///     *key
+/// }
+///
+/// #[salsa::database(NoSendSyncStorage)]
+/// #[derive(Default)]
+/// struct DatabaseImpl {
+///     runtime: salsa::Runtime<DatabaseImpl>,
+/// }
+///
+/// impl salsa::Database for DatabaseImpl {
+///     fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseImpl> {
+///         &self.runtime
+///     }
+/// }
+///
+/// fn is_send<T: Send>(_: T) { }
+///
+/// fn assert_send() {
+///    is_send(DatabaseImpl::default());
+/// }
+/// ```
+fn test_key_not_sync_db_not_send() {}
+
+/// Test that a database with a key/value that is not `Sync` will
+/// not be `Sync`.
+///
+/// ```compile_fail,E0277
+/// use std::rc::Rc;
+///
+/// #[salsa::query_group(NoSendSyncStorage)]
+/// trait NoSendSyncDatabase: salsa::Database {
+///     fn no_send_sync_value(&self, key: bool) -> Cell<bool>;
+///     fn no_send_sync_key(&self, key: Cell<bool>) -> bool;
+/// }
+///
+/// fn no_send_sync_value(_db: &impl NoSendSyncDatabase, key: bool) -> Cell<bool> {
+///     Cell::new(key)
+/// }
+///
+/// fn no_send_sync_key(_db: &impl NoSendSyncDatabase, key: Cell<bool>) -> bool {
+///     *key
+/// }
+///
+/// #[salsa::database(NoSendSyncStorage)]
+/// #[derive(Default)]
+/// struct DatabaseImpl {
+///     runtime: salsa::Runtime<DatabaseImpl>,
+/// }
+///
+/// impl salsa::Database for DatabaseImpl {
+///     fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseImpl> {
+///         &self.runtime
+///     }
+/// }
+///
+/// fn is_sync<T: Sync>(_: T) { }
+///
+/// fn assert_send() {
+///    is_sync(DatabaseImpl::default());
+/// }
+/// ```
+fn test_key_not_sync_db_not_sync() {}

--- a/src/input.rs
+++ b/src/input.rs
@@ -186,7 +186,7 @@ where
         changed_at.changed_since(revision)
     }
 
-    fn is_constant(&self, _db: &DB, key: &Q::Key) -> bool {
+    fn is_constant(&self, _db: &DB, key: &Q::Key, _database_key: &DB::DatabaseKey) -> bool {
         let map_read = self.map.read();
         map_read
             .get(key)

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -252,7 +252,7 @@ where
     fn intern_check(&self, db: &DB, key: &Q::Key) -> Option<StampedValue<InternId>> {
         let revision_now = db.salsa_runtime().current_revision();
 
-        // First,
+        // First, try with read lock -- this only works if `accessed_at` is up to date.
         {
             let tables = self.tables.read();
             let &index = tables.map.get(key)?;
@@ -282,7 +282,7 @@ where
             }
         }
 
-        // Next,
+        // Acquire write lock if necessary.
         let mut tables = self.tables.write();
         let &index = tables.map.get(key)?;
         match &mut tables.values[index.as_usize()] {

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -418,7 +418,7 @@ where
         }
     }
 
-    fn is_constant(&self, _db: &DB, _key: &Q::Key) -> bool {
+    fn is_constant(&self, _db: &DB, _key: &Q::Key, _database_key: &DB::DatabaseKey) -> bool {
         false
     }
 
@@ -563,7 +563,7 @@ where
         changed_at.changed_since(revision)
     }
 
-    fn is_constant(&self, _db: &DB, _key: &Q::Key) -> bool {
+    fn is_constant(&self, _db: &DB, _key: &Q::Key, _database_key: &DB::DatabaseKey) -> bool {
         false
     }
 

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -6,14 +6,16 @@ use crate::plumbing::QueryStorageMassOps;
 use crate::plumbing::QueryStorageOps;
 use crate::runtime::ChangedAt;
 use crate::runtime::Revision;
-use crate::runtime::StampedValue;
 use crate::Query;
 use crate::{Database, DiscardIf, SweepStrategy};
+use crossbeam::atomic::AtomicCell;
 use parking_lot::RwLock;
 use rustc_hash::FxHashMap;
 use std::collections::hash_map::Entry;
 use std::convert::From;
+use std::fmt::Debug;
 use std::hash::Hash;
+use std::sync::Arc;
 
 /// Handles storage where the value is 'derived' by executing a
 /// function (in contrast to "inputs").
@@ -81,22 +83,37 @@ impl InternKey for InternId {
 
 enum InternValue<K> {
     /// The value has not been gc'd.
-    Present {
-        value: K,
-
-        /// When was this intern'd?
-        ///
-        /// (This informs the "changed-at" result)
-        interned_at: Revision,
-
-        /// When was it accessed?
-        ///
-        /// (This informs the garbage collector)
-        accessed_at: Revision,
-    },
+    Present { slot: Arc<Slot<K>> },
 
     /// Free-list -- the index is the next
     Free { next: Option<InternId> },
+}
+
+#[derive(Debug)]
+struct Slot<K> {
+    /// Index of this slot in the list of interned values;
+    /// set to None if gc'd.
+    index: InternId,
+
+    /// Value that was interned.
+    value: K,
+
+    /// When was this intern'd?
+    ///
+    /// (This informs the "changed-at" result)
+    interned_at: Revision,
+
+    /// When was it accessed? Equal to `None` if this slot has
+    /// been garbage collected.
+    ///
+    /// This has a subtle interaction with the garbage
+    /// collector. First, we will never GC anything accessed in the
+    /// current revision.
+    ///
+    /// To protect a slot from being GC'd, we can therefore update the
+    /// `accessed_at` field to `Some(revision_now)` before releasing
+    /// the read-lock on our interning tables.
+    accessed_at: AtomicCell<Option<Revision>>,
 }
 
 impl<DB, Q> std::panic::RefUnwindSafe for InternedStorage<DB, Q>
@@ -145,6 +162,41 @@ where
     }
 }
 
+impl<K: Debug + Hash + Eq> InternTables<K> {
+    /// Returns the slot for the given key.
+    ///
+    /// The slot will have its "accessed at" field updated to its current revision,
+    /// ensuring that it cannot be GC'd until the current queries complete.
+    fn slot_for_key(&self, key: &K, revision_now: Revision) -> Option<Arc<Slot<K>>> {
+        let index = self.map.get(key)?;
+        Some(self.slot_for_index(*index, revision_now))
+    }
+
+    /// Returns the slot at the given index.
+    ///
+    /// The slot will have its "accessed at" field updated to its current revision,
+    /// ensuring that it cannot be GC'd until the current queries complete.
+    fn slot_for_index(&self, index: InternId, revision_now: Revision) -> Arc<Slot<K>> {
+        match &self.values[index.as_usize()] {
+            InternValue::Present { slot } => {
+                // Subtle: we must update the "accessed at" to the
+                // current revision *while the lock is held* to
+                // prevent this slot from being GC'd.
+                let updated = slot.try_update_accessed_at(revision_now);
+                assert!(
+                    updated,
+                    "failed to update slot {:?} while holding read lock",
+                    slot
+                );
+                slot.clone()
+            }
+            InternValue::Free { .. } => {
+                panic!("index {:?} is free but should not be", index);
+            }
+        }
+    }
+}
+
 impl<K> Default for InternTables<K>
 where
     K: Eq + Hash,
@@ -165,7 +217,12 @@ where
     Q::Value: InternKey,
     DB: Database,
 {
-    fn intern_index(&self, db: &DB, key: &Q::Key) -> StampedValue<InternId> {
+    /// If `key` has already been interned, returns its slot. Otherwise, creates a new slot.
+    ///
+    /// In either case, the `accessed_at` field of the slot is updated
+    /// to the current revision, ensuring that the slot cannot be GC'd
+    /// while the current queries execute.
+    fn intern_index(&self, db: &DB, key: &Q::Key) -> Arc<Slot<Q::Key>> {
         if let Some(i) = self.intern_check(db, key) {
             return i;
         }
@@ -180,23 +237,15 @@ where
             Entry::Vacant(entry) => entry,
             Entry::Occupied(entry) => {
                 // Somebody inserted this key while we were waiting
-                // for the write lock.
+                // for the write lock. In this case, we don't need to
+                // update the `accessed_at` field because they should
+                // have already done so!
                 let index = *entry.get();
                 match &tables.values[index.as_usize()] {
-                    InternValue::Present {
-                        value,
-                        interned_at,
-                        accessed_at,
-                    } => {
-                        debug_assert_eq!(owned_key2, *value);
-                        debug_assert_eq!(*accessed_at, revision_now);
-                        return StampedValue {
-                            value: index,
-                            changed_at: ChangedAt {
-                                is_constant: false,
-                                revision: *interned_at,
-                            },
-                        };
+                    InternValue::Present { slot } => {
+                        debug_assert_eq!(owned_key2, slot.value);
+                        debug_assert_eq!(slot.accessed_at.load(), Some(revision_now));
+                        return slot.clone();
                     }
 
                     InternValue::Free { .. } => {
@@ -206,179 +255,60 @@ where
             }
         };
 
-        let index = match tables.first_free {
+        let create_slot = |index: InternId| {
+            Arc::new(Slot {
+                index,
+                value: owned_key2,
+                interned_at: revision_now,
+                accessed_at: AtomicCell::new(Some(revision_now)),
+            })
+        };
+
+        let (slot, index);
+        match tables.first_free {
             None => {
-                let index = InternId::from(tables.values.len());
-                tables.values.push(InternValue::Present {
-                    value: owned_key2,
-                    interned_at: revision_now,
-                    accessed_at: revision_now,
-                });
-                index
+                index = InternId::from(tables.values.len());
+                slot = create_slot(index);
+                tables
+                    .values
+                    .push(InternValue::Present { slot: slot.clone() });
             }
 
             Some(i) => {
+                index = i;
+                slot = create_slot(index);
+
                 let next_free = match &tables.values[i.as_usize()] {
                     InternValue::Free { next } => *next,
-                    InternValue::Present { value, .. } => {
+                    InternValue::Present { slot } => {
                         panic!(
                             "index {:?} was supposed to be free but contains {:?}",
-                            i, value
+                            i, slot.value
                         );
                     }
                 };
 
-                tables.values[i.as_usize()] = InternValue::Present {
-                    value: owned_key2,
-                    interned_at: revision_now,
-                    accessed_at: revision_now,
-                };
+                tables.values[index.as_usize()] = InternValue::Present { slot: slot.clone() };
                 tables.first_free = next_free;
-                i
             }
-        };
+        }
 
         entry.insert(index);
 
-        StampedValue {
-            value: index,
-            changed_at: ChangedAt {
-                is_constant: false,
-                revision: revision_now,
-            },
-        }
+        slot
     }
 
-    fn intern_check(&self, db: &DB, key: &Q::Key) -> Option<StampedValue<InternId>> {
+    fn intern_check(&self, db: &DB, key: &Q::Key) -> Option<Arc<Slot<Q::Key>>> {
         let revision_now = db.salsa_runtime().current_revision();
-
-        // First, try with read lock -- this only works if `accessed_at` is up to date.
-        {
-            let tables = self.tables.read();
-            let &index = tables.map.get(key)?;
-            match &tables.values[index.as_usize()] {
-                InternValue::Present {
-                    interned_at,
-                    accessed_at,
-                    ..
-                } => {
-                    if *accessed_at == revision_now {
-                        return Some(StampedValue {
-                            value: index,
-                            changed_at: ChangedAt {
-                                is_constant: false,
-                                revision: *interned_at,
-                            },
-                        });
-                    }
-                }
-
-                InternValue::Free { .. } => {
-                    panic!(
-                        "key {:?} maps to index {:?} is free but should not be",
-                        key, index
-                    );
-                }
-            }
-        }
-
-        // Acquire write lock if necessary.
-        let mut tables = self.tables.write();
-        let &index = tables.map.get(key)?;
-        match &mut tables.values[index.as_usize()] {
-            InternValue::Present {
-                interned_at,
-                accessed_at,
-                ..
-            } => {
-                *accessed_at = revision_now;
-
-                return Some(StampedValue {
-                    value: index,
-                    changed_at: ChangedAt {
-                        is_constant: false,
-                        revision: *interned_at,
-                    },
-                });
-            }
-
-            InternValue::Free { .. } => {
-                panic!(
-                    "key {:?} maps to index {:?} is free but should not be",
-                    key, index
-                );
-            }
-        }
+        let slot = self.tables.read().slot_for_key(key, revision_now)?;
+        Some(slot)
     }
 
     /// Given an index, lookup and clone its value, updating the
     /// `accessed_at` time if necessary.
-    fn lookup_value<R>(
-        &self,
-        db: &DB,
-        index: InternId,
-        op: impl FnOnce(&Q::Key) -> R,
-    ) -> StampedValue<R> {
-        let index = index.as_usize();
+    fn lookup_value(&self, db: &DB, index: InternId) -> Arc<Slot<Q::Key>> {
         let revision_now = db.salsa_runtime().current_revision();
-
-        {
-            let tables = self.tables.read();
-            debug_assert!(
-                index < tables.values.len(),
-                "interned key ``{:?}({})` is out of bounds",
-                Q::default(),
-                index,
-            );
-            match &tables.values[index] {
-                InternValue::Present {
-                    accessed_at,
-                    interned_at,
-                    value,
-                } => {
-                    if *accessed_at == revision_now {
-                        return StampedValue {
-                            value: op(value),
-                            changed_at: ChangedAt {
-                                is_constant: false,
-                                revision: *interned_at,
-                            },
-                        };
-                    }
-                }
-
-                InternValue::Free { .. } => panic!(
-                    "interned key `{:?}({})` has been garbage collected",
-                    Q::default(),
-                    index,
-                ),
-            }
-        }
-
-        let mut tables = self.tables.write();
-        match &mut tables.values[index] {
-            InternValue::Present {
-                accessed_at,
-                interned_at,
-                value,
-            } => {
-                *accessed_at = revision_now;
-
-                return StampedValue {
-                    value: op(value),
-                    changed_at: ChangedAt {
-                        is_constant: false,
-                        revision: *interned_at,
-                    },
-                };
-            }
-
-            InternValue::Free { .. } => panic!(
-                "interned key `{:?}({})` has been garbage collected",
-                Q::default(),
-                index,
-            ),
-        }
+        self.tables.read().slot_for_index(index, revision_now)
     }
 }
 
@@ -394,12 +324,17 @@ where
         key: &Q::Key,
         database_key: &DB::DatabaseKey,
     ) -> Result<Q::Value, CycleDetected> {
-        let StampedValue { value, changed_at } = self.intern_index(db, key);
-
-        db.salsa_runtime()
-            .report_query_read(database_key, changed_at);
-
-        Ok(<Q::Value>::from_intern_id(value))
+        let slot = self.intern_index(db, key);
+        let changed_at = slot.interned_at;
+        let index = slot.index;
+        db.salsa_runtime().report_query_read(
+            database_key,
+            ChangedAt {
+                is_constant: false,
+                revision: changed_at,
+            },
+        );
+        Ok(<Q::Value>::from_intern_id(index))
     }
 
     fn maybe_changed_since(
@@ -410,10 +345,7 @@ where
         _database_key: &DB::DatabaseKey,
     ) -> bool {
         match self.intern_check(db, key) {
-            Some(StampedValue {
-                value: _,
-                changed_at,
-            }) => changed_at.changed_since(revision),
+            Some(slot) => slot.interned_at > revision,
             None => true,
         }
     }
@@ -452,8 +384,8 @@ where
             first_free,
         } = &mut *tables;
         map.retain(|key, intern_index| {
-            let discard = match strategy.discard_if {
-                DiscardIf::Never => false,
+            match strategy.discard_if {
+                DiscardIf::Never => true,
 
                 // NB: Interned keys *never* discard keys unless they
                 // are outdated, regardless of the sweep strategy. This is
@@ -467,8 +399,17 @@ where
                 // revision don't have this problem. Anything
                 // dependent on them would regard itself as dirty if
                 // they are removed and also be forced to re-execute.
-                DiscardIf::Always | DiscardIf::Outdated => match values[intern_index.as_usize()] {
-                    InternValue::Present { accessed_at, .. } => accessed_at < revision_now,
+                DiscardIf::Always | DiscardIf::Outdated => match &values[intern_index.as_usize()] {
+                    InternValue::Present { slot, .. } => {
+                        if slot.try_collect(revision_now) {
+                            values[intern_index.as_usize()] =
+                                InternValue::Free { next: *first_free };
+                            *first_free = Some(*intern_index);
+                            false
+                        } else {
+                            true
+                        }
+                    }
 
                     InternValue::Free { .. } => {
                         panic!(
@@ -477,14 +418,7 @@ where
                         );
                     }
                 },
-            };
-
-            if discard {
-                values[intern_index.as_usize()] = InternValue::Free { next: *first_free };
-                *first_free = Some(*intern_index);
             }
-
-            !discard
         });
     }
 }
@@ -515,12 +449,14 @@ where
 
         let group_storage = <DB as HasQueryGroup<Q::Group>>::group_storage(db);
         let interned_storage = IQ::query_storage(group_storage);
-        let StampedValue { value, changed_at } =
-            interned_storage.lookup_value(db, index, Clone::clone);
-
+        let slot = interned_storage.lookup_value(db, index);
+        let changed_at = ChangedAt {
+            is_constant: false,
+            revision: slot.interned_at,
+        };
+        let value = slot.value.clone();
         db.salsa_runtime()
             .report_query_read(database_key, changed_at);
-
         Ok(value)
     }
 
@@ -555,12 +491,8 @@ where
 
         let group_storage = <DB as HasQueryGroup<Q::Group>>::group_storage(db);
         let interned_storage = IQ::query_storage(group_storage);
-        let StampedValue {
-            value: (),
-            changed_at,
-        } = interned_storage.lookup_value(db, index, |_| ());
-
-        changed_at.changed_since(revision)
+        let slot = interned_storage.lookup_value(db, index);
+        slot.interned_at > revision
     }
 
     fn is_constant(&self, _db: &DB, _key: &Q::Key, _database_key: &DB::DatabaseKey) -> bool {
@@ -600,4 +532,55 @@ where
     DB: Database,
 {
     fn sweep(&self, _db: &DB, _strategy: SweepStrategy) {}
+}
+
+impl<K> Slot<K> {
+    /// Updates the `accessed_at` time to be `revision_now` (if
+    /// necessary).  Returns true if the update was successful, or
+    /// false if the slot has been GC'd in the interim.
+    fn try_update_accessed_at(&self, revision_now: Revision) -> bool {
+        if let Some(accessed_at) = self.accessed_at.load() {
+            match self
+                .accessed_at
+                .compare_exchange(Some(accessed_at), Some(revision_now))
+            {
+                Ok(_) => true,
+                Err(Some(r)) => {
+                    // Somebody was racing with us to update the field -- but they
+                    // also updated it to revision now, so that's cool.
+                    debug_assert_eq!(r, revision_now);
+                    true
+                }
+                Err(None) => {
+                    // The garbage collector was racing with us and it swept this
+                    // slot before we could mark it as accessed.
+                    false
+                }
+            }
+        } else {
+            false
+        }
+    }
+
+    /// Invoked during sweeping to try and collect this slot. Fails if
+    /// the slot has been accessed in the current revision. Note that
+    /// this access could be racing with the attempt to collect (in
+    /// particular, when verifying dependencies).
+    fn try_collect(&self, revision_now: Revision) -> bool {
+        let accessed_at = self.accessed_at.load().unwrap();
+        if accessed_at < revision_now {
+            match self.accessed_at.compare_exchange(Some(accessed_at), None) {
+                Ok(_) => true,
+                Err(r) => {
+                    // The only one racing with us can be a
+                    // verification attempt, which will always bump
+                    // `accessed_at` to the current revision.
+                    debug_assert_eq!(r, Some(revision_now));
+                    false
+                }
+            }
+        } else {
+            false
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ mod derived;
 mod input;
 mod intern_id;
 mod interned;
+mod lru;
 mod runtime;
 
 pub mod debug;
@@ -22,9 +23,9 @@ pub mod plumbing;
 
 use crate::plumbing::CycleDetected;
 use crate::plumbing::InputQueryStorageOps;
+use crate::plumbing::LruQueryStorageOps;
 use crate::plumbing::QueryStorageMassOps;
 use crate::plumbing::QueryStorageOps;
-use crate::plumbing::LruQueryStorageOps;
 use derive_new::new;
 use std::fmt::{self, Debug};
 use std::hash::Hash;
@@ -547,8 +548,7 @@ where
     where
         Q::Storage: plumbing::LruQueryStorageOps,
     {
-        self.storage
-            .set_lru_capacity(cap);
+        self.storage.set_lru_capacity(cap);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 //! re-execute the derived queries and it will try to re-use results
 //! from previous invocations as appropriate.
 
+mod dependency;
 mod derived;
 mod input;
 mod intern_id;
@@ -458,10 +459,10 @@ where
     /// queries (those with no inputs, or those with more than one
     /// input) the key will be a tuple.
     pub fn get(&self, key: Q::Key) -> Q::Value {
-        let database_key = self.database_key(&key);
         self.storage
-            .try_fetch(self.db, &key, &database_key)
+            .try_fetch(self.db, &key)
             .unwrap_or_else(|CycleDetected| {
+                let database_key = self.database_key(&key);
                 self.db
                     .salsa_runtime()
                     .report_unexpected_cycle(database_key)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 
 mod dependency;
 mod derived;
+mod doctest;
 mod input;
 mod intern_id;
 mod interned;
@@ -404,7 +405,13 @@ where
 
 /// Trait implements by all of the "special types" associated with
 /// each of your queries.
-pub trait Query<DB: Database>: Debug + Default + Sized + 'static {
+///
+/// Unsafe trait obligation: Asserts that the Key/Value associated
+/// types for this trait are a part of the `Group::GroupData` type.
+/// In particular, `Group::GroupData: Send + Sync` must imply that
+/// `Key: Send + Sync` and `Value: Send + Sync`. This is relied upon
+/// by the dependency tracking logic.
+pub unsafe trait Query<DB: Database>: Debug + Default + Sized + 'static {
     /// Type that you you give as a parameter -- for queries with zero
     /// or more than one input, this will be a tuple.
     type Key: Clone + Debug + Hash + Eq;

--- a/src/lru.rs
+++ b/src/lru.rs
@@ -1,0 +1,164 @@
+use arc_swap::ArcSwapOption;
+use arc_swap::Lease;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+mod test;
+
+/// A very simple concurrent lru list, built using a doubly linked
+/// list of Arcs.
+///
+/// The list uses a very simple locking scheme and will probably
+/// suffer under high contention. This could certainly be improved.
+///
+/// We assume but do not verify that each node is only used with one
+/// list. If this is not the case, it is not *unsafe*, but panics and
+/// weird results will ensue.
+///
+/// Each "node" in the list is of type `Node` and must implement
+/// `LruNode`, which is a trait that gives access to a field of type
+/// `LruLinks<Node>`, which stores the prev/next points.
+#[derive(Debug)]
+pub(crate) struct Lru<Node>
+where
+    Node: LruNode,
+{
+    len: usize,
+    head: Option<Arc<Node>>,
+    tail: Option<Arc<Node>>,
+}
+
+pub(crate) trait LruNode: Sized + Debug {
+    fn links(&self) -> &LruLinks<Self>;
+}
+
+pub(crate) struct LruLinks<Node> {
+    prev: ArcSwapOption<Node>,
+    next: ArcSwapOption<Node>,
+}
+
+impl<Node> Default for Lru<Node>
+where
+    Node: LruNode,
+{
+    fn default() -> Self {
+        Lru {
+            len: 0,
+            head: None,
+            tail: None,
+        }
+    }
+}
+
+impl<Node> Drop for Lru<Node>
+where
+    Node: LruNode,
+{
+    fn drop(&mut self) {
+        self.clear();
+    }
+}
+
+impl<Node> Lru<Node>
+where
+    Node: LruNode,
+{
+    /// Removes everyting from the list.
+    pub fn clear(&mut self) {
+        // Not terribly efficient at the moment.
+        while self.pop_lru().is_some() {}
+    }
+
+    /// Removes the least-recently-used item in the list.
+    pub fn pop_lru(&mut self) -> Option<Arc<Node>> {
+        log::debug!("pop_lru(self={:?})", self);
+        let node = self.tail.take()?;
+        debug_assert!(node.links().next.load().is_none());
+        self.tail = node.links().prev.swap(None);
+        if let Some(new_tail) = &self.tail {
+            new_tail.links().next.store(None);
+            self.len -= 1;
+        } else {
+            self.head = None;
+        }
+        Some(node)
+    }
+
+    /// Makes `node` the least-recently-used item in the list, adding
+    /// it to the list if it was not already a member.
+    pub fn promote(&mut self, node: Arc<Node>) -> usize {
+        log::debug!("promote(node={:?})", node);
+        let node = node.clone();
+
+        let node_links = node.links();
+
+        // First: check if the node is already in the linked list and has neighbors.
+        // If so, let's unlink it.
+        {
+            let old_prev = node_links.prev.lease().into_option();
+            let old_next = node_links.next.lease().into_option();
+            log::debug!("promote: old_prev={:?}", old_prev);
+            log::debug!("promote: old_next={:?}", old_next);
+            match (old_prev, old_next) {
+                (Some(old_prev), Some(old_next)) => {
+                    // Node is in the middle of the list.
+                    old_prev.links().next.store(Some(Lease::upgrade(&old_next)));
+                    old_next
+                        .links()
+                        .prev
+                        .store(Some(Lease::into_upgrade(old_prev)));
+                    self.len -= 1;
+                }
+                (None, Some(_)) => {
+                    // Node is already at the head of the list. Nothing to do here.
+                    return self.len;
+                }
+                (Some(old_prev), None) => {
+                    // Node is at the tail of the (non-empty) list.
+                    old_prev.links().next.store(None);
+                    self.tail = Some(Lease::into_upgrade(old_prev));
+                    self.len -= 1;
+                }
+                (None, None) => {
+                    // Node is either not in the list *or* at the head of a singleton list.
+                    if let Some(head) = &self.head {
+                        if Arc::ptr_eq(head, &node) {
+                            // Node is at the head.
+                            return self.len;
+                        }
+                    }
+                }
+            }
+        }
+
+        // At this point, the node's links are stale but the node is not a member
+        // of the list.
+        let current_head: Option<Arc<Node>> = self.head.clone();
+        if let Some(current_head) = &current_head {
+            current_head.links().prev.store(Some(node.clone()));
+        }
+        node_links.next.store(current_head);
+        node_links.prev.store(None);
+        if self.len == 0 {
+            self.tail = Some(node.clone());
+        }
+        self.head = Some(node);
+        self.len += 1;
+        return self.len;
+    }
+}
+
+impl<Node> Default for LruLinks<Node> {
+    fn default() -> Self {
+        Self {
+            prev: ArcSwapOption::default(),
+            next: ArcSwapOption::default(),
+        }
+    }
+}
+
+impl<Node> std::fmt::Debug for LruLinks<Node> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(fmt, "LruLinks {{ .. }}")
+    }
+}

--- a/src/lru.rs
+++ b/src/lru.rs
@@ -1,6 +1,5 @@
 use parking_lot::Mutex;
 use rand::rngs::SmallRng;
-use rand::FromEntropy;
 use rand::Rng;
 use rand::SeedableRng;
 use std::fmt::Debug;
@@ -58,16 +57,17 @@ where
     }
 }
 
+// We always use a fixed seed for our randomness so that we have
+// predictable results.
+const LRU_SEED: &str = "Hello, Rustaceans";
+
 impl<Node> Lru<Node>
 where
     Node: LruNode,
 {
     /// Creates a new LRU list where LRU caching is disabled.
     pub fn new() -> Self {
-        Lru {
-            green_zone: AtomicUsize::new(0),
-            data: Mutex::new(LruData::new()),
-        }
+        Self::with_seed(LRU_SEED)
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
@@ -137,11 +137,6 @@ impl<Node> LruData<Node>
 where
     Node: LruNode,
 {
-    fn new() -> Self {
-        Self::with_rng(SmallRng::from_entropy())
-    }
-
-    #[cfg_attr(not(test), allow(dead_code))]
     fn with_seed(seed_str: &str) -> Self {
         Self::with_rng(rng_with_seed(seed_str))
     }

--- a/src/lru.rs
+++ b/src/lru.rs
@@ -69,6 +69,19 @@ where
         while self.pop_lru().is_some() {}
     }
 
+    /// Current number of entries
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn record_use(&mut self, node: Arc<Node>, capacity: usize) -> Option<Arc<Node>> {
+        if self.promote(node) > capacity {
+            return self.pop_lru();
+        } else {
+            None
+        }
+    }
+
     /// Removes the least-recently-used item in the list.
     pub fn pop_lru(&mut self) -> Option<Arc<Node>> {
         log::debug!("pop_lru(self={:?})", self);

--- a/src/lru.rs
+++ b/src/lru.rs
@@ -10,19 +10,16 @@ use std::sync::Arc;
 
 mod test;
 
-/// A very simple concurrent lru list, built using a doubly linked
-/// list of Arcs.
-///
-/// The list uses a very simple locking scheme and will probably
-/// suffer under high contention. This could certainly be improved.
+/// A simple and approximate concurrent lru list.
 ///
 /// We assume but do not verify that each node is only used with one
 /// list. If this is not the case, it is not *unsafe*, but panics and
 /// weird results will ensue.
 ///
 /// Each "node" in the list is of type `Node` and must implement
-/// `LruNode`, which is a trait that gives access to a field of type
-/// `LruLinks<Node>`, which stores the prev/next points.
+/// `LruNode`, which is a trait that gives access to a field that
+/// stores the index in the list. This index gives us a rough idea of
+/// how recently the node has been used.
 #[derive(Debug)]
 pub(crate) struct Lru<Node>
 where

--- a/src/lru.rs
+++ b/src/lru.rs
@@ -1,6 +1,11 @@
-use arc_swap::ArcSwapOption;
-use arc_swap::Lease;
+use parking_lot::Mutex;
+use rand::rngs::SmallRng;
+use rand::FromEntropy;
+use rand::Rng;
+use rand::SeedableRng;
 use std::fmt::Debug;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 mod test;
@@ -23,18 +28,28 @@ pub(crate) struct Lru<Node>
 where
     Node: LruNode,
 {
-    len: usize,
-    head: Option<Arc<Node>>,
-    tail: Option<Arc<Node>>,
+    green_zone: AtomicUsize,
+    data: Mutex<LruData<Node>>,
+}
+
+#[derive(Debug)]
+struct LruData<Node> {
+    end_red_zone: usize,
+    end_yellow_zone: usize,
+    end_green_zone: usize,
+    rng: SmallRng,
+    entries: Vec<Arc<Node>>,
 }
 
 pub(crate) trait LruNode: Sized + Debug {
-    fn links(&self) -> &LruLinks<Self>;
+    fn lru_index(&self) -> &LruIndex;
 }
 
-pub(crate) struct LruLinks<Node> {
-    prev: ArcSwapOption<Node>,
-    next: ArcSwapOption<Node>,
+#[derive(Debug)]
+pub(crate) struct LruIndex {
+    /// Index in the approprate LRU list, or std::usize::MAX if not a
+    /// member.
+    index: AtomicUsize,
 }
 
 impl<Node> Default for Lru<Node>
@@ -42,20 +57,7 @@ where
     Node: LruNode,
 {
     fn default() -> Self {
-        Lru {
-            len: 0,
-            head: None,
-            tail: None,
-        }
-    }
-}
-
-impl<Node> Drop for Lru<Node>
-where
-    Node: LruNode,
-{
-    fn drop(&mut self) {
-        self.clear();
+        Lru::new()
     }
 }
 
@@ -63,115 +65,278 @@ impl<Node> Lru<Node>
 where
     Node: LruNode,
 {
-    /// Removes everyting from the list.
-    pub fn clear(&mut self) {
-        // Not terribly efficient at the moment.
-        while self.pop_lru().is_some() {}
+    /// Creates a new LRU list where LRU caching is disabled.
+    pub fn new() -> Self {
+        Lru {
+            green_zone: AtomicUsize::new(0),
+            data: Mutex::new(LruData::new()),
+        }
     }
 
-    /// Current number of entries
-    pub fn len(&self) -> usize {
-        self.len
+    #[cfg_attr(not(test), allow(dead_code))]
+    fn with_seed(seed: &str) -> Self {
+        Lru {
+            green_zone: AtomicUsize::new(0),
+            data: Mutex::new(LruData::with_seed(seed)),
+        }
     }
 
-    pub fn record_use(&mut self, node: Arc<Node>, capacity: usize) -> Option<Arc<Node>> {
-        if self.promote(node) > capacity {
-            return self.pop_lru();
+    /// Adjust the total number of nodes permitted to have a value at
+    /// once.  If `len` is zero, this disables LRU caching completely.
+    pub fn set_lru_capacity(&self, len: usize) {
+        let mut data = self.data.lock();
+
+        // We require each zone to have at least 1 slot. Therefore,
+        // the length cannot be just 1 or 2.
+        if len == 0 {
+            self.green_zone.store(0, Ordering::Release);
+            data.resize(0, 0, 0);
         } else {
-            None
+            let len = std::cmp::max(len, 3);
+
+            // Top 10% is the green zone. This must be at least length 1.
+            let green_zone = std::cmp::max(len / 10, 1);
+
+            // Next 20% is the yellow zone.
+            let yellow_zone = std::cmp::max(len / 5, 1);
+
+            // Remaining 70% is the red zone.
+            let red_zone = len - yellow_zone - green_zone;
+
+            // We need quick access to the green zone.
+            self.green_zone.store(green_zone, Ordering::Release);
+
+            // Resize existing array.
+            data.resize(green_zone, yellow_zone, red_zone);
         }
     }
 
-    /// Removes the least-recently-used item in the list.
-    pub fn pop_lru(&mut self) -> Option<Arc<Node>> {
-        log::debug!("pop_lru(self={:?})", self);
-        let node = self.tail.take()?;
-        debug_assert!(node.links().next.load().is_none());
-        self.tail = node.links().prev.swap(None);
-        if let Some(new_tail) = &self.tail {
-            new_tail.links().next.store(None);
-            self.len -= 1;
-        } else {
-            self.head = None;
-        }
-        Some(node)
-    }
+    /// Records that `node` was used. This may displace an old node (if the LRU limits are
+    pub fn record_use(&self, node: &Arc<Node>) -> Option<Arc<Node>> {
+        log::debug!("record_use(node={:?})", node);
 
-    /// Makes `node` the least-recently-used item in the list, adding
-    /// it to the list if it was not already a member.
-    pub fn promote(&mut self, node: Arc<Node>) -> usize {
-        log::debug!("promote(node={:?})", node);
-        let node = node.clone();
-
-        let node_links = node.links();
-
-        // First: check if the node is already in the linked list and has neighbors.
-        // If so, let's unlink it.
-        {
-            let old_prev = node_links.prev.lease().into_option();
-            let old_next = node_links.next.lease().into_option();
-            log::debug!("promote: old_prev={:?}", old_prev);
-            log::debug!("promote: old_next={:?}", old_next);
-            match (old_prev, old_next) {
-                (Some(old_prev), Some(old_next)) => {
-                    // Node is in the middle of the list.
-                    old_prev.links().next.store(Some(Lease::upgrade(&old_next)));
-                    old_next
-                        .links()
-                        .prev
-                        .store(Some(Lease::into_upgrade(old_prev)));
-                    self.len -= 1;
-                }
-                (None, Some(_)) => {
-                    // Node is already at the head of the list. Nothing to do here.
-                    return self.len;
-                }
-                (Some(old_prev), None) => {
-                    // Node is at the tail of the (non-empty) list.
-                    old_prev.links().next.store(None);
-                    self.tail = Some(Lease::into_upgrade(old_prev));
-                    self.len -= 1;
-                }
-                (None, None) => {
-                    // Node is either not in the list *or* at the head of a singleton list.
-                    if let Some(head) = &self.head {
-                        if Arc::ptr_eq(head, &node) {
-                            // Node is at the head.
-                            return self.len;
-                        }
-                    }
-                }
-            }
+        // Load green zone length and check if the LRU cache is even enabled.
+        let green_zone = self.green_zone.load(Ordering::Acquire);
+        log::debug!("record_use: green_zone={}", green_zone);
+        if green_zone == 0 {
+            return None;
         }
 
-        // At this point, the node's links are stale but the node is not a member
-        // of the list.
-        let current_head: Option<Arc<Node>> = self.head.clone();
-        if let Some(current_head) = &current_head {
-            current_head.links().prev.store(Some(node.clone()));
+        // Find current index of list (if any) and the current length
+        // of our green zone.
+        let index = node.lru_index().load();
+        log::debug!("record_use: index={}", index);
+
+        // Already a member of the list, and in the green zone -- nothing to do!
+        if index < green_zone {
+            return None;
         }
-        node_links.next.store(current_head);
-        node_links.prev.store(None);
-        if self.len == 0 {
-            self.tail = Some(node.clone());
-        }
-        self.head = Some(node);
-        self.len += 1;
-        return self.len;
+
+        self.data.lock().record_use(node)
     }
 }
 
-impl<Node> Default for LruLinks<Node> {
+impl<Node> LruData<Node>
+where
+    Node: LruNode,
+{
+    fn new() -> Self {
+        Self::with_rng(SmallRng::from_entropy())
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    fn with_seed(seed_str: &str) -> Self {
+        Self::with_rng(rng_with_seed(seed_str))
+    }
+
+    fn with_rng(rng: SmallRng) -> Self {
+        LruData {
+            end_yellow_zone: 0,
+            end_green_zone: 0,
+            end_red_zone: 0,
+            entries: Vec::new(),
+            rng,
+        }
+    }
+
+    fn green_zone(&self) -> std::ops::Range<usize> {
+        0..self.end_green_zone
+    }
+
+    fn yellow_zone(&self) -> std::ops::Range<usize> {
+        self.end_green_zone..self.end_yellow_zone
+    }
+
+    fn red_zone(&self) -> std::ops::Range<usize> {
+        self.end_yellow_zone..self.end_red_zone
+    }
+
+    fn resize(&mut self, len_green_zone: usize, len_yellow_zone: usize, len_red_zone: usize) {
+        self.end_green_zone = len_green_zone;
+        self.end_yellow_zone = self.end_green_zone + len_yellow_zone;
+        self.end_red_zone = self.end_yellow_zone + len_red_zone;
+        let entries = std::mem::replace(&mut self.entries, Vec::with_capacity(self.end_red_zone));
+
+        log::debug!("green_zone = {:?}", self.green_zone());
+        log::debug!("yellow_zone = {:?}", self.yellow_zone());
+        log::debug!("red_zone = {:?}", self.red_zone());
+
+        // We expect to resize when the LRU cache is basically empty.
+        // So just forget all the old LRU indices to start.
+        for entry in entries {
+            entry.lru_index().clear();
+        }
+    }
+
+    /// Records that a node was used. If it is already a member of the
+    /// LRU list, it is promoted to the green zone (unless it's
+    /// already there). Otherwise, it is added to the list first and
+    /// *then* promoted to the green zone. Adding a new node to the
+    /// list may displace an old member of the red zone, in which case
+    /// that is returned.
+    fn record_use(&mut self, node: &Arc<Node>) -> Option<Arc<Node>> {
+        log::debug!("record_use(node={:?})", node);
+
+        // NB: When this is invoked, we have typically already loaded
+        // the LRU index (to check if it is in green zone). But that
+        // check was done outside the lock and -- for all we know --
+        // the index may have changed since. So we always reload.
+        let index = node.lru_index().load();
+
+        if index < self.end_green_zone {
+            None
+        } else if index < self.end_yellow_zone {
+            self.promote_yellow_to_green(node, index);
+            None
+        } else if index < self.end_red_zone {
+            self.promote_red_to_green(node, index);
+            None
+        } else {
+            self.insert_new(node)
+        }
+    }
+
+    /// Inserts a node that is not yet a member of the LRU list. If
+    /// the list is at capacity, this can displace an existing member.
+    fn insert_new(&mut self, node: &Arc<Node>) -> Option<Arc<Node>> {
+        debug_assert!(!node.lru_index().is_in_lru());
+
+        // Easy case: we still have capacity. Push it, and then promote
+        // it up to the appropriate zone.
+        let len = self.entries.len();
+        if len < self.end_red_zone {
+            self.entries.push(node.clone());
+            node.lru_index().store(len);
+            log::debug!("inserted node {:?} at {}", node, len);
+            return self.record_use(node);
+        }
+
+        // Harder case: no capacity. Create some by evicting somebody from red
+        // zone and then promoting.
+        let victim_index = self.pick_index(self.red_zone());
+        let victim_node = std::mem::replace(&mut self.entries[victim_index], node.clone());
+        log::debug!("evicting red node {:?} from {}", victim_node, victim_index);
+        victim_node.lru_index().clear();
+        self.promote_red_to_green(node, victim_index);
+        Some(victim_node)
+    }
+
+    /// Promotes the node `node`, stored at `red_index` (in the red
+    /// zone), into a green index, demoting yellow/green nodes at
+    /// random.
+    ///
+    /// NB: It is not required that `node.lru_index()` is up-to-date
+    /// when entering this method.
+    fn promote_red_to_green(&mut self, node: &Arc<Node>, red_index: usize) {
+        debug_assert!(self.red_zone().contains(&red_index));
+
+        // Pick a yellow at random and switch places with it.
+        //
+        // Subtle: we do not update `node.lru_index` *yet* -- we're
+        // going to invoke `self.promote_yellow` next, and it will get
+        // updated then.
+        let yellow_index = self.pick_index(self.yellow_zone());
+        log::debug!(
+            "demoting yellow node {:?} from {} to red at {}",
+            self.entries[yellow_index],
+            yellow_index,
+            red_index,
+        );
+        self.entries.swap(yellow_index, red_index);
+        self.entries[red_index].lru_index().store(red_index);
+
+        // Now move ourselves up into the green zone.
+        self.promote_yellow_to_green(node, yellow_index);
+    }
+
+    /// Promotes the node `node`, stored at `yellow_index` (in the
+    /// yellow zone), into a green index, demoting a green node at
+    /// random to replace it.
+    ///
+    /// NB: It is not required that `node.lru_index()` is up-to-date
+    /// when entering this method.
+    fn promote_yellow_to_green(&mut self, node: &Arc<Node>, yellow_index: usize) {
+        debug_assert!(self.yellow_zone().contains(&yellow_index));
+
+        // Pick a yellow at random and switch places with it.
+        let green_index = self.pick_index(self.green_zone());
+        log::debug!(
+            "demoting green node {:?} from {} to yellow at {}",
+            self.entries[green_index],
+            green_index,
+            yellow_index
+        );
+        self.entries.swap(green_index, yellow_index);
+        self.entries[yellow_index].lru_index().store(yellow_index);
+        node.lru_index().store(green_index);
+
+        log::debug!("promoted {:?} to green index {}", node, green_index);
+    }
+
+    fn pick_index(&mut self, zone: std::ops::Range<usize>) -> usize {
+        let end_index = std::cmp::min(zone.end, self.entries.len());
+        self.rng.gen_range(zone.start, end_index)
+    }
+}
+
+impl Default for LruIndex {
     fn default() -> Self {
         Self {
-            prev: ArcSwapOption::default(),
-            next: ArcSwapOption::default(),
+            index: AtomicUsize::new(std::usize::MAX),
         }
     }
 }
 
-impl<Node> std::fmt::Debug for LruLinks<Node> {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(fmt, "LruLinks {{ .. }}")
+impl LruIndex {
+    fn load(&self) -> usize {
+        self.index.load(Ordering::Acquire) // see note on ordering below
+    }
+
+    fn store(&self, value: usize) {
+        self.index.store(value, Ordering::Release) // see note on ordering below
+    }
+
+    fn clear(&self) {
+        self.store(std::usize::MAX);
+    }
+
+    fn is_in_lru(&self) -> bool {
+        self.load() != std::usize::MAX
     }
 }
+
+fn rng_with_seed(seed_str: &str) -> SmallRng {
+    let mut seed: [u8; 16] = [0; 16];
+    for (i, &b) in seed_str.as_bytes().iter().take(16).enumerate() {
+        seed[i] = b;
+    }
+    SmallRng::from_seed(seed)
+}
+
+// A note on ordering:
+//
+// I chose to use AcqRel for the ordering but I don't think it's
+// strictly needed.  All writes occur under a lock, so they should be
+// ordered w/r/t one another.  As for the reads, they can occur
+// outside the lock, but they don't themselves enable dependent reads
+// -- if the reads are out of bounds, we would acquire a lock.

--- a/src/lru/test.rs
+++ b/src/lru/test.rs
@@ -1,117 +1,89 @@
 #![cfg(test)]
 
 use super::*;
+use linked_hash_map::LinkedHashMap;
 
 #[derive(Debug)]
 struct TestNode {
-    data: usize,
-    links: LruLinks<TestNode>,
+    id: usize,
+    index: LruIndex,
 }
 
 impl TestNode {
-    fn new(data: usize) -> Arc<Self> {
+    fn new(id: usize) -> Arc<Self> {
         Arc::new(TestNode {
-            data,
-            links: LruLinks::default(),
+            id,
+            index: Default::default(),
         })
     }
 }
 
 impl LruNode for TestNode {
-    fn links(&self) -> &LruLinks<TestNode> {
-        &self.links
+    fn lru_index(&self) -> &LruIndex {
+        &self.index
     }
 }
 
-#[test]
-fn queue() {
-    let mut lru = Lru::default();
-    let n1 = TestNode::new(1);
-    let n2 = TestNode::new(2);
-    let n3 = TestNode::new(3);
+const LRU_SEED: &str = "Hello, Rustaceans";
+const PICK_SEED: &str = "Wippity WIP";
 
-    assert!(lru.pop_lru().is_none());
+/// Randomly requests nodes and compares the performance of a
+/// *perfect* LRU vs our more approximate version. Since all the
+/// random number generators use fixed seeds, these results are
+/// reproducible. Returns (oracle_hits, lru_hits) -- i.e., the number
+/// of times that the oracle had something in cache vs the number of
+/// times that our LRU did.
+fn compare(num_nodes: usize, capacity: usize, requests: usize) -> (usize, usize) {
+    // Remember the clock each time we access a given element.
+    let mut last_access: Vec<usize> = (0..num_nodes).map(|_| 0).collect();
 
-    assert_eq!(lru.promote(n1.clone()), 1);
-    assert_eq!(lru.promote(n2.clone()), 2);
-    assert_eq!(lru.promote(n3.clone()), 3);
+    // Use a linked hash map as our *oracle* -- we track each node we
+    // requested and (as the value) the clock in which we requested
+    // it. When the capacity is exceed, we can pop the oldest.
+    let mut oracle = LinkedHashMap::new();
 
-    assert!(Arc::ptr_eq(&n1, &lru.pop_lru().unwrap()));
-    assert!(Arc::ptr_eq(&n2, &lru.pop_lru().unwrap()));
-    assert!(Arc::ptr_eq(&n3, &lru.pop_lru().unwrap()));
-    assert!(lru.pop_lru().is_none());
+    let lru = Lru::with_seed(LRU_SEED);
+    lru.set_lru_capacity(capacity);
+
+    let nodes: Vec<_> = (0..num_nodes).map(|i| TestNode::new(i)).collect();
+
+    let mut oracle_hits = 0;
+    let mut lru_hits = 0;
+
+    let mut pick_rng = super::rng_with_seed(PICK_SEED);
+    for clock in (0..requests).map(|n| n + 1) {
+        let request_id: usize = pick_rng.gen_range(0, num_nodes);
+
+        last_access[request_id] = clock;
+
+        if oracle.contains_key(&request_id) {
+            oracle_hits += 1;
+        }
+
+        if nodes[request_id].index.is_in_lru() {
+            lru_hits += 1;
+        }
+
+        // maintain the oracle LRU
+        oracle.insert(request_id, ());
+        if oracle.len() > capacity {
+            oracle.pop_front().unwrap();
+        }
+
+        // maintain our own version
+        if let Some(lru_evicted) = lru.record_use(&nodes[request_id]) {
+            assert!(!lru_evicted.index.is_in_lru());
+        }
+    }
+
+    println!("oracle_hits = {}", oracle_hits);
+    println!("lru_hits = {}", lru_hits);
+    (oracle_hits, lru_hits)
 }
 
 #[test]
-fn promote_last() {
-    let mut lru = Lru::default();
-    let n1 = TestNode::new(1);
-    let n2 = TestNode::new(2);
-    let n3 = TestNode::new(3);
-
-    assert_eq!(lru.promote(n1.clone()), 1);
-    assert_eq!(lru.promote(n2.clone()), 2);
-    assert_eq!(lru.promote(n3.clone()), 3);
-    assert_eq!(lru.promote(n1.clone()), 3);
-
-    assert!(Arc::ptr_eq(&n2, &lru.pop_lru().unwrap()));
-    assert!(Arc::ptr_eq(&n3, &lru.pop_lru().unwrap()));
-    assert!(Arc::ptr_eq(&n1, &lru.pop_lru().unwrap()));
-    assert!(lru.pop_lru().is_none());
-}
-
-#[test]
-fn promote_middle() {
-    let mut lru = Lru::default();
-    let n1 = TestNode::new(1);
-    let n2 = TestNode::new(2);
-    let n3 = TestNode::new(3);
-
-    assert_eq!(lru.promote(n1.clone()), 1);
-    assert_eq!(lru.promote(n2.clone()), 2);
-    assert_eq!(lru.promote(n3.clone()), 3);
-    assert_eq!(lru.promote(n2.clone()), 3);
-
-    assert!(Arc::ptr_eq(&n1, &lru.pop_lru().unwrap()));
-    assert!(Arc::ptr_eq(&n3, &lru.pop_lru().unwrap()));
-    assert!(Arc::ptr_eq(&n2, &lru.pop_lru().unwrap()));
-    assert!(&lru.pop_lru().is_none());
-}
-
-#[test]
-fn promote_head() {
-    let mut lru = Lru::default();
-    let n1 = TestNode::new(1);
-    let n2 = TestNode::new(2);
-    let n3 = TestNode::new(3);
-
-    assert_eq!(lru.promote(n1.clone()), 1);
-    assert_eq!(lru.promote(n2.clone()), 2);
-    assert_eq!(lru.promote(n3.clone()), 3);
-    assert_eq!(lru.promote(n3.clone()), 3);
-
-    assert!(Arc::ptr_eq(&n1, &lru.pop_lru().unwrap()));
-    assert!(Arc::ptr_eq(&n2, &lru.pop_lru().unwrap()));
-    assert!(Arc::ptr_eq(&n3, &lru.pop_lru().unwrap()));
-    assert!(&lru.pop_lru().is_none());
-}
-
-#[test]
-fn promote_rev() {
-    let mut lru = Lru::default();
-    let n1 = TestNode::new(1);
-    let n2 = TestNode::new(2);
-    let n3 = TestNode::new(3);
-
-    assert_eq!(lru.promote(n1.clone()), 1);
-    assert_eq!(lru.promote(n2.clone()), 2);
-    assert_eq!(lru.promote(n3.clone()), 3);
-    assert_eq!(lru.promote(n3.clone()), 3);
-    assert_eq!(lru.promote(n2.clone()), 3);
-    assert_eq!(lru.promote(n1.clone()), 3);
-
-    assert!(Arc::ptr_eq(&n3, &lru.pop_lru().unwrap()));
-    assert!(Arc::ptr_eq(&n2, &lru.pop_lru().unwrap()));
-    assert!(Arc::ptr_eq(&n1, &lru.pop_lru().unwrap()));
-    assert!(&lru.pop_lru().is_none());
+fn scenario_a() {
+    let (oracle_hits, lru_hits) = compare(1000, 100, 10000);
+    assert_eq!(oracle_hits, 993);
+    assert_eq!(lru_hits, 973);
 }

--- a/src/lru/test.rs
+++ b/src/lru/test.rs
@@ -1,0 +1,117 @@
+#![cfg(test)]
+
+use super::*;
+
+#[derive(Debug)]
+struct TestNode {
+    data: usize,
+    links: LruLinks<TestNode>,
+}
+
+impl TestNode {
+    fn new(data: usize) -> Arc<Self> {
+        Arc::new(TestNode {
+            data,
+            links: LruLinks::default(),
+        })
+    }
+}
+
+impl LruNode for TestNode {
+    fn links(&self) -> &LruLinks<TestNode> {
+        &self.links
+    }
+}
+
+#[test]
+fn queue() {
+    let mut lru = Lru::default();
+    let n1 = TestNode::new(1);
+    let n2 = TestNode::new(2);
+    let n3 = TestNode::new(3);
+
+    assert!(lru.pop_lru().is_none());
+
+    assert_eq!(lru.promote(n1.clone()), 1);
+    assert_eq!(lru.promote(n2.clone()), 2);
+    assert_eq!(lru.promote(n3.clone()), 3);
+
+    assert!(Arc::ptr_eq(&n1, &lru.pop_lru().unwrap()));
+    assert!(Arc::ptr_eq(&n2, &lru.pop_lru().unwrap()));
+    assert!(Arc::ptr_eq(&n3, &lru.pop_lru().unwrap()));
+    assert!(lru.pop_lru().is_none());
+}
+
+#[test]
+fn promote_last() {
+    let mut lru = Lru::default();
+    let n1 = TestNode::new(1);
+    let n2 = TestNode::new(2);
+    let n3 = TestNode::new(3);
+
+    assert_eq!(lru.promote(n1.clone()), 1);
+    assert_eq!(lru.promote(n2.clone()), 2);
+    assert_eq!(lru.promote(n3.clone()), 3);
+    assert_eq!(lru.promote(n1.clone()), 3);
+
+    assert!(Arc::ptr_eq(&n2, &lru.pop_lru().unwrap()));
+    assert!(Arc::ptr_eq(&n3, &lru.pop_lru().unwrap()));
+    assert!(Arc::ptr_eq(&n1, &lru.pop_lru().unwrap()));
+    assert!(lru.pop_lru().is_none());
+}
+
+#[test]
+fn promote_middle() {
+    let mut lru = Lru::default();
+    let n1 = TestNode::new(1);
+    let n2 = TestNode::new(2);
+    let n3 = TestNode::new(3);
+
+    assert_eq!(lru.promote(n1.clone()), 1);
+    assert_eq!(lru.promote(n2.clone()), 2);
+    assert_eq!(lru.promote(n3.clone()), 3);
+    assert_eq!(lru.promote(n2.clone()), 3);
+
+    assert!(Arc::ptr_eq(&n1, &lru.pop_lru().unwrap()));
+    assert!(Arc::ptr_eq(&n3, &lru.pop_lru().unwrap()));
+    assert!(Arc::ptr_eq(&n2, &lru.pop_lru().unwrap()));
+    assert!(&lru.pop_lru().is_none());
+}
+
+#[test]
+fn promote_head() {
+    let mut lru = Lru::default();
+    let n1 = TestNode::new(1);
+    let n2 = TestNode::new(2);
+    let n3 = TestNode::new(3);
+
+    assert_eq!(lru.promote(n1.clone()), 1);
+    assert_eq!(lru.promote(n2.clone()), 2);
+    assert_eq!(lru.promote(n3.clone()), 3);
+    assert_eq!(lru.promote(n3.clone()), 3);
+
+    assert!(Arc::ptr_eq(&n1, &lru.pop_lru().unwrap()));
+    assert!(Arc::ptr_eq(&n2, &lru.pop_lru().unwrap()));
+    assert!(Arc::ptr_eq(&n3, &lru.pop_lru().unwrap()));
+    assert!(&lru.pop_lru().is_none());
+}
+
+#[test]
+fn promote_rev() {
+    let mut lru = Lru::default();
+    let n1 = TestNode::new(1);
+    let n2 = TestNode::new(2);
+    let n3 = TestNode::new(3);
+
+    assert_eq!(lru.promote(n1.clone()), 1);
+    assert_eq!(lru.promote(n2.clone()), 2);
+    assert_eq!(lru.promote(n3.clone()), 3);
+    assert_eq!(lru.promote(n3.clone()), 3);
+    assert_eq!(lru.promote(n2.clone()), 3);
+    assert_eq!(lru.promote(n1.clone()), 3);
+
+    assert!(Arc::ptr_eq(&n3, &lru.pop_lru().unwrap()));
+    assert!(Arc::ptr_eq(&n2, &lru.pop_lru().unwrap()));
+    assert!(Arc::ptr_eq(&n1, &lru.pop_lru().unwrap()));
+    assert!(&lru.pop_lru().is_none());
+}

--- a/src/lru/test.rs
+++ b/src/lru/test.rs
@@ -25,7 +25,6 @@ impl LruNode for TestNode {
     }
 }
 
-const LRU_SEED: &str = "Hello, Rustaceans";
 const PICK_SEED: &str = "Wippity WIP";
 
 /// Randomly requests nodes and compares the performance of a
@@ -48,7 +47,7 @@ fn compare(
     // it. When the capacity is exceed, we can pop the oldest.
     let mut oracle = LinkedHashMap::new();
 
-    let lru = Lru::with_seed(LRU_SEED);
+    let lru = Lru::with_seed(super::LRU_SEED);
     lru.set_lru_capacity(capacity);
 
     let nodes: Vec<_> = (0..num_nodes).map(|i| TestNode::new(i)).collect();

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -31,6 +31,12 @@ pub trait DatabaseStorageTypes: Sized {
     /// for a more open-ended option.
     type DatabaseKey: DatabaseKey<Self>;
 
+    /// An associated type that contains all the query keys/values
+    /// that can appear in the database. This is used as part of the
+    /// slot mechanism to determine when database handles are
+    /// send/sync/'static.
+    type DatabaseData;
+
     /// Defines the "storage type", where all the query data is kept.
     /// This type is defined by the `database_storage` macro.
     type DatabaseStorage: Default;
@@ -110,6 +116,7 @@ where
 pub trait QueryGroup<DB: Database> {
     type GroupStorage;
     type GroupKey;
+    type GroupData;
 }
 
 /// Trait implemented by a database for each group that it supports.

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -146,7 +146,7 @@ where
         &self,
         db: &DB,
         key: &Q::Key,
-        descriptor: &DB::DatabaseKey,
+        database_key: &DB::DatabaseKey,
     ) -> Result<Q::Value, CycleDetected>;
 
     /// True if the query **may** have changed since the given
@@ -172,11 +172,11 @@ where
         db: &DB,
         revision: Revision,
         key: &Q::Key,
-        descriptor: &DB::DatabaseKey,
+        database_key: &DB::DatabaseKey,
     ) -> bool;
 
     /// Check if `key` is (currently) believed to be a constant.
-    fn is_constant(&self, db: &DB, key: &Q::Key) -> bool;
+    fn is_constant(&self, db: &DB, key: &Q::Key, database_key: &DB::DatabaseKey) -> bool;
 
     /// Get the (current) set of the entries in the query storage
     fn entries<C>(&self, db: &DB) -> C
@@ -192,13 +192,13 @@ where
     DB: Database,
     Q: Query<DB>,
 {
-    fn set(&self, db: &DB, key: &Q::Key, descriptor: &DB::DatabaseKey, new_value: Q::Value);
+    fn set(&self, db: &DB, key: &Q::Key, database_key: &DB::DatabaseKey, new_value: Q::Value);
 
     fn set_constant(
         &self,
         db: &DB,
         key: &Q::Key,
-        descriptor: &DB::DatabaseKey,
+        database_key: &DB::DatabaseKey,
         new_value: Q::Value,
     );
 }
@@ -206,10 +206,6 @@ where
 /// An optional trait that is implemented for "user mutable" storage:
 /// that is, storage whose value is not derived from other storage but
 /// is set independently.
-pub trait LruQueryStorageOps: Default
-{
-    fn set_lru_capacity(
-        &self,
-        new_capacity: usize,
-    );
+pub trait LruQueryStorageOps: Default {
+    fn set_lru_capacity(&self, new_capacity: usize);
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -453,8 +453,8 @@ impl<DB: Database> Default for SharedState<DB> {
             next_id: AtomicUsize::new(1),
             storage: Default::default(),
             query_lock: Default::default(),
-            revision: Default::default(),
-            pending_revision: Default::default(),
+            revision: AtomicU64::new(1),
+            pending_revision: AtomicU64::new(1),
             dependency_graph: Default::default(),
         }
     }
@@ -517,7 +517,7 @@ impl<DB: Database> ActiveQuery<DB> {
             database_key,
             changed_at: ChangedAt {
                 is_constant: true,
-                revision: Revision::ZERO,
+                revision: Revision::START,
             },
             dependencies: Some(FxIndexSet::default()),
         }
@@ -567,7 +567,7 @@ pub struct Revision {
 }
 
 impl Revision {
-    pub(crate) const ZERO: Self = Revision { generation: 0 };
+    pub(crate) const START: Self = Revision { generation: 1 };
 
     fn next(self) -> Revision {
         Revision {

--- a/src/runtime/local_state.rs
+++ b/src/runtime/local_state.rs
@@ -1,3 +1,4 @@
+use crate::dependency::Dependency;
 use crate::runtime::ActiveQuery;
 use crate::runtime::ChangedAt;
 use crate::runtime::Revision;
@@ -57,9 +58,9 @@ impl<DB: Database> LocalState<DB> {
             .map(|active_query| active_query.database_key.clone())
     }
 
-    pub(super) fn report_query_read(&self, database_key: &DB::DatabaseKey, changed_at: ChangedAt) {
+    pub(super) fn report_query_read(&self, dependency: Dependency<DB>, changed_at: ChangedAt) {
         if let Some(top_query) = self.query_stack.borrow_mut().last_mut() {
-            top_query.add_read(database_key, changed_at);
+            top_query.add_read(dependency, changed_at);
         }
     }
 


### PR DESCRIPTION
As discussed on Zulip this PR series optimizes our internal dependency data structures to avoid hashing of keys/values on query revalidation. My measurements found this to be approximately a ~35% win, though @matklad saw results up to 50%. 

This PR *does* introduce some subtle logic around Send+Sync owing to the use of trait objects. It requires a bit of a hack to ensure that the database is Send+Sync iff the keys/values are Send+Sync. I found what feels like a decent solution to this problem by transmuting a `Arc<dyn Slot>` to a `Arc<dyn Slot + Send + Sync>` and using phantom-data to ensure that the composite is only send+sync if the keys/values are send+sync. The truth is that this is kind of overkill since slots are not exposed outside of the database, and if the keys/values are not send+sync, the database as a whole won't be -- but it still feels good to try and be precise here.

| version | from scratch | trivial change x 10 |
| --- | --- | --- |
| master | ~4.5s | 815-820ms |
| approx. LRU | ~4.5s | 537ms |
| precise LRU | 4.5-4.8s | 540-550ms |