### PR TITLE
Implement QueryTable constructor manually instead of using derive-new

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ readme = "README.md"
 
 [dependencies]
 crossbeam = "0.7.1"
-derive-new = "0.5.5"
 indexmap = "1.0.1"
 log = "0.4.5"
 parking_lot = "0.9.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,6 @@ use crate::plumbing::LruQueryStorageOps;
 use crate::plumbing::QueryStorageMassOps;
 use crate::plumbing::QueryStorageOps;
 use crate::revision::Revision;
-use derive_new::new;
 use std::fmt::{self, Debug};
 use std::hash::Hash;
 use std::sync::Arc;
@@ -453,7 +452,6 @@ pub unsafe trait Query<DB: Database>: Debug + Default + Sized + 'static {
 /// Gives access to various less common operations on queries.
 ///
 /// [the `query_mut` method]: trait.Database#method.query
-#[derive(new)]
 pub struct QueryTable<'me, DB, Q>
 where
     DB: plumbing::GetQueryTable<Q>,
@@ -463,11 +461,16 @@ where
     storage: &'me Q::Storage,
 }
 
-impl<DB, Q> QueryTable<'_, DB, Q>
+impl<'me, DB, Q> QueryTable<'me, DB, Q>
 where
     DB: plumbing::GetQueryTable<Q>,
     Q: Query<DB>,
 {
+    /// Constructs a new `QueryTable`.
+    pub fn new(db: &'me DB, storage: &'me Q::Storage) -> Self {
+        Self { db, storage }
+    }
+
     /// Execute the query on a given input. Usually it's easier to
     /// invoke the trait method directly. Note that for variadic
     /// queries (those with no inputs, or those with more than one
@@ -495,7 +498,6 @@ where
 /// set the value of an input query.
 ///
 /// [the `query_mut` method]: trait.Database#method.query_mut
-#[derive(new)]
 pub struct QueryTableMut<'me, DB, Q>
 where
     DB: plumbing::GetQueryTable<Q>,
@@ -505,11 +507,16 @@ where
     storage: Arc<Q::Storage>,
 }
 
-impl<DB, Q> QueryTableMut<'_, DB, Q>
+impl<'me, DB, Q> QueryTableMut<'me, DB, Q>
 where
     DB: plumbing::GetQueryTable<Q>,
     Q: Query<DB>,
 {
+    /// Constructs a new `QueryTableMut`.
+    pub fn new(db: &'me mut DB, storage: Arc<Q::Storage>) -> Self {
+        Self { db, storage }
+    }
+
     fn database_key(&self, key: &Q::Key) -> DB::DatabaseKey {
         <DB as plumbing::GetQueryTable<Q>>::database_key(&self.db, key.clone())
     }


### PR DESCRIPTION
While `derive-new` isn't on the critical path, it still takes some 6 seconds to compile on a reasonably fast laptop, and the freed up CPU can be used for something else:

![image](https://user-images.githubusercontent.com/308347/66145713-10606d00-e614-11e9-9a36-bb809b297171.png)

![image](https://user-images.githubusercontent.com/308347/66145724-15252100-e614-11e9-9b61-2ffd0061ea30.png)

Perhaps it's worth writing a couple of lines of code by hand.