### PR TITLE
feat: Allow sub-queries to run concurrently

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ readme = "README.md"
 async-trait = "0.1"
 crossbeam-utils = { version = "0.7.1", default-features = false }
 indexmap = "1.0.1"
-futures-util = { version = "0.3", default-features = false }
 futures-channel = { version = "0.3", features = ["alloc"], default-features = false, optional = true }
+futures-util = { version = "0.3", default-features = false, optional = true }
 lock_api = "0.4"
 log = "0.4.5"
 parking_lot = "0.11.0"
@@ -35,4 +35,4 @@ tokio = { version = "0.2", features = ["macros", "rt-core"] }
 
 [features]
 default = ["async"]
-async = ["futures-channel", "salsa-macros/async"]
+async = ["futures-channel", "futures-util", "salsa-macros/async"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ readme = "README.md"
 async-trait = "0.1"
 crossbeam-utils = { version = "0.7.1", default-features = false }
 indexmap = "1.0.1"
-futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
+futures-channel = { version = "0.3", features = ["alloc"], default-features = false }
 lock_api = "0.4"
 log = "0.4.5"
 parking_lot = "0.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ async-trait = "0.1"
 crossbeam-utils = { version = "0.7.1", default-features = false }
 indexmap = "1.0.1"
 futures-util = { version = "0.3", default-features = false }
-futures-channel = { version = "0.3", features = ["alloc"], default-features = false }
+futures-channel = { version = "0.3", features = ["alloc"], default-features = false, optional = true }
 lock_api = "0.4"
 log = "0.4.5"
 parking_lot = "0.11.0"
@@ -32,3 +32,7 @@ rand_distr = "0.2.1"
 tokio = { version = "0.2", features = ["macros", "rt-core"] }
 
 [workspace]
+
+[features]
+default = ["async"]
+async = ["futures-channel", "salsa-macros/async"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,10 @@ description = "A generic framework for on-demand, incrementalized computation (e
 readme = "README.md"
 
 [dependencies]
+async-trait = "0.1"
 crossbeam-utils = { version = "0.7.1", default-features = false }
 indexmap = "1.0.1"
+futures = "0.3"
 lock_api = "0.4"
 log = "0.4.5"
 parking_lot = "0.11.0"
@@ -26,5 +28,6 @@ env_logger = "0.7"
 linked-hash-map = "0.5.2"
 rand = "0.7"
 rand_distr = "0.2.1"
+tokio = { version = "0.2", features = ["macros", "rt-core"] }
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ description = "A generic framework for on-demand, incrementalized computation (e
 readme = "README.md"
 
 [dependencies]
-async-trait = "0.1"
 crossbeam-utils = { version = "0.7.1", default-features = false }
 indexmap = "1.0.1"
 futures-channel = { version = "0.3", features = ["alloc"], default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ salsa-macros = { version = "0.15.0", path = "components/salsa-macros" }
 [dev-dependencies]
 diff = "0.1.0"
 env_logger = "0.7"
+futures-util = { version = "0.3", features = ["async-await"] }
 linked-hash-map = "0.5.2"
 rand = "0.7"
 rand_distr = "0.2.1"

--- a/book/src/rfcs/RFC0006-Dynamic-Databases.md
+++ b/book/src/rfcs/RFC0006-Dynamic-Databases.md
@@ -542,7 +542,7 @@ changes are made, so that the signature looks like:
 // Before this RFC:
 pub struct DerivedStorage<Q, MP>
 where
-    Q: QueryFunction,
+    for<'f> Q: QueryFunction<'f>,
     MP: MemoizationPolicy<DB, Q>,
 ```
 

--- a/book/src/rfcs/RFC0006-Dynamic-Databases.md
+++ b/book/src/rfcs/RFC0006-Dynamic-Databases.md
@@ -310,8 +310,8 @@ Therefore `QueryFunction` for example can become:
 
 ```rust,ignore
 pub trait QueryFunction: Query {
-    fn execute(db: &Self::DynDb, key: Self::Key) -> Self::Value;
-    fn recover(db: &Self::DynDb, cycle: &[DB::DatabaseKey], key: &Self::Key) -> Option<Self::Value> {
+    fn execute(db: &<Self as QueryDb<'_>>::DynDb, key: Self::Key) -> Self::Value;
+    fn recover(db: &<Self as QueryDb<'_>>::DynDb, cycle: &[DB::DatabaseKey], key: &Self::Key) -> Option<Self::Value> {
         let _ = (db, cycle, key);
         None
     }
@@ -455,7 +455,7 @@ we have to make a few changes:
 
 One downside of this proposal is that the `salsa::Database` trait now has a
 `'static` bound. This is a result of the lack of GATs -- in particular, the
-queries expect a `Q::DynDb` as argument. In the query definition, we have
+queries expect a `<Q as QueryDb<'_>>::DynDb` as argument. In the query definition, we have
 something like `type DynDb = dyn QueryGroupDatabase`, which in turn defaults to
 `dyn::QueryGroupDatabase + 'static`.
 

--- a/book/src/rfcs/RFC0007-Async-Queries.md
+++ b/book/src/rfcs/RFC0007-Async-Queries.md
@@ -1,0 +1,102 @@
+
+## Metadata
+
+* Author: marwes
+* Date: 2020-08-04
+* Introduced in: [salsa-rs/salsa#1](https://github.com/salsa-rs/salsa/pull/1) (please update once you open your PR)
+
+## Summary
+
+Allow salsa databases to define derived queries that execute asynchronous code.
+
+## Motivation
+
+Asynchronous code is typically not needed for compilers as they typically do not need to wait on IO. However there is still utility in writing asynchronous queries
+as asynchronous tasks model queries waiting for eachother really well. There may also be non-compiler uses for salsa where the async nature may be useful (think caching a resource fetch over the network).
+
+### Our goal
+
+Allow `async fn` to be written for any query that needs to be `async`.
+
+## User's guide
+
+Any salsa query that involves running user code (not input or interned queries) can now be written as an `async fn`. These queries accept the database as an `&mut salsa::OwnedDb<'_, dyn MyDatabase>` (or `&mut dyn MyDatabase` as a convenience for the top query) object instead of `&dyn MyDatabase` as a way to preserve `Send` for the returned futures but are otherwise identical.
+
+```rust
+#[salsa::query_group(AsyncStorage)]
+trait Async: Send {
+    async fn query(&self, x: u32) -> u32;
+}
+
+async fn query(db: &mut salsa::OwnedDb<'_, dyn Async>, x: u32) -> u32 {
+    async_function(db, x, "abc").await
+}
+```
+
+## Reference guide
+
+To avoid duplication all operations on derived queries are now written as `async fn`. Since these `async` functions end up capturing the database parameter and we want the returned futures to implement `Send` we need to change these functions so they accept `&mut` instead of `&`. But we also do not want a running query to use any `&mut` operations. To resolve this the internal `QueryDb` is extended with a `Db` type that is used to parameterize queries over `&dyn MyDatabase` and `salsa::OwnedDb<'_, dyn MyDatabase>`. The latter is used for `async` queries and works in a similar way to `Snapshot`. User code can only retrieve a `&` reference, while the salsa internals can still retrieve the `&mut` reference within (as such there is also a `From` conversion from `Snapshot` to `OwnedDb`).
+
+```rust
+pub trait QueryDb<'d>: QueryBase {
+    /// Dyn version of the associated trait for this query group.
+    type DynDb: ?Sized + Database + HasQueryGroup<Self::Group> + 'd;
+
+    /// Sized version of `DynDb`, &'d Self::DynDb for synchronous queries
+    type Db: std::ops::Deref<Target = Self::DynDb> + AsAsyncDatabase<Self::DynDb>;
+}
+```
+
+The only internal operation in a query that blocks for a "long" time is waiting for a query that is currently executing. For async queries we want to yield to the executor here instead of blocking whereas synchronous queries want to just block the thread. While we could just use an async-aware primitive for this and invoke synchronous queries with an executor capable of handling this that would force a small but potentially noticeable overhead for synchronous queries. 
+
+To resolve this we can instead parameterize over this `BlockingFuture` with a type which just blocks for synchronous queries and uses a real async-aware type for async queries. This then allows for a truly minimal "executor" which doesn't need to handle `Poll::Pending` at all
+
+```rust
+/// Calls a future synchronously without an actual way to resume to future.
+pub(crate) fn sync_future<F>(mut f: F) -> F::Output
+where
+    F: Future,
+{
+    use std::task::{RawWaker, RawWakerVTable, Waker};
+
+    unsafe {
+        type WakerState = ();
+
+        static VTABLE: RawWakerVTable =
+            RawWakerVTable::new(|p| RawWaker::new(p, &VTABLE), |_| (), |_| (), |_| ());
+
+        let waker_state = WakerState::default();
+        let waker = Waker::from_raw(RawWaker::new(
+            &waker_state as *const WakerState as *const (),
+            &VTABLE,
+        ));
+        let mut context = Context::from_waker(&waker);
+
+        match Pin::new_unchecked(&mut f).poll(&mut context) {
+            Poll::Ready(x) => x,
+            Poll::Pending => unreachable!(),
+        }
+    }
+}
+```
+
+The `QueryFunction` trait which represented the user code actually being invoke are changed to return a `Future`. For `async` queries this must be a boxed future but for synchronous queries this can just be the non-allocating `Ready` future that were ported from the `futures` crate to avoid a dependency on it.
+
+```rust
+pub trait QueryFunctionBase: QueryBase {
+    type BlockingFuture: BlockingFutureTrait<WaitResult<Self::Value, DatabaseKeyIndex>>;
+}
+
+pub trait QueryFunction<'f, 'd>: QueryFunctionBase + QueryDb<'d> {
+    type Future: Future<Output = Self::Value> + 'f;
+
+    fn execute(db: &'f mut <Self as QueryDb<'d>>::Db, key: Self::Key) -> Self::Future;
+    ...
+}
+```
+
+The functions `QueryStorageOps::try_fetch` and `QueryStorageOps::maybe_changed_since` were extracted to a `QueryStorageOpsSync` trait and a matching `QueryStorageOpsAsync` trait were added. Through this split the synchronous code does not need to allocate the boxed future that the async variant must return and it also ensures that other queries such as `input` never implements the `async` functions.
+
+## Alternatives and future work
+
+The slightly awkward `OwnedDb` could perhaps be avoided if salsa's `RefCell` usage were removed. However my attempts so far hasn't yielded a workable solution.

--- a/components/salsa-macros/Cargo.toml
+++ b/components/salsa-macros/Cargo.toml
@@ -16,3 +16,6 @@ heck = "0.3"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full", "extra-traits"] }
+
+[features]
+async = []

--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -418,7 +418,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
                 /// single input. You can also use it to invoke this query, though
                 /// it's more common to use the trait method on the database
                 /// itself.
-                #trait_vis fn in_db<'me, 'd>(self, db: &'me (#dyn_db + 'd)) -> salsa::QueryTable<'me, Self, (#dyn_db + 'd)>
+                #trait_vis fn in_db(self, db: &#dyn_db) -> salsa::QueryTable<'_, Self>
                 {
                     salsa::plumbing::get_query_table::<#qt>(db)
                 }

--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -469,6 +469,15 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
                 impl #async_trait_name for salsa::OwnedDb<'_, #dyn_db + '_> {
                     #async_query_fn_definitions
                 }
+
+                impl<DB> #async_trait_name for salsa::Snapshot<DB>
+                where
+                    #db_bounds
+                    DB: salsa::ParallelDatabase,
+                    DB: salsa::plumbing::HasQueryGroup<#group_struct>,
+                {
+                    #async_query_fn_definitions
+                }
             });
         }
     }

--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -598,7 +598,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
             let invoke = query.invoke_tt();
 
             let recover = if let Some(cycle_recovery_fn) = &query.cycle {
-                quote! {
+                quote_spanned! { cycle_recovery_fn.span() =>
                     fn recover(db: &<Self as salsa::QueryDb<'d>>::DynDb, cycle: &[salsa::DatabaseKeyIndex], #key_pattern: &<Self as salsa::QueryBase>::Key)
                         -> Option<<Self as salsa::QueryBase>::Value> {
                         Some(#cycle_recovery_fn(

--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -605,13 +605,13 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
             let future = if query.is_async {
                 quote!(salsa::BoxFuture<'f, Self::Value>)
             } else {
-                quote!(futures::future::Ready<Self::Value>)
+                quote!(salsa::plumbing::Ready<Self::Value>)
             };
 
             let wrap_future = if query.is_async {
                 quote!(Box::pin)
             } else {
-                quote!(futures::future::ready)
+                quote!(salsa::plumbing::ready)
             };
 
             let blocking_future = if query.is_async {

--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -202,10 +202,16 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
                     None
                 };
 
+                let is_async = method.sig.asyncness.is_some();
+
+                if is_async && !cfg!(feature = "async") {
+                    panic!("The `async` feature must be enabled to use async query functions!")
+                }
+
                 queries.push(Query {
                     query_type,
                     query_name,
-                    is_async: method.sig.asyncness.is_some(),
+                    is_async,
                     fn_name: method.sig.ident,
                     attrs,
                     storage,

--- a/examples/compiler/compiler.rs
+++ b/examples/compiler/compiler.rs
@@ -28,7 +28,7 @@ pub trait Compiler: Interner {
 /// dolor,sit,amet,
 /// consectetur,adipiscing,elit
 /// ```
-fn all_classes(db: &dyn Compiler) -> Arc<Vec<Class>> {
+fn all_classes<'d>(db: &(dyn Compiler + 'd)) -> Arc<Vec<Class>> {
     let string = db.input_string();
 
     let rows = string.split('\n');
@@ -53,13 +53,13 @@ fn all_classes(db: &dyn Compiler) -> Arc<Vec<Class>> {
     Arc::new(classes)
 }
 
-fn fields(db: &dyn Compiler, class: Class) -> Arc<Vec<Field>> {
+fn fields<'d>(db: &(dyn Compiler + 'd), class: Class) -> Arc<Vec<Field>> {
     let class = db.lookup_intern_class(class);
     let fields = class.fields.clone();
     Arc::new(fields)
 }
 
-fn all_fields(db: &dyn Compiler) -> Arc<Vec<Field>> {
+fn all_fields<'d>(db: &(dyn Compiler + 'd)) -> Arc<Vec<Field>> {
     Arc::new(
         db.all_classes()
             .iter()

--- a/src/blocking_future.rs
+++ b/src/blocking_future.rs
@@ -6,7 +6,11 @@ use std::{
     task::{Context, Poll},
 };
 
-use parking_lot::{Condvar, Mutex};
+use {
+    futures_channel::oneshot,
+    futures_util::future::{self, FutureExt},
+    parking_lot::{Condvar, Mutex},
+};
 
 #[doc(hidden)]
 pub struct BlockingFuture<T> {
@@ -120,11 +124,9 @@ impl<T> BlockingFutureTrait<T> for BlockingFuture<T> {
     }
 }
 
-use futures::{channel::oneshot, future::FutureExt};
-
 /// Async variant of BlockingFuture
 pub type BlockingAsyncFuture<T> =
-    futures::future::Map<oneshot::Receiver<T>, fn(Result<T, oneshot::Canceled>) -> Option<T>>;
+    future::Map<oneshot::Receiver<T>, fn(Result<T, oneshot::Canceled>) -> Option<T>>;
 
 impl<T> PromiseTrait<T> for oneshot::Sender<T> {
     fn fulfil(self, value: T) {

--- a/src/blocking_future.rs
+++ b/src/blocking_future.rs
@@ -6,11 +6,13 @@ use std::{
     task::{Context, Poll},
 };
 
+#[cfg(feature = "async")]
 use {
     futures_channel::oneshot,
     futures_util::future::{self, FutureExt},
-    parking_lot::{Condvar, Mutex},
 };
+
+use parking_lot::{Condvar, Mutex};
 
 #[doc(hidden)]
 pub struct BlockingFuture<T> {
@@ -125,15 +127,18 @@ impl<T> BlockingFutureTrait<T> for BlockingFuture<T> {
 }
 
 /// Async variant of BlockingFuture
+#[cfg(feature = "async")]
 pub type BlockingAsyncFuture<T> =
     future::Map<oneshot::Receiver<T>, fn(Result<T, oneshot::Canceled>) -> Option<T>>;
 
+#[cfg(feature = "async")]
 impl<T> PromiseTrait<T> for oneshot::Sender<T> {
     fn fulfil(self, value: T) {
         let _ = self.send(value);
     }
 }
 
+#[cfg(feature = "async")]
 impl<T> BlockingFutureTrait<T> for BlockingAsyncFuture<T> {
     type Promise = oneshot::Sender<T>;
     fn new() -> (Self, Self::Promise) {

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -4,7 +4,7 @@
 use crate::durability::Durability;
 use crate::plumbing::QueryStorageOps;
 use crate::Query;
-use crate::QueryTable;
+use crate::{QueryDb, QueryTable};
 use std::iter::FromIterator;
 
 /// Additional methods on queries that can be used to "peek into"
@@ -49,7 +49,7 @@ impl<K, V> TableEntry<K, V> {
     }
 }
 
-impl<'d, Q> DebugQueryTable for QueryTable<'_, Q>
+impl<'me, Q> DebugQueryTable for QueryTable<'me, Q, &'me <Q as QueryDb<'me>>::DynDb>
 where
     Q: Query,
     Q::Storage: QueryStorageOps<Q>,
@@ -58,13 +58,13 @@ where
     type Value = Q::Value;
 
     fn durability(&self, key: Q::Key) -> Durability {
-        self.storage.durability(&self.db, &key)
+        QueryStorageOps::durability(&*self.storage, self.db, &key)
     }
 
     fn entries<C>(&self) -> C
     where
         C: FromIterator<TableEntry<Self::Key, Self::Value>>,
     {
-        self.storage.entries(&self.db)
+        QueryStorageOps::entries(&*self.storage, self.db)
     }
 }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -58,13 +58,13 @@ where
     type Value = Q::Value;
 
     fn durability(&self, key: Q::Key) -> Durability {
-        self.storage.durability(self.db, &key)
+        self.storage.durability(&self.db, &key)
     }
 
     fn entries<C>(&self) -> C
     where
         C: FromIterator<TableEntry<Self::Key, Self::Value>>,
     {
-        self.storage.entries(self.db)
+        self.storage.entries(&self.db)
     }
 }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -4,7 +4,7 @@
 use crate::durability::Durability;
 use crate::plumbing::QueryStorageOps;
 use crate::Query;
-use crate::{QueryDb, QueryTable};
+use crate::QueryTable;
 use std::iter::FromIterator;
 
 /// Additional methods on queries that can be used to "peek into"
@@ -49,7 +49,7 @@ impl<K, V> TableEntry<K, V> {
     }
 }
 
-impl<'d, Q> DebugQueryTable for QueryTable<'_, Q, <Q as QueryDb<'d>>::DynDb>
+impl<'d, Q> DebugQueryTable for QueryTable<'_, Q>
 where
     Q: Query,
     Q::Storage: QueryStorageOps<Q>,

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -4,7 +4,7 @@
 use crate::durability::Durability;
 use crate::plumbing::QueryStorageOps;
 use crate::Query;
-use crate::QueryTable;
+use crate::{QueryDb, QueryTable};
 use std::iter::FromIterator;
 
 /// Additional methods on queries that can be used to "peek into"
@@ -49,9 +49,9 @@ impl<K, V> TableEntry<K, V> {
     }
 }
 
-impl<Q> DebugQueryTable for QueryTable<'_, Q>
+impl<Q, DB> DebugQueryTable for QueryTable<'_, Q, DB>
 where
-    Q: Query,
+    Q: Query + for<'d> QueryDb<'d, DynDb = DB>,
 {
     type Key = Q::Key;
     type Value = Q::Value;

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -49,9 +49,10 @@ impl<K, V> TableEntry<K, V> {
     }
 }
 
-impl<Q, DB> DebugQueryTable for QueryTable<'_, Q, DB>
+impl<'d, Q> DebugQueryTable for QueryTable<'_, Q, <Q as QueryDb<'d>>::DynDb>
 where
-    Q: Query + for<'d> QueryDb<'d, DynDb = DB>,
+    Q: Query,
+    Q::Storage: QueryStorageOps<Q>,
 {
     type Key = Q::Key;
     type Value = Q::Value;

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -184,6 +184,10 @@ where
             .filter_map(|slot| slot.as_table_entry())
             .collect()
     }
+
+    fn peek(&self, db: &<Q as QueryDb<'_>>::DynDb, key: &Q::Key) -> Option<Q::Value> {
+        self.slot(key).peek(db).map(|v| v.value)
+    }
 }
 
 impl<Q, MP> QueryStorageOpsSync<Q> for DerivedStorage<Q, MP>

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -223,6 +223,7 @@ where
     }
 }
 
+#[cfg(feature = "async")]
 impl<Q, MP> QueryStorageOpsAsync<Q> for DerivedStorage<Q, MP>
 where
     for<'f, 'd> Q: AsyncQueryFunction<'f, 'd>,

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -5,10 +5,9 @@ use crate::plumbing::DerivedQueryStorageOps;
 use crate::plumbing::LruQueryStorageOps;
 use crate::plumbing::QueryFunction;
 use crate::plumbing::QueryStorageMassOps;
-use crate::plumbing::{
-    AsyncQueryFunction, QueryFunctionBase, QueryStorageOps, QueryStorageOpsAsync,
-    QueryStorageOpsSync,
-};
+#[cfg(feature = "async")]
+use crate::plumbing::{AsyncQueryFunction, QueryStorageOpsAsync};
+use crate::plumbing::{QueryFunctionBase, QueryStorageOps, QueryStorageOpsSync};
 use crate::runtime::{FxIndexMap, StampedValue};
 use crate::{
     blocking_future::{BlockingFuture, BlockingFutureTrait},

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -126,7 +126,7 @@ where
 
     fn fmt_index(
         &self,
-        _db: &<Q as QueryDb<'_>>::DynDb,
+        _db: &mut <Q as QueryDb<'_>>::Db,
         index: DatabaseKeyIndex,
         fmt: &mut std::fmt::Formatter<'_>,
     ) -> std::fmt::Result {
@@ -139,7 +139,7 @@ where
 
     fn maybe_changed_since(
         &self,
-        db: &<Q as QueryDb<'_>>::DynDb,
+        db: &mut <Q as QueryDb<'_>>::Db,
         input: DatabaseKeyIndex,
         revision: Revision,
     ) -> bool {
@@ -157,7 +157,7 @@ where
 
     fn try_fetch(
         &self,
-        db: &<Q as QueryDb<'_>>::DynDb,
+        db: &mut <Q as QueryDb<'_>>::Db,
         key: &Q::Key,
     ) -> Result<Q::Value, CycleError<DatabaseKeyIndex>> {
         let slot = self.slot(key);

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -48,7 +48,7 @@ where
 {
 }
 
-pub trait MemoizationPolicy<Q>: Send + Sync + 'static
+pub trait MemoizationPolicy<Q>: Send + Sync
 where
     Q: QueryFunction,
 {

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -7,7 +7,7 @@ use crate::plumbing::QueryFunction;
 use crate::plumbing::QueryStorageMassOps;
 use crate::plumbing::QueryStorageOps;
 use crate::runtime::{FxIndexMap, StampedValue};
-use crate::{CycleError, Database, DatabaseKeyIndex, Revision, Runtime, SweepStrategy};
+use crate::{CycleError, Database, DatabaseKeyIndex, QueryDb, Revision, Runtime, SweepStrategy};
 use parking_lot::RwLock;
 use std::convert::TryFrom;
 use std::marker::PhantomData;
@@ -126,7 +126,7 @@ where
 
     fn fmt_index(
         &self,
-        _db: &Q::DynDb,
+        _db: &<Q as QueryDb<'_>>::DynDb,
         index: DatabaseKeyIndex,
         fmt: &mut std::fmt::Formatter<'_>,
     ) -> std::fmt::Result {
@@ -139,7 +139,7 @@ where
 
     fn maybe_changed_since(
         &self,
-        db: &Q::DynDb,
+        db: &<Q as QueryDb<'_>>::DynDb,
         input: DatabaseKeyIndex,
         revision: Revision,
     ) -> bool {
@@ -157,7 +157,7 @@ where
 
     fn try_fetch(
         &self,
-        db: &Q::DynDb,
+        db: &<Q as QueryDb<'_>>::DynDb,
         key: &Q::Key,
     ) -> Result<Q::Value, CycleError<DatabaseKeyIndex>> {
         let slot = self.slot(key);
@@ -177,11 +177,11 @@ where
         Ok(value)
     }
 
-    fn durability(&self, db: &Q::DynDb, key: &Q::Key) -> Durability {
+    fn durability(&self, db: &<Q as QueryDb<'_>>::DynDb, key: &Q::Key) -> Durability {
         self.slot(key).durability(db)
     }
 
-    fn entries<C>(&self, _db: &Q::DynDb) -> C
+    fn entries<C>(&self, _db: &<Q as QueryDb<'_>>::DynDb) -> C
     where
         C: std::iter::FromIterator<TableEntry<Q::Key, Q::Value>>,
     {
@@ -226,7 +226,7 @@ where
     Q: QueryFunction,
     MP: MemoizationPolicy<Q>,
 {
-    fn invalidate(&self, db: &mut Q::DynDb, key: &Q::Key) {
+    fn invalidate(&self, db: &mut <Q as QueryDb<'_>>::DynDb, key: &Q::Key) {
         db.salsa_runtime_mut()
             .with_incremented_revision(&mut |_new_revision| {
                 let map_read = self.slot_map.read();

--- a/src/derived/slot.rs
+++ b/src/derived/slot.rs
@@ -510,7 +510,7 @@ where
                 changed_at: result.value.changed_at,
                 durability: result.value.durability,
             };
-            db.salsa_runtime().mark_cycle_participants(&err);
+            db.salsa_runtime().mark_cycle_participants(&err.cycle);
             Q::recover(db, &err.cycle, &self.key)
                 .map(|value| StampedValue {
                     value,
@@ -978,7 +978,7 @@ where
                 let runtime = self.db.salsa_runtime();
                 assert_eq!(id, runtime.id());
 
-                runtime.unblock_queries_blocked_on_self(self.database_key_index);
+                runtime.unblock_queries_blocked_on_self(Some(self.database_key_index));
 
                 match new_value {
                     // If anybody has installed themselves in our "waiting"

--- a/src/derived/slot.rs
+++ b/src/derived/slot.rs
@@ -14,11 +14,13 @@ use crate::{
     CycleError, Database, DatabaseKeyIndex, DiscardIf, DiscardWhat, Event, EventKind, QueryBase,
     QueryDb, SweepStrategy,
 };
-use futures::Future;
+
 use log::{debug, info};
 use parking_lot::Mutex;
 use parking_lot::{RawRwLock, RwLock};
 use smallvec::SmallVec;
+
+use std::future::Future;
 use std::marker::PhantomData;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -610,7 +612,7 @@ where
         db: &'db mut <Q as QueryDb<'d>>::Db,
         revision: Revision,
     ) -> impl Future<Output = bool> + Captures<'me> + Captures<'db> + Captures<'d> + 'f {
-        use futures::future::{ready, Either, Ready};
+        use futures_util::future::{ready, Either, Ready};
 
         fn done<L, R>(l: L) -> Either<Ready<L>, R> {
             Either::Left(ready(l))

--- a/src/derived/slot.rs
+++ b/src/derived/slot.rs
@@ -11,7 +11,8 @@ use crate::runtime::Runtime;
 use crate::runtime::RuntimeId;
 use crate::runtime::StampedValue;
 use crate::{
-    CycleError, Database, DatabaseKeyIndex, DiscardIf, DiscardWhat, Event, EventKind, SweepStrategy,
+    CycleError, Database, DatabaseKeyIndex, DiscardIf, DiscardWhat, Event, EventKind, QueryDb,
+    SweepStrategy,
 };
 use log::{debug, info};
 use parking_lot::Mutex;
@@ -125,7 +126,7 @@ where
 
     pub(super) fn read(
         &self,
-        db: &Q::DynDb,
+        db: &<Q as QueryDb<'_>>::DynDb,
     ) -> Result<StampedValue<Q::Value>, CycleError<DatabaseKeyIndex>> {
         let runtime = db.salsa_runtime();
 
@@ -153,7 +154,7 @@ where
     /// shows a potentially out of date value.
     fn read_upgrade(
         &self,
-        db: &Q::DynDb,
+        db: &<Q as QueryDb<'_>>::DynDb,
         revision_now: Revision,
     ) -> Result<StampedValue<Q::Value>, CycleError<DatabaseKeyIndex>> {
         let runtime = db.salsa_runtime();
@@ -326,7 +327,7 @@ where
     /// Note that in case `ProbeState::UpToDate`, the lock will have been released.
     fn probe<StateGuard>(
         &self,
-        db: &Q::DynDb,
+        db: &<Q as QueryDb<'_>>::DynDb,
         state: StateGuard,
         runtime: &Runtime,
         revision_now: Revision,
@@ -419,7 +420,7 @@ where
         ProbeState::StaleOrAbsent(state)
     }
 
-    pub(super) fn durability(&self, db: &Q::DynDb) -> Durability {
+    pub(super) fn durability(&self, db: &<Q as QueryDb<'_>>::DynDb) -> Durability {
         match &*self.state.read() {
             QueryState::NotComputed => Durability::LOW,
             QueryState::InProgress { .. } => panic!("query in progress"),
@@ -532,7 +533,11 @@ where
         }
     }
 
-    pub(super) fn maybe_changed_since(&self, db: &Q::DynDb, revision: Revision) -> bool {
+    pub(super) fn maybe_changed_since(
+        &self,
+        db: &<Q as QueryDb<'_>>::DynDb,
+        revision: Revision,
+    ) -> bool {
         let runtime = db.salsa_runtime();
         let revision_now = runtime.current_revision();
 
@@ -721,7 +726,7 @@ where
     /// computed (but first drop the lock on the map).
     fn register_with_in_progress_thread(
         &self,
-        _db: &Q::DynDb,
+        _db: &<Q as QueryDb<'_>>::DynDb,
         runtime: &Runtime,
         other_id: RuntimeId,
         waiting: &Mutex<SmallVec<[Promise<WaitResult<Q::Value, DatabaseKeyIndex>>; 2]>>,
@@ -886,7 +891,7 @@ where
 {
     fn validate_memoized_value(
         &mut self,
-        db: &Q::DynDb,
+        db: &<Q as QueryDb<'_>>::DynDb,
         revision_now: Revision,
     ) -> Option<StampedValue<Q::Value>> {
         // If we don't have a memoized value, nothing to validate.
@@ -1032,7 +1037,7 @@ where
 #[allow(dead_code)]
 fn check_static<Q, MP>()
 where
-    Q: QueryFunction,
+    Q: QueryFunction + 'static,
     MP: MemoizationPolicy<Q>,
     Q::Key: 'static,
     Q::Value: 'static,

--- a/src/derived/slot.rs
+++ b/src/derived/slot.rs
@@ -1038,7 +1038,7 @@ where
 fn check_static<Q, MP>()
 where
     Q: QueryFunction + 'static,
-    MP: MemoizationPolicy<Q>,
+    MP: MemoizationPolicy<Q> + 'static,
     Q::Key: 'static,
     Q::Value: 'static,
 {

--- a/src/input.rs
+++ b/src/input.rs
@@ -76,24 +76,6 @@ where
         write!(fmt, "{}({:?})", Q::QUERY_NAME, key)
     }
 
-    fn maybe_changed_since(
-        &self,
-        db: &mut <Q as QueryDb<'_>>::Db,
-        input: DatabaseKeyIndex,
-        revision: Revision,
-    ) -> bool {
-        assert_eq!(input.group_index, self.group_index);
-        assert_eq!(input.query_index, Q::QUERY_INDEX);
-        let slot = self
-            .slots
-            .read()
-            .get_index(input.key_index as usize)
-            .unwrap()
-            .1
-            .clone();
-        slot.maybe_changed_since(db, revision)
-    }
-
     fn durability(&self, _db: &<Q as QueryDb<'_>>::DynDb, key: &Q::Key) -> Durability {
         match self.slot(key) {
             Some(slot) => slot.stamped_value.read().durability,
@@ -122,6 +104,24 @@ impl<Q> QueryStorageOpsSync<Q> for InputStorage<Q>
 where
     Q: Query,
 {
+    fn maybe_changed_since(
+        &self,
+        db: &mut <Q as QueryDb<'_>>::Db,
+        input: DatabaseKeyIndex,
+        revision: Revision,
+    ) -> bool {
+        assert_eq!(input.group_index, self.group_index);
+        assert_eq!(input.query_index, Q::QUERY_INDEX);
+        let slot = self
+            .slots
+            .read()
+            .get_index(input.key_index as usize)
+            .unwrap()
+            .1
+            .clone();
+        slot.maybe_changed_since(db, revision)
+    }
+
     fn try_fetch(
         &self,
         db: &mut <Q as QueryDb<'_>>::Db,

--- a/src/input.rs
+++ b/src/input.rs
@@ -98,6 +98,10 @@ where
             })
             .collect()
     }
+
+    fn peek(&self, _db: &<Q as QueryDb<'_>>::DynDb, _key: &Q::Key) -> Option<Q::Value> {
+        None // TODO ?
+    }
 }
 
 impl<Q> QueryStorageOpsSync<Q> for InputStorage<Q>

--- a/src/input.rs
+++ b/src/input.rs
@@ -65,7 +65,7 @@ where
 
     fn fmt_index(
         &self,
-        _db: &<Q as QueryDb<'_>>::DynDb,
+        _db: &mut <Q as QueryDb<'_>>::Db,
         index: DatabaseKeyIndex,
         fmt: &mut std::fmt::Formatter<'_>,
     ) -> std::fmt::Result {
@@ -78,7 +78,7 @@ where
 
     fn maybe_changed_since(
         &self,
-        db: &<Q as QueryDb<'_>>::DynDb,
+        db: &mut <Q as QueryDb<'_>>::Db,
         input: DatabaseKeyIndex,
         revision: Revision,
     ) -> bool {
@@ -96,7 +96,7 @@ where
 
     fn try_fetch(
         &self,
-        db: &<Q as QueryDb<'_>>::DynDb,
+        db: &mut <Q as QueryDb<'_>>::Db,
         key: &Q::Key,
     ) -> Result<Q::Value, CycleError<DatabaseKeyIndex>> {
         let slot = self

--- a/src/input.rs
+++ b/src/input.rs
@@ -99,8 +99,12 @@ where
             .collect()
     }
 
-    fn peek(&self, _db: &<Q as QueryDb<'_>>::DynDb, _key: &Q::Key) -> Option<Q::Value> {
-        None // TODO ?
+    fn peek(&self, _db: &<Q as QueryDb<'_>>::DynDb, key: &Q::Key) -> Option<Q::Value> {
+        let slot = self.slot(key)?;
+
+        let StampedValue { value, .. } = slot.stamped_value.read().clone();
+
+        Some(value)
     }
 }
 

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -304,19 +304,6 @@ where
         write!(fmt, "{}({:?})", Q::QUERY_NAME, slot.value)
     }
 
-    fn maybe_changed_since(
-        &self,
-        db: &mut <Q as QueryDb<'_>>::Db,
-        input: DatabaseKeyIndex,
-        revision: Revision,
-    ) -> bool {
-        assert_eq!(input.group_index, self.group_index);
-        assert_eq!(input.query_index, Q::QUERY_INDEX);
-        let intern_id = InternId::from(input.key_index);
-        let slot = self.lookup_value(db, intern_id);
-        slot.maybe_changed_since(db, revision)
-    }
-
     fn durability(&self, _db: &<Q as QueryDb<'_>>::DynDb, _key: &Q::Key) -> Durability {
         INTERN_DURABILITY
     }
@@ -341,6 +328,19 @@ where
     Q: Query,
     Q::Value: InternKey,
 {
+    fn maybe_changed_since(
+        &self,
+        db: &mut <Q as QueryDb<'_>>::Db,
+        input: DatabaseKeyIndex,
+        revision: Revision,
+    ) -> bool {
+        assert_eq!(input.group_index, self.group_index);
+        assert_eq!(input.query_index, Q::QUERY_INDEX);
+        let intern_id = InternId::from(input.key_index);
+        let slot = self.lookup_value(db, intern_id);
+        slot.maybe_changed_since(db, revision)
+    }
+
     fn try_fetch(
         &self,
         db: &mut <Q as QueryDb<'_>>::Db,
@@ -484,18 +484,6 @@ where
         interned_storage.fmt_index(Q::convert_dyn_db(db), index, fmt)
     }
 
-    fn maybe_changed_since(
-        &self,
-        db: &mut <Q as QueryDb<'_>>::Db,
-        input: DatabaseKeyIndex,
-        revision: Revision,
-    ) -> bool {
-        let group_storage =
-            <<Q as QueryDb<'_>>::DynDb as HasQueryGroup<Q::Group>>::group_storage(db);
-        let interned_storage = IQ::query_storage(Q::convert_group_storage(group_storage)).clone();
-        interned_storage.maybe_changed_since(Q::convert_db(db), input, revision)
-    }
-
     fn durability(&self, _db: &<Q as QueryDb<'_>>::DynDb, _key: &Q::Key) -> Durability {
         INTERN_DURABILITY
     }
@@ -526,6 +514,18 @@ where
     IQ: Query<Key = Q::Value, Value = Q::Key, Storage = InternedStorage<IQ>>,
     for<'d> Q: EqualDynDb<'d, IQ>,
 {
+    fn maybe_changed_since(
+        &self,
+        db: &mut <Q as QueryDb<'_>>::Db,
+        input: DatabaseKeyIndex,
+        revision: Revision,
+    ) -> bool {
+        let group_storage =
+            <<Q as QueryDb<'_>>::DynDb as HasQueryGroup<Q::Group>>::group_storage(db);
+        let interned_storage = IQ::query_storage(Q::convert_group_storage(group_storage)).clone();
+        interned_storage.maybe_changed_since(Q::convert_db(db), input, revision)
+    }
+
     fn try_fetch(
         &self,
         db: &mut <Q as QueryDb<'_>>::Db,

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -321,6 +321,10 @@ where
             })
             .collect()
     }
+
+    fn peek(&self, _db: &<Q as QueryDb<'_>>::DynDb, _key: &Q::Key) -> Option<Q::Value> {
+        None // TODO ?
+    }
 }
 
 impl<Q> QueryStorageOpsSync<Q> for InternedStorage<Q>
@@ -503,6 +507,10 @@ where
                 TableEntry::new(<Q::Key>::from_intern_id(*index), Some(key.clone()))
             })
             .collect()
+    }
+
+    fn peek(&self, _db: &<Q as QueryDb<'_>>::DynDb, _key: &Q::Key) -> Option<Q::Value> {
+        None // TODO ?
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,14 +25,14 @@ pub mod debug;
 #[doc(hidden)]
 pub mod plumbing;
 
-#[cfg(feature = "async")]
-use crate::plumbing::AsyncQueryFunction;
 use crate::plumbing::DerivedQueryStorageOps;
 use crate::plumbing::InputQueryStorageOps;
 use crate::plumbing::LruQueryStorageOps;
 use crate::plumbing::QueryStorageMassOps;
 use crate::plumbing::QueryStorageOps;
-use crate::plumbing::{HasQueryGroup, QueryStorageOpsAsync, QueryStorageOpsSync};
+#[cfg(feature = "async")]
+use crate::plumbing::{AsyncQueryFunction, QueryStorageOpsAsync};
+use crate::plumbing::{HasQueryGroup, QueryStorageOpsSync};
 pub use crate::revision::Revision;
 use std::fmt::{self, Debug};
 use std::hash::Hash;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,6 @@ use std::sync::Arc;
 pub use crate::durability::Durability;
 pub use crate::intern_id::InternId;
 pub use crate::interned::InternKey;
-pub use crate::runtime::AsyncDb;
 pub use crate::runtime::Runtime;
 pub use crate::runtime::RuntimeId;
 pub use crate::storage::Storage;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -526,6 +526,12 @@ where
     {
         self.storage.sweep(self.db.salsa_runtime(), strategy);
     }
+
+    /// Peeks at the value at `Q::Key`. If it is currently in cache then it returns
+    /// `Some`, otherwise `None`
+    pub fn peek(&self, key: &Q::Key) -> Option<Q::Value> {
+        self.storage.peek(self.db, key)
+    }
 }
 
 impl<'me, Q> QueryTable<'me, Q, <Q as QueryDb<'me>>::Db>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,11 +25,14 @@ pub mod debug;
 #[doc(hidden)]
 pub mod plumbing;
 
+#[cfg(feature = "async")]
+use crate::plumbing::AsyncQueryFunction;
 use crate::plumbing::DerivedQueryStorageOps;
 use crate::plumbing::InputQueryStorageOps;
 use crate::plumbing::LruQueryStorageOps;
 use crate::plumbing::QueryStorageMassOps;
 use crate::plumbing::QueryStorageOps;
+use crate::plumbing::{HasQueryGroup, QueryStorageOpsAsync, QueryStorageOpsSync};
 pub use crate::revision::Revision;
 use std::fmt::{self, Debug};
 use std::hash::Hash;
@@ -517,6 +520,7 @@ where
     }
 }
 
+#[cfg(feature = "async")]
 impl<'me, Q> QueryTable<'me, Q>
 where
     Q: QueryBase,
@@ -663,6 +667,5 @@ pub type BoxFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T
 #[allow(unused_imports)]
 #[macro_use]
 extern crate salsa_macros;
-use plumbing::{AsyncQueryFunction, HasQueryGroup, QueryStorageOpsAsync, QueryStorageOpsSync};
 #[doc(hidden)]
 pub use salsa_macros::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -464,22 +464,21 @@ pub trait Query: Debug + Default + Sized + for<'d> QueryDb<'d> {
 /// Gives access to various less common operations on queries.
 ///
 /// [the `query` method]: trait.Database.html#method.query
-pub struct QueryTable<'me, Q, DB>
+pub struct QueryTable<'me, Q>
 where
     Q: Query,
-    DB: ?Sized,
 {
-    db: &'me DB,
+    db: &'me <Q as QueryDb<'me>>::DynDb,
     storage: &'me Q::Storage,
 }
 
-impl<'me, 'd, Q> QueryTable<'me, Q, <Q as QueryDb<'d>>::DynDb>
+impl<'me, Q> QueryTable<'me, Q>
 where
     Q: Query,
     Q::Storage: QueryStorageOps<Q>,
 {
     /// Constructs a new `QueryTable`.
-    pub fn new(db: &'me <Q as QueryDb<'d>>::DynDb, storage: &'me Q::Storage) -> Self {
+    pub fn new(db: &'me <Q as QueryDb<'me>>::DynDb, storage: &'me Q::Storage) -> Self {
         Self { db, storage }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -848,6 +848,11 @@ where
     }
 
     #[doc(hidden)]
+    pub fn __internal_into_db(self) -> &'a mut T {
+        self.db
+    }
+
+    #[doc(hidden)]
     pub fn __internal_get_db(&mut self) -> &mut T {
         self.db
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -695,6 +695,41 @@ where
 /// A boxed future used in the salsa traits
 pub type BoxFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;
 
+/// Encapsulates a mutable reference to a database while only giving out shared references.
+/// Use for asynchronous queries to make the database references passed `Send`
+#[allow(explicit_outlives_requirements)] // https://github.com/rust-lang/rust/issues/60993
+pub struct OwnedDb<'a, T>
+where
+    T: ?Sized,
+{
+    db: &'a mut T,
+}
+
+impl<'a, T> std::ops::Deref for OwnedDb<'a, T>
+where
+    T: ?Sized,
+{
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        self.db
+    }
+}
+
+impl<'a, T> OwnedDb<'a, T>
+where
+    T: ?Sized,
+{
+    #[doc(hidden)]
+    pub fn new(db: &'a mut T) -> Self {
+        Self { db }
+    }
+
+    #[doc(hidden)]
+    pub fn __internal_get_db(&mut self) -> &mut T {
+        self.db
+    }
+}
+
 // Re-export the procedural macros.
 #[allow(unused_imports)]
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ pub use crate::storage::Storage;
 /// The base trait which your "query context" must implement. Gives
 /// access to the salsa runtime, which you must embed into your query
 /// context (along with whatever other state you may require).
-pub trait Database: 'static + plumbing::DatabaseOps {
+pub trait Database: plumbing::DatabaseOps {
     /// Iterates through all query storage and removes any values that
     /// have not been used since the last revision was created. The
     /// intended use-cycle is that you first execute all of your
@@ -419,9 +419,13 @@ where
     }
 }
 
+pub trait QueryDb<'d>: Sized {
+    type DynDb: ?Sized + Database + 'd;
+}
+
 /// Trait implements by all of the "special types" associated with
 /// each of your queries.
-pub trait Query: Debug + Default + Sized + 'static {
+pub trait Query: Debug + Default + Sized + for<'d> QueryDb<'d> {
     /// Type that you you give as a parameter -- for queries with zero
     /// or more than one input, this will be a tuple.
     type Key: Clone + Debug + Hash + Eq;
@@ -433,13 +437,10 @@ pub trait Query: Debug + Default + Sized + 'static {
     type Storage: plumbing::QueryStorageOps<Self>;
 
     /// Associate query group struct.
-    type Group: plumbing::QueryGroup<DynDb = Self::DynDb, GroupStorage = Self::GroupStorage>;
+    type Group: plumbing::QueryGroup<GroupStorage = Self::GroupStorage>;
 
     /// Generated struct that contains storage for all queries in a group.
     type GroupStorage;
-
-    /// Dyn version of the associated trait for this query group.
-    type DynDb: ?Sized + Database + HasQueryGroup<Self::Group>;
 
     /// A unique index identifying this query within the group.
     const QUERY_INDEX: u16;
@@ -455,20 +456,21 @@ pub trait Query: Debug + Default + Sized + 'static {
 /// Gives access to various less common operations on queries.
 ///
 /// [the `query` method]: trait.Database.html#method.query
-pub struct QueryTable<'me, Q>
+pub struct QueryTable<'me, Q, DB>
 where
-    Q: Query + 'me,
+    Q: Query,
+    DB: ?Sized,
 {
-    db: &'me Q::DynDb,
+    db: &'me DB,
     storage: &'me Q::Storage,
 }
 
-impl<'me, Q> QueryTable<'me, Q>
+impl<'me, 'd, Q> QueryTable<'me, Q, <Q as QueryDb<'d>>::DynDb>
 where
     Q: Query,
 {
     /// Constructs a new `QueryTable`.
-    pub fn new(db: &'me Q::DynDb, storage: &'me Q::Storage) -> Self {
+    pub fn new(db: &'me <Q as QueryDb<'d>>::DynDb, storage: &'me Q::Storage) -> Self {
         Self { db, storage }
     }
 
@@ -514,7 +516,7 @@ pub struct QueryTableMut<'me, Q>
 where
     Q: Query + 'me,
 {
-    db: &'me mut Q::DynDb,
+    db: &'me mut <Q as QueryDb<'static>>::DynDb,
     storage: Arc<Q::Storage>,
 }
 
@@ -523,7 +525,7 @@ where
     Q: Query,
 {
     /// Constructs a new `QueryTableMut`.
-    pub fn new(db: &'me mut Q::DynDb, storage: Arc<Q::Storage>) -> Self {
+    pub fn new(db: &'me mut <Q as QueryDb<'static>>::DynDb, storage: Arc<Q::Storage>) -> Self {
         Self { db, storage }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,6 +448,11 @@ where
     pub fn new(db: DB) -> Self {
         Snapshot { db }
     }
+
+    #[doc(hidden)]
+    pub fn __internal_get_db(&mut self) -> &mut DB {
+        &mut self.db
+    }
 }
 
 impl<DB> std::ops::Deref for Snapshot<DB>

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -22,6 +22,7 @@ pub use crate::{
     revision::Revision,
     BoxFuture, DatabaseKeyIndex, QueryBase, QueryDb, Runtime,
 };
+pub use futures_util::future::{ready, Ready};
 
 #[derive(Clone, Debug)]
 pub struct CycleDetected {

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -86,10 +86,13 @@ pub trait QueryFunction: Query {
 
 /// Create a query table, which has access to the storage for the query
 /// and offers methods like `get`.
-pub fn get_query_table<'me, Q, DB>(db: &'me DB) -> QueryTable<'me, Q, DB>
+pub fn get_query_table<'d, 'me, Q>(
+    db: &'me <Q as QueryDb<'d>>::DynDb,
+) -> QueryTable<'me, Q, <Q as QueryDb<'d>>::DynDb>
 where
-    Q: Query + for<'d> QueryDb<'d, DynDb = DB> + 'me,
-    DB: HasQueryGroup<Q::Group>,
+    'd: 'me,
+    Q: Query + 'me,
+    Q::Storage: QueryStorageOps<Q>,
 {
     let group_storage: &Q::GroupStorage = HasQueryGroup::group_storage(db);
     let query_storage: &Q::Storage = Q::query_storage(group_storage);
@@ -98,12 +101,9 @@ where
 
 /// Create a mutable query table, which has access to the storage
 /// for the query and offers methods like `set`.
-pub fn get_query_table_mut<'me, Q>(
-    db: &'me mut <Q as QueryDb<'static>>::DynDb,
-) -> QueryTableMut<'me, Q>
+pub fn get_query_table_mut<'me, Q>(db: &'me mut <Q as QueryDb<'me>>::DynDb) -> QueryTableMut<'me, Q>
 where
     Q: Query,
-    <Q as QueryDb<'static>>::DynDb: HasQueryGroup<Q::Group>,
 {
     let group_storage: &Q::GroupStorage = HasQueryGroup::group_storage(db);
     let query_storage = Q::query_storage(group_storage).clone();

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -10,7 +10,7 @@ use crate::QueryTableMut;
 use crate::RuntimeId;
 use crate::SweepStrategy;
 use std::fmt::Debug;
-use std::hash::Hash;
+use std::{hash::Hash, sync::Arc};
 
 pub use crate::derived::DependencyStorage;
 pub use crate::derived::MemoizedStorage;
@@ -72,7 +72,7 @@ pub trait QueryStorageMassOps {
 pub trait DatabaseKey: Clone + Debug + Eq + Hash {}
 
 pub trait QueryFunction: Query {
-    fn execute(db: &<Self as QueryDb<'_>>::DynDb, key: Self::Key) -> Self::Value;
+    fn execute(db: &mut <Self as QueryDb<'_>>::Db, key: Self::Key) -> Self::Value;
 
     fn recover(
         db: &<Self as QueryDb<'_>>::DynDb,
@@ -86,13 +86,13 @@ pub trait QueryFunction: Query {
 
 /// Create a query table, which has access to the storage for the query
 /// and offers methods like `get`.
-pub fn get_query_table<'me, Q>(db: &'me <Q as QueryDb<'me>>::DynDb) -> QueryTable<'me, Q>
+pub fn get_query_table<'me, Q>(db: <Q as QueryDb<'me>>::Db) -> QueryTable<'me, Q>
 where
     Q: Query + 'me,
     Q::Storage: QueryStorageOps<Q>,
 {
-    let group_storage: &Q::GroupStorage = HasQueryGroup::group_storage(db);
-    let query_storage: &Q::Storage = Q::query_storage(group_storage);
+    let group_storage: &Q::GroupStorage = HasQueryGroup::group_storage(&*db);
+    let query_storage: Arc<Q::Storage> = Q::query_storage(group_storage).clone();
     QueryTable::new(db, query_storage)
 }
 
@@ -134,7 +134,7 @@ where
     /// Format a database key index in a suitable way.
     fn fmt_index(
         &self,
-        db: &<Q as QueryDb<'_>>::DynDb,
+        db: &mut <Q as QueryDb<'_>>::Db,
         index: DatabaseKeyIndex,
         fmt: &mut std::fmt::Formatter<'_>,
     ) -> std::fmt::Result;
@@ -143,7 +143,7 @@ where
     /// changed since the given revision.
     fn maybe_changed_since(
         &self,
-        db: &<Q as QueryDb<'_>>::DynDb,
+        db: &mut <Q as QueryDb<'_>>::Db,
         input: DatabaseKeyIndex,
         revision: Revision,
     ) -> bool;
@@ -157,7 +157,7 @@ where
     /// itself.
     fn try_fetch(
         &self,
-        db: &<Q as QueryDb<'_>>::DynDb,
+        db: &mut <Q as QueryDb<'_>>::Db,
         key: &Q::Key,
     ) -> Result<Q::Value, CycleError<DatabaseKeyIndex>>;
 

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -121,7 +121,9 @@ where
 
 /// Create a query table, which has access to the storage for the query
 /// and offers methods like `get`.
-pub fn get_query_table<'me, Q>(db: <Q as QueryDb<'me>>::Db) -> QueryTable<'me, Q>
+pub fn get_query_table<'me, Q>(
+    db: &'me <Q as QueryDb<'me>>::DynDb,
+) -> QueryTable<'me, Q, &'me <Q as QueryDb<'me>>::DynDb>
 where
     Q: Query,
     Q::Storage: QueryStorageOps<Q>,
@@ -129,6 +131,18 @@ where
     let group_storage: &Q::GroupStorage = HasQueryGroup::group_storage(&*db);
     let query_storage: Arc<Q::Storage> = Q::query_storage(group_storage).clone();
     QueryTable::new(db, query_storage)
+}
+
+pub fn get_query_table_async<'me, Q>(
+    db: <Q as QueryDb<'me>>::Db,
+) -> QueryTable<'me, Q, <Q as QueryDb<'me>>::Db>
+where
+    Q: Query,
+    Q::Storage: QueryStorageOps<Q>,
+{
+    let group_storage: &Q::GroupStorage = HasQueryGroup::group_storage(&*db);
+    let query_storage: Arc<Q::Storage> = Q::query_storage(group_storage).clone();
+    QueryTable::new_async(db, query_storage)
 }
 
 /// Create a mutable query table, which has access to the storage

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -86,11 +86,8 @@ pub trait QueryFunction: Query {
 
 /// Create a query table, which has access to the storage for the query
 /// and offers methods like `get`.
-pub fn get_query_table<'d, 'me, Q>(
-    db: &'me <Q as QueryDb<'d>>::DynDb,
-) -> QueryTable<'me, Q, <Q as QueryDb<'d>>::DynDb>
+pub fn get_query_table<'me, Q>(db: &'me <Q as QueryDb<'me>>::DynDb) -> QueryTable<'me, Q>
 where
-    'd: 'me,
     Q: Query + 'me,
     Q::Storage: QueryStorageOps<Q>,
 {

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -195,9 +195,11 @@ where
     fn entries<C>(&self, db: &<Q as QueryDb<'_>>::DynDb) -> C
     where
         C: std::iter::FromIterator<TableEntry<Q::Key, Q::Value>>;
+
+    fn peek(&self, db: &<Q as QueryDb<'_>>::DynDb, _key: &Q::Key) -> Option<Q::Value>;
 }
 
-pub trait QueryStorageOpsSync<Q>
+pub trait QueryStorageOpsSync<Q>: QueryStorageOps<Q>
 where
     Self: QueryStorageMassOps,
     Q: Query,

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -10,7 +10,13 @@ use crate::QueryTableMut;
 use crate::RuntimeId;
 use crate::SweepStrategy;
 use std::fmt::Debug;
-use std::{future::Future, hash::Hash, sync::Arc};
+use std::{
+    future::Future,
+    hash::Hash,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
 
 #[cfg(feature = "async")]
 pub use crate::blocking_future::BlockingAsyncFuture;
@@ -24,7 +30,6 @@ pub use crate::{
     revision::Revision,
     BoxFuture, DatabaseKeyIndex, QueryBase, QueryDb, Runtime,
 };
-pub use futures_util::future::{ready, Ready};
 
 #[derive(Clone, Debug)]
 pub struct CycleDetected {
@@ -100,6 +105,7 @@ pub trait QueryFunction<'f, 'd>: QueryFunctionBase + QueryDb<'d> {
 // Workaround for `for<'d> <Q as QueryDb<'d>>::Db: Send` being impossible to fulfill at callsites (in the generated code).
 // Helps rustc understand that the future and database are actually `Send`
 #[doc(hidden)]
+#[cfg(feature = "async")]
 pub trait AsyncQueryFunction<'f, 'd>:
     QueryFunction<
     'f,
@@ -271,9 +277,7 @@ pub(crate) fn sync_future<F>(mut f: F) -> F::Output
 where
     F: Future,
 {
-    use std::pin::Pin;
-
-    use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+    use std::task::{RawWaker, RawWakerVTable, Waker};
 
     unsafe {
         type WakerState = ();
@@ -293,4 +297,22 @@ where
             Poll::Pending => unreachable!(),
         }
     }
+}
+
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct Ready<T>(Option<T>);
+
+impl<T> Unpin for Ready<T> {}
+
+impl<T> Future for Ready<T> {
+    type Output = T;
+
+    #[inline]
+    fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<T> {
+        Poll::Ready(self.0.take().expect("Ready polled after completion"))
+    }
+}
+
+pub fn ready<T>(t: T) -> Ready<T> {
+    Ready(Some(t))
 }

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -12,13 +12,15 @@ use crate::SweepStrategy;
 use std::fmt::Debug;
 use std::{future::Future, hash::Hash, sync::Arc};
 
+#[cfg(feature = "async")]
+pub use crate::blocking_future::BlockingAsyncFuture;
 pub use crate::derived::DependencyStorage;
 pub use crate::derived::{MemoizedStorage, WaitResult};
 pub use crate::input::InputStorage;
 pub use crate::interned::InternedStorage;
 pub use crate::interned::LookupInternedStorage;
 pub use crate::{
-    blocking_future::{BlockingAsyncFuture, BlockingFuture, BlockingFutureTrait},
+    blocking_future::{BlockingFuture, BlockingFutureTrait},
     revision::Revision,
     BoxFuture, DatabaseKeyIndex, QueryBase, QueryDb, Runtime,
 };
@@ -203,6 +205,7 @@ where
     ) -> Result<Q::Value, CycleError<DatabaseKeyIndex>>;
 }
 
+#[cfg(feature = "async")]
 pub trait QueryStorageOpsAsync<Q>: QueryStorageOps<Q>
 where
     Self: QueryStorageMassOps,

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -17,7 +17,7 @@ pub use crate::derived::MemoizedStorage;
 pub use crate::input::InputStorage;
 pub use crate::interned::InternedStorage;
 pub use crate::interned::LookupInternedStorage;
-pub use crate::{revision::Revision, DatabaseKeyIndex, Runtime};
+pub use crate::{revision::Revision, DatabaseKeyIndex, QueryDb, Runtime};
 
 #[derive(Clone, Debug)]
 pub struct CycleDetected {
@@ -72,10 +72,10 @@ pub trait QueryStorageMassOps {
 pub trait DatabaseKey: Clone + Debug + Eq + Hash {}
 
 pub trait QueryFunction: Query {
-    fn execute(db: &Self::DynDb, key: Self::Key) -> Self::Value;
+    fn execute(db: &<Self as QueryDb<'_>>::DynDb, key: Self::Key) -> Self::Value;
 
     fn recover(
-        db: &Self::DynDb,
+        db: &<Self as QueryDb<'_>>::DynDb,
         cycle: &[DatabaseKeyIndex],
         key: &Self::Key,
     ) -> Option<Self::Value> {
@@ -86,9 +86,10 @@ pub trait QueryFunction: Query {
 
 /// Create a query table, which has access to the storage for the query
 /// and offers methods like `get`.
-pub fn get_query_table<Q>(db: &Q::DynDb) -> QueryTable<'_, Q>
+pub fn get_query_table<'me, Q, DB>(db: &'me DB) -> QueryTable<'me, Q, DB>
 where
-    Q: Query,
+    Q: Query + for<'d> QueryDb<'d, DynDb = DB> + 'me,
+    DB: HasQueryGroup<Q::Group>,
 {
     let group_storage: &Q::GroupStorage = HasQueryGroup::group_storage(db);
     let query_storage: &Q::Storage = Q::query_storage(group_storage);
@@ -97,9 +98,12 @@ where
 
 /// Create a mutable query table, which has access to the storage
 /// for the query and offers methods like `set`.
-pub fn get_query_table_mut<Q>(db: &mut Q::DynDb) -> QueryTableMut<'_, Q>
+pub fn get_query_table_mut<'me, Q>(
+    db: &'me mut <Q as QueryDb<'static>>::DynDb,
+) -> QueryTableMut<'me, Q>
 where
     Q: Query,
+    <Q as QueryDb<'static>>::DynDb: HasQueryGroup<Q::Group>,
 {
     let group_storage: &Q::GroupStorage = HasQueryGroup::group_storage(db);
     let query_storage = Q::query_storage(group_storage).clone();
@@ -133,7 +137,7 @@ where
     /// Format a database key index in a suitable way.
     fn fmt_index(
         &self,
-        db: &Q::DynDb,
+        db: &<Q as QueryDb<'_>>::DynDb,
         index: DatabaseKeyIndex,
         fmt: &mut std::fmt::Formatter<'_>,
     ) -> std::fmt::Result;
@@ -142,7 +146,7 @@ where
     /// changed since the given revision.
     fn maybe_changed_since(
         &self,
-        db: &Q::DynDb,
+        db: &<Q as QueryDb<'_>>::DynDb,
         input: DatabaseKeyIndex,
         revision: Revision,
     ) -> bool;
@@ -156,15 +160,15 @@ where
     /// itself.
     fn try_fetch(
         &self,
-        db: &Q::DynDb,
+        db: &<Q as QueryDb<'_>>::DynDb,
         key: &Q::Key,
     ) -> Result<Q::Value, CycleError<DatabaseKeyIndex>>;
 
     /// Returns the durability associated with a given key.
-    fn durability(&self, db: &Q::DynDb, key: &Q::Key) -> Durability;
+    fn durability(&self, db: &<Q as QueryDb<'_>>::DynDb, key: &Q::Key) -> Durability;
 
     /// Get the (current) set of the entries in the query storage
-    fn entries<C>(&self, db: &Q::DynDb) -> C
+    fn entries<C>(&self, db: &<Q as QueryDb<'_>>::DynDb) -> C
     where
         C: std::iter::FromIterator<TableEntry<Q::Key, Q::Value>>;
 }
@@ -176,7 +180,13 @@ pub trait InputQueryStorageOps<Q>
 where
     Q: Query,
 {
-    fn set(&self, db: &mut Q::DynDb, key: &Q::Key, new_value: Q::Value, durability: Durability);
+    fn set(
+        &self,
+        db: &mut <Q as QueryDb<'_>>::DynDb,
+        key: &Q::Key,
+        new_value: Q::Value,
+        durability: Durability,
+    );
 }
 
 /// An optional trait that is implemented for "user mutable" storage:
@@ -190,5 +200,5 @@ pub trait DerivedQueryStorageOps<Q>
 where
     Q: Query,
 {
-    fn invalidate(&self, db: &mut Q::DynDb, key: &Q::Key);
+    fn invalidate(&self, db: &mut <Q as QueryDb<'_>>::DynDb, key: &Q::Key);
 }

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -2,6 +2,7 @@
 
 use crate::debug::TableEntry;
 use crate::durability::Durability;
+use crate::AsAsyncDatabase;
 use crate::CycleError;
 use crate::Database;
 use crate::Query;
@@ -68,6 +69,13 @@ pub trait DatabaseOps {
     /// True if the computed value for `input` may have changed since `revision`.
     fn maybe_changed_since(&self, input: DatabaseKeyIndex, revision: Revision) -> bool;
 
+    /// True if the computed value for `input` may have changed since `revision`.
+    fn maybe_changed_since_async(
+        &mut self,
+        input: DatabaseKeyIndex,
+        revision: Revision,
+    ) -> BoxFuture<'_, bool>;
+
     /// Executes the callback for each kind of query.
     fn for_each_query(&self, op: &mut dyn FnMut(&dyn QueryStorageMassOps));
 }
@@ -110,13 +118,18 @@ pub trait AsyncQueryFunction<'f, 'd>:
     QueryFunction<
     'f,
     'd,
+    DynDb = <Self as AsyncQueryFunction<'f, 'd>>::SendDynDb,
     Db = <Self as AsyncQueryFunction<'f, 'd>>::SendDb,
     Future = crate::BoxFuture<'f, <Self as QueryBase>::Value>,
 >
 where
     <Self as QueryBase>::Value: Send + 'f,
 {
-    type SendDb: std::ops::Deref<Target = Self::DynDb> + Send + 'd;
+    type SendDynDb: ?Sized + Database + HasQueryGroup<Self::Group> + Send + 'd;
+    type SendDb: std::ops::Deref<Target = Self::DynDb>
+        + AsAsyncDatabase<Self::SendDynDb>
+        + Send
+        + 'd;
 }
 
 /// Create a query table, which has access to the storage for the query

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -10,14 +10,18 @@ use crate::QueryTableMut;
 use crate::RuntimeId;
 use crate::SweepStrategy;
 use std::fmt::Debug;
-use std::{hash::Hash, sync::Arc};
+use std::{future::Future, hash::Hash, sync::Arc};
 
 pub use crate::derived::DependencyStorage;
-pub use crate::derived::MemoizedStorage;
+pub use crate::derived::{MemoizedStorage, WaitResult};
 pub use crate::input::InputStorage;
 pub use crate::interned::InternedStorage;
 pub use crate::interned::LookupInternedStorage;
-pub use crate::{revision::Revision, DatabaseKeyIndex, QueryDb, Runtime};
+pub use crate::{
+    blocking_future::{BlockingAsyncFuture, BlockingFuture, BlockingFutureTrait},
+    revision::Revision,
+    BoxFuture, DatabaseKeyIndex, QueryBase, QueryDb, Runtime,
+};
 
 #[derive(Clone, Debug)]
 pub struct CycleDetected {
@@ -71,11 +75,17 @@ pub trait QueryStorageMassOps {
 
 pub trait DatabaseKey: Clone + Debug + Eq + Hash {}
 
-pub trait QueryFunction: Query {
-    fn execute(db: &mut <Self as QueryDb<'_>>::Db, key: Self::Key) -> Self::Value;
+pub trait QueryFunctionBase: QueryBase {
+    type BlockingFuture: BlockingFutureTrait<WaitResult<Self::Value, DatabaseKeyIndex>>;
+}
+
+pub trait QueryFunction<'f, 'd>: QueryFunctionBase + QueryDb<'d> {
+    type Future: Future<Output = Self::Value> + 'f;
+
+    fn execute(db: &'f mut <Self as QueryDb<'d>>::Db, key: Self::Key) -> Self::Future;
 
     fn recover(
-        db: &<Self as QueryDb<'_>>::DynDb,
+        db: &<Self as QueryDb<'d>>::DynDb,
         cycle: &[DatabaseKeyIndex],
         key: &Self::Key,
     ) -> Option<Self::Value> {
@@ -84,11 +94,27 @@ pub trait QueryFunction: Query {
     }
 }
 
+// Workaround for `for<'d> <Q as QueryDb<'d>>::Db: Send` being impossible to fulfill at callsites (in the generated code).
+// Helps rustc understand that the future and database are actually `Send`
+#[doc(hidden)]
+pub trait AsyncQueryFunction<'f, 'd>:
+    QueryFunction<
+    'f,
+    'd,
+    Db = <Self as AsyncQueryFunction<'f, 'd>>::SendDb,
+    Future = crate::BoxFuture<'f, <Self as QueryBase>::Value>,
+>
+where
+    <Self as QueryBase>::Value: Send + 'f,
+{
+    type SendDb: std::ops::Deref<Target = Self::DynDb> + Send + 'd;
+}
+
 /// Create a query table, which has access to the storage for the query
 /// and offers methods like `get`.
 pub fn get_query_table<'me, Q>(db: <Q as QueryDb<'me>>::Db) -> QueryTable<'me, Q>
 where
-    Q: Query + 'me,
+    Q: Query,
     Q::Storage: QueryStorageOps<Q>,
 {
     let group_storage: &Q::GroupStorage = HasQueryGroup::group_storage(&*db);
@@ -134,7 +160,7 @@ where
     /// Format a database key index in a suitable way.
     fn fmt_index(
         &self,
-        db: &mut <Q as QueryDb<'_>>::Db,
+        db: &<Q as QueryDb<'_>>::DynDb,
         index: DatabaseKeyIndex,
         fmt: &mut std::fmt::Formatter<'_>,
     ) -> std::fmt::Result;
@@ -148,6 +174,20 @@ where
         revision: Revision,
     ) -> bool;
 
+    /// Returns the durability associated with a given key.
+    fn durability(&self, db: &<Q as QueryDb<'_>>::DynDb, key: &Q::Key) -> Durability;
+
+    /// Get the (current) set of the entries in the query storage
+    fn entries<C>(&self, db: &<Q as QueryDb<'_>>::DynDb) -> C
+    where
+        C: std::iter::FromIterator<TableEntry<Q::Key, Q::Value>>;
+}
+
+pub trait QueryStorageOpsSync<Q>
+where
+    Self: QueryStorageMassOps,
+    Q: Query,
+{
     /// Execute the query, returning the result (often, the result
     /// will be memoized).  This is the "main method" for
     /// queries.
@@ -160,14 +200,27 @@ where
         db: &mut <Q as QueryDb<'_>>::Db,
         key: &Q::Key,
     ) -> Result<Q::Value, CycleError<DatabaseKeyIndex>>;
+}
 
-    /// Returns the durability associated with a given key.
-    fn durability(&self, db: &<Q as QueryDb<'_>>::DynDb, key: &Q::Key) -> Durability;
-
-    /// Get the (current) set of the entries in the query storage
-    fn entries<C>(&self, db: &<Q as QueryDb<'_>>::DynDb) -> C
-    where
-        C: std::iter::FromIterator<TableEntry<Q::Key, Q::Value>>;
+pub trait QueryStorageOpsAsync<Q>: QueryStorageOps<Q>
+where
+    Self: QueryStorageMassOps,
+    Q: for<'f, 'd> AsyncQueryFunction<'f, 'd>,
+    Q::Key: Send + Sync,
+    Q::Value: Send + Sync,
+{
+    /// Execute the query, returning the result (often, the result
+    /// will be memoized).  This is the "main method" for
+    /// queries.
+    ///
+    /// Returns `Err` in the event of a cycle, meaning that computing
+    /// the value for this `key` is recursively attempting to fetch
+    /// itself.
+    fn try_fetch_async<'f>(
+        &'f self,
+        db: &'f mut <Q as AsyncQueryFunction<'_, '_>>::SendDb,
+        key: &'f Q::Key,
+    ) -> crate::BoxFuture<'f, Result<Q::Value, CycleError<DatabaseKeyIndex>>>;
 }
 
 /// An optional trait that is implemented for "user mutable" storage:
@@ -198,4 +251,50 @@ where
     Q: Query,
 {
     fn invalidate(&self, db: &mut <Q as QueryDb<'_>>::DynDb, key: &Q::Key);
+}
+
+/// Calls a future synchronously without an actual way to resume to future.
+pub(crate) fn sync_future<F>(mut f: F) -> F::Output
+where
+    F: Future,
+{
+    use std::{
+        pin::Pin,
+        sync::{Condvar, Mutex},
+    };
+
+    use futures::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+
+    unsafe {
+        type WakerState = Condvar;
+
+        static VTABLE: RawWakerVTable = RawWakerVTable::new(
+            |p| RawWaker::new(p, &VTABLE),
+            |p| unsafe {
+                (&*(p as *const WakerState)).notify_one();
+            },
+            |p| unsafe {
+                (&*(p as *const WakerState)).notify_one();
+            },
+            |_| (),
+        );
+
+        let waker_state = WakerState::new();
+        let waker = Waker::from_raw(RawWaker::new(
+            &waker_state as *const WakerState as *const (),
+            &VTABLE,
+        ));
+        let mut context = Context::from_waker(&waker);
+
+        let mutex = Mutex::new(());
+        let mut guard = mutex.lock().unwrap();
+        loop {
+            match Pin::new_unchecked(&mut f).poll(&mut context) {
+                Poll::Ready(x) => break x,
+                Poll::Pending => {
+                    guard = waker_state.wait(guard).unwrap();
+                }
+            }
+        }
+    }
 }

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -165,15 +165,6 @@ where
         fmt: &mut std::fmt::Formatter<'_>,
     ) -> std::fmt::Result;
 
-    /// True if the value of `input`, which must be from this query, may have
-    /// changed since the given revision.
-    fn maybe_changed_since(
-        &self,
-        db: &mut <Q as QueryDb<'_>>::Db,
-        input: DatabaseKeyIndex,
-        revision: Revision,
-    ) -> bool;
-
     /// Returns the durability associated with a given key.
     fn durability(&self, db: &<Q as QueryDb<'_>>::DynDb, key: &Q::Key) -> Durability;
 
@@ -188,6 +179,15 @@ where
     Self: QueryStorageMassOps,
     Q: Query,
 {
+    /// True if the value of `input`, which must be from this query, may have
+    /// changed since the given revision.
+    fn maybe_changed_since(
+        &self,
+        db: &mut <Q as QueryDb<'_>>::Db,
+        input: DatabaseKeyIndex,
+        revision: Revision,
+    ) -> bool;
+
     /// Execute the query, returning the result (often, the result
     /// will be memoized).  This is the "main method" for
     /// queries.
@@ -209,6 +209,15 @@ where
     Q::Key: Send + Sync,
     Q::Value: Send + Sync,
 {
+    /// True if the value of `input`, which must be from this query, may have
+    /// changed since the given revision.
+    fn maybe_changed_since_async<'f>(
+        &'f self,
+        db: &'f mut <Q as AsyncQueryFunction<'_, '_>>::SendDb,
+        input: DatabaseKeyIndex,
+        revision: Revision,
+    ) -> crate::BoxFuture<'f, bool>;
+
     /// Execute the query, returning the result (often, the result
     /// will be memoized).  This is the "main method" for
     /// queries.

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -826,34 +826,6 @@ impl Drop for RevisionGuard {
     }
 }
 
-/// TODO
-pub struct AsyncDb<'a, T>
-where
-    T: ?Sized + Database,
-{
-    db: &'a mut T,
-}
-
-impl<T> std::ops::Deref for AsyncDb<'_, T>
-where
-    T: ?Sized + Database,
-{
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        self.db
-    }
-}
-
-impl<'a, T> AsyncDb<'a, T>
-where
-    T: ?Sized + Database,
-{
-    /// TODO
-    pub fn new(db: &'a mut T) -> Self {
-        AsyncDb { db }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/runtime/local_state.rs
+++ b/src/runtime/local_state.rs
@@ -104,7 +104,7 @@ impl std::panic::RefUnwindSafe for LocalState {}
 /// is returned to represent its slot. The guard can be used to pop
 /// the query from the stack -- in the case of unwinding, the guard's
 /// destructor will also remove the query.
-pub(super) struct ActiveQueryGuard<'me, DB>
+pub(crate) struct ActiveQueryGuard<'me, DB>
 where
     DB: std::ops::Deref,
     DB::Target: Database,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,4 +1,4 @@
-use crate::{plumbing::DatabaseStorageTypes, Runtime};
+use crate::{plumbing::DatabaseStorageTypes, ForkState, Runtime};
 use std::sync::Arc;
 
 /// Stores the cached results and dependency information for all the queries
@@ -48,6 +48,14 @@ impl<DB: DatabaseStorageTypes> Storage<DB> {
         Storage {
             query_store: self.query_store.clone(),
             runtime: self.runtime.snapshot(),
+        }
+    }
+
+    /// Returns a "forked" runtime, suitable to call concurrent queries.
+    pub fn fork(&self, forker: ForkState) -> Self {
+        Storage {
+            query_store: self.query_store.clone(),
+            runtime: self.runtime.fork(forker),
         }
     }
 }

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -1,6 +1,8 @@
 #![cfg(feature = "async")]
 use std::task::Poll;
 
+use salsa::OwnedDb;
+
 #[salsa::database(async AsyncStorage)]
 #[derive(Default)]
 struct AsyncDatabase {
@@ -30,21 +32,21 @@ fn recover(_: &dyn Async, _: &[String], _: &u32) -> u32 {
     0
 }
 
-async fn output(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
+async fn output(db: &mut OwnedDb<'_, (dyn Async + '_)>, x: u32) -> u32 {
     yield_().await;
     db.output_inner(x).await
 }
 
-async fn output_inner(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
+async fn output_inner(db: &mut OwnedDb<'_, (dyn Async + '_)>, x: u32) -> u32 {
     yield_().await;
     db.input(x) * 2
 }
 
-async fn output_dependencies(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
+async fn output_dependencies(db: &mut OwnedDb<'_, (dyn Async + '_)>, x: u32) -> u32 {
     db.output(x).await
 }
 
-async fn output_transparent(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
+async fn output_transparent(db: &mut OwnedDb<'_, (dyn Async + '_)>, x: u32) -> u32 {
     db.output(x).await
 }
 

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -17,6 +17,9 @@ trait Async: Send {
     async fn output(&self, x: u32) -> u32;
 
     async fn output_inner(&self, x: u32) -> u32;
+
+    #[salsa::transparent]
+    async fn output_transparent(&self, x: u32) -> u32;
 }
 
 async fn output(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
@@ -27,6 +30,10 @@ async fn output(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
 async fn output_inner(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
     yield_().await;
     db.input(x) * 2
+}
+
+async fn output_transparent(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
+    db.output(x).await
 }
 
 async fn yield_() {

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -16,11 +16,11 @@ trait Async: Send {
     async fn output_inner(&self, x: u32) -> u32;
 }
 
-async fn output(db: &mut AsyncDb<'_, (dyn Async + '_)>, x: u32) -> u32 {
+async fn output(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
     db.output_inner(x).await
 }
 
-async fn output_inner(db: &mut AsyncDb<'_, (dyn Async + '_)>, x: u32) -> u32 {
+async fn output_inner(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
     db.input(x) * 2
 }
 

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -16,10 +16,18 @@ trait Async: Send {
 
     async fn output(&self, x: u32) -> u32;
 
+    #[salsa::cycle(recover)]
     async fn output_inner(&self, x: u32) -> u32;
+
+    #[salsa::dependencies]
+    async fn output_dependencies(&self, x: u32) -> u32;
 
     #[salsa::transparent]
     async fn output_transparent(&self, x: u32) -> u32;
+}
+
+fn recover(_: &dyn Async, _: &[String], _: &u32) -> u32 {
+    0
 }
 
 async fn output(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
@@ -30,6 +38,10 @@ async fn output(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
 async fn output_inner(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
     yield_().await;
     db.input(x) * 2
+}
+
+async fn output_dependencies(db: &mut OwnedAsync<'_>, x: u32) -> u32 {
+    db.output(x).await
 }
 
 async fn output_transparent(db: &mut OwnedAsync<'_>, x: u32) -> u32 {

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "async")]
+
 #[salsa::database(async AsyncStorage)]
 #[derive(Default)]
 struct AsyncDatabase {

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -1,0 +1,33 @@
+#[salsa::database(async AsyncStorage)]
+#[derive(Default)]
+struct AsyncDatabase {
+    storage: salsa::Storage<Self>,
+}
+
+impl salsa::Database for AsyncDatabase {}
+
+#[salsa::query_group(AsyncStorage)]
+trait Async: Send {
+    #[salsa::input]
+    fn input(&self, x: u32) -> u32;
+
+    async fn output(&self, x: u32) -> u32;
+
+    async fn output_inner(&self, x: u32) -> u32;
+}
+
+async fn output(db: &mut AsyncDb<'_, (dyn Async + '_)>, x: u32) -> u32 {
+    db.output_inner(x).await
+}
+
+async fn output_inner(db: &mut AsyncDb<'_, (dyn Async + '_)>, x: u32) -> u32 {
+    db.input(x) * 2
+}
+
+#[tokio::test]
+async fn basic() {
+    let mut query = AsyncDatabase::default();
+    query.set_input(22, 23);
+    assert_eq!(query.output(22).await, 46);
+    assert_eq!(query.output(22).await, 46);
+}

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "async")]
 use std::task::Poll;
 
-use salsa::OwnedDb;
+use salsa::{OwnedDb, ParallelDatabase};
 
 #[salsa::database(async AsyncStorage)]
 #[derive(Default)]
@@ -10,43 +10,58 @@ struct AsyncDatabase {
 }
 
 impl salsa::Database for AsyncDatabase {}
+impl salsa::ParallelDatabase for AsyncDatabase {
+    fn snapshot(&self) -> salsa::Snapshot<Self> {
+        salsa::Snapshot::new(Self {
+            storage: self.storage.snapshot(),
+        })
+    }
+
+    fn fork(&self, forker: salsa::ForkState) -> salsa::Snapshot<Self> {
+        salsa::Snapshot::new(Self {
+            storage: self.storage.fork(forker),
+        })
+    }
+}
 
 #[salsa::query_group(AsyncStorage)]
 trait Async: Send {
     #[salsa::input]
-    fn input(&self, x: u32) -> u32;
+    fn input(&self, x: String) -> u32;
 
-    async fn output(&self, x: u32) -> u32;
+    async fn output(&self, x: String) -> u32;
+
+    async fn query2(&self, x: String) -> u32;
 
     #[salsa::cycle(recover)]
-    async fn output_inner(&self, x: u32) -> u32;
+    async fn output_inner(&self, x: String) -> u32;
 
     #[salsa::dependencies]
-    async fn output_dependencies(&self, x: u32) -> u32;
+    async fn output_dependencies(&self, x: String) -> u32;
 
     #[salsa::transparent]
-    async fn output_transparent(&self, x: u32) -> u32;
+    async fn output_transparent(&self, x: String) -> u32;
 }
 
-fn recover(_: &dyn Async, _: &[String], _: &u32) -> u32 {
+fn recover<T>(_: &dyn Async, _: &[String], _: &T) -> u32 {
     0
 }
 
-async fn output(db: &mut OwnedDb<'_, (dyn Async + '_)>, x: u32) -> u32 {
+async fn output(db: &mut OwnedDb<'_, (dyn Async + '_)>, x: String) -> u32 {
     yield_().await;
     db.output_inner(x).await
 }
 
-async fn output_inner(db: &mut OwnedDb<'_, (dyn Async + '_)>, x: u32) -> u32 {
+async fn output_inner(db: &mut OwnedDb<'_, (dyn Async + '_)>, x: String) -> u32 {
     yield_().await;
     db.input(x) * 2
 }
 
-async fn output_dependencies(db: &mut OwnedDb<'_, (dyn Async + '_)>, x: u32) -> u32 {
+async fn output_dependencies(db: &mut OwnedDb<'_, (dyn Async + '_)>, x: String) -> u32 {
     db.output(x).await
 }
 
-async fn output_transparent(db: &mut OwnedDb<'_, (dyn Async + '_)>, x: u32) -> u32 {
+async fn output_transparent(db: &mut OwnedDb<'_, (dyn Async + '_)>, x: String) -> u32 {
     db.output(x).await
 }
 
@@ -64,12 +79,37 @@ async fn yield_() {
     .await;
 }
 
+async fn query2(db: &mut OwnedDb<'_, dyn Async + '_>, x: String) -> u32 {
+    if x == "depends" {
+        yield_().await;
+        db.query2("base".into()).await + db.input(x)
+    } else {
+        yield_().await;
+        db.input(x)
+    }
+}
+
 #[tokio::test]
 async fn basic() {
     let mut query = AsyncDatabase::default();
-    query.set_input(22, 23);
-    assert_eq!(query.output(22).await, 46);
-    assert_eq!(query.output(22).await, 46);
+    query.set_input("a".into(), 23);
+    assert_eq!(query.output("a".into()).await, 46);
+    assert_eq!(query.output("a".into()).await, 46);
+}
+
+#[tokio::test]
+async fn dependency_on_concurrent() {
+    let mut query = AsyncDatabase::default();
+    query.set_input("base".into(), 2);
+    query.set_input("depends".into(), 1);
+
+    let forker = query.forker();
+    let mut db1 = forker.fork();
+    let mut db2 = forker.fork();
+    assert_eq!(
+        futures_util::join!(db1.query2("depends".into()), db2.query2("base".into())),
+        (3, 2)
+    );
 }
 
 fn assert_send<T: Send>(_: T) {}

--- a/tests/cycles.rs
+++ b/tests/cycles.rs
@@ -19,6 +19,12 @@ impl ParallelDatabase for DatabaseImpl {
             storage: self.storage.snapshot(),
         })
     }
+
+    fn fork(&self, forker: salsa::ForkState) -> salsa::Snapshot<Self> {
+        salsa::Snapshot::new(Self {
+            storage: self.storage.fork(forker),
+        })
+    }
 }
 
 #[salsa::query_group(GroupStruct)]

--- a/tests/interned.rs
+++ b/tests/interned.rs
@@ -16,6 +16,12 @@ impl salsa::ParallelDatabase for Database {
             storage: self.storage.snapshot(),
         })
     }
+
+    fn fork(&self, forker: salsa::ForkState) -> salsa::Snapshot<Self> {
+        salsa::Snapshot::new(Self {
+            storage: self.storage.fork(forker),
+        })
+    }
 }
 
 #[salsa::query_group(InternStorage)]

--- a/tests/panic_safely.rs
+++ b/tests/panic_safely.rs
@@ -37,6 +37,12 @@ impl salsa::ParallelDatabase for DatabaseStruct {
             storage: self.storage.snapshot(),
         })
     }
+
+    fn fork(&self, forker: salsa::ForkState) -> salsa::Snapshot<Self> {
+        salsa::Snapshot::new(Self {
+            storage: self.storage.fork(forker),
+        })
+    }
 }
 
 #[test]

--- a/tests/parallel/setup.rs
+++ b/tests/parallel/setup.rs
@@ -207,6 +207,13 @@ impl ParallelDatabase for ParDatabaseImpl {
             knobs: self.knobs.clone(),
         })
     }
+
+    fn fork(&self, forker: salsa::ForkState) -> salsa::Snapshot<Self> {
+        salsa::Snapshot::new(Self {
+            storage: self.storage.fork(forker),
+            knobs: self.knobs.clone(),
+        })
+    }
 }
 
 impl Knobs for ParDatabaseImpl {

--- a/tests/parallel/stress.rs
+++ b/tests/parallel/stress.rs
@@ -49,6 +49,12 @@ impl salsa::ParallelDatabase for StressDatabaseImpl {
             storage: self.storage.snapshot(),
         })
     }
+
+    fn fork(&self, forker: salsa::ForkState) -> salsa::Snapshot<Self> {
+        salsa::Snapshot::new(Self {
+            storage: self.storage.fork(forker),
+        })
+    }
 }
 
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
This is an update of [gluon's](https://github.com/gluon-lang/gluon) fork of salsa on top of #244. So it has been in use for a bit, but the implementation isn't great atm. However I would like to discuss if this API is good enough, or if something else is needed.

This adds a `forker` method to each `ParallelDatabase`. Through the returned `Forker` object it is possible to create new database instances on which queries can be executed concurrently as long as they finish before the `Forker` object is dropped. This is only checked dynamically since a scoped api like crossbeams scoped threads doesn't work well with futures. This is also the reason for cloning instead of borrowing the query stack.

In the synchronous case both of these could be fixed if necessary at the cost of some duplication.

cc #80