### PR TITLE
Log `MemoInputs` in human-readable form

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -603,7 +603,7 @@ pub(crate) struct ComputedQueryResult<V> {
     pub(crate) changed_at: Revision,
 
     /// Complete set of subqueries that were accessed, or `None` if
-    /// there was an untracked the read.
+    /// there was an untracked read.
     pub(crate) dependencies: Option<FxIndexSet<DatabaseKeyIndex>>,
 
     /// The cycle if one occured while computing this value


### PR DESCRIPTION
This makes it possible to debug unwanted query dependencies by looking at the log output.

Previous output:

```
[2021-05-05T13:15:48Z DEBUG salsa::derived::slot] read_upgrade(FileItemTreeQuery(HirFileId(FileId(FileId(0))))): result.changed_at=R6, result.durability=Durability(0), result.dependencies = Some(
        {
            DatabaseKeyIndex {
                group_index: 1,
                query_index: 0,
                key_index: 0,
            },
            DatabaseKeyIndex {
                group_index: 2,
                query_index: 0,
                key_index: 0,
            },
        },
    )
[2021-05-05T13:15:48Z DEBUG salsa::derived::slot] read_upgrade(FileItemTreeQuery(HirFileId(FileId(FileId(0))))): inputs=Tracked { inputs: [DatabaseKeyIndex { group_index: 1, query_index: 0, key_index: 0 }, DatabaseKeyIndex { group_index: 2, query_index: 0, key_index: 0 }] }
```

New output:

```
[2021-05-05T13:31:26Z DEBUG salsa::derived::slot] read_upgrade(FileItemTreeQuery(HirFileId(FileId(FileId(0))))): result.changed_at=R6, result.durability=Durability(0), result.dependencies = Some({DatabaseKeyIndex { group_index: 1, query_index: 0, key_index: 0 }, DatabaseKeyIndex { group_index: 2, query_index: 0, key_index: 0 }})
[2021-05-05T13:31:26Z DEBUG salsa::derived::slot] read_upgrade(FileItemTreeQuery(HirFileId(FileId(FileId(0))))): inputs=Tracked {
        inputs: [
            parse(FileId(0)),
            ast_id_map(HirFileId(FileId(FileId(0)))),
        ],
    }
```