### PR TITLE
use AtomicU64 for RuntimeId

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -10,7 +10,7 @@ use rustc_hash::{FxHashMap, FxHasher};
 use smallvec::SmallVec;
 use std::fmt::Write;
 use std::hash::BuildHasherDefault;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 pub(crate) type FxIndexSet<K> = indexmap::IndexSet<K, BuildHasherDefault<FxHasher>>;
@@ -478,7 +478,7 @@ struct SharedState<DB: Database> {
     storage: DB::DatabaseStorage,
 
     /// Stores the next id to use for a snapshotted runtime (starts at 1).
-    next_id: AtomicUsize,
+    next_id: AtomicU64,
 
     /// Whenever derived queries are executing, they acquire this lock
     /// in read mode. Mutating inputs (and thus creating a new
@@ -514,7 +514,7 @@ struct SharedState<DB: Database> {
 impl<DB: Database> SharedState<DB> {
     fn with_durabilities(durabilities: usize) -> Self {
         SharedState {
-            next_id: AtomicUsize::new(1),
+            next_id: AtomicU64::new(1),
             storage: Default::default(),
             query_lock: Default::default(),
             revisions: (0..durabilities).map(|_| AtomicRevision::start()).collect(),
@@ -624,7 +624,7 @@ impl<DB: Database> ActiveQuery<DB> {
 /// complete, its `RuntimeId` may potentially be re-used.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct RuntimeId {
-    counter: usize,
+    counter: u64,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
We don't use `RuntimeId` to index memory, so using usize is
not the best fit semantically