### PR TITLE
Use a boxed slice to store dependencies

### DIFF
--- a/src/derived/slot.rs
+++ b/src/derived/slot.rs
@@ -11,7 +11,6 @@ use crate::plumbing::GetQueryTable;
 use crate::plumbing::HasQueryGroup;
 use crate::plumbing::QueryFunction;
 use crate::revision::Revision;
-use crate::runtime::FxIndexSet;
 use crate::runtime::Runtime;
 use crate::runtime::RuntimeId;
 use crate::runtime::StampedValue;
@@ -89,9 +88,7 @@ where
 /// inputs accessed during query execution.
 pub(super) enum MemoInputs<DB: Database> {
     /// Non-empty set of inputs, fully known
-    Tracked {
-        inputs: Arc<FxIndexSet<Dependency<DB>>>,
-    },
+    Tracked { inputs: Arc<[Dependency<DB>]> },
 
     /// Empty set of inputs, fully known.
     NoInputs,
@@ -294,7 +291,11 @@ where
                     MemoInputs::NoInputs
                 } else {
                     MemoInputs::Tracked {
-                        inputs: Arc::new(dependencies),
+                        inputs: dependencies
+                            .into_iter()
+                            .collect::<Vec<_>>()
+                            .into_boxed_slice()
+                            .into(),
                     }
                 }
             }

--- a/src/derived/slot.rs
+++ b/src/derived/slot.rs
@@ -291,11 +291,7 @@ where
                     MemoInputs::NoInputs
                 } else {
                     MemoInputs::Tracked {
-                        inputs: dependencies
-                            .into_iter()
-                            .collect::<Vec<_>>()
-                            .into_boxed_slice()
-                            .into(),
+                        inputs: dependencies.into_iter().collect(),
                     }
                 }
             }


### PR DESCRIPTION
`FxIndexSet` has considerable overhead and is only iterated over once it's in the `Slot`. Use a boxed slice instead, saving 300-400 MB of memory in a rust-analyzer benchmark.