### PR TITLE
WIP Make the database state Sync for the sake of async queries

### DIFF
--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -222,7 +222,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
 
         query_fn_definitions.extend(quote! {
             fn #fn_name(&self, #(#key_names: #keys),*) -> #value {
-                <Self as salsa::plumbing::GetQueryTable<#qt>>::get_query_table(self).get((#(#key_names),*))
+                <Self as salsa::plumbing::GetQueryTable<#qt>>::get_query_table(salsa::DbQuery::top(self)).get((#(#key_names),*))
             }
         });
 
@@ -415,7 +415,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
 
             let recover = if let Some(cycle_recovery_fn) = &query.cycle {
                 quote! {
-                    fn recover(db: &DB, cycle: &[DB::DatabaseKey], #key_pattern: &<Self as salsa::Query<DB>>::Key)
+                    fn recover(db: &salsa::DbQuery<DB>, cycle: &[DB::DatabaseKey], #key_pattern: &<Self as salsa::Query<DB>>::Key)
                         -> Option<<Self as salsa::Query<DB>>::Value> {
                         Some(#cycle_recovery_fn(
                                 db,
@@ -435,7 +435,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
                     DB: salsa::plumbing::HasQueryGroup<#group_struct>,
                     DB: salsa::Database,
                 {
-                    fn execute(db: &DB, #key_pattern: <Self as salsa::Query<DB>>::Key)
+                    fn execute(db: &salsa::DbQuery<DB>, #key_pattern: <Self as salsa::Query<DB>>::Key)
                         -> <Self as salsa::Query<DB>>::Value {
                         #invoke(db, #(#key_names),*)
                     }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -59,13 +59,13 @@ where
     type Value = Q::Value;
 
     fn durability(&self, key: Q::Key) -> Durability {
-        self.storage.durability(self.db, &key)
+        self.storage.durability(&self.db, &key)
     }
 
     fn entries<C>(&self) -> C
     where
         C: FromIterator<TableEntry<Self::Key, Self::Value>>,
     {
-        self.storage.entries(self.db)
+        self.storage.entries(&self.db)
     }
 }

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -1,5 +1,6 @@
 use crate::revision::Revision;
 use crate::Database;
+use crate::DbQuery;
 use std::fmt::Debug;
 use std::hash::Hasher;
 use std::ptr;
@@ -12,7 +13,7 @@ use std::sync::Arc;
 pub(crate) unsafe trait DatabaseSlot<DB: Database>: Debug {
     /// Returns true if the value of this query may have changed since
     /// the given revision.
-    fn maybe_changed_since(&self, db: &DB, revision: Revision) -> bool;
+    fn maybe_changed_since(&self, db: &DbQuery<'_, DB>, revision: Revision) -> bool;
 }
 
 pub(crate) struct Dependency<DB: Database> {
@@ -32,7 +33,7 @@ impl<DB: Database> Dependency<DB> {
         }
     }
 
-    pub(crate) fn maybe_changed_since(&self, db: &DB, revision: Revision) -> bool {
+    pub(crate) fn maybe_changed_since(&self, db: &DbQuery<'_, DB>, revision: Revision) -> bool {
         self.slot.maybe_changed_since(db, revision)
     }
 }

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -8,6 +8,7 @@ use crate::plumbing::QueryFunction;
 use crate::plumbing::QueryStorageMassOps;
 use crate::plumbing::QueryStorageOps;
 use crate::runtime::StampedValue;
+use crate::DbQuery;
 use crate::{CycleError, Database, SweepStrategy};
 use parking_lot::RwLock;
 use rustc_hash::FxHashMap;
@@ -131,7 +132,11 @@ where
     DB: Database + HasQueryGroup<Q::Group>,
     MP: MemoizationPolicy<DB, Q>,
 {
-    fn try_fetch(&self, db: &DB, key: &Q::Key) -> Result<Q::Value, CycleError<DB::DatabaseKey>> {
+    fn try_fetch(
+        &self,
+        db: &DbQuery<DB>,
+        key: &Q::Key,
+    ) -> Result<Q::Value, CycleError<DB::DatabaseKey>> {
         let slot = self.slot(key);
         let StampedValue {
             value,

--- a/src/derived/slot.rs
+++ b/src/derived/slot.rs
@@ -14,6 +14,7 @@ use crate::runtime::FxIndexSet;
 use crate::runtime::Runtime;
 use crate::runtime::RuntimeId;
 use crate::runtime::StampedValue;
+use crate::DbQuery;
 use crate::{CycleError, Database, DiscardIf, DiscardWhat, Event, EventKind, SweepStrategy};
 use log::{debug, info};
 use parking_lot::Mutex;
@@ -127,7 +128,7 @@ where
 
     pub(super) fn read(
         &self,
-        db: &DB,
+        db: &DbQuery<'_, DB>,
     ) -> Result<StampedValue<Q::Value>, CycleError<DB::DatabaseKey>> {
         let runtime = db.salsa_runtime();
 
@@ -155,7 +156,7 @@ where
     /// shows a potentially out of date value.
     fn read_upgrade(
         &self,
-        db: &DB,
+        db: &DbQuery<'_, DB>,
         revision_now: Revision,
     ) -> Result<StampedValue<Q::Value>, CycleError<DB::DatabaseKey>> {
         let runtime = db.salsa_runtime();
@@ -327,7 +328,7 @@ where
     /// Note that in case `ProbeState::UpToDate`, the lock will have been released.
     fn probe<StateGuard>(
         &self,
-        db: &DB,
+        db: &DbQuery<'_, DB>,
         state: StateGuard,
         runtime: &Runtime<DB>,
         revision_now: Revision,
@@ -725,7 +726,7 @@ where
 
     fn validate_memoized_value(
         &mut self,
-        db: &DB,
+        db: &DbQuery<'_, DB>,
         revision_now: Revision,
     ) -> Option<StampedValue<Q::Value>> {
         // If we don't have a memoized value, nothing to validate.
@@ -851,7 +852,7 @@ where
     DB: Database + HasQueryGroup<Q::Group>,
     MP: MemoizationPolicy<DB, Q>,
 {
-    fn maybe_changed_since(&self, db: &DB, revision: Revision) -> bool {
+    fn maybe_changed_since(&self, db: &DbQuery<'_, DB>, revision: Revision) -> bool {
         let runtime = db.salsa_runtime();
         let revision_now = runtime.current_revision();
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -8,6 +8,7 @@ use crate::revision::Revision;
 use crate::runtime::StampedValue;
 use crate::CycleError;
 use crate::Database;
+use crate::DbQuery;
 use crate::Event;
 use crate::EventKind;
 use crate::Query;
@@ -74,7 +75,11 @@ where
     Q: Query<DB>,
     DB: Database,
 {
-    fn try_fetch(&self, db: &DB, key: &Q::Key) -> Result<Q::Value, CycleError<DB::DatabaseKey>> {
+    fn try_fetch(
+        &self,
+        db: &DbQuery<DB>,
+        key: &Q::Key,
+    ) -> Result<Q::Value, CycleError<DB::DatabaseKey>> {
         let slot = self
             .slot(key)
             .unwrap_or_else(|| panic!("no value set for {:?}({:?})", Q::default(), key));
@@ -206,7 +211,7 @@ where
     Q: Query<DB>,
     DB: Database,
 {
-    fn maybe_changed_since(&self, _db: &DB, revision: Revision) -> bool {
+    fn maybe_changed_since(&self, _db: &DbQuery<DB>, revision: Revision) -> bool {
         debug!(
             "maybe_changed_since(slot={:?}, revision={:?})",
             self, revision,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -612,6 +612,15 @@ pub struct DbQuery<'db, DB: Database> {
     db: &'db DB,
 }
 
+impl<'db, DB: Database> Clone for DbQuery<'db, DB> {
+    fn clone(&self) -> Self {
+        DbQuery {
+            query_stack: self.query_stack.clone(),
+            db: self.db,
+        }
+    }
+}
+
 impl<'db, DB: Database> std::ops::Deref for DbQuery<'db, DB> {
     type Target = &'db DB;
     fn deref(&self) -> &Self::Target {
@@ -631,6 +640,18 @@ impl<'db, DB: Database> DbQuery<'db, DB> {
             query_stack: Default::default(),
             db,
         }
+    }
+}
+
+impl<'db, DB: Database> From<&'_ Self> for DbQuery<'db, DB> {
+    fn from(db: &Self) -> Self {
+        db.clone()
+    }
+}
+
+impl<'db, DB: Database> From<&'db DB> for DbQuery<'db, DB> {
+    fn from(db: &'db DB) -> Self {
+        Self::top(db)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -622,15 +622,9 @@ impl<'db, DB: Database> Clone for DbQuery<'db, DB> {
 }
 
 impl<'db, DB: Database> std::ops::Deref for DbQuery<'db, DB> {
-    type Target = &'db DB;
+    type Target = DB;
     fn deref(&self) -> &Self::Target {
-        &self.db
-    }
-}
-
-impl<DB: Database> std::ops::DerefMut for DbQuery<'_, DB> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.db
+        self.db
     }
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -18,6 +18,8 @@ pub(crate) type FxIndexSet<K> = indexmap::IndexSet<K, BuildHasherDefault<FxHashe
 mod local_state;
 use local_state::LocalState;
 
+pub(crate) use self::local_state::QueryStack;
+
 /// The salsa runtime stores the storage for all queries as well as
 /// tracking the query stack and dependencies between cycles.
 ///

--- a/src/runtime/local_state.rs
+++ b/src/runtime/local_state.rs
@@ -4,6 +4,22 @@ use crate::runtime::ActiveQuery;
 use crate::runtime::Revision;
 use crate::Database;
 use std::cell::{Ref, RefCell, RefMut};
+use std::sync::Arc;
+
+pub(crate) struct QueryStack<DB: Database>(Arc<QueryStackInner<DB>>);
+enum QueryStackInner<DB: Database> {
+    Top,
+    Query {
+        query: ActiveQuery<DB>,
+        next: QueryStack<DB>,
+    },
+}
+
+impl<DB: Database> Default for QueryStack<DB> {
+    fn default() -> Self {
+        QueryStack(Arc::new(QueryStackInner::Top))
+    }
+}
 
 /// State that is specific to a single execution thread.
 ///

--- a/src/runtime/local_state.rs
+++ b/src/runtime/local_state.rs
@@ -21,6 +21,12 @@ impl<DB: Database> Default for QueryStack<DB> {
     }
 }
 
+impl<DB: Database> Clone for QueryStack<DB> {
+    fn clone(&self) -> Self {
+        QueryStack(self.0.clone())
+    }
+}
+
 /// State that is specific to a single execution thread.
 ///
 /// Internally, this type uses ref-cells.

--- a/tests/cycles.rs
+++ b/tests/cycles.rs
@@ -47,50 +47,50 @@ trait Database: salsa::Database {
     fn cycle_c(&self) -> Result<(), Error>;
 }
 
-fn recover_a(_db: &impl Database, cycle: &[String]) -> Result<(), Error> {
+fn recover_a(_db: &salsa::DbQuery<impl Database>, cycle: &[String]) -> Result<(), Error> {
     Err(Error {
         cycle: cycle.to_owned(),
     })
 }
 
-fn recover_b(_db: &impl Database, cycle: &[String]) -> Result<(), Error> {
+fn recover_b(_db: &salsa::DbQuery<impl Database>, cycle: &[String]) -> Result<(), Error> {
     Err(Error {
         cycle: cycle.to_owned(),
     })
 }
 
-fn memoized_a(db: &impl Database) -> () {
+fn memoized_a(db: &salsa::DbQuery<impl Database>) -> () {
     db.memoized_b()
 }
 
-fn memoized_b(db: &impl Database) -> () {
+fn memoized_b(db: &salsa::DbQuery<impl Database>) -> () {
     db.memoized_a()
 }
 
-fn volatile_a(db: &impl Database) -> () {
+fn volatile_a(db: &salsa::DbQuery<impl Database>) -> () {
     db.salsa_runtime().report_untracked_read();
     db.volatile_b()
 }
 
-fn volatile_b(db: &impl Database) -> () {
+fn volatile_b(db: &salsa::DbQuery<impl Database>) -> () {
     db.salsa_runtime().report_untracked_read();
     db.volatile_a()
 }
 
-fn cycle_leaf(_db: &impl Database) -> () {}
+fn cycle_leaf(_db: &salsa::DbQuery<impl Database>) -> () {}
 
-fn cycle_a(db: &impl Database) -> Result<(), Error> {
+fn cycle_a(db: &salsa::DbQuery<impl Database>) -> Result<(), Error> {
     let _ = db.cycle_b();
     Ok(())
 }
 
-fn cycle_b(db: &impl Database) -> Result<(), Error> {
+fn cycle_b(db: &salsa::DbQuery<impl Database>) -> Result<(), Error> {
     db.cycle_leaf();
     let _ = db.cycle_a();
     Ok(())
 }
 
-fn cycle_c(db: &impl Database) -> Result<(), Error> {
+fn cycle_c(db: &salsa::DbQuery<impl Database>) -> Result<(), Error> {
     db.cycle_b()
 }
 

--- a/tests/cycles.rs
+++ b/tests/cycles.rs
@@ -47,50 +47,50 @@ trait Database: salsa::Database {
     fn cycle_c(&self) -> Result<(), Error>;
 }
 
-fn recover_a(_db: &salsa::DbQuery<impl Database>, cycle: &[String]) -> Result<(), Error> {
+fn recover_a(_db: &impl Database, cycle: &[String]) -> Result<(), Error> {
     Err(Error {
         cycle: cycle.to_owned(),
     })
 }
 
-fn recover_b(_db: &salsa::DbQuery<impl Database>, cycle: &[String]) -> Result<(), Error> {
+fn recover_b(_db: &impl Database, cycle: &[String]) -> Result<(), Error> {
     Err(Error {
         cycle: cycle.to_owned(),
     })
 }
 
-fn memoized_a(db: &salsa::DbQuery<impl Database>) -> () {
+fn memoized_a(db: &impl Database) -> () {
     db.memoized_b()
 }
 
-fn memoized_b(db: &salsa::DbQuery<impl Database>) -> () {
+fn memoized_b(db: &impl Database) -> () {
     db.memoized_a()
 }
 
-fn volatile_a(db: &salsa::DbQuery<impl Database>) -> () {
+fn volatile_a(db: &impl Database) -> () {
     db.salsa_runtime().report_untracked_read();
     db.volatile_b()
 }
 
-fn volatile_b(db: &salsa::DbQuery<impl Database>) -> () {
+fn volatile_b(db: &impl Database) -> () {
     db.salsa_runtime().report_untracked_read();
     db.volatile_a()
 }
 
-fn cycle_leaf(_db: &salsa::DbQuery<impl Database>) -> () {}
+fn cycle_leaf(_db: &impl Database) -> () {}
 
-fn cycle_a(db: &salsa::DbQuery<impl Database>) -> Result<(), Error> {
+fn cycle_a(db: &impl Database) -> Result<(), Error> {
     let _ = db.cycle_b();
     Ok(())
 }
 
-fn cycle_b(db: &salsa::DbQuery<impl Database>) -> Result<(), Error> {
+fn cycle_b(db: &impl Database) -> Result<(), Error> {
     db.cycle_leaf();
     let _ = db.cycle_a();
     Ok(())
 }
 
-fn cycle_c(db: &salsa::DbQuery<impl Database>) -> Result<(), Error> {
+fn cycle_c(db: &impl Database) -> Result<(), Error> {
     db.cycle_b()
 }
 


### PR DESCRIPTION
An attempt to resolve the want for queries to use `&` without needing interior mutability. This is currently achieved by the `DbQuery` wrapper type which stores a linked list of queries. As this needs to be outside of the database itself, the user facing code will either need to mention the `DbQuery<impl MyDatabase>` instead of just `impl MyDatabase`. Or a pair of traits (as it is currently) will be needed to represent a database that is either inside or outside a `DbQuery` object.

Tests are not all compiling yet and there are lots of hacks, but I think this could be a plausible implementation at least.