### PR TITLE
Replace usage of `std::mpsc` with something more light-weight

### DIFF
--- a/src/blocking_future.rs
+++ b/src/blocking_future.rs
@@ -1,0 +1,84 @@
+use parking_lot::{Condvar, Mutex};
+use std::mem;
+use std::sync::Arc;
+
+pub(crate) struct BlockingFuture<T> {
+    slot: Arc<Slot<T>>,
+}
+
+pub(crate) struct Promise<T> {
+    fulfilled: bool,
+    slot: Arc<Slot<T>>,
+}
+
+impl<T> BlockingFuture<T> {
+    pub(crate) fn new() -> (BlockingFuture<T>, Promise<T>) {
+        let future = BlockingFuture {
+            slot: Default::default(),
+        };
+        let promise = Promise {
+            fulfilled: false,
+            slot: Arc::clone(&future.slot),
+        };
+        (future, promise)
+    }
+
+    pub(crate) fn wait(self) -> Option<T> {
+        let mut guard = self.slot.lock.lock();
+        if guard.is_empty() {
+            // parking_lot guarantees absence of spurious wake ups
+            self.slot.cvar.wait(&mut guard);
+        }
+        match mem::replace(&mut *guard, State::Dead) {
+            State::Empty => unreachable!(),
+            State::Full(it) => Some(it),
+            State::Dead => None,
+        }
+    }
+}
+
+impl<T> Promise<T> {
+    pub(crate) fn fulfil(mut self, value: T) {
+        self.fulfilled = true;
+        self.transition(State::Full(value));
+    }
+    fn transition(&mut self, new_state: State<T>) {
+        let mut guard = self.slot.lock.lock();
+        *guard = new_state;
+        self.slot.cvar.notify_one();
+    }
+}
+
+impl<T> Drop for Promise<T> {
+    fn drop(&mut self) {
+        if !self.fulfilled {
+            self.transition(State::Dead);
+        }
+    }
+}
+
+struct Slot<T> {
+    lock: Mutex<State<T>>,
+    cvar: Condvar,
+}
+
+impl<T> Default for Slot<T> {
+    fn default() -> Slot<T> {
+        Slot {
+            lock: Mutex::new(State::Empty),
+            cvar: Condvar::new(),
+        }
+    }
+}
+
+enum State<T> {
+    Empty,
+    Full(T),
+    Dead,
+}
+
+impl<T> State<T> {
+    fn is_empty(&self) -> bool {
+        matches!(self, State::Empty)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ mod interned;
 mod lru;
 mod revision;
 mod runtime;
+mod blocking_future;
 
 pub mod debug;
 /// Items in this module are public for implementation reasons,


### PR DESCRIPTION
cargo llvm-lines shows that some amount of llvm lines is spend on
`std::mpsc`. Given that this is not the most loved standard library
module, and that our usage of mpsc is extremely limited, it seems
worth-while to implement oneshot channel using parking_lot.

I was going to submit an issue about how we should do this, but then accidentally just impled the thing :D 