### PR TITLE
Add failing test for cycle revalidation

### DIFF
--- a/tests/cycles.rs
+++ b/tests/cycles.rs
@@ -123,6 +123,14 @@ fn inner_cycle() {
 }
 
 #[test]
+fn cycle_revalidate() {
+    let mut db = DatabaseImpl::default();
+    assert!(db.cycle_a().is_err());
+    CycleLeafQuery.in_db_mut(&mut db).invalidate(&());
+    assert!(db.cycle_a().is_err());
+}
+
+#[test]
 fn parallel_cycle() {
     let _ = env_logger::try_init();
 


### PR DESCRIPTION
The following test hits the `unwrap` in [runtime.rs:415](https://github.com/salsa-rs/salsa/blob/789cf5e99b9ec40715f30e0aac5bd53e6191d052/src/runtime.rs#L415). I encountered this panic while working on rust-analyzer.

As far as I understand, `report_unexpected_cycle` assumes the query we hit the cycle on has to be executing right now, but that's not the case here: it's just being revalidated (through `validate_memoized_value`). I'm not sure what the correct way to handle this is?