### PR TITLE
Remove dead code

### DIFF
--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -403,7 +403,6 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
             }
         });
 
-        if query.storage.supports_mut() {}
         output.extend(quote! {
             impl #qt {
                 /// Like `in_db`, but gives access to methods for setting the
@@ -700,18 +699,6 @@ impl QueryStorage {
             | QueryStorage::InternedLookup { .. }
             | QueryStorage::Transparent => false,
             QueryStorage::Memoized | QueryStorage::Dependencies => true,
-        }
-    }
-
-    /// Does this type of query support `&mut` operations?
-    fn supports_mut(&self) -> bool {
-        match self {
-            QueryStorage::Input => true,
-            QueryStorage::Interned
-            | QueryStorage::InternedLookup { .. }
-            | QueryStorage::Transparent
-            | QueryStorage::Memoized
-            | QueryStorage::Dependencies => false,
         }
     }
 }


### PR DESCRIPTION
This was added in https://github.com/salsa-rs/salsa/commit/fd036a4f154c46253443b3a79b6f4400c40e87b1, but never actually came into effect.

Granting access to `QueryTableMut` for every query type should be harmless, because every method on that type has a where-clause that makes it only work with the right query storage type.