### PR TITLE
Make `query_group` attribute helpers actual attribute items

### DIFF
--- a/components/salsa-macros/src/lib.rs
+++ b/components/salsa-macros/src/lib.rs
@@ -146,3 +146,81 @@ pub fn query_group(args: TokenStream, input: TokenStream) -> TokenStream {
 pub fn database(args: TokenStream, input: TokenStream) -> TokenStream {
     database_storage::database(args, input)
 }
+
+/// Helper attribute for [`macro@query_group`] setting the storage
+/// to memoized for this query. This is the default storage.
+///
+/// The result is memoized between calls. If the inputs have
+/// changed, we will recompute the value, but then compare against
+/// the old memoized value, which can significantly reduce the
+/// amount of recomputation required in new revisions. This does
+/// require that the value implements `Eq`.
+#[proc_macro_attribute]
+pub fn memoized(_: TokenStream, _: TokenStream) -> TokenStream {
+    panic!("`memoized` may only be used on functions inside a `query_group` annotated trait")
+}
+
+/// Helper attribute for [`macro@query_group`] setting the storage
+/// to dependencies for this query.
+///
+/// The value is not cached, so the query will be recomputed every time
+/// it is needed. We do track the inputs, however, so if they have not
+/// changed, then things that rely on this query may be known not to
+/// have changed.
+#[proc_macro_attribute]
+pub fn dependencies(_: TokenStream, _: TokenStream) -> TokenStream {
+    panic!("`dependencies` may only be used on functions inside a `query_group` annotated trait")
+}
+
+/// Helper attribute for [`macro@query_group`] setting the storage
+/// to input for this query.
+///
+/// Specifying `storage input` will give you an **input
+/// query**. Unlike derived queries, whose value is given by a
+/// function, input queries are explicitly set by doing
+/// `db.query(QueryType).set(key, value)` (where `QueryType` is the
+/// `type` specified for the query). Accessing a value that has not
+/// yet been set will panic. Each time you invoke `set`, we assume the
+/// value has changed, and so we will potentially re-execute derived
+/// queries that read (transitively) from this input.
+#[proc_macro_attribute]
+pub fn input(_: TokenStream, _: TokenStream) -> TokenStream {
+    panic!("`input` may only be used on functions inside a `query_group` annotated trait")
+}
+
+/// Helper attribute for [`macro@query_group`] setting the storage
+/// to interned for this query.
+#[proc_macro_attribute]
+pub fn interned(_: TokenStream, _: TokenStream) -> TokenStream {
+    panic!("`interned` may only be used on functions inside a `query_group` annotated trait")
+}
+
+/// Helper attribute for [`macro@query_group`].
+#[proc_macro_attribute]
+pub fn cycle(_: TokenStream, _: TokenStream) -> TokenStream {
+    panic!("`cycle` may only be used on functions inside a `query_group` annotated trait")
+}
+
+/// Helper attribute for [`macro@query_group`] which explicitly sets
+/// the function to call when this query must be recomputed.
+/// The default is to call a function in the same module with the
+/// same name as the query.
+#[proc_macro_attribute]
+pub fn invoke(_: TokenStream, _: TokenStream) -> TokenStream {
+    panic!("`invoke` may only be used on functions inside a `query_group` annotated trait")
+}
+
+/// Helper attribute for [`macro@query_group`], specifies the name of the
+/// dummy struct created for the query. Default is the name of the
+/// query, in camel case, plus the word "Query" (e.g.,
+/// `MyQueryQuery` and `OtherQueryQuery` in the examples above).
+#[proc_macro_attribute]
+pub fn query_type(_: TokenStream, _: TokenStream) -> TokenStream {
+    panic!("`query_type` may only be used on functions inside a `query_group` annotated trait")
+}
+
+/// Helper attribute for [`macro@query_group`].
+#[proc_macro_attribute]
+pub fn transparent(_: TokenStream, _: TokenStream) -> TokenStream {
+    panic!("`transparent` may only be used on functions inside a `query_group` annotated trait")
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,7 +209,7 @@ pub trait ParallelDatabase: Database + Send {
     /// series of queries in parallel and arranging the results. Using
     /// this method for that purpose ensures that those queries will
     /// see a consistent view of the database (it is also advisable
-    /// for those queries to use the [`Runtime::unwind_if_cancelled`]
+    /// for those queries to use the [`Database::unwind_if_cancelled`]
     /// method to check for cancellation).
     ///
     /// # Panics


### PR DESCRIPTION
This is a small exploration in proc-macro space to see if we can make attribute helper macros(not the derive kind) more visible for users as well as more IDE friendly. As things are currently, these are basically just syntax the attribute consumes and as such they do not really exist anywhere.

This PR tries to change that by introducing these helpers as actualy attribute items. They error our if actually invoked as their main use is to be consumed by the actual `query_group` macro instead.
Making these proper items gives us a few nice properties, for one we can document them and have rustdoc show them as well, OTOH this could also be considered problematic as this pollutes the attribute listing of the crate, or rather the attribute(macro) namespace in general.

Note the documentation is rather spotty, partially just copied from the main doc of the `query_group` attribute, as I do not have too much knowledge about the purpose of these helper attributes myself.

IDEs can also benefit from this, as prior to this, the attributes actually never resolved to anything that existed, IDEs couldn't do anything with them and instead treated them as mere tokens sometimes resolving them to potentially incorrect things. Now we can actually resolve them properly, giving us hover messages
![image](https://user-images.githubusercontent.com/3757771/144757149-cd83805e-d5e0-44d2-bff1-8624a6d47af5.png)
as well as autocompletion
![image](https://user-images.githubusercontent.com/3757771/144757358-cede221c-fbe0-4615-ad30-c7277b0caab8.png)
and basically anything else an IDE might offer.