### PR TITLE
remove some unneeded lifetime parameters

### DIFF
--- a/examples/compiler/compiler.rs
+++ b/examples/compiler/compiler.rs
@@ -28,7 +28,7 @@ pub trait Compiler: Interner {
 /// dolor,sit,amet,
 /// consectetur,adipiscing,elit
 /// ```
-fn all_classes<'d>(db: &(dyn Compiler + 'd)) -> Arc<Vec<Class>> {
+fn all_classes(db: &dyn Compiler) -> Arc<Vec<Class>> {
     let string = db.input_string();
 
     let rows = string.split('\n');
@@ -53,13 +53,13 @@ fn all_classes<'d>(db: &(dyn Compiler + 'd)) -> Arc<Vec<Class>> {
     Arc::new(classes)
 }
 
-fn fields<'d>(db: &(dyn Compiler + 'd), class: Class) -> Arc<Vec<Field>> {
+fn fields(db: &dyn Compiler, class: Class) -> Arc<Vec<Field>> {
     let class = db.lookup_intern_class(class);
     let fields = class.fields.clone();
     Arc::new(fields)
 }
 
-fn all_fields<'d>(db: &(dyn Compiler + 'd)) -> Arc<Vec<Field>> {
+fn all_fields(db: &dyn Compiler) -> Arc<Vec<Field>> {
     Arc::new(
         db.all_classes()
             .iter()


### PR DESCRIPTION
Makes the compiler example read better.