### PR TITLE
CI installs `rustfmt` where needed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ matrix.rust }}
+        components: rustfmt
         default: true
     - uses: actions-rs/cargo@v1
       with:


### PR DESCRIPTION
Only the stable toolchain appears to install `rustfmt` by default