### PR TITLE
Fix deploy book

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ deploy:
   provider: pages
   skip-cleanup: true
   github-token: $GITHUB_TOKEN
-  local-dir: book/book
+  local-dir: book/book/html
   keep-history: false
   on:
     branch: master


### PR DESCRIPTION
`mdbook` generate two directories: `html` with rendered book and `linkcheck` with output of `mdbook-linkcheck`. Set deploy only `html` dir.