### PR TITLE
permit gc to collect slot keys

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -21,8 +21,8 @@ pub trait DebugQueryTable {
     /// Returns a lower bound on the durability for the given key.
     /// This is typically the minimum durability of all values that
     /// the query accessed, but we may return a lower durability in
-    /// some cases.
-    fn durability(&self, key: Self::Key) -> Durability;
+    /// some cases, or `None` if no value for `key` has been computed.
+    fn durability(&self, key: Self::Key) -> Option<Durability>;
 
     /// Get the (current) set of the entries in the query table.
     fn entries<C>(&self) -> C
@@ -58,7 +58,7 @@ where
     type Key = Q::Key;
     type Value = Q::Value;
 
-    fn durability(&self, key: Q::Key) -> Durability {
+    fn durability(&self, key: Q::Key) -> Option<Durability> {
         self.storage.durability(self.db, &key)
     }
 

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -160,11 +160,8 @@ where
         Ok(value)
     }
 
-    fn durability(&self, db: &DB, key: &Q::Key) -> Durability {
-        match self.get_slot(key) {
-            Some(slot) => slot.durability(db),
-            None => Durability::LOW,
-        }
+    fn durability(&self, db: &DB, key: &Q::Key) -> Option<Durability> {
+        Some(self.get_slot(key)?.durability(db))
     }
 
     fn entries<C>(&self, _db: &DB) -> C

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -186,11 +186,9 @@ where
     MP: MemoizationPolicy<DB, Q>,
 {
     fn sweep(&self, db: &DB, strategy: SweepStrategy) {
-        let map_read = self.slot_map.read();
+        let mut map_write = self.slot_map.write();
         let revision_now = db.salsa_runtime().current_revision();
-        for slot in map_read.values() {
-            slot.sweep(revision_now, strategy);
-        }
+        map_write.retain(|_key, slot| !slot.sweep(revision_now, strategy));
     }
 }
 

--- a/src/derived/slot.rs
+++ b/src/derived/slot.rs
@@ -110,6 +110,10 @@ enum ProbeResult<V, K, G> {
 pub(super) enum ReadResult<V, K> {
     Ok(StampedValue<V>),
     CycleError(CycleError<K>),
+
+    /// This slot was marked as invalidated and a fresh one must be
+    /// created.
+    Invalidated,
 }
 
 impl<DB, Q, MP> Slot<DB, Q, MP>
@@ -960,7 +964,7 @@ where
                                 );
                                 v.changed_at > revision
                             }
-                            ReadResult::CycleError(_) => true,
+                            ReadResult::Invalidated | ReadResult::CycleError(_) => true,
                         };
                     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -91,11 +91,8 @@ where
         Ok(value)
     }
 
-    fn durability(&self, _db: &DB, key: &Q::Key) -> Durability {
-        match self.slot(key) {
-            Some(slot) => slot.stamped_value.read().durability,
-            None => panic!("no value set for {:?}({:?})", Q::default(), key),
-        }
+    fn durability(&self, _db: &DB, key: &Q::Key) -> Option<Durability> {
+        Some(self.slot(key)?.stamped_value.read().durability)
     }
 
     fn entries<C>(&self, _db: &DB) -> C

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -329,8 +329,8 @@ where
         Ok(<Q::Value>::from_intern_id(index))
     }
 
-    fn durability(&self, _db: &DB, _key: &Q::Key) -> Durability {
-        INTERN_DURABILITY
+    fn durability(&self, _db: &DB, _key: &Q::Key) -> Option<Durability> {
+        Some(INTERN_DURABILITY)
     }
 
     fn entries<C>(&self, _db: &DB) -> C
@@ -431,8 +431,8 @@ where
         Ok(value)
     }
 
-    fn durability(&self, _db: &DB, _key: &Q::Key) -> Durability {
-        INTERN_DURABILITY
+    fn durability(&self, _db: &DB, _key: &Q::Key) -> Option<Durability> {
+        Some(INTERN_DURABILITY)
     }
 
     fn entries<C>(&self, db: &DB) -> C

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -158,7 +158,7 @@ where
     fn try_fetch(&self, db: &DB, key: &Q::Key) -> Result<Q::Value, CycleError<DB::DatabaseKey>>;
 
     /// Returns the durability associated with a given key.
-    fn durability(&self, db: &DB, key: &Q::Key) -> Durability;
+    fn durability(&self, db: &DB, key: &Q::Key) -> Option<Durability>;
 
     /// Get the (current) set of the entries in the query storage
     fn entries<C>(&self, db: &DB) -> C

--- a/tests/gc/interned.rs
+++ b/tests/gc/interned.rs
@@ -122,7 +122,7 @@ fn discard_durability_after_synthetic_write_low() {
     // This will assign index 0 for "foo".
     let foo1a = db.repeat_intern1("foo");
     assert_eq!(
-        Durability::HIGH,
+        Some(Durability::HIGH),
         db.query(RepeatIntern1Query).durability("foo")
     );
 
@@ -163,7 +163,7 @@ fn discard_durability_after_synthetic_write_high() {
     let foo1a = db.repeat_intern1("foo");
     assert_eq!(
         Durability::HIGH,
-        db.query(RepeatIntern1Query).durability("foo")
+        db.query(RepeatIntern1Query).durability("foo").unwrap()
     );
 
     // Trigger a new revision -- marking even high things as having changed.

--- a/tests/incremental/constants.rs
+++ b/tests/incremental/constants.rs
@@ -69,7 +69,10 @@ fn not_constant() {
     db.set_input('a', 22);
     db.set_input('b', 44);
     assert_eq!(db.add('a', 'b'), 66);
-    assert_eq!(Durability::LOW, db.query(AddQuery).durability(('a', 'b')));
+    assert_eq!(
+        Some(Durability::LOW),
+        db.query(AddQuery).durability(('a', 'b'))
+    );
 }
 
 #[test]
@@ -79,7 +82,10 @@ fn durability() {
     db.set_input_with_durability('a', 22, Durability::HIGH);
     db.set_input_with_durability('b', 44, Durability::HIGH);
     assert_eq!(db.add('a', 'b'), 66);
-    assert_eq!(Durability::HIGH, db.query(AddQuery).durability(('a', 'b')));
+    assert_eq!(
+        Some(Durability::HIGH),
+        db.query(AddQuery).durability(('a', 'b'))
+    );
 }
 
 #[test]
@@ -89,7 +95,10 @@ fn mixed_constant() {
     db.set_input_with_durability('a', 22, Durability::HIGH);
     db.set_input('b', 44);
     assert_eq!(db.add('a', 'b'), 66);
-    assert_eq!(Durability::LOW, db.query(AddQuery).durability(('a', 'b')));
+    assert_eq!(
+        Some(Durability::LOW),
+        db.query(AddQuery).durability(('a', 'b'))
+    );
 }
 
 #[test]
@@ -99,20 +108,29 @@ fn becomes_constant_with_change() {
     db.set_input('a', 22);
     db.set_input('b', 44);
     assert_eq!(db.add('a', 'b'), 66);
-    assert_eq!(Durability::LOW, db.query(AddQuery).durability(('a', 'b')));
+    assert_eq!(
+        Some(Durability::LOW),
+        db.query(AddQuery).durability(('a', 'b'))
+    );
 
     db.set_input_with_durability('a', 23, Durability::HIGH);
     assert_eq!(db.add('a', 'b'), 67);
-    assert_eq!(Durability::LOW, db.query(AddQuery).durability(('a', 'b')));
+    assert_eq!(
+        Some(Durability::LOW),
+        db.query(AddQuery).durability(('a', 'b'))
+    );
 
     db.set_input_with_durability('b', 45, Durability::HIGH);
     assert_eq!(db.add('a', 'b'), 68);
-    assert_eq!(Durability::HIGH, db.query(AddQuery).durability(('a', 'b')));
+    assert_eq!(
+        Some(Durability::HIGH),
+        db.query(AddQuery).durability(('a', 'b'))
+    );
 
     db.set_input_with_durability('b', 45, Durability::MEDIUM);
     assert_eq!(db.add('a', 'b'), 68);
     assert_eq!(
-        Durability::MEDIUM,
+        Some(Durability::MEDIUM),
         db.query(AddQuery).durability(('a', 'b'))
     );
 }


### PR DESCRIPTION
In the older codebase, GC could never collect a slot key. We now enable this by transforming slots to a *removed* state. There is a slight race condition in that someone *reading* the slot might now race with the GC which would remove it in the meantime; in that case we simply try again.