### PR TITLE
update on_demand_inputs invalidation

### DIFF
--- a/book/src/common_patterns/on_demand_inputs.md
+++ b/book/src/common_patterns/on_demand_inputs.md
@@ -43,7 +43,9 @@ impl FileWatcher for MyDatabase {
 }
 ```
 
-* We declare the query as a derived query (which is the default).
-* In the query implementation, we don't call any other query and just directly read file from disk.
-* Because the query doesn't read any inputs, it will be assigned a `HIGH` durability by default, which we override with `report_synthetic_read`.
-* The result of the query is cached, and we must call `invalidate` to clear this cache.
+- We declare the query as a derived query (which is the default).
+- In the query implementation, we don't call any other query and just directly read file from disk.
+- Because the query doesn't read any inputs, it will be assigned a `HIGH` durability by default, which we override with `report_synthetic_read`.
+- The result of the query is cached, and we must call `invalidate` to clear this cache.
+
+A complete, runnable file-watching example can be found in [this git repo](https://github.com/ChristopherBiscardi/salsa-file-watch-example/blob/f968dc8ea13a90373f91d962f173de3fe6ae24cd/main.rs) along with [a write-up](https://www.christopherbiscardi.com/on-demand-lazy-inputs-for-incremental-computation-in-salsa-with-file-watching-powered-by-notify-in-rust) that explains more about the code and what it is doing.

--- a/book/src/common_patterns/on_demand_inputs.md
+++ b/book/src/common_patterns/on_demand_inputs.md
@@ -38,7 +38,7 @@ struct MyDatabase { ... }
 impl FileWatcher for MyDatabase {
     fn watch(&self, path: &Path) { ... }
     fn did_change_file(&mut self, path: &Path) {
-        self.query_mut(ReadQuery).invalidate(path);
+        ReadQuery.in_db_mut(self).invalidate(path);
     }
 }
 ```


### PR DESCRIPTION
The query in the on demand input example in the book seems out of date since at least https://github.com/salsa-rs/salsa/commit/9b9dbcca8c8e12b24b7c25470af9e070684821e1#diff-c86c61ef2a1841ef63294b8494f6a783

I also have a more complete example of integrating with notify [in this git repo](https://github.com/ChristopherBiscardi/salsa-file-watch-example/blob/f968dc8ea13a90373f91d962f173de3fe6ae24cd/main.rs) with a [writeup](https://www.christopherbiscardi.com/on-demand-lazy-inputs-for-incremental-computation-in-salsa-with-file-watching-powered-by-notify-in-rust) to go with it. I'm happy to put that code and such in this file if you think that would be better.