### PR TITLE
Fix `invalidate` and `report_synthetic_read`

### DIFF
--- a/src/derived.rs
+++ b/src/derived.rs
@@ -229,11 +229,11 @@ where
         Q::Key: Borrow<S>,
     {
         db.salsa_runtime_mut()
-            .with_incremented_revision(&mut |_new_revision| {
+            .with_incremented_revision(&mut |new_revision| {
                 let map_read = self.slot_map.read();
 
                 if let Some(slot) = map_read.get(key) {
-                    if let Some(durability) = slot.invalidate() {
+                    if let Some(durability) = slot.invalidate(new_revision) {
                         return Some(durability);
                     }
                 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -280,7 +280,8 @@ impl Runtime {
     ///
     /// This is mostly useful to control the durability level for [on-demand inputs](https://salsa-rs.github.io/salsa/common_patterns/on_demand_inputs.html).
     pub fn report_synthetic_read(&self, durability: Durability) {
-        self.local_state.report_synthetic_read(durability);
+        self.local_state
+            .report_synthetic_read(durability, self.current_revision());
     }
 
     /// Obviously, this should be user configurable at some point.
@@ -526,8 +527,9 @@ impl ActiveQuery {
         self.changed_at = changed_at;
     }
 
-    fn add_synthetic_read(&mut self, durability: Durability) {
+    fn add_synthetic_read(&mut self, durability: Durability, current_revision: Revision) {
         self.durability = self.durability.min(durability);
+        self.changed_at = current_revision;
     }
 }
 

--- a/src/runtime/local_state.rs
+++ b/src/runtime/local_state.rs
@@ -81,9 +81,9 @@ impl LocalState {
         }
     }
 
-    pub(super) fn report_synthetic_read(&self, durability: Durability) {
+    pub(super) fn report_synthetic_read(&self, durability: Durability, current_revision: Revision) {
         if let Some(top_query) = self.query_stack.borrow_mut().last_mut() {
-            top_query.add_synthetic_read(durability);
+            top_query.add_synthetic_read(durability, current_revision);
         }
     }
 }

--- a/tests/on_demand_inputs.rs
+++ b/tests/on_demand_inputs.rs
@@ -73,6 +73,12 @@ fn on_demand_input_works() {
     AQuery.in_db_mut(&mut db).invalidate(&1);
     assert_eq!(db.b(1), 92);
     assert_eq!(db.a(1), 92);
+
+    // Downstream queries should also be rerun if we call `a` first.
+    db.external_state.insert(1, 50);
+    AQuery.in_db_mut(&mut db).invalidate(&1);
+    assert_eq!(db.a(1), 50);
+    assert_eq!(db.b(1), 50);
 }
 
 #[test]


### PR DESCRIPTION
Fixes https://github.com/salsa-rs/salsa/issues/246
Fixes https://github.com/salsa-rs/salsa/issues/277

`report_synthetic_read` only forced the durability of the current query to some lower value, but didn't set its `changed_at` value, leading to downstream queries assuming that they could reuse the query's value when they could not. Force `changed_at` to the current revision to fix that. This will not result in unnecessary invocations of the query, because salsa still treats it as pure, and won't re-run it if its inputs are up to date.

Additionally, `invalidate` did also not set the slot's `changed_at` field, which is fixed by setting it to the newly created revision.