### PR TITLE
Implement "opinionated cancellation"

### DIFF
--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -447,14 +447,18 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
                 /// deadlock.
                 ///
                 /// Before blocking, the thread that is attempting to `set` will
-                /// also set a cancellation flag. In the threads operating on
-                /// snapshots, you can use the [`is_current_revision_canceled`]
-                /// method to check for this flag and bring those operations to a
-                /// close, thus allowing the `set` to succeed. Ignoring this flag
-                /// may lead to "starvation", meaning that the thread attempting
-                /// to `set` has to wait a long, long time. =)
+                /// also set a cancellation flag. This will cause any query
+                /// invocations in other threads to unwind with a `Canceled`
+                /// sentinel value and eventually let the `set` succeed once all
+                /// threads have unwound past the salsa invocation.
                 ///
-                /// [`is_current_revision_canceled`]: struct.Runtime.html#method.is_current_revision_canceled
+                /// If your query implementations are performing expensive
+                /// operations without invoking another query, you can also use
+                /// the `Runtime::unwind_if_cancelled` method to check for an
+                /// ongoing cancelation and bring those operations to a close,
+                /// thus allowing the `set` to succeed. Otherwise, long-running
+                /// computations may lead to "starvation", meaning that the
+                /// thread attempting to `set` has to wait a long, long time. =)
                 #trait_vis fn in_db_mut(self, db: &mut #dyn_db) -> salsa::QueryTableMut<'_, Self>
                 {
                     salsa::plumbing::get_query_table_mut::<#qt>(db)

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -162,6 +162,8 @@ where
         db: &<Q as QueryDb<'_>>::DynDb,
         key: &Q::Key,
     ) -> Result<Q::Value, CycleError<DatabaseKeyIndex>> {
+        db.salsa_runtime().unwind_if_canceled();
+
         let slot = self.slot(key);
         let StampedValue {
             value,

--- a/src/derived/slot.rs
+++ b/src/derived/slot.rs
@@ -541,6 +541,8 @@ where
         let runtime = db.salsa_runtime();
         let revision_now = runtime.current_revision();
 
+        runtime.unwind_if_canceled();
+
         debug!(
             "maybe_changed_since({:?}) called with revision={:?}, revision_now={:?}",
             self, revision, revision_now,

--- a/src/input.rs
+++ b/src/input.rs
@@ -99,6 +99,8 @@ where
         db: &<Q as QueryDb<'_>>::DynDb,
         key: &Q::Key,
     ) -> Result<Q::Value, CycleError<DatabaseKeyIndex>> {
+        db.salsa_runtime().unwind_if_canceled();
+
         let slot = self
             .slot(key)
             .unwrap_or_else(|| panic!("no value set for {:?}({:?})", Q::default(), key));

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -322,6 +322,8 @@ where
         db: &<Q as QueryDb<'_>>::DynDb,
         key: &Q::Key,
     ) -> Result<Q::Value, CycleError<DatabaseKeyIndex>> {
+        db.salsa_runtime().unwind_if_canceled();
+
         let slot = self.intern_index(db, key);
         let changed_at = slot.interned_at;
         let index = slot.index;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,6 +1,6 @@
-use crate::durability::Durability;
 use crate::plumbing::CycleDetected;
 use crate::revision::{AtomicRevision, Revision};
+use crate::{durability::Durability, Canceled};
 use crate::{CycleError, Database, DatabaseKeyIndex, Event, EventKind};
 use log::debug;
 use parking_lot::lock_api::{RawRwLock, RawRwLockRecursive};
@@ -156,89 +156,31 @@ impl Runtime {
         self.shared_state.pending_revision.load()
     }
 
-    /// Check if the current revision is canceled. If this method ever
-    /// returns true, the currently executing query is also marked as
-    /// having an *untracked read* -- this means that, in the next
-    /// revision, we will always recompute its value "as if" some
-    /// input had changed. This means that, if your revision is
-    /// canceled (which indicates that current query results will be
-    /// ignored) your query is free to shortcircuit and return
-    /// whatever it likes.
+    /// Starts unwinding the stack if the current revision is canceled.
     ///
-    /// This method is useful for implementing cancellation of queries.
-    /// You can do it in one of two ways, via `Result`s or via unwinding.
+    /// This method can be called by query implementations that perform
+    /// potentially expensive computations, in order to speed up propagation of
+    /// cancelation.
     ///
-    /// The `Result` approach looks like this:
-    ///
-    ///   * Some queries invoke `is_current_revision_canceled` and
-    ///     return a special value, like `Err(Canceled)`, if it returns
-    ///     `true`.
-    ///   * Other queries propagate the special value using `?` operator.
-    ///   * API around top-level queries checks if the result is `Ok` or
-    ///     `Err(Canceled)`.
-    ///
-    /// The `panic` approach works in a similar way:
-    ///
-    ///   * Some queries invoke `is_current_revision_canceled` and
-    ///     panic with a special value, like `Canceled`, if it returns
-    ///     true.
-    ///   * The implementation of `Database` trait overrides
-    ///     `on_propagated_panic` to throw this special value as well.
-    ///     This way, panic gets propagated naturally through dependant
-    ///     queries, even across the threads.
-    ///   * API around top-level queries converts a `panic` into `Result` by
-    ///     catching the panic (using either `std::panic::catch_unwind` or
-    ///     threads) and downcasting the payload to `Canceled` (re-raising
-    ///     panic if downcast fails).
-    ///
-    /// Note that salsa is explicitly designed to be panic-safe, so cancellation
-    /// via unwinding is 100% valid approach to cancellation.
+    /// Cancelation will automatically be triggered by salsa on any query
+    /// invocation.
     #[inline]
-    pub fn is_current_revision_canceled(&self) -> bool {
+    pub fn unwind_if_canceled(&self) {
         let current_revision = self.current_revision();
         let pending_revision = self.pending_revision();
         debug!(
-            "is_current_revision_canceled: current_revision={:?}, pending_revision={:?}",
+            "unwind_if_cancelled: current_revision={:?}, pending_revision={:?}",
             current_revision, pending_revision
         );
         if pending_revision > current_revision {
-            self.report_untracked_read();
-            true
-        } else {
-            // Subtle: If the current revision is not canceled, we
-            // still report an **anonymous** read, which will bump up
-            // the revision number to be at least the last
-            // non-canceled revision. This is needed to ensure
-            // deterministic reads and avoid salsa-rs/salsa#66. The
-            // specific scenario we are trying to avoid is tested by
-            // `no_back_dating_in_cancellation`; it works like
-            // this. Imagine we have 3 queries, where Query3 invokes
-            // Query2 which invokes Query1. Then:
-            //
-            // - In Revision R1:
-            //   - Query1: Observes cancelation and returns sentinel S.
-            //     - Recorded inputs: Untracked, because we observed cancelation.
-            //   - Query2: Reads Query1 and propagates sentinel S.
-            //     - Recorded inputs: Query1, changed-at=R1
-            //   - Query3: Reads Query2 and propagates sentinel S. (Inputs = Query2, ChangedAt R1)
-            //     - Recorded inputs: Query2, changed-at=R1
-            // - In Revision R2:
-            //   - Query1: Observes no cancelation. All of its inputs last changed in R0,
-            //     so it returns a valid value with "changed at" of R0.
-            //     - Recorded inputs: ..., changed-at=R0
-            //   - Query2: Recomputes its value and returns correct result.
-            //     - Recorded inputs: Query1, changed-at=R0 <-- key problem!
-            //   - Query3: sees that Query2's result last changed in R0, so it thinks it
-            //     can re-use its value from R1 (which is the sentinel value).
-            //
-            // The anonymous read here prevents that scenario: Query1
-            // winds up with a changed-at setting of R2, which is the
-            // "pending revision", and hence Query2 and Query3
-            // are recomputed.
-            assert_eq!(pending_revision, current_revision);
-            self.report_anon_read(pending_revision);
-            false
+            self.unwind_canceled();
         }
+    }
+
+    #[cold]
+    fn unwind_canceled(&self) {
+        self.report_untracked_read();
+        Canceled::throw();
     }
 
     /// Acquires the **global query write lock** (ensuring that no queries are
@@ -379,18 +321,6 @@ impl Runtime {
     /// This is mostly useful to control the durability level for [on-demand inputs](https://salsa-rs.github.io/salsa/common_patterns/on_demand_inputs.html).
     pub fn report_synthetic_read(&self, durability: Durability) {
         self.local_state.report_synthetic_read(durability);
-    }
-
-    /// An "anonymous" read is a read that doesn't come from executing
-    /// a query, but from some other internal operation. It just
-    /// modifies the "changed at" to be at least the given revision.
-    /// (It also does not disqualify a query from being considered
-    /// constant, since it is used for queries that don't give back
-    /// actual *data*.)
-    ///
-    /// This is used when queries check if they have been canceled.
-    fn report_anon_read(&self, revision: Revision) {
-        self.local_state.report_anon_read(revision)
     }
 
     /// Obviously, this should be user configurable at some point.
@@ -638,10 +568,6 @@ impl ActiveQuery {
 
     fn add_synthetic_read(&mut self, durability: Durability) {
         self.durability = self.durability.min(durability);
-    }
-
-    fn add_anon_read(&mut self, changed_at: Revision) {
-        self.changed_at = self.changed_at.max(changed_at);
     }
 }
 

--- a/src/runtime/local_state.rs
+++ b/src/runtime/local_state.rs
@@ -86,12 +86,6 @@ impl LocalState {
             top_query.add_synthetic_read(durability);
         }
     }
-
-    pub(super) fn report_anon_read(&self, revision: Revision) {
-        if let Some(top_query) = self.query_stack.borrow_mut().last_mut() {
-            top_query.add_anon_read(revision);
-        }
-    }
 }
 
 impl std::panic::RefUnwindSafe for LocalState {}

--- a/tests/parallel/cancellation.rs
+++ b/tests/parallel/cancellation.rs
@@ -1,27 +1,16 @@
-use crate::setup::{CancelationFlag, Canceled, Knobs, ParDatabase, ParDatabaseImpl, WithValue};
-use salsa::ParallelDatabase;
+use crate::setup::{CancelationFlag, Knobs, ParDatabase, ParDatabaseImpl, WithValue};
+use salsa::{Canceled, ParallelDatabase};
 
 macro_rules! assert_canceled {
-    ($flag:expr, $thread:expr) => {
-        if $flag == CancelationFlag::Panic {
-            match $thread.join() {
-                Ok(value) => panic!("expected cancelation, got {:?}", value),
-                Err(payload) => match payload.downcast::<Canceled>() {
-                    Ok(_) => {}
-                    Err(payload) => ::std::panic::resume_unwind(payload),
-                },
-            }
-        } else {
-            assert_eq!($thread.join().unwrap(), usize::max_value());
+    ($thread:expr) => {
+        match $thread.join() {
+            Ok(value) => panic!("expected cancelation, got {:?}", value),
+            Err(payload) => match payload.downcast::<Canceled>() {
+                Ok(_) => {}
+                Err(payload) => ::std::panic::resume_unwind(payload),
+            },
         }
     };
-}
-
-/// We have to falvors of cancellation: based on unwindig and based on anon
-/// reads. This checks both,
-fn check_cancelation(f: impl Fn(CancelationFlag)) {
-    f(CancelationFlag::Panic);
-    f(CancelationFlag::SpecialValue);
 }
 
 /// Add test where a call to `sum` is cancelled by a simultaneous
@@ -29,133 +18,87 @@ fn check_cancelation(f: impl Fn(CancelationFlag)) {
 /// though none of the inputs have changed.
 #[test]
 fn in_par_get_set_cancellation_immediate() {
-    check_cancelation(|flag| {
-        let mut db = ParDatabaseImpl::default();
+    let mut db = ParDatabaseImpl::default();
 
-        db.set_input('a', 100);
-        db.set_input('b', 010);
-        db.set_input('c', 001);
-        db.set_input('d', 0);
+    db.set_input('a', 100);
+    db.set_input('b', 010);
+    db.set_input('c', 001);
+    db.set_input('d', 0);
 
-        let thread1 = std::thread::spawn({
-            let db = db.snapshot();
-            move || {
-                // This will not return until it sees cancellation is
-                // signaled.
-                db.knobs().sum_signal_on_entry.with_value(1, || {
-                    db.knobs()
-                        .sum_wait_for_cancellation
-                        .with_value(flag, || db.sum("abc"))
-                })
-            }
-        });
+    let thread1 = std::thread::spawn({
+        let db = db.snapshot();
+        move || {
+            // This will not return until it sees cancellation is
+            // signaled.
+            db.knobs().sum_signal_on_entry.with_value(1, || {
+                db.knobs()
+                    .sum_wait_for_cancellation
+                    .with_value(CancelationFlag::Panic, || db.sum("abc"))
+            })
+        }
+    });
 
-        // Wait until we have entered `sum` in the other thread.
-        db.wait_for(1);
+    // Wait until we have entered `sum` in the other thread.
+    db.wait_for(1);
 
-        // Try to set the input. This will signal cancellation.
-        db.set_input('d', 1000);
+    // Try to set the input. This will signal cancellation.
+    db.set_input('d', 1000);
 
-        // This should re-compute the value (even though no input has changed).
-        let thread2 = std::thread::spawn({
-            let db = db.snapshot();
-            move || db.sum("abc")
-        });
+    // This should re-compute the value (even though no input has changed).
+    let thread2 = std::thread::spawn({
+        let db = db.snapshot();
+        move || db.sum("abc")
+    });
 
-        assert_eq!(db.sum("d"), 1000);
-        assert_canceled!(flag, thread1);
-        assert_eq!(thread2.join().unwrap(), 111);
-    })
+    assert_eq!(db.sum("d"), 1000);
+    assert_canceled!(thread1);
+    assert_eq!(thread2.join().unwrap(), 111);
 }
 
 /// Here, we check that `sum`'s cancellation is propagated
 /// to `sum2` properly.
 #[test]
 fn in_par_get_set_cancellation_transitive() {
-    check_cancelation(|flag| {
-        let mut db = ParDatabaseImpl::default();
+    let mut db = ParDatabaseImpl::default();
 
-        db.set_input('a', 100);
-        db.set_input('b', 010);
-        db.set_input('c', 001);
-        db.set_input('d', 0);
+    db.set_input('a', 100);
+    db.set_input('b', 010);
+    db.set_input('c', 001);
+    db.set_input('d', 0);
 
-        let thread1 = std::thread::spawn({
-            let db = db.snapshot();
-            move || {
-                // This will not return until it sees cancellation is
-                // signaled.
-                db.knobs().sum_signal_on_entry.with_value(1, || {
-                    db.knobs()
-                        .sum_wait_for_cancellation
-                        .with_value(flag, || db.sum2("abc"))
-                })
-            }
-        });
+    let thread1 = std::thread::spawn({
+        let db = db.snapshot();
+        move || {
+            // This will not return until it sees cancellation is
+            // signaled.
+            db.knobs().sum_signal_on_entry.with_value(1, || {
+                db.knobs()
+                    .sum_wait_for_cancellation
+                    .with_value(CancelationFlag::Panic, || db.sum2("abc"))
+            })
+        }
+    });
 
-        // Wait until we have entered `sum` in the other thread.
-        db.wait_for(1);
+    // Wait until we have entered `sum` in the other thread.
+    db.wait_for(1);
 
-        // Try to set the input. This will signal cancellation.
-        db.set_input('d', 1000);
+    // Try to set the input. This will signal cancellation.
+    db.set_input('d', 1000);
 
-        // This should re-compute the value (even though no input has changed).
-        let thread2 = std::thread::spawn({
-            let db = db.snapshot();
-            move || db.sum2("abc")
-        });
+    // This should re-compute the value (even though no input has changed).
+    let thread2 = std::thread::spawn({
+        let db = db.snapshot();
+        move || db.sum2("abc")
+    });
 
-        assert_eq!(db.sum2("d"), 1000);
-        assert_canceled!(flag, thread1);
-        assert_eq!(thread2.join().unwrap(), 111);
-    })
+    assert_eq!(db.sum2("d"), 1000);
+    assert_canceled!(thread1);
+    assert_eq!(thread2.join().unwrap(), 111);
 }
 
 /// https://github.com/salsa-rs/salsa/issues/66
 #[test]
 fn no_back_dating_in_cancellation() {
-    check_cancelation(|flag| {
-        let mut db = ParDatabaseImpl::default();
-
-        db.set_input('a', 1);
-        let thread1 = std::thread::spawn({
-            let db = db.snapshot();
-            move || {
-                // Here we compute a long-chain of queries,
-                // but the last one gets cancelled.
-                db.knobs().sum_signal_on_entry.with_value(1, || {
-                    db.knobs()
-                        .sum_wait_for_cancellation
-                        .with_value(flag, || db.sum3("a"))
-                })
-            }
-        });
-
-        db.wait_for(1);
-
-        // Set unrelated input to bump revision
-        db.set_input('b', 2);
-
-        // Here we should recompuet the whole chain again, clearing the cancellation
-        // state. If we get `usize::max()` here, it is a bug!
-        assert_eq!(db.sum3("a"), 1);
-
-        assert_canceled!(flag, thread1);
-
-        db.set_input('a', 3);
-        db.set_input('a', 4);
-        assert_eq!(db.sum3("ab"), 6);
-    })
-}
-
-/// Here, we compute `sum3_drop_sum` and -- in the process -- observe
-/// a cancellation. As a result, we have to recompute `sum` when we
-/// reinvoke `sum3_drop_sum` and we have to re-execute
-/// `sum2_drop_sum`.  But the result of `sum2_drop_sum` doesn't
-/// change, so we don't have to re-execute `sum3_drop_sum`.
-/// This only works with SpecialValue cancellation strategy.
-#[test]
-fn transitive_cancellation() {
     let mut db = ParDatabaseImpl::default();
 
     db.set_input('a', 1);
@@ -167,21 +110,23 @@ fn transitive_cancellation() {
             db.knobs().sum_signal_on_entry.with_value(1, || {
                 db.knobs()
                     .sum_wait_for_cancellation
-                    .with_value(CancelationFlag::SpecialValue, || db.sum3_drop_sum("a"))
+                    .with_value(CancelationFlag::Panic, || db.sum3("a"))
             })
         }
     });
 
     db.wait_for(1);
 
+    // Set unrelated input to bump revision
     db.set_input('b', 2);
 
-    // Check that when we call `sum3_drop_sum` we don't wind up having
-    // to actually re-execute it, because the result of `sum2` winds
-    // up not changing.
-    db.knobs().sum3_drop_sum_should_panic.with_value(true, || {
-        assert_eq!(db.sum3_drop_sum("a"), 22);
-    });
+    // Here we should recompuet the whole chain again, clearing the cancellation
+    // state. If we get `usize::max()` here, it is a bug!
+    assert_eq!(db.sum3("a"), 1);
 
-    assert_eq!(thread1.join().unwrap(), 22);
+    assert_canceled!(thread1);
+
+    db.set_input('a', 3);
+    db.set_input('a', 4);
+    assert_eq!(db.sum3("ab"), 6);
 }

--- a/tests/parallel/race.rs
+++ b/tests/parallel/race.rs
@@ -1,3 +1,5 @@
+use std::panic::AssertUnwindSafe;
+
 use crate::setup::{ParDatabase, ParDatabaseImpl};
 use salsa::ParallelDatabase;
 
@@ -14,8 +16,10 @@ fn in_par_get_set_race() {
     let thread1 = std::thread::spawn({
         let db = db.snapshot();
         move || {
-            let v = db.sum("abc");
-            v
+            salsa::catch_cancellation(AssertUnwindSafe(|| {
+                let v = db.sum("abc");
+                v
+            }))
         }
     });
 
@@ -26,13 +30,13 @@ fn in_par_get_set_race() {
 
     // If the 1st thread runs first, you get 111, otherwise you get
     // 1011; if they run concurrently and the 1st thread observes the
-    // cancelation, you get back usize::max.
-    let value1 = thread1.join().unwrap();
-    assert!(
-        value1 == 111 || value1 == 1011 || value1 == std::usize::MAX,
-        "illegal result {}",
-        value1
-    );
+    // cancelation, it'll unwind.
+    let result1 = thread1.join().unwrap();
+    if let Ok(value1) = result1 {
+        assert!(value1 == 111 || value1 == 1011, "illegal result {}", value1);
+    }
 
+    // thread2 can not observe a cancellation because it performs a
+    // database write before running any other queries.
     assert_eq!(thread2.join().unwrap(), 1000);
 }

--- a/tests/parallel/setup.rs
+++ b/tests/parallel/setup.rs
@@ -2,8 +2,11 @@ use crate::signal::Signal;
 use salsa::Database;
 use salsa::ParallelDatabase;
 use salsa::Snapshot;
-use std::cell::Cell;
 use std::sync::Arc;
+use std::{
+    cell::Cell,
+    panic::{catch_unwind, resume_unwind, AssertUnwindSafe},
+};
 
 #[salsa::query_group(Par)]
 pub(crate) trait ParDatabase: Knobs {
@@ -25,16 +28,6 @@ pub(crate) trait ParDatabase: Knobs {
     fn sum3_drop_sum(&self, key: &'static str) -> usize;
 }
 
-#[derive(PartialEq, Eq)]
-pub(crate) struct Canceled;
-
-impl Canceled {
-    fn throw() -> ! {
-        // Don't print backtrace
-        std::panic::resume_unwind(Box::new(Canceled));
-    }
-}
-
 /// Various "knobs" and utilities used by tests to force
 /// a certain behavior.
 pub(crate) trait Knobs {
@@ -53,11 +46,14 @@ impl<T> WithValue<T> for Cell<T> {
     fn with_value<R>(&self, value: T, closure: impl FnOnce() -> R) -> R {
         let old_value = self.replace(value);
 
-        let result = closure();
+        let result = catch_unwind(AssertUnwindSafe(|| closure()));
 
         self.set(old_value);
 
-        result
+        match result {
+            Ok(r) => r,
+            Err(payload) => resume_unwind(payload),
+        }
     }
 }
 
@@ -65,7 +61,6 @@ impl<T> WithValue<T> for Cell<T> {
 pub(crate) enum CancelationFlag {
     Down,
     Panic,
-    SpecialValue,
 }
 
 impl Default for CancelationFlag {
@@ -126,28 +121,13 @@ fn sum(db: &dyn ParDatabase, key: &'static str) -> usize {
 
     match db.knobs().sum_wait_for_cancellation.get() {
         CancelationFlag::Down => (),
-        flag => {
+        CancelationFlag::Panic => {
             log::debug!("waiting for cancellation");
-            while !db.salsa_runtime().is_current_revision_canceled() {
+            loop {
+                db.salsa_runtime().unwind_if_canceled();
                 std::thread::yield_now();
             }
-            log::debug!("observed cancelation");
-            if flag == CancelationFlag::Panic {
-                Canceled::throw();
-            }
         }
-    }
-
-    // Check for cancelation and return MAX if so. Note that we check
-    // for cancelation *deterministically* -- but if
-    // `sum_wait_for_cancellation` is set, we will block
-    // beforehand. Deterministic execution is a requirement for valid
-    // salsa user code. It's also important to some tests that `sum`
-    // *attempts* to invoke `is_current_revision_canceled` even if we
-    // know it will not be canceled, because that helps us keep the
-    // accounting up to date.
-    if db.salsa_runtime().is_current_revision_canceled() {
-        return std::usize::MAX; // when we are cancelled, we return usize::MAX.
     }
 
     db.wait_for(db.knobs().sum_wait_for_on_exit.get());
@@ -193,10 +173,6 @@ impl Database for ParDatabaseImpl {
 
             _ => {}
         }
-    }
-
-    fn on_propagated_panic(&self) -> ! {
-        Canceled::throw()
     }
 }
 

--- a/tests/parallel/stress.rs
+++ b/tests/parallel/stress.rs
@@ -10,28 +10,22 @@ use salsa::SweepStrategy;
 const N_MUTATOR_OPS: usize = 100;
 const N_READER_OPS: usize = 100;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct Canceled;
-type Cancelable<T> = Result<T, Canceled>;
-
 #[salsa::query_group(Stress)]
 trait StressDatabase: salsa::Database {
     #[salsa::input]
     fn a(&self, key: usize) -> usize;
 
-    fn b(&self, key: usize) -> Cancelable<usize>;
+    fn b(&self, key: usize) -> usize;
 
-    fn c(&self, key: usize) -> Cancelable<usize>;
+    fn c(&self, key: usize) -> usize;
 }
 
-fn b(db: &dyn StressDatabase, key: usize) -> Cancelable<usize> {
-    if db.salsa_runtime().is_current_revision_canceled() {
-        return Err(Canceled);
-    }
-    Ok(db.a(key))
+fn b(db: &dyn StressDatabase, key: usize) -> usize {
+    db.salsa_runtime().unwind_if_canceled();
+    db.a(key)
 }
 
-fn c(db: &dyn StressDatabase, key: usize) -> Cancelable<usize> {
+fn c(db: &dyn StressDatabase, key: usize) -> usize {
     db.b(key)
 }
 
@@ -127,9 +121,7 @@ impl rand::distributions::Distribution<ReadOp> for rand::distributions::Standard
 fn db_reader_thread(db: &StressDatabaseImpl, ops: Vec<ReadOp>, check_cancellation: bool) {
     for op in ops {
         if check_cancellation {
-            if db.salsa_runtime().is_current_revision_canceled() {
-                return;
-            }
+            db.salsa_runtime().unwind_if_canceled();
         }
         op.execute(db);
     }
@@ -199,12 +191,12 @@ fn stress_test() {
                 check_cancellation,
             } => all_threads.push(std::thread::spawn({
                 let db = db.snapshot();
-                move || db_reader_thread(&db, ops, check_cancellation)
+                move || salsa::catch_cancellation(|| db_reader_thread(&db, ops, check_cancellation))
             })),
         }
     }
 
     for thread in all_threads {
-        thread.join().unwrap();
+        thread.join().unwrap().ok();
     }
 }


### PR DESCRIPTION
This implements the design described in RFC https://github.com/salsa-rs/salsa/pull/262.

Currently, the `in_par_get_set_cancellation` test is failing. I'm not completely sure what it is trying to test (the comment on the test does not match its behavior), so I couldn't fix it.