### PR TITLE
release 0.14.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Salsa developers"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"
@@ -18,7 +18,7 @@ rustc-hash = "1.0"
 smallvec = "0.6.5"
 rand = { version = "0.7", features = [ "small_rng" ] }
 
-salsa-macros = { version = "0.13.0", path = "components/salsa-macros" }
+salsa-macros = { version = "0.14.0", path = "components/salsa-macros" }
 
 [dev-dependencies]
 rand_distr = "0.2.1"

--- a/components/salsa-macros/Cargo.toml
+++ b/components/salsa-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa-macros"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Salsa developers"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
- adopt the new `Durability` API proposed in [RFC #6]
- adopt `AtomicU64` for `runtimeId` (#182)
- use `ptr::eq` and `ptr::hash` for readability
- upgrade parking lot
- remove needless clone

[RFC #6]: https://github.com/salsa-rs/salsa-rfcs/pull/6