### PR TITLE
Use parking_lot's `upgradable_read` in `read_upgrade`

### DIFF
--- a/src/derived/slot.rs
+++ b/src/derived/slot.rs
@@ -16,8 +16,7 @@ use crate::runtime::RuntimeId;
 use crate::runtime::StampedValue;
 use crate::{CycleError, Database, DiscardIf, DiscardWhat, Event, EventKind, SweepStrategy};
 use log::{debug, info};
-use parking_lot::Mutex;
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
 use smallvec::SmallVec;
 use std::marker::PhantomData;
 use std::ops::Deref;
@@ -165,13 +164,10 @@ where
         // Check with an upgradable read to see if there is a value
         // already. (This permits other readers but prevents anyone
         // else from running `read_upgrade` at the same time.)
-        //
-        // FIXME(Amanieu/parking_lot#101) -- we are using a write-lock
-        // and not an upgradable read here because upgradable reads
-        // can sometimes encounter deadlocks.
-        let old_memo = match self.probe(db, self.state.write(), runtime, revision_now) {
+        let old_memo = match self.probe(db, self.state.upgradable_read(), runtime, revision_now) {
             ProbeState::UpToDate(v) => return v,
-            ProbeState::StaleOrAbsent(mut state) => {
+            ProbeState::StaleOrAbsent(state) => {
+                let mut state = RwLockUpgradableReadGuard::upgrade(state);
                 match std::mem::replace(&mut *state, QueryState::in_progress(runtime.id())) {
                     QueryState::Memoized(old_memo) => Some(old_memo),
                     QueryState::InProgress { .. } => unreachable!(),


### PR DESCRIPTION
The bug in parking_lot that made it necessary to use a write-lock has
been fixed and we can go back to using an upgradable read-lock.

This cleanup is part of issue #188.

Signed-off-by: Michal Terepeta <michal.terepeta@gmail.com>