### PR TITLE
Fix book workflow

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -7,29 +7,25 @@ on:
   pull_request:
     paths:
     - 'book/**'
+    - '.github/workflows/book.yml'
 
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
     env:
-      MDBOOK_VERSION: '0.4.0'
-      MDBOOK_LINKCHECK_VERSION: '0.7.0'
-      MDBOOK_MERMAID_VERSION: '^0.4'
+      MDBOOK_VERSION: '0.4.8'
+      MDBOOK_LINKCHECK_VERSION: '0.7.4'
+      MDBOOK_MERMAID_VERSION: '0.8.1'
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      with:
-        path: ~/.cargo/bin
-        key: ${{ env.MDBOOK_MERMAID_VERSION }}
     - name: Install mdbook
       run: |
-        mkdir -p $HOME/mdbook $HOME/mdbook-linkcheck
-        curl -L https://github.com/rust-lang/mdBook/releases/download/v$MDBOOK_VERSION/mdbook-v$MDBOOK_VERSION-x86_64-unknown-linux-gnu.tar.gz | tar xz -C $HOME/mdbook
-        echo "::add-path::${HOME}/mdbook/"
-        curl -L https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v$MDBOOK_LINKCHECK_VERSION/mdbook-linkcheck-v$MDBOOK_LINKCHECK_VERSION-x86_64-unknown-linux-gnu.tar.gz | tar xz -C $HOME/mdbook-linkcheck
-        echo "::add-path::${HOME}/mdbook-linkcheck/"
-        mdbook-mermaid --version || cargo install mdbook-mermaid --version $MDBOOK_MERMAID_VERSION --debug
+        curl -L https://github.com/rust-lang/mdBook/releases/download/v$MDBOOK_VERSION/mdbook-v$MDBOOK_VERSION-x86_64-unknown-linux-gnu.tar.gz | tar xz -C ~/.cargo/bin
+        curl -L https://github.com/badboy/mdbook-mermaid/releases/download/v$MDBOOK_MERMAID_VERSION/mdbook-mermaid-v$MDBOOK_MERMAID_VERSION-x86_64-unknown-linux-gnu.tar.gz | tar xz -C ~/.cargo/bin
+        curl -L https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v$MDBOOK_LINKCHECK_VERSION/mdbook-linkcheck.v$MDBOOK_LINKCHECK_VERSION.x86_64-unknown-linux-gnu.zip -O
+        unzip mdbook-linkcheck.v$MDBOOK_LINKCHECK_VERSION.x86_64-unknown-linux-gnu.zip -d ~/.cargo/bin
+        chmod +x ~/.cargo/bin/mdbook-linkcheck
     - name: Build
       run: mdbook build
       working-directory: book


### PR DESCRIPTION
Removes the [deprecated](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) `add-path` command and bumps the versions.