### PR TITLE
require `&mut self` for moving to a new revision (breaking)

### DIFF
--- a/examples/compiler/implementation.rs
+++ b/examples/compiler/implementation.rs
@@ -27,8 +27,12 @@ pub struct DatabaseImpl {
 
 /// This impl tells salsa where to find the salsa runtime.
 impl salsa::Database for DatabaseImpl {
-    fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseImpl> {
+    fn salsa_runtime(&self) -> &salsa::Runtime<Self> {
         &self.runtime
+    }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime<Self> {
+        &mut self.runtime
     }
 }
 

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -79,8 +79,12 @@ struct DatabaseStruct {
 
 // Tell salsa where to find the runtime in your context.
 impl salsa::Database for DatabaseStruct {
-    fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseStruct> {
+    fn salsa_runtime(&self) -> &salsa::Runtime<Self> {
         &self.runtime
+    }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime<Self> {
+        &mut self.runtime
     }
 }
 

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -197,8 +197,8 @@ where
     DB: Database + HasQueryGroup<Q::Group>,
     MP: MemoizationPolicy<DB, Q>,
 {
-    fn invalidate(&self, db: &DB, key: &Q::Key) {
-        db.salsa_runtime().with_incremented_revision(|guard| {
+    fn invalidate(&self, db: &mut DB, key: &Q::Key) {
+        db.salsa_runtime_mut().with_incremented_revision(|guard| {
             let map_read = self.slot_map.read();
 
             if let Some(slot) = map_read.get(key) {

--- a/src/doctest.rs
+++ b/src/doctest.rs
@@ -27,8 +27,12 @@
 /// }
 ///
 /// impl salsa::Database for DatabaseImpl {
-///     fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseImpl> {
+///     fn salsa_runtime(&self) -> &salsa::Runtime<Self> {
 ///         &self.runtime
+///     }
+///
+///     fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime<Self> {
+///         &mut self.runtime
 ///     }
 /// }
 ///
@@ -68,8 +72,12 @@ fn test_key_not_send_db_not_send() {}
 /// }
 ///
 /// impl salsa::Database for DatabaseImpl {
-///     fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseImpl> {
+///     fn salsa_runtime(&self) -> &salsa::Runtime<Self> {
 ///         &self.runtime
+///     }
+///
+///     fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime<Self> {
+///         &mut self.runtime
 ///     }
 /// }
 ///
@@ -108,8 +116,12 @@ fn test_key_not_sync_db_not_send() {}
 /// }
 ///
 /// impl salsa::Database for DatabaseImpl {
-///     fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseImpl> {
+///     fn salsa_runtime(&self) -> &salsa::Runtime<Self> {
 ///         &self.runtime
+///     }
+///
+///     fn salsa_runtime(&mut self) -> &mut salsa::Runtime<Self> {
+///         &mut self.runtime
 ///     }
 /// }
 ///

--- a/src/input.rs
+++ b/src/input.rs
@@ -130,7 +130,7 @@ where
 {
     fn set(
         &self,
-        db: &DB,
+        db: &mut DB,
         key: &Q::Key,
         database_key: &DB::DatabaseKey,
         value: Q::Value,
@@ -166,7 +166,7 @@ where
         // keys, we only need a new revision if the key used to
         // exist. But we may add such methods in the future and this
         // case doesn't generally seem worth optimizing for.
-        db.salsa_runtime().with_incremented_revision(|guard| {
+        db.salsa_runtime_mut().with_incremented_revision(|guard| {
             let mut slots = self.slots.write();
 
             // Do this *after* we acquire the lock, so that we are not

--- a/src/input.rs
+++ b/src/input.rs
@@ -144,6 +144,13 @@ where
             durability
         );
 
+        db.salsa_event(|| Event {
+            runtime_id: db.salsa_runtime().id(),
+            kind: EventKind::WillChangeInputValue {
+                database_key: database_key.clone(),
+            },
+        });
+
         // The value is changing, so we need a new revision (*). We also
         // need to update the 'last changed' revision by invoking
         // `guard.mark_durability_as_changed`.
@@ -161,13 +168,6 @@ where
         // case doesn't generally seem worth optimizing for.
         db.salsa_runtime().with_incremented_revision(|guard| {
             let mut slots = self.slots.write();
-
-            db.salsa_event(|| Event {
-                runtime_id: db.salsa_runtime().id(),
-                kind: EventKind::WillChangeInputValue {
-                    database_key: database_key.clone(),
-                },
-            });
 
             // Do this *after* we acquire the lock, so that we are not
             // racing with somebody else to modify this same cell.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,9 @@ pub trait Database: plumbing::DatabaseStorageTypes + plumbing::DatabaseOps {
     /// Gives access to the underlying salsa runtime.
     fn salsa_runtime(&self) -> &Runtime<Self>;
 
+    /// Gives access to the underlying salsa runtime.
+    fn salsa_runtime_mut(&mut self) -> &mut Runtime<Self>;
+
     /// Iterates through all query storage and removes any values that
     /// have not been used since the last revision was created. The
     /// intended use-cycle is that you first execute all of your

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ use crate::revision::Revision;
 use derive_new::new;
 use std::fmt::{self, Debug};
 use std::hash::Hash;
+use std::sync::Arc;
 
 pub use crate::durability::Durability;
 pub use crate::intern_id::InternId;
@@ -439,7 +440,7 @@ pub unsafe trait Query<DB: Database>: Debug + Default + Sized + 'static {
     type GroupKey;
 
     /// Extact storage for this query from the storage for its group.
-    fn query_storage(group_storage: &Self::GroupStorage) -> &Self::Storage;
+    fn query_storage(group_storage: &Self::GroupStorage) -> &Arc<Self::Storage>;
 
     /// Create group key for this query.
     fn group_key(key: Self::Key) -> Self::GroupKey;
@@ -498,7 +499,7 @@ where
     Q: Query<DB> + 'me,
 {
     db: &'me DB,
-    storage: &'me Q::Storage,
+    storage: Arc<Q::Storage>,
 }
 
 impl<DB, Q> QueryTableMut<'_, DB, Q>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -501,7 +501,7 @@ where
     DB: plumbing::GetQueryTable<Q>,
     Q: Query<DB> + 'me,
 {
-    db: &'me DB,
+    db: &'me mut DB,
     storage: Arc<Q::Storage>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -521,7 +521,7 @@ where
     /// and cancellation on [the `query_mut` method].
     ///
     /// [the `query_mut` method]: trait.Database#method.query_mut
-    pub fn set(&self, key: Q::Key, value: Q::Value)
+    pub fn set(&mut self, key: Q::Key, value: Q::Value)
     where
         Q::Storage: plumbing::InputQueryStorageOps<DB, Q>,
     {
@@ -536,7 +536,7 @@ where
     /// and cancellation on [the `query_mut` method].
     ///
     /// [the `query_mut` method]: trait.Database#method.query_mut
-    pub fn set_with_durability(&self, key: Q::Key, value: Q::Value, durability: Durability)
+    pub fn set_with_durability(&mut self, key: Q::Key, value: Q::Value, durability: Durability)
     where
         Q::Storage: plumbing::InputQueryStorageOps<DB, Q>,
     {
@@ -565,7 +565,7 @@ where
     ///
     /// This is most commonly used as part of the [on-demand input
     /// pattern](https://salsa-rs.github.io/salsa/common_patterns/on_demand_inputs.html).
-    pub fn invalidate(&self, key: &Q::Key)
+    pub fn invalidate(&mut self, key: &Q::Key)
     where
         Q::Storage: plumbing::DerivedQueryStorageOps<DB, Q>,
     {

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -176,7 +176,7 @@ where
 {
     fn set(
         &self,
-        db: &DB,
+        db: &mut DB,
         key: &Q::Key,
         database_key: &DB::DatabaseKey,
         new_value: Q::Value,
@@ -196,5 +196,5 @@ where
     DB: Database,
     Q: Query<DB>,
 {
-    fn invalidate(&self, db: &DB, key: &Q::Key);
+    fn invalidate(&self, db: &mut DB, key: &Q::Key);
 }

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -104,14 +104,14 @@ where
 {
     fn get_query_table(db: &DB) -> QueryTable<'_, DB, Q> {
         let group_storage: &Q::GroupStorage = HasQueryGroup::group_storage(db);
-        let query_storage = Q::query_storage(group_storage);
+        let query_storage: &Q::Storage = Q::query_storage(group_storage);
         QueryTable::new(db, query_storage)
     }
 
     fn get_query_table_mut(db: &mut DB) -> QueryTableMut<'_, DB, Q> {
         let db = &*db;
         let group_storage: &Q::GroupStorage = HasQueryGroup::group_storage(db);
-        let query_storage = Q::query_storage(group_storage);
+        let query_storage = Q::query_storage(group_storage).clone();
         QueryTableMut::new(db, query_storage)
     }
 

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -109,7 +109,6 @@ where
     }
 
     fn get_query_table_mut(db: &mut DB) -> QueryTableMut<'_, DB, Q> {
-        let db = &*db;
         let group_storage: &Q::GroupStorage = HasQueryGroup::group_storage(db);
         let query_storage = Q::query_storage(group_storage).clone();
         QueryTableMut::new(db, query_storage)

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -143,7 +143,7 @@ where
     /// cancellation. If you invoke it while a snapshot exists, it
     /// will block until that snapshot is dropped -- if that snapshot
     /// is owned by the current thread, this could trigger deadlock.
-    pub fn synthetic_write(&self, durability: Durability) {
+    pub fn synthetic_write(&mut self, durability: Durability) {
         self.with_incremented_revision(|guard| {
             guard.mark_durability_as_changed(durability);
         });

--- a/tests/cycles.rs
+++ b/tests/cycles.rs
@@ -12,8 +12,12 @@ struct DatabaseImpl {
 }
 
 impl salsa::Database for DatabaseImpl {
-    fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseImpl> {
+    fn salsa_runtime(&self) -> &salsa::Runtime<Self> {
         &self.runtime
+    }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime<Self> {
+        &mut self.runtime
     }
 }
 

--- a/tests/dyn_trait.rs
+++ b/tests/dyn_trait.rs
@@ -7,8 +7,12 @@ struct DynTraitDatabase {
 }
 
 impl salsa::Database for DynTraitDatabase {
-    fn salsa_runtime(&self) -> &salsa::Runtime<DynTraitDatabase> {
+    fn salsa_runtime(&self) -> &salsa::Runtime<Self> {
         &self.runtime
+    }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime<Self> {
+        &mut self.runtime
     }
 }
 

--- a/tests/gc/db.rs
+++ b/tests/gc/db.rs
@@ -14,6 +14,10 @@ impl salsa::Database for DatabaseImpl {
     fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseImpl> {
         &self.runtime
     }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime<DatabaseImpl> {
+        &mut self.runtime
+    }
 }
 
 impl DatabaseImpl {

--- a/tests/gc/derived_tests.rs
+++ b/tests/gc/derived_tests.rs
@@ -11,7 +11,7 @@ fn compute_one_write_low() {
     db.set_use_triangular(5, false);
     db.compute(5);
 
-    db.salsa_runtime().synthetic_write(Durability::LOW);
+    db.salsa_runtime_mut().synthetic_write(Durability::LOW);
 
     assert_keys! {
         db,
@@ -49,7 +49,7 @@ fn compute_one_write_high() {
     // Doing a synthetic write with durability *high* means that we
     // will revalidate the things `compute(5)` uses, and hence they
     // are not discarded.
-    db.salsa_runtime().synthetic_write(Durability::HIGH);
+    db.salsa_runtime_mut().synthetic_write(Durability::HIGH);
 
     assert_keys! {
         db,
@@ -116,7 +116,7 @@ fn compute_switch() {
     }
 
     // Now run `compute` *again* in next revision.
-    db.salsa_runtime().synthetic_write(Durability::LOW);
+    db.salsa_runtime_mut().synthetic_write(Durability::LOW);
     assert_eq!(db.compute(5), 15);
     db.sweep_all(SweepStrategy::discard_outdated());
 
@@ -145,7 +145,7 @@ fn compute_all() {
     db.set_max(6);
 
     db.compute_all();
-    db.salsa_runtime().synthetic_write(Durability::LOW);
+    db.salsa_runtime_mut().synthetic_write(Durability::LOW);
     db.compute_all();
     db.sweep_all(SweepStrategy::discard_outdated());
 

--- a/tests/gc/discard_values.rs
+++ b/tests/gc/discard_values.rs
@@ -5,14 +5,14 @@ use salsa::{Database, Durability, SweepStrategy};
 
 #[test]
 fn sweep_default() {
-    let db = db::DatabaseImpl::default();
+    let mut db = db::DatabaseImpl::default();
 
     db.fibonacci(5);
 
     let k: Vec<_> = db.query(FibonacciQuery).entries();
     assert_eq!(k.len(), 6);
 
-    db.salsa_runtime().synthetic_write(Durability::LOW);
+    db.salsa_runtime_mut().synthetic_write(Durability::LOW);
 
     db.fibonacci(5);
     db.fibonacci(3);

--- a/tests/gc/interned.rs
+++ b/tests/gc/interned.rs
@@ -74,13 +74,13 @@ fn discard_during_same_revision() {
 /// exercises precisely that scenario.
 #[test]
 fn discard_outdated() {
-    let db = db::DatabaseImpl::default();
+    let mut db = db::DatabaseImpl::default();
 
     let foo_from_rev0 = db.repeat_intern1("foo");
     let bar_from_rev0 = db.repeat_intern1("bar");
 
     // Trigger a new revision.
-    db.salsa_runtime().synthetic_write(Durability::HIGH);
+    db.salsa_runtime_mut().synthetic_write(Durability::HIGH);
 
     // In this revision, we use "bar".
     let bar_from_rev1 = db.repeat_intern1("bar");
@@ -117,7 +117,7 @@ fn discard_outdated() {
 /// keys (which are considered durability HIGH).
 #[test]
 fn discard_durability_after_synthetic_write_low() {
-    let db = db::DatabaseImpl::default();
+    let mut db = db::DatabaseImpl::default();
 
     // This will assign index 0 for "foo".
     let foo1a = db.repeat_intern1("foo");
@@ -127,7 +127,7 @@ fn discard_durability_after_synthetic_write_low() {
     );
 
     // Trigger a new revision.
-    db.salsa_runtime().synthetic_write(Durability::LOW);
+    db.salsa_runtime_mut().synthetic_write(Durability::LOW);
 
     // If we are not careful, this would remove the interned key for
     // "foo".
@@ -157,7 +157,7 @@ fn discard_durability_after_synthetic_write_low() {
 /// `Durability::HIGH`.
 #[test]
 fn discard_durability_after_synthetic_write_high() {
-    let db = db::DatabaseImpl::default();
+    let mut db = db::DatabaseImpl::default();
 
     // This will assign index 0 for "foo".
     let foo1a = db.repeat_intern1("foo");
@@ -167,7 +167,7 @@ fn discard_durability_after_synthetic_write_high() {
     );
 
     // Trigger a new revision -- marking even high things as having changed.
-    db.salsa_runtime().synthetic_write(Durability::HIGH);
+    db.salsa_runtime_mut().synthetic_write(Durability::HIGH);
 
     // We are now able to collect "collect".
     db.query(InternStrQuery).sweep(

--- a/tests/gc/shallow_constant_tests.rs
+++ b/tests/gc/shallow_constant_tests.rs
@@ -24,14 +24,14 @@ fn one_rev() {
 
 #[test]
 fn two_rev_nothing() {
-    let db = db::DatabaseImpl::default();
+    let mut db = db::DatabaseImpl::default();
 
     db.fibonacci(5);
 
     let k: Vec<_> = db.query(FibonacciQuery).entries();
     assert_eq!(k.len(), 6);
 
-    db.salsa_runtime().synthetic_write(Durability::LOW);
+    db.salsa_runtime_mut().synthetic_write(Durability::LOW);
 
     // Nothing was used in this revision, so
     // everything gets collected.
@@ -43,14 +43,14 @@ fn two_rev_nothing() {
 
 #[test]
 fn two_rev_one_use() {
-    let db = db::DatabaseImpl::default();
+    let mut db = db::DatabaseImpl::default();
 
     db.fibonacci(5);
 
     let k: Vec<_> = db.query(FibonacciQuery).entries();
     assert_eq!(k.len(), 6);
 
-    db.salsa_runtime().synthetic_write(Durability::LOW);
+    db.salsa_runtime_mut().synthetic_write(Durability::LOW);
 
     db.fibonacci(5);
 
@@ -66,14 +66,14 @@ fn two_rev_one_use() {
 
 #[test]
 fn two_rev_two_uses() {
-    let db = db::DatabaseImpl::default();
+    let mut db = db::DatabaseImpl::default();
 
     db.fibonacci(5);
 
     let k: Vec<_> = db.query(FibonacciQuery).entries();
     assert_eq!(k.len(), 6);
 
-    db.salsa_runtime().synthetic_write(Durability::LOW);
+    db.salsa_runtime_mut().synthetic_write(Durability::LOW);
 
     db.fibonacci(5);
     db.fibonacci(3);

--- a/tests/incremental/implementation.rs
+++ b/tests/incremental/implementation.rs
@@ -55,7 +55,11 @@ impl TestContext for TestContextImpl {
 }
 
 impl salsa::Database for TestContextImpl {
-    fn salsa_runtime(&self) -> &salsa::Runtime<TestContextImpl> {
+    fn salsa_runtime(&self) -> &salsa::Runtime<Self> {
         &self.runtime
+    }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime<Self> {
+        &mut self.runtime
     }
 }

--- a/tests/incremental/memoized_volatile.rs
+++ b/tests/incremental/memoized_volatile.rs
@@ -48,7 +48,7 @@ fn volatile_x2() {
 /// - On the first run of R2, we recompute everything (since Memoized1 result *did* change).
 #[test]
 fn revalidate() {
-    let query = TestContextImpl::default();
+    let mut query = TestContextImpl::default();
 
     query.memoized2();
     query.assert_log(&["Memoized2 invoked", "Memoized1 invoked", "Volatile invoked"]);
@@ -58,7 +58,7 @@ fn revalidate() {
 
     // Second generation: volatile will change (to 1) but memoized1
     // will not (still 0, as 1/2 = 0)
-    query.salsa_runtime().synthetic_write(Durability::LOW);
+    query.salsa_runtime_mut().synthetic_write(Durability::LOW);
     query.memoized2();
     query.assert_log(&["Memoized1 invoked", "Volatile invoked"]);
     query.memoized2();
@@ -67,7 +67,7 @@ fn revalidate() {
     // Third generation: volatile will change (to 2) and memoized1
     // will too (to 1).  Therefore, after validating that Memoized1
     // changed, we now invoke Memoized2.
-    query.salsa_runtime().synthetic_write(Durability::LOW);
+    query.salsa_runtime_mut().synthetic_write(Durability::LOW);
 
     query.memoized2();
     query.assert_log(&["Memoized1 invoked", "Volatile invoked", "Memoized2 invoked"]);

--- a/tests/interned.rs
+++ b/tests/interned.rs
@@ -9,8 +9,12 @@ struct Database {
 }
 
 impl salsa::Database for Database {
-    fn salsa_runtime(&self) -> &salsa::Runtime<Database> {
+    fn salsa_runtime(&self) -> &salsa::Runtime<Self> {
         &self.runtime
+    }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime<Self> {
+        &mut self.runtime
     }
 }
 

--- a/tests/lru.rs
+++ b/tests/lru.rs
@@ -47,8 +47,12 @@ struct Database {
 }
 
 impl salsa::Database for Database {
-    fn salsa_runtime(&self) -> &salsa::Runtime<Database> {
+    fn salsa_runtime(&self) -> &salsa::Runtime<Self> {
         &self.runtime
+    }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime<Self> {
+        &mut self.runtime
     }
 }
 

--- a/tests/no_send_sync.rs
+++ b/tests/no_send_sync.rs
@@ -23,8 +23,12 @@ struct DatabaseImpl {
 }
 
 impl salsa::Database for DatabaseImpl {
-    fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseImpl> {
+    fn salsa_runtime(&self) -> &salsa::Runtime<Self> {
         &self.runtime
+    }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime<Self> {
+        &mut self.runtime
     }
 }
 

--- a/tests/on_demand_inputs.rs
+++ b/tests/on_demand_inputs.rs
@@ -43,8 +43,12 @@ struct Database {
 }
 
 impl salsa::Database for Database {
-    fn salsa_runtime(&self) -> &salsa::Runtime<Database> {
+    fn salsa_runtime(&self) -> &salsa::Runtime<Self> {
         &self.runtime
+    }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime<Self> {
+        &mut self.runtime
     }
 
     fn salsa_event(&self, event_fn: impl Fn() -> salsa::Event<Self>) {

--- a/tests/on_demand_inputs.rs
+++ b/tests/on_demand_inputs.rs
@@ -100,13 +100,13 @@ fn on_demand_input_durability() {
         }
     }));
 
-    db.salsa_runtime().synthetic_write(Durability::LOW);
+    db.salsa_runtime_mut().synthetic_write(Durability::LOW);
     validated.set(0);
     assert_eq!(db.c(1), 10);
     assert_eq!(db.c(2), 20);
     assert_eq!(validated.get(), 2);
 
-    db.salsa_runtime().synthetic_write(Durability::HIGH);
+    db.salsa_runtime_mut().synthetic_write(Durability::HIGH);
     validated.set(0);
     assert_eq!(db.c(1), 10);
     assert_eq!(db.c(2), 20);

--- a/tests/panic_safely.rs
+++ b/tests/panic_safely.rs
@@ -30,8 +30,12 @@ struct DatabaseStruct {
 }
 
 impl salsa::Database for DatabaseStruct {
-    fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseStruct> {
+    fn salsa_runtime(&self) -> &salsa::Runtime<Self> {
         &self.runtime
+    }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime<Self> {
+        &mut self.runtime
     }
 }
 

--- a/tests/parallel/setup.rs
+++ b/tests/parallel/setup.rs
@@ -192,8 +192,12 @@ pub(crate) struct ParDatabaseImpl {
 }
 
 impl Database for ParDatabaseImpl {
-    fn salsa_runtime(&self) -> &salsa::Runtime<ParDatabaseImpl> {
+    fn salsa_runtime(&self) -> &salsa::Runtime<Self> {
         &self.runtime
+    }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime<Self> {
+        &mut self.runtime
     }
 
     fn salsa_event(&self, event_fn: impl Fn() -> salsa::Event<Self>) {

--- a/tests/parallel/stress.rs
+++ b/tests/parallel/stress.rs
@@ -45,6 +45,10 @@ impl salsa::Database for StressDatabaseImpl {
     fn salsa_runtime(&self) -> &salsa::Runtime<StressDatabaseImpl> {
         &self.runtime
     }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime<StressDatabaseImpl> {
+        &mut self.runtime
+    }
 }
 
 impl salsa::ParallelDatabase for StressDatabaseImpl {

--- a/tests/requires.rs
+++ b/tests/requires.rs
@@ -50,8 +50,12 @@ struct Database {
 }
 
 impl salsa::Database for Database {
-    fn salsa_runtime(&self) -> &salsa::Runtime<Database> {
+    fn salsa_runtime(&self) -> &salsa::Runtime<Self> {
         &self.runtime
+    }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime<Self> {
+        &mut self.runtime
     }
 }
 

--- a/tests/storage_varieties/implementation.rs
+++ b/tests/storage_varieties/implementation.rs
@@ -20,4 +20,8 @@ impl salsa::Database for DatabaseImpl {
     fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseImpl> {
         &self.runtime
     }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime<DatabaseImpl> {
+        &mut self.runtime
+    }
 }

--- a/tests/storage_varieties/tests.rs
+++ b/tests/storage_varieties/tests.rs
@@ -15,12 +15,12 @@ fn memoized_twice() {
 
 #[test]
 fn volatile_twice() {
-    let db = DatabaseImpl::default();
+    let mut db = DatabaseImpl::default();
     let v1 = db.volatile();
     let v2 = db.volatile(); // volatiles are cached, so 2nd read returns the same
     assert_eq!(v1, v2);
 
-    db.salsa_runtime().synthetic_write(Durability::LOW); // clears volatile caches
+    db.salsa_runtime_mut().synthetic_write(Durability::LOW); // clears volatile caches
 
     let v3 = db.volatile(); // will re-increment the counter
     let v4 = db.volatile(); // second call will be cached
@@ -30,7 +30,7 @@ fn volatile_twice() {
 
 #[test]
 fn intermingled() {
-    let db = DatabaseImpl::default();
+    let mut db = DatabaseImpl::default();
     let v1 = db.volatile();
     let v2 = db.memoized();
     let v3 = db.volatile(); // cached
@@ -40,7 +40,7 @@ fn intermingled() {
     assert_eq!(v1, v3);
     assert_eq!(v2, v4);
 
-    db.salsa_runtime().synthetic_write(Durability::LOW); // clears volatile caches
+    db.salsa_runtime_mut().synthetic_write(Durability::LOW); // clears volatile caches
 
     let v5 = db.memoized(); // re-executes volatile, caches new result
     let v6 = db.memoized(); // re-use cached result

--- a/tests/transparent.rs
+++ b/tests/transparent.rs
@@ -24,8 +24,12 @@ struct Database {
 }
 
 impl salsa::Database for Database {
-    fn salsa_runtime(&self) -> &salsa::Runtime<Database> {
+    fn salsa_runtime(&self) -> &salsa::Runtime<Self> {
         &self.runtime
+    }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime<Self> {
+        &mut self.runtime
     }
 }
 

--- a/tests/variadic.rs
+++ b/tests/variadic.rs
@@ -35,8 +35,12 @@ struct DatabaseStruct {
 }
 
 impl salsa::Database for DatabaseStruct {
-    fn salsa_runtime(&self) -> &salsa::Runtime<DatabaseStruct> {
+    fn salsa_runtime(&self) -> &salsa::Runtime<Self> {
         &self.runtime
+    }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime<Self> {
+        &mut self.runtime
     }
 }
 


### PR DESCRIPTION
We always *intended* that to create a new revision you needed `&mut self`, but this was enforced not by the `SalsaRuntime` itself but by the DB. The reason for this was primarily that we needed to have (a) a reference to the DB that overlapped with (b) a reference to query tables owned by the database, and that didn't permit `&mut`. But if we move those query tables into an `Arc`, we can resolve this problem, and then we can have `with_incremented_revision` take `&mut self` (which is what this PR does).

This would be largely unobservable to users, except that it it fixes an existing hole in the API and hence is a breaking change (it also requires a new `salsa_runtime_mut` method). The hole is that before you could invoke `synthetic_write` with only an `&DB`, which means you could do it from a `Frozen<DB>`. This was not intended.