### PR TITLE
Update book workflow

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -4,19 +4,21 @@ on:
   push:
     branches:
     - master
+    - staging
+    - trying
   pull_request:
     paths:
     - 'book/**'
     - '.github/workflows/book.yml'
 
 jobs:
-  build:
-    name: Build
+  book:
+    name: Book
     runs-on: ubuntu-latest
     env:
-      MDBOOK_VERSION: '0.4.8'
+      MDBOOK_VERSION: '0.4.12'
       MDBOOK_LINKCHECK_VERSION: '0.7.4'
-      MDBOOK_MERMAID_VERSION: '0.8.1'
+      MDBOOK_MERMAID_VERSION: '0.8.3'
     steps:
     - uses: actions/checkout@v2
     - name: Install mdbook
@@ -37,7 +39,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    needs: build
+    needs: book
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
     - uses: actions/download-artifact@v2

--- a/book/book.toml
+++ b/book/book.toml
@@ -16,7 +16,7 @@ additional-js =["mermaid.min.js", "mermaid-init.js"]
 [output.linkcheck]
 follow-web-links = true
 traverse-parent-directories = false
+exclude = ['bilibili\.com']
 [preprocessor]
 [preprocessor.mermaid]
 command = "mdbook-mermaid"
-

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,6 @@
 status = [
     "Test (stable, false)",
+    "Book"
 ]
 delete_merged_branches = true
 timeout_sec = 1200 # 20 min


### PR DESCRIPTION
I noticed the book workflow [failing](https://github.com/salsa-rs/salsa/runs/3568827495?check_suite_focus=true) on master. This PR attempts to fix the failing workflow and prevent failing book deploys in the future.

- Add the book build to `bors.toml`.
- Make sure the book workflow runs for the bors branches (`staging` and `trying`).
- Exclude the bilibili domain in the mdbook-linkcheck config to prevent the 403s.

I also bumped mdbook and mdbook-mermaid versions.