### PR TITLE
feat: Allow queries to be defined as async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ readme = "README.md"
 async-trait = "0.1"
 crossbeam-utils = { version = "0.7.1", default-features = false }
 indexmap = "1.0.1"
-futures-util = { version = "0.3", default-features = false }
 futures-channel = { version = "0.3", features = ["alloc"], default-features = false, optional = true }
+futures-util = { version = "0.3", default-features = false, optional = true }
 lock_api = "0.4"
 log = "0.4.5"
 parking_lot = "0.11.0"
@@ -35,4 +35,4 @@ tokio = { version = "0.2", features = ["macros", "rt-core"] }
 
 [features]
 default = ["async"]
-async = ["futures-channel", "salsa-macros/async"]
+async = ["futures-channel", "futures-util", "salsa-macros/async"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ readme = "README.md"
 async-trait = "0.1"
 crossbeam-utils = { version = "0.7.1", default-features = false }
 indexmap = "1.0.1"
-futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
+futures-channel = { version = "0.3", features = ["alloc"], default-features = false }
 lock_api = "0.4"
 log = "0.4.5"
 parking_lot = "0.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ async-trait = "0.1"
 crossbeam-utils = { version = "0.7.1", default-features = false }
 indexmap = "1.0.1"
 futures-util = { version = "0.3", default-features = false }
-futures-channel = { version = "0.3", features = ["alloc"], default-features = false }
+futures-channel = { version = "0.3", features = ["alloc"], default-features = false, optional = true }
 lock_api = "0.4"
 log = "0.4.5"
 parking_lot = "0.11.0"
@@ -32,3 +32,7 @@ rand_distr = "0.2.1"
 tokio = { version = "0.2", features = ["macros", "rt-core"] }
 
 [workspace]
+
+[features]
+default = ["async"]
+async = ["futures-channel", "salsa-macros/async"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,10 @@ description = "A generic framework for on-demand, incrementalized computation (e
 readme = "README.md"
 
 [dependencies]
+async-trait = "0.1"
 crossbeam-utils = { version = "0.7.1", default-features = false }
 indexmap = "1.0.1"
+futures = "0.3"
 lock_api = "0.4"
 log = "0.4.5"
 parking_lot = "0.11.0"
@@ -26,5 +28,6 @@ env_logger = "0.7"
 linked-hash-map = "0.5.2"
 rand = "0.7"
 rand_distr = "0.2.1"
+tokio = { version = "0.2", features = ["macros", "rt-core"] }
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ description = "A generic framework for on-demand, incrementalized computation (e
 readme = "README.md"
 
 [dependencies]
-async-trait = "0.1"
 crossbeam-utils = { version = "0.7.1", default-features = false }
 indexmap = "1.0.1"
 futures-channel = { version = "0.3", features = ["alloc"], default-features = false, optional = true }

--- a/book/src/rfcs/RFC0006-Dynamic-Databases.md
+++ b/book/src/rfcs/RFC0006-Dynamic-Databases.md
@@ -542,7 +542,7 @@ changes are made, so that the signature looks like:
 // Before this RFC:
 pub struct DerivedStorage<Q, MP>
 where
-    Q: QueryFunction,
+    for<'f> Q: QueryFunction<'f>,
     MP: MemoizationPolicy<DB, Q>,
 ```
 

--- a/book/src/rfcs/RFC0007-Async-Queries.md
+++ b/book/src/rfcs/RFC0007-Async-Queries.md
@@ -1,0 +1,102 @@
+
+## Metadata
+
+* Author: marwes
+* Date: 2020-08-04
+* Introduced in: [salsa-rs/salsa#1](https://github.com/salsa-rs/salsa/pull/1) (please update once you open your PR)
+
+## Summary
+
+Allow salsa databases to define derived queries that execute asynchronous code.
+
+## Motivation
+
+Asynchronous code is typically not needed for compilers as they typically do not need to wait on IO. However there is still utility in writing asynchronous queries
+as asynchronous tasks model queries waiting for eachother really well. There may also be non-compiler uses for salsa where the async nature may be useful (think caching a resource fetch over the network).
+
+### Our goal
+
+Allow `async fn` to be written for any query that needs to be `async`.
+
+## User's guide
+
+Any salsa query that involves running user code (not input or interned queries) can now be written as an `async fn`. These queries accept the database as an `&mut salsa::OwnedDb<'_, dyn MyDatabase>` (or `&mut dyn MyDatabase` as a convenience for the top query) object instead of `&dyn MyDatabase` as a way to preserve `Send` for the returned futures but are otherwise identical.
+
+```rust
+#[salsa::query_group(AsyncStorage)]
+trait Async: Send {
+    async fn query(&self, x: u32) -> u32;
+}
+
+async fn query(db: &mut salsa::OwnedDb<'_, dyn Async>, x: u32) -> u32 {
+    async_function(db, x, "abc").await
+}
+```
+
+## Reference guide
+
+To avoid duplication all operations on derived queries are now written as `async fn`. Since these `async` functions end up capturing the database parameter and we want the returned futures to implement `Send` we need to change these functions so they accept `&mut` instead of `&`. But we also do not want a running query to use any `&mut` operations. To resolve this the internal `QueryDb` is extended with a `Db` type that is used to parameterize queries over `&dyn MyDatabase` and `salsa::OwnedDb<'_, dyn MyDatabase>`. The latter is used for `async` queries and works in a similar way to `Snapshot`. User code can only retrieve a `&` reference, while the salsa internals can still retrieve the `&mut` reference within (as such there is also a `From` conversion from `Snapshot` to `OwnedDb`).
+
+```rust
+pub trait QueryDb<'d>: QueryBase {
+    /// Dyn version of the associated trait for this query group.
+    type DynDb: ?Sized + Database + HasQueryGroup<Self::Group> + 'd;
+
+    /// Sized version of `DynDb`, &'d Self::DynDb for synchronous queries
+    type Db: std::ops::Deref<Target = Self::DynDb> + AsAsyncDatabase<Self::DynDb>;
+}
+```
+
+The only internal operation in a query that blocks for a "long" time is waiting for a query that is currently executing. For async queries we want to yield to the executor here instead of blocking whereas synchronous queries want to just block the thread. While we could just use an async-aware primitive for this and invoke synchronous queries with an executor capable of handling this that would force a small but potentially noticeable overhead for synchronous queries. 
+
+To resolve this we can instead parameterize over this `BlockingFuture` with a type which just blocks for synchronous queries and uses a real async-aware type for async queries. This then allows for a truly minimal "executor" which doesn't need to handle `Poll::Pending` at all
+
+```rust
+/// Calls a future synchronously without an actual way to resume to future.
+pub(crate) fn sync_future<F>(mut f: F) -> F::Output
+where
+    F: Future,
+{
+    use std::task::{RawWaker, RawWakerVTable, Waker};
+
+    unsafe {
+        type WakerState = ();
+
+        static VTABLE: RawWakerVTable =
+            RawWakerVTable::new(|p| RawWaker::new(p, &VTABLE), |_| (), |_| (), |_| ());
+
+        let waker_state = WakerState::default();
+        let waker = Waker::from_raw(RawWaker::new(
+            &waker_state as *const WakerState as *const (),
+            &VTABLE,
+        ));
+        let mut context = Context::from_waker(&waker);
+
+        match Pin::new_unchecked(&mut f).poll(&mut context) {
+            Poll::Ready(x) => x,
+            Poll::Pending => unreachable!(),
+        }
+    }
+}
+```
+
+The `QueryFunction` trait which represented the user code actually being invoke are changed to return a `Future`. For `async` queries this must be a boxed future but for synchronous queries this can just be the non-allocating `Ready` future that were ported from the `futures` crate to avoid a dependency on it.
+
+```rust
+pub trait QueryFunctionBase: QueryBase {
+    type BlockingFuture: BlockingFutureTrait<WaitResult<Self::Value, DatabaseKeyIndex>>;
+}
+
+pub trait QueryFunction<'f, 'd>: QueryFunctionBase + QueryDb<'d> {
+    type Future: Future<Output = Self::Value> + 'f;
+
+    fn execute(db: &'f mut <Self as QueryDb<'d>>::Db, key: Self::Key) -> Self::Future;
+    ...
+}
+```
+
+The functions `QueryStorageOps::try_fetch` and `QueryStorageOps::maybe_changed_since` were extracted to a `QueryStorageOpsSync` trait and a matching `QueryStorageOpsAsync` trait were added. Through this split the synchronous code does not need to allocate the boxed future that the async variant must return and it also ensures that other queries such as `input` never implements the `async` functions.
+
+## Alternatives and future work
+
+The slightly awkward `OwnedDb` could perhaps be avoided if salsa's `RefCell` usage were removed. However my attempts so far hasn't yielded a workable solution.

--- a/components/salsa-macros/Cargo.toml
+++ b/components/salsa-macros/Cargo.toml
@@ -16,3 +16,6 @@ heck = "0.3"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full", "extra-traits"] }
+
+[features]
+async = []

--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -598,7 +598,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
             let invoke = query.invoke_tt();
 
             let recover = if let Some(cycle_recovery_fn) = &query.cycle {
-                quote! {
+                quote_spanned! { cycle_recovery_fn.span() =>
                     fn recover(db: &<Self as salsa::QueryDb<'d>>::DynDb, cycle: &[salsa::DatabaseKeyIndex], #key_pattern: &<Self as salsa::QueryBase>::Key)
                         -> Option<<Self as salsa::QueryBase>::Value> {
                         Some(#cycle_recovery_fn(

--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -605,13 +605,13 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
             let future = if query.is_async {
                 quote!(salsa::BoxFuture<'f, Self::Value>)
             } else {
-                quote!(futures::future::Ready<Self::Value>)
+                quote!(salsa::plumbing::Ready<Self::Value>)
             };
 
             let wrap_future = if query.is_async {
                 quote!(Box::pin)
             } else {
-                quote!(futures::future::ready)
+                quote!(salsa::plumbing::ready)
             };
 
             let blocking_future = if query.is_async {

--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -202,10 +202,16 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
                     None
                 };
 
+                let is_async = method.sig.asyncness.is_some();
+
+                if is_async && !cfg!(feature = "async") {
+                    panic!("The `async` feature must be enabled to use async query functions!")
+                }
+
                 queries.push(Query {
                     query_type,
                     query_name,
-                    is_async: method.sig.asyncness.is_some(),
+                    is_async,
                     fn_name: method.sig.ident,
                     attrs,
                     storage,

--- a/src/blocking_future.rs
+++ b/src/blocking_future.rs
@@ -6,7 +6,11 @@ use std::{
     task::{Context, Poll},
 };
 
-use parking_lot::{Condvar, Mutex};
+use {
+    futures_channel::oneshot,
+    futures_util::future::{self, FutureExt},
+    parking_lot::{Condvar, Mutex},
+};
 
 #[doc(hidden)]
 pub struct BlockingFuture<T> {
@@ -120,11 +124,9 @@ impl<T> BlockingFutureTrait<T> for BlockingFuture<T> {
     }
 }
 
-use futures::{channel::oneshot, future::FutureExt};
-
 /// Async variant of BlockingFuture
 pub type BlockingAsyncFuture<T> =
-    futures::future::Map<oneshot::Receiver<T>, fn(Result<T, oneshot::Canceled>) -> Option<T>>;
+    future::Map<oneshot::Receiver<T>, fn(Result<T, oneshot::Canceled>) -> Option<T>>;
 
 impl<T> PromiseTrait<T> for oneshot::Sender<T> {
     fn fulfil(self, value: T) {

--- a/src/blocking_future.rs
+++ b/src/blocking_future.rs
@@ -6,11 +6,13 @@ use std::{
     task::{Context, Poll},
 };
 
+#[cfg(feature = "async")]
 use {
     futures_channel::oneshot,
     futures_util::future::{self, FutureExt},
-    parking_lot::{Condvar, Mutex},
 };
+
+use parking_lot::{Condvar, Mutex};
 
 #[doc(hidden)]
 pub struct BlockingFuture<T> {
@@ -125,15 +127,18 @@ impl<T> BlockingFutureTrait<T> for BlockingFuture<T> {
 }
 
 /// Async variant of BlockingFuture
+#[cfg(feature = "async")]
 pub type BlockingAsyncFuture<T> =
     future::Map<oneshot::Receiver<T>, fn(Result<T, oneshot::Canceled>) -> Option<T>>;
 
+#[cfg(feature = "async")]
 impl<T> PromiseTrait<T> for oneshot::Sender<T> {
     fn fulfil(self, value: T) {
         let _ = self.send(value);
     }
 }
 
+#[cfg(feature = "async")]
 impl<T> BlockingFutureTrait<T> for BlockingAsyncFuture<T> {
     type Promise = oneshot::Sender<T>;
     fn new() -> (Self, Self::Promise) {

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -4,7 +4,7 @@
 use crate::durability::Durability;
 use crate::plumbing::QueryStorageOps;
 use crate::Query;
-use crate::QueryTable;
+use crate::{QueryDb, QueryTable};
 use std::iter::FromIterator;
 
 /// Additional methods on queries that can be used to "peek into"
@@ -49,7 +49,7 @@ impl<K, V> TableEntry<K, V> {
     }
 }
 
-impl<'d, Q> DebugQueryTable for QueryTable<'_, Q>
+impl<'me, Q> DebugQueryTable for QueryTable<'me, Q, &'me <Q as QueryDb<'me>>::DynDb>
 where
     Q: Query,
     Q::Storage: QueryStorageOps<Q>,
@@ -58,13 +58,13 @@ where
     type Value = Q::Value;
 
     fn durability(&self, key: Q::Key) -> Durability {
-        self.storage.durability(&self.db, &key)
+        QueryStorageOps::durability(&*self.storage, self.db, &key)
     }
 
     fn entries<C>(&self) -> C
     where
         C: FromIterator<TableEntry<Self::Key, Self::Value>>,
     {
-        self.storage.entries(&self.db)
+        QueryStorageOps::entries(&*self.storage, self.db)
     }
 }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -58,13 +58,13 @@ where
     type Value = Q::Value;
 
     fn durability(&self, key: Q::Key) -> Durability {
-        self.storage.durability(self.db, &key)
+        self.storage.durability(&self.db, &key)
     }
 
     fn entries<C>(&self) -> C
     where
         C: FromIterator<TableEntry<Self::Key, Self::Value>>,
     {
-        self.storage.entries(self.db)
+        self.storage.entries(&self.db)
     }
 }

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -5,10 +5,9 @@ use crate::plumbing::DerivedQueryStorageOps;
 use crate::plumbing::LruQueryStorageOps;
 use crate::plumbing::QueryFunction;
 use crate::plumbing::QueryStorageMassOps;
-use crate::plumbing::{
-    AsyncQueryFunction, QueryFunctionBase, QueryStorageOps, QueryStorageOpsAsync,
-    QueryStorageOpsSync,
-};
+#[cfg(feature = "async")]
+use crate::plumbing::{AsyncQueryFunction, QueryStorageOpsAsync};
+use crate::plumbing::{QueryFunctionBase, QueryStorageOps, QueryStorageOpsSync};
 use crate::runtime::{FxIndexMap, StampedValue};
 use crate::{
     blocking_future::{BlockingFuture, BlockingFutureTrait},

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -5,9 +5,15 @@ use crate::plumbing::DerivedQueryStorageOps;
 use crate::plumbing::LruQueryStorageOps;
 use crate::plumbing::QueryFunction;
 use crate::plumbing::QueryStorageMassOps;
-use crate::plumbing::QueryStorageOps;
+use crate::plumbing::{
+    AsyncQueryFunction, QueryFunctionBase, QueryStorageOps, QueryStorageOpsAsync,
+    QueryStorageOpsSync,
+};
 use crate::runtime::{FxIndexMap, StampedValue};
-use crate::{CycleError, Database, DatabaseKeyIndex, QueryDb, Revision, Runtime, SweepStrategy};
+use crate::{
+    blocking_future::{BlockingFuture, BlockingFutureTrait},
+    CycleError, Database, DatabaseKeyIndex, QueryBase, QueryDb, Revision, Runtime, SweepStrategy,
+};
 use parking_lot::RwLock;
 use std::borrow::Borrow;
 use std::convert::TryFrom;
@@ -17,6 +23,8 @@ use std::sync::Arc;
 
 mod slot;
 use slot::Slot;
+
+pub use slot::WaitResult;
 
 /// Memoized queries store the result plus a list of the other queries
 /// that they invoked. This means we can avoid recomputing them when
@@ -32,7 +40,7 @@ pub type DependencyStorage<Q> = DerivedStorage<Q, NeverMemoizeValue>;
 /// function (in contrast to "inputs").
 pub struct DerivedStorage<Q, MP>
 where
-    Q: QueryFunction,
+    Q: QueryFunctionBase,
     MP: MemoizationPolicy<Q>,
 {
     group_index: u16,
@@ -43,7 +51,7 @@ where
 
 impl<Q, MP> std::panic::RefUnwindSafe for DerivedStorage<Q, MP>
 where
-    Q: QueryFunction,
+    Q: QueryFunctionBase,
     MP: MemoizationPolicy<Q>,
     Q::Key: std::panic::RefUnwindSafe,
     Q::Value: std::panic::RefUnwindSafe,
@@ -52,7 +60,7 @@ where
 
 pub trait MemoizationPolicy<Q>: Send + Sync
 where
-    Q: QueryFunction,
+    Q: QueryBase,
 {
     fn should_memoize_value(key: &Q::Key) -> bool;
 
@@ -62,7 +70,7 @@ where
 pub enum AlwaysMemoizeValue {}
 impl<Q> MemoizationPolicy<Q> for AlwaysMemoizeValue
 where
-    Q: QueryFunction,
+    Q: QueryFunctionBase,
     Q::Value: Eq,
 {
     fn should_memoize_value(_key: &Q::Key) -> bool {
@@ -77,7 +85,7 @@ where
 pub enum NeverMemoizeValue {}
 impl<Q> MemoizationPolicy<Q> for NeverMemoizeValue
 where
-    Q: QueryFunction,
+    Q: QueryFunctionBase,
 {
     fn should_memoize_value(_key: &Q::Key) -> bool {
         false
@@ -90,7 +98,7 @@ where
 
 impl<Q, MP> DerivedStorage<Q, MP>
 where
-    Q: QueryFunction,
+    Q: QueryFunctionBase,
     MP: MemoizationPolicy<Q>,
 {
     fn slot(&self, key: &Q::Key) -> Arc<Slot<Q, MP>> {
@@ -114,7 +122,7 @@ where
 
 impl<Q, MP> QueryStorageOps<Q> for DerivedStorage<Q, MP>
 where
-    Q: QueryFunction,
+    for<'f, 'd> Q: QueryFunction<'f, 'd>,
     MP: MemoizationPolicy<Q>,
 {
     fn new(group_index: u16) -> Self {
@@ -128,7 +136,7 @@ where
 
     fn fmt_index(
         &self,
-        _db: &mut <Q as QueryDb<'_>>::Db,
+        _db: &<Q as QueryDb<'_>>::DynDb,
         index: DatabaseKeyIndex,
         fmt: &mut std::fmt::Formatter<'_>,
     ) -> std::fmt::Result {
@@ -154,29 +162,7 @@ where
             .unwrap()
             .1
             .clone();
-        slot.maybe_changed_since(db, revision)
-    }
-
-    fn try_fetch(
-        &self,
-        db: &mut <Q as QueryDb<'_>>::Db,
-        key: &Q::Key,
-    ) -> Result<Q::Value, CycleError<DatabaseKeyIndex>> {
-        let slot = self.slot(key);
-        let StampedValue {
-            value,
-            durability,
-            changed_at,
-        } = slot.read(db)?;
-
-        if let Some(evicted) = self.lru_list.record_use(&slot) {
-            evicted.evict();
-        }
-
-        db.salsa_runtime()
-            .report_query_read(slot.database_key_index(), durability, changed_at);
-
-        Ok(value)
+        crate::plumbing::sync_future(slot.maybe_changed_since(db, revision))
     }
 
     fn durability(&self, db: &<Q as QueryDb<'_>>::DynDb, key: &Q::Key) -> Durability {
@@ -195,9 +181,75 @@ where
     }
 }
 
+impl<Q, MP> QueryStorageOpsSync<Q> for DerivedStorage<Q, MP>
+where
+    for<'f, 'd> Q: QueryFunction<'f, 'd>,
+    Q: QueryFunctionBase<
+        BlockingFuture = BlockingFuture<WaitResult<<Q as QueryBase>::Value, DatabaseKeyIndex>>,
+    >,
+    MP: MemoizationPolicy<Q>,
+{
+    fn try_fetch(
+        &self,
+        db: &mut <Q as QueryDb<'_>>::Db,
+        key: &Q::Key,
+    ) -> Result<Q::Value, CycleError<DatabaseKeyIndex>> {
+        let slot = self.slot(key);
+        let StampedValue {
+            value,
+            durability,
+            changed_at,
+        } = crate::plumbing::sync_future(slot.read(db))?;
+
+        if let Some(evicted) = self.lru_list.record_use(&slot) {
+            evicted.evict();
+        }
+
+        db.salsa_runtime()
+            .report_query_read(slot.database_key_index(), durability, changed_at);
+
+        Ok(value)
+    }
+}
+
+impl<Q, MP> QueryStorageOpsAsync<Q> for DerivedStorage<Q, MP>
+where
+    for<'f, 'd> Q: AsyncQueryFunction<'f, 'd>,
+    Q::BlockingFuture: Send,
+    Q::Key: Send + Sync,
+    Q::Value: Send + Sync,
+    <Q::BlockingFuture as BlockingFutureTrait<WaitResult<Q::Value, DatabaseKeyIndex>>>::Promise:
+        Send + Sync,
+    MP: MemoizationPolicy<Q>,
+{
+    fn try_fetch_async<'f>(
+        &'f self,
+        db: &'f mut <Q as AsyncQueryFunction<'_, '_>>::SendDb,
+        key: &'f Q::Key,
+    ) -> crate::BoxFuture<'f, Result<Q::Value, CycleError<DatabaseKeyIndex>>> {
+        Box::pin(async move {
+            let slot = self.slot(key);
+            let StampedValue {
+                value,
+                durability,
+                changed_at,
+            } = slot.read(db).await?;
+
+            if let Some(evicted) = self.lru_list.record_use(&slot) {
+                evicted.evict();
+            }
+
+            db.salsa_runtime()
+                .report_query_read(slot.database_key_index(), durability, changed_at);
+
+            Ok(value)
+        })
+    }
+}
+
 impl<Q, MP> QueryStorageMassOps for DerivedStorage<Q, MP>
 where
-    Q: QueryFunction,
+    for<'f, 'd> Q: QueryFunction<'f, 'd>,
     MP: MemoizationPolicy<Q>,
 {
     fn sweep(&self, runtime: &Runtime, strategy: SweepStrategy) {
@@ -215,7 +267,7 @@ where
 
 impl<Q, MP> LruQueryStorageOps for DerivedStorage<Q, MP>
 where
-    Q: QueryFunction,
+    for<'f, 'd> Q: QueryFunction<'f, 'd>,
     MP: MemoizationPolicy<Q>,
 {
     fn set_lru_capacity(&self, new_capacity: usize) {
@@ -225,7 +277,7 @@ where
 
 impl<Q, MP> DerivedQueryStorageOps<Q> for DerivedStorage<Q, MP>
 where
-    Q: QueryFunction,
+    for<'f, 'd> Q: QueryFunction<'f, 'd>,
     MP: MemoizationPolicy<Q>,
 {
     fn invalidate<S>(&self, db: &mut <Q as QueryDb<'_>>::DynDb, key: &S)

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -128,7 +128,7 @@ where
 
     fn fmt_index(
         &self,
-        _db: &<Q as QueryDb<'_>>::DynDb,
+        _db: &mut <Q as QueryDb<'_>>::Db,
         index: DatabaseKeyIndex,
         fmt: &mut std::fmt::Formatter<'_>,
     ) -> std::fmt::Result {
@@ -141,7 +141,7 @@ where
 
     fn maybe_changed_since(
         &self,
-        db: &<Q as QueryDb<'_>>::DynDb,
+        db: &mut <Q as QueryDb<'_>>::Db,
         input: DatabaseKeyIndex,
         revision: Revision,
     ) -> bool {
@@ -159,7 +159,7 @@ where
 
     fn try_fetch(
         &self,
-        db: &<Q as QueryDb<'_>>::DynDb,
+        db: &mut <Q as QueryDb<'_>>::Db,
         key: &Q::Key,
     ) -> Result<Q::Value, CycleError<DatabaseKeyIndex>> {
         let slot = self.slot(key);

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -147,24 +147,6 @@ where
         write!(fmt, "{}({:?})", Q::QUERY_NAME, key)
     }
 
-    fn maybe_changed_since(
-        &self,
-        db: &mut <Q as QueryDb<'_>>::Db,
-        input: DatabaseKeyIndex,
-        revision: Revision,
-    ) -> bool {
-        assert_eq!(input.group_index, self.group_index);
-        assert_eq!(input.query_index, Q::QUERY_INDEX);
-        let slot = self
-            .slot_map
-            .read()
-            .get_index(input.key_index as usize)
-            .unwrap()
-            .1
-            .clone();
-        crate::plumbing::sync_future(slot.maybe_changed_since(db, revision))
-    }
-
     fn durability(&self, db: &<Q as QueryDb<'_>>::DynDb, key: &Q::Key) -> Durability {
         self.slot(key).durability(db)
     }
@@ -189,6 +171,24 @@ where
     >,
     MP: MemoizationPolicy<Q>,
 {
+    fn maybe_changed_since(
+        &self,
+        db: &mut <Q as QueryDb<'_>>::Db,
+        input: DatabaseKeyIndex,
+        revision: Revision,
+    ) -> bool {
+        assert_eq!(input.group_index, self.group_index);
+        assert_eq!(input.query_index, Q::QUERY_INDEX);
+        let slot = self
+            .slot_map
+            .read()
+            .get_index(input.key_index as usize)
+            .unwrap()
+            .1
+            .clone();
+        crate::plumbing::sync_future(slot.maybe_changed_since(db, revision))
+    }
+
     fn try_fetch(
         &self,
         db: &mut <Q as QueryDb<'_>>::Db,
@@ -222,6 +222,26 @@ where
         Send + Sync,
     MP: MemoizationPolicy<Q>,
 {
+    fn maybe_changed_since_async<'f>(
+        &'f self,
+        db: &'f mut <Q as AsyncQueryFunction<'_, '_>>::SendDb,
+        input: DatabaseKeyIndex,
+        revision: Revision,
+    ) -> crate::BoxFuture<'f, bool> {
+        Box::pin(async move {
+            assert_eq!(input.group_index, self.group_index);
+            assert_eq!(input.query_index, Q::QUERY_INDEX);
+            let slot = self
+                .slot_map
+                .read()
+                .get_index(input.key_index as usize)
+                .unwrap()
+                .1
+                .clone();
+            slot.maybe_changed_since(db, revision).await
+        })
+    }
+
     fn try_fetch_async<'f>(
         &'f self,
         db: &'f mut <Q as AsyncQueryFunction<'_, '_>>::SendDb,

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -225,6 +225,7 @@ where
     }
 }
 
+#[cfg(feature = "async")]
 impl<Q, MP> QueryStorageOpsAsync<Q> for DerivedStorage<Q, MP>
 where
     for<'f, 'd> Q: AsyncQueryFunction<'f, 'd>,

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -186,6 +186,10 @@ where
             .filter_map(|slot| slot.as_table_entry())
             .collect()
     }
+
+    fn peek(&self, db: &<Q as QueryDb<'_>>::DynDb, key: &Q::Key) -> Option<Q::Value> {
+        self.slot(key).peek(db).map(|v| v.value)
+    }
 }
 
 impl<Q, MP> QueryStorageOpsSync<Q> for DerivedStorage<Q, MP>

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -98,9 +98,35 @@ where
 
 impl<Q, MP> DerivedStorage<Q, MP>
 where
-    Q: QueryFunctionBase,
+    for<'f, 'd> Q: QueryFunction<'f, 'd>,
     MP: MemoizationPolicy<Q>,
 {
+    fn record_fetch(
+        &self,
+        db: &<Q as QueryDb<'_>>::DynDb,
+        slot: &Arc<Slot<Q, MP>>,
+        durability: Durability,
+        changed_at: Revision,
+    ) {
+        if let Some(evicted) = self.lru_list.record_use(slot) {
+            evicted.evict();
+        }
+
+        db.salsa_runtime()
+            .report_query_read(slot.database_key_index(), durability, changed_at);
+    }
+
+    fn maybe_changed_since_get_slot(&self, input: &DatabaseKeyIndex) -> Arc<Slot<Q, MP>> {
+        assert_eq!(input.group_index, self.group_index);
+        assert_eq!(input.query_index, Q::QUERY_INDEX);
+        self.slot_map
+            .read()
+            .get_index(input.key_index as usize)
+            .unwrap()
+            .1
+            .clone()
+    }
+
     fn slot(&self, key: &Q::Key) -> Arc<Slot<Q, MP>> {
         if let Some(v) = self.slot_map.read().get(key) {
             return v.clone();
@@ -177,15 +203,7 @@ where
         input: DatabaseKeyIndex,
         revision: Revision,
     ) -> bool {
-        assert_eq!(input.group_index, self.group_index);
-        assert_eq!(input.query_index, Q::QUERY_INDEX);
-        let slot = self
-            .slot_map
-            .read()
-            .get_index(input.key_index as usize)
-            .unwrap()
-            .1
-            .clone();
+        let slot = self.maybe_changed_since_get_slot(&input);
         crate::plumbing::sync_future(slot.maybe_changed_since(db, revision))
     }
 
@@ -201,12 +219,7 @@ where
             changed_at,
         } = crate::plumbing::sync_future(slot.read(db))?;
 
-        if let Some(evicted) = self.lru_list.record_use(&slot) {
-            evicted.evict();
-        }
-
-        db.salsa_runtime()
-            .report_query_read(slot.database_key_index(), durability, changed_at);
+        self.record_fetch(db, &slot, durability, changed_at);
 
         Ok(value)
     }
@@ -229,15 +242,7 @@ where
         revision: Revision,
     ) -> crate::BoxFuture<'f, bool> {
         Box::pin(async move {
-            assert_eq!(input.group_index, self.group_index);
-            assert_eq!(input.query_index, Q::QUERY_INDEX);
-            let slot = self
-                .slot_map
-                .read()
-                .get_index(input.key_index as usize)
-                .unwrap()
-                .1
-                .clone();
+            let slot = self.maybe_changed_since_get_slot(&input);
             slot.maybe_changed_since(db, revision).await
         })
     }
@@ -255,12 +260,7 @@ where
                 changed_at,
             } = slot.read(db).await?;
 
-            if let Some(evicted) = self.lru_list.record_use(&slot) {
-                evicted.evict();
-            }
-
-            db.salsa_runtime()
-                .report_query_read(slot.database_key_index(), durability, changed_at);
+            self.record_fetch(db, &slot, durability, changed_at);
 
             Ok(value)
         })

--- a/src/derived/slot.rs
+++ b/src/derived/slot.rs
@@ -14,11 +14,13 @@ use crate::{
     CycleError, Database, DatabaseKeyIndex, DiscardIf, DiscardWhat, Event, EventKind, QueryBase,
     QueryDb, SweepStrategy,
 };
-use futures::Future;
+
 use log::{debug, info};
 use parking_lot::Mutex;
 use parking_lot::{RawRwLock, RwLock};
 use smallvec::SmallVec;
+
+use std::future::Future;
 use std::marker::PhantomData;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -610,7 +612,7 @@ where
         db: &'db mut <Q as QueryDb<'d>>::Db,
         revision: Revision,
     ) -> impl Future<Output = bool> + Captures<'me> + Captures<'db> + Captures<'d> + 'f {
-        use futures::future::{ready, Either, Ready};
+        use futures_util::future::{ready, Either, Ready};
 
         fn done<L, R>(l: L) -> Either<Ready<L>, R> {
             Either::Left(ready(l))

--- a/src/input.rs
+++ b/src/input.rs
@@ -76,24 +76,6 @@ where
         write!(fmt, "{}({:?})", Q::QUERY_NAME, key)
     }
 
-    fn maybe_changed_since(
-        &self,
-        db: &mut <Q as QueryDb<'_>>::Db,
-        input: DatabaseKeyIndex,
-        revision: Revision,
-    ) -> bool {
-        assert_eq!(input.group_index, self.group_index);
-        assert_eq!(input.query_index, Q::QUERY_INDEX);
-        let slot = self
-            .slots
-            .read()
-            .get_index(input.key_index as usize)
-            .unwrap()
-            .1
-            .clone();
-        slot.maybe_changed_since(db, revision)
-    }
-
     fn durability(&self, _db: &<Q as QueryDb<'_>>::DynDb, key: &Q::Key) -> Durability {
         match self.slot(key) {
             Some(slot) => slot.stamped_value.read().durability,
@@ -122,6 +104,24 @@ impl<Q> QueryStorageOpsSync<Q> for InputStorage<Q>
 where
     Q: Query,
 {
+    fn maybe_changed_since(
+        &self,
+        db: &mut <Q as QueryDb<'_>>::Db,
+        input: DatabaseKeyIndex,
+        revision: Revision,
+    ) -> bool {
+        assert_eq!(input.group_index, self.group_index);
+        assert_eq!(input.query_index, Q::QUERY_INDEX);
+        let slot = self
+            .slots
+            .read()
+            .get_index(input.key_index as usize)
+            .unwrap()
+            .1
+            .clone();
+        slot.maybe_changed_since(db, revision)
+    }
+
     fn try_fetch(
         &self,
         db: &mut <Q as QueryDb<'_>>::Db,

--- a/src/input.rs
+++ b/src/input.rs
@@ -98,6 +98,10 @@ where
             })
             .collect()
     }
+
+    fn peek(&self, _db: &<Q as QueryDb<'_>>::DynDb, _key: &Q::Key) -> Option<Q::Value> {
+        None // TODO ?
+    }
 }
 
 impl<Q> QueryStorageOpsSync<Q> for InputStorage<Q>

--- a/src/input.rs
+++ b/src/input.rs
@@ -65,7 +65,7 @@ where
 
     fn fmt_index(
         &self,
-        _db: &<Q as QueryDb<'_>>::DynDb,
+        _db: &mut <Q as QueryDb<'_>>::Db,
         index: DatabaseKeyIndex,
         fmt: &mut std::fmt::Formatter<'_>,
     ) -> std::fmt::Result {
@@ -78,7 +78,7 @@ where
 
     fn maybe_changed_since(
         &self,
-        db: &<Q as QueryDb<'_>>::DynDb,
+        db: &mut <Q as QueryDb<'_>>::Db,
         input: DatabaseKeyIndex,
         revision: Revision,
     ) -> bool {
@@ -96,7 +96,7 @@ where
 
     fn try_fetch(
         &self,
-        db: &<Q as QueryDb<'_>>::DynDb,
+        db: &mut <Q as QueryDb<'_>>::Db,
         key: &Q::Key,
     ) -> Result<Q::Value, CycleError<DatabaseKeyIndex>> {
         let slot = self

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -304,19 +304,6 @@ where
         write!(fmt, "{}({:?})", Q::QUERY_NAME, slot.value)
     }
 
-    fn maybe_changed_since(
-        &self,
-        db: &mut <Q as QueryDb<'_>>::Db,
-        input: DatabaseKeyIndex,
-        revision: Revision,
-    ) -> bool {
-        assert_eq!(input.group_index, self.group_index);
-        assert_eq!(input.query_index, Q::QUERY_INDEX);
-        let intern_id = InternId::from(input.key_index);
-        let slot = self.lookup_value(db, intern_id);
-        slot.maybe_changed_since(db, revision)
-    }
-
     fn durability(&self, _db: &<Q as QueryDb<'_>>::DynDb, _key: &Q::Key) -> Durability {
         INTERN_DURABILITY
     }
@@ -341,6 +328,19 @@ where
     Q: Query,
     Q::Value: InternKey,
 {
+    fn maybe_changed_since(
+        &self,
+        db: &mut <Q as QueryDb<'_>>::Db,
+        input: DatabaseKeyIndex,
+        revision: Revision,
+    ) -> bool {
+        assert_eq!(input.group_index, self.group_index);
+        assert_eq!(input.query_index, Q::QUERY_INDEX);
+        let intern_id = InternId::from(input.key_index);
+        let slot = self.lookup_value(db, intern_id);
+        slot.maybe_changed_since(db, revision)
+    }
+
     fn try_fetch(
         &self,
         db: &mut <Q as QueryDb<'_>>::Db,
@@ -484,18 +484,6 @@ where
         interned_storage.fmt_index(Q::convert_dyn_db(db), index, fmt)
     }
 
-    fn maybe_changed_since(
-        &self,
-        db: &mut <Q as QueryDb<'_>>::Db,
-        input: DatabaseKeyIndex,
-        revision: Revision,
-    ) -> bool {
-        let group_storage =
-            <<Q as QueryDb<'_>>::DynDb as HasQueryGroup<Q::Group>>::group_storage(db);
-        let interned_storage = IQ::query_storage(Q::convert_group_storage(group_storage)).clone();
-        interned_storage.maybe_changed_since(Q::convert_db(db), input, revision)
-    }
-
     fn durability(&self, _db: &<Q as QueryDb<'_>>::DynDb, _key: &Q::Key) -> Durability {
         INTERN_DURABILITY
     }
@@ -526,6 +514,18 @@ where
     IQ: Query<Key = Q::Value, Value = Q::Key, Storage = InternedStorage<IQ>>,
     for<'d> Q: EqualDynDb<'d, IQ>,
 {
+    fn maybe_changed_since(
+        &self,
+        db: &mut <Q as QueryDb<'_>>::Db,
+        input: DatabaseKeyIndex,
+        revision: Revision,
+    ) -> bool {
+        let group_storage =
+            <<Q as QueryDb<'_>>::DynDb as HasQueryGroup<Q::Group>>::group_storage(db);
+        let interned_storage = IQ::query_storage(Q::convert_group_storage(group_storage)).clone();
+        interned_storage.maybe_changed_since(Q::convert_db(db), input, revision)
+    }
+
     fn try_fetch(
         &self,
         db: &mut <Q as QueryDb<'_>>::Db,

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -321,6 +321,10 @@ where
             })
             .collect()
     }
+
+    fn peek(&self, _db: &<Q as QueryDb<'_>>::DynDb, _key: &Q::Key) -> Option<Q::Value> {
+        None // TODO ?
+    }
 }
 
 impl<Q> QueryStorageOpsSync<Q> for InternedStorage<Q>
@@ -503,6 +507,10 @@ where
                 TableEntry::new(<Q::Key>::from_intern_id(*index), Some(key.clone()))
             })
             .collect()
+    }
+
+    fn peek(&self, _db: &<Q as QueryDb<'_>>::DynDb, _key: &Q::Key) -> Option<Q::Value> {
+        None // TODO ?
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,14 +25,14 @@ pub mod debug;
 #[doc(hidden)]
 pub mod plumbing;
 
-#[cfg(feature = "async")]
-use crate::plumbing::AsyncQueryFunction;
 use crate::plumbing::DerivedQueryStorageOps;
 use crate::plumbing::InputQueryStorageOps;
 use crate::plumbing::LruQueryStorageOps;
 use crate::plumbing::QueryStorageMassOps;
 use crate::plumbing::QueryStorageOps;
-use crate::plumbing::{HasQueryGroup, QueryStorageOpsAsync, QueryStorageOpsSync};
+#[cfg(feature = "async")]
+use crate::plumbing::{AsyncQueryFunction, QueryStorageOpsAsync};
+use crate::plumbing::{HasQueryGroup, QueryStorageOpsSync};
 pub use crate::revision::Revision;
 use std::fmt::{self, Debug};
 use std::hash::Hash;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,6 @@ use std::sync::Arc;
 pub use crate::durability::Durability;
 pub use crate::intern_id::InternId;
 pub use crate::interned::InternKey;
-pub use crate::runtime::AsyncDb;
 pub use crate::runtime::Runtime;
 pub use crate::runtime::RuntimeId;
 pub use crate::storage::Storage;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -526,6 +526,12 @@ where
     {
         self.storage.sweep(self.db.salsa_runtime(), strategy);
     }
+
+    /// Peeks at the value at `Q::Key`. If it is currently in cache then it returns
+    /// `Some`, otherwise `None`
+    pub fn peek(&self, key: &Q::Key) -> Option<Q::Value> {
+        self.storage.peek(self.db, key)
+    }
 }
 
 impl<'me, Q> QueryTable<'me, Q, <Q as QueryDb<'me>>::Db>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,11 +25,14 @@ pub mod debug;
 #[doc(hidden)]
 pub mod plumbing;
 
+#[cfg(feature = "async")]
+use crate::plumbing::AsyncQueryFunction;
 use crate::plumbing::DerivedQueryStorageOps;
 use crate::plumbing::InputQueryStorageOps;
 use crate::plumbing::LruQueryStorageOps;
 use crate::plumbing::QueryStorageMassOps;
 use crate::plumbing::QueryStorageOps;
+use crate::plumbing::{HasQueryGroup, QueryStorageOpsAsync, QueryStorageOpsSync};
 pub use crate::revision::Revision;
 use std::fmt::{self, Debug};
 use std::hash::Hash;
@@ -517,6 +520,7 @@ where
     }
 }
 
+#[cfg(feature = "async")]
 impl<'me, Q> QueryTable<'me, Q>
 where
     Q: QueryBase,
@@ -663,6 +667,5 @@ pub type BoxFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T
 #[allow(unused_imports)]
 #[macro_use]
 extern crate salsa_macros;
-use plumbing::{AsyncQueryFunction, HasQueryGroup, QueryStorageOpsAsync, QueryStorageOpsSync};
 #[doc(hidden)]
 pub use salsa_macros::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -695,6 +695,41 @@ where
 /// A boxed future used in the salsa traits
 pub type BoxFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;
 
+/// Encapsulates a mutable reference to a database while only giving out shared references.
+/// Use for asynchronous queries to make the database references passed `Send`
+#[allow(explicit_outlives_requirements)] // https://github.com/rust-lang/rust/issues/60993
+pub struct OwnedDb<'a, T>
+where
+    T: ?Sized,
+{
+    db: &'a mut T,
+}
+
+impl<'a, T> std::ops::Deref for OwnedDb<'a, T>
+where
+    T: ?Sized,
+{
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        self.db
+    }
+}
+
+impl<'a, T> OwnedDb<'a, T>
+where
+    T: ?Sized,
+{
+    #[doc(hidden)]
+    pub fn new(db: &'a mut T) -> Self {
+        Self { db }
+    }
+
+    #[doc(hidden)]
+    pub fn __internal_get_db(&mut self) -> &mut T {
+        self.db
+    }
+}
+
 // Re-export the procedural macros.
 #[allow(unused_imports)]
 #[macro_use]

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -13,13 +13,15 @@ use std::borrow::Borrow;
 use std::fmt::Debug;
 use std::{future::Future, hash::Hash, sync::Arc};
 
+#[cfg(feature = "async")]
+pub use crate::blocking_future::BlockingAsyncFuture;
 pub use crate::derived::DependencyStorage;
 pub use crate::derived::{MemoizedStorage, WaitResult};
 pub use crate::input::InputStorage;
 pub use crate::interned::InternedStorage;
 pub use crate::interned::LookupInternedStorage;
 pub use crate::{
-    blocking_future::{BlockingAsyncFuture, BlockingFuture, BlockingFutureTrait},
+    blocking_future::{BlockingFuture, BlockingFutureTrait},
     revision::Revision,
     BoxFuture, DatabaseKeyIndex, QueryBase, QueryDb, Runtime,
 };
@@ -204,6 +206,7 @@ where
     ) -> Result<Q::Value, CycleError<DatabaseKeyIndex>>;
 }
 
+#[cfg(feature = "async")]
 pub trait QueryStorageOpsAsync<Q>: QueryStorageOps<Q>
 where
     Self: QueryStorageMassOps,

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -166,15 +166,6 @@ where
         fmt: &mut std::fmt::Formatter<'_>,
     ) -> std::fmt::Result;
 
-    /// True if the value of `input`, which must be from this query, may have
-    /// changed since the given revision.
-    fn maybe_changed_since(
-        &self,
-        db: &mut <Q as QueryDb<'_>>::Db,
-        input: DatabaseKeyIndex,
-        revision: Revision,
-    ) -> bool;
-
     /// Returns the durability associated with a given key.
     fn durability(&self, db: &<Q as QueryDb<'_>>::DynDb, key: &Q::Key) -> Durability;
 
@@ -189,6 +180,15 @@ where
     Self: QueryStorageMassOps,
     Q: Query,
 {
+    /// True if the value of `input`, which must be from this query, may have
+    /// changed since the given revision.
+    fn maybe_changed_since(
+        &self,
+        db: &mut <Q as QueryDb<'_>>::Db,
+        input: DatabaseKeyIndex,
+        revision: Revision,
+    ) -> bool;
+
     /// Execute the query, returning the result (often, the result
     /// will be memoized).  This is the "main method" for
     /// queries.
@@ -210,6 +210,15 @@ where
     Q::Key: Send + Sync,
     Q::Value: Send + Sync,
 {
+    /// True if the value of `input`, which must be from this query, may have
+    /// changed since the given revision.
+    fn maybe_changed_since_async<'f>(
+        &'f self,
+        db: &'f mut <Q as AsyncQueryFunction<'_, '_>>::SendDb,
+        input: DatabaseKeyIndex,
+        revision: Revision,
+    ) -> crate::BoxFuture<'f, bool>;
+
     /// Execute the query, returning the result (often, the result
     /// will be memoized).  This is the "main method" for
     /// queries.

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -196,9 +196,11 @@ where
     fn entries<C>(&self, db: &<Q as QueryDb<'_>>::DynDb) -> C
     where
         C: std::iter::FromIterator<TableEntry<Q::Key, Q::Value>>;
+
+    fn peek(&self, db: &<Q as QueryDb<'_>>::DynDb, _key: &Q::Key) -> Option<Q::Value>;
 }
 
-pub trait QueryStorageOpsSync<Q>
+pub trait QueryStorageOpsSync<Q>: QueryStorageOps<Q>
 where
     Self: QueryStorageMassOps,
     Q: Query,

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -23,6 +23,7 @@ pub use crate::{
     revision::Revision,
     BoxFuture, DatabaseKeyIndex, QueryBase, QueryDb, Runtime,
 };
+pub use futures_util::future::{ready, Ready};
 
 #[derive(Clone, Debug)]
 pub struct CycleDetected {

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -122,7 +122,9 @@ where
 
 /// Create a query table, which has access to the storage for the query
 /// and offers methods like `get`.
-pub fn get_query_table<'me, Q>(db: <Q as QueryDb<'me>>::Db) -> QueryTable<'me, Q>
+pub fn get_query_table<'me, Q>(
+    db: &'me <Q as QueryDb<'me>>::DynDb,
+) -> QueryTable<'me, Q, &'me <Q as QueryDb<'me>>::DynDb>
 where
     Q: Query,
     Q::Storage: QueryStorageOps<Q>,
@@ -130,6 +132,18 @@ where
     let group_storage: &Q::GroupStorage = HasQueryGroup::group_storage(&*db);
     let query_storage: Arc<Q::Storage> = Q::query_storage(group_storage).clone();
     QueryTable::new(db, query_storage)
+}
+
+pub fn get_query_table_async<'me, Q>(
+    db: <Q as QueryDb<'me>>::Db,
+) -> QueryTable<'me, Q, <Q as QueryDb<'me>>::Db>
+where
+    Q: Query,
+    Q::Storage: QueryStorageOps<Q>,
+{
+    let group_storage: &Q::GroupStorage = HasQueryGroup::group_storage(&*db);
+    let query_storage: Arc<Q::Storage> = Q::query_storage(group_storage).clone();
+    QueryTable::new_async(db, query_storage)
 }
 
 /// Create a mutable query table, which has access to the storage

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -271,43 +271,26 @@ pub(crate) fn sync_future<F>(mut f: F) -> F::Output
 where
     F: Future,
 {
-    use std::{
-        pin::Pin,
-        sync::{Condvar, Mutex},
-    };
+    use std::pin::Pin;
 
-    use futures::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+    use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
     unsafe {
-        type WakerState = Condvar;
+        type WakerState = ();
 
-        static VTABLE: RawWakerVTable = RawWakerVTable::new(
-            |p| RawWaker::new(p, &VTABLE),
-            |p| unsafe {
-                (&*(p as *const WakerState)).notify_one();
-            },
-            |p| unsafe {
-                (&*(p as *const WakerState)).notify_one();
-            },
-            |_| (),
-        );
+        static VTABLE: RawWakerVTable =
+            RawWakerVTable::new(|p| RawWaker::new(p, &VTABLE), |_| (), |_| (), |_| ());
 
-        let waker_state = WakerState::new();
+        let waker_state = WakerState::default();
         let waker = Waker::from_raw(RawWaker::new(
             &waker_state as *const WakerState as *const (),
             &VTABLE,
         ));
         let mut context = Context::from_waker(&waker);
 
-        let mutex = Mutex::new(());
-        let mut guard = mutex.lock().unwrap();
-        loop {
-            match Pin::new_unchecked(&mut f).poll(&mut context) {
-                Poll::Ready(x) => break x,
-                Poll::Pending => {
-                    guard = waker_state.wait(guard).unwrap();
-                }
-            }
+        match Pin::new_unchecked(&mut f).poll(&mut context) {
+            Poll::Ready(x) => x,
+            Poll::Pending => unreachable!(),
         }
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -826,34 +826,6 @@ impl Drop for RevisionGuard {
     }
 }
 
-/// TODO
-pub struct AsyncDb<'a, T>
-where
-    T: ?Sized + Database,
-{
-    db: &'a mut T,
-}
-
-impl<T> std::ops::Deref for AsyncDb<'_, T>
-where
-    T: ?Sized + Database,
-{
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        self.db
-    }
-}
-
-impl<'a, T> AsyncDb<'a, T>
-where
-    T: ?Sized + Database,
-{
-    /// TODO
-    pub fn new(db: &'a mut T) -> Self {
-        AsyncDb { db }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/runtime/local_state.rs
+++ b/src/runtime/local_state.rs
@@ -104,7 +104,7 @@ impl std::panic::RefUnwindSafe for LocalState {}
 /// is returned to represent its slot. The guard can be used to pop
 /// the query from the stack -- in the case of unwinding, the guard's
 /// destructor will also remove the query.
-pub(super) struct ActiveQueryGuard<'me, DB>
+pub(crate) struct ActiveQueryGuard<'me, DB>
 where
     DB: std::ops::Deref,
     DB::Target: Database,

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -1,6 +1,8 @@
 #![cfg(feature = "async")]
 use std::task::Poll;
 
+use salsa::OwnedDb;
+
 #[salsa::database(async AsyncStorage)]
 #[derive(Default)]
 struct AsyncDatabase {
@@ -30,21 +32,21 @@ fn recover(_: &dyn Async, _: &[String], _: &u32) -> u32 {
     0
 }
 
-async fn output(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
+async fn output(db: &mut OwnedDb<'_, (dyn Async + '_)>, x: u32) -> u32 {
     yield_().await;
     db.output_inner(x).await
 }
 
-async fn output_inner(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
+async fn output_inner(db: &mut OwnedDb<'_, (dyn Async + '_)>, x: u32) -> u32 {
     yield_().await;
     db.input(x) * 2
 }
 
-async fn output_dependencies(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
+async fn output_dependencies(db: &mut OwnedDb<'_, (dyn Async + '_)>, x: u32) -> u32 {
     db.output(x).await
 }
 
-async fn output_transparent(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
+async fn output_transparent(db: &mut OwnedDb<'_, (dyn Async + '_)>, x: u32) -> u32 {
     db.output(x).await
 }
 

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -17,6 +17,9 @@ trait Async: Send {
     async fn output(&self, x: u32) -> u32;
 
     async fn output_inner(&self, x: u32) -> u32;
+
+    #[salsa::transparent]
+    async fn output_transparent(&self, x: u32) -> u32;
 }
 
 async fn output(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
@@ -27,6 +30,10 @@ async fn output(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
 async fn output_inner(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
     yield_().await;
     db.input(x) * 2
+}
+
+async fn output_transparent(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
+    db.output(x).await
 }
 
 async fn yield_() {

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -16,11 +16,11 @@ trait Async: Send {
     async fn output_inner(&self, x: u32) -> u32;
 }
 
-async fn output(db: &mut AsyncDb<'_, (dyn Async + '_)>, x: u32) -> u32 {
+async fn output(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
     db.output_inner(x).await
 }
 
-async fn output_inner(db: &mut AsyncDb<'_, (dyn Async + '_)>, x: u32) -> u32 {
+async fn output_inner(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
     db.input(x) * 2
 }
 

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -16,10 +16,18 @@ trait Async: Send {
 
     async fn output(&self, x: u32) -> u32;
 
+    #[salsa::cycle(recover)]
     async fn output_inner(&self, x: u32) -> u32;
+
+    #[salsa::dependencies]
+    async fn output_dependencies(&self, x: u32) -> u32;
 
     #[salsa::transparent]
     async fn output_transparent(&self, x: u32) -> u32;
+}
+
+fn recover(_: &dyn Async, _: &[String], _: &u32) -> u32 {
+    0
 }
 
 async fn output(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
@@ -30,6 +38,10 @@ async fn output(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
 async fn output_inner(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
     yield_().await;
     db.input(x) * 2
+}
+
+async fn output_dependencies(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
+    db.output(x).await
 }
 
 async fn output_transparent(db: &mut OwnedAsync<'_>, x: u32) -> u32 {

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "async")]
+
 #[salsa::database(async AsyncStorage)]
 #[derive(Default)]
 struct AsyncDatabase {

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -1,0 +1,33 @@
+#[salsa::database(async AsyncStorage)]
+#[derive(Default)]
+struct AsyncDatabase {
+    storage: salsa::Storage<Self>,
+}
+
+impl salsa::Database for AsyncDatabase {}
+
+#[salsa::query_group(AsyncStorage)]
+trait Async: Send {
+    #[salsa::input]
+    fn input(&self, x: u32) -> u32;
+
+    async fn output(&self, x: u32) -> u32;
+
+    async fn output_inner(&self, x: u32) -> u32;
+}
+
+async fn output(db: &mut AsyncDb<'_, (dyn Async + '_)>, x: u32) -> u32 {
+    db.output_inner(x).await
+}
+
+async fn output_inner(db: &mut AsyncDb<'_, (dyn Async + '_)>, x: u32) -> u32 {
+    db.input(x) * 2
+}
+
+#[tokio::test]
+async fn basic() {
+    let mut query = AsyncDatabase::default();
+    query.set_input(22, 23);
+    assert_eq!(query.output(22).await, 46);
+    assert_eq!(query.output(22).await, 46);
+}


### PR DESCRIPTION
This is a complete rewrite of my previous attempt of async queries and solves basically all the issues of that PR!

* The database only needs to be `Send` if an `async` query are used, normal synchronous queries can still have non-sync values, keys etc,

* Async queries require a mutable reference to the database but sync queries still works with shared references. To prevent async queries from calling mutating methods the database gets wrapped with a newtype which only provides public access to the async query methods or a shared reference which gives access to the sync queries.

* While the main derived query path is now async, sync queries still uses blocking and going from async to sync is a very light wrapper so there should be basically now overhead (not even any boxed futures!).

There are still some issues I need to cleanup and I need to add some more tests but basically everything is there already. You may note that there are a few hacks to get the types to work out (which I point out with comments in the source). Due to the use of higher ranked lifetimes rustc is unable to see that `Send` exists or that `DynDb` is the same in interned queries but with a pair of helper traits I appear to get around these issues (may need some deeper explanation).