### PR TITLE
Expose proc macro docs via the main crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -605,5 +605,4 @@ impl std::error::Error for Cancelled {}
 #[macro_use]
 extern crate salsa_macros;
 use plumbing::HasQueryGroup;
-#[doc(hidden)]
 pub use salsa_macros::*;


### PR DESCRIPTION
Improve visibility by placing the `database` and `query_group` proc macros at the bottom of the main docs page, instead of manually browsing to the docs for the `salsa-macros` crate.