### PR TITLE
Remove unused crossbeam_utils dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ repository = "https://github.com/salsa-rs/salsa"
 description = "A generic framework for on-demand, incrementalized computation (experimental)"
 
 [dependencies]
-crossbeam-utils = { version = "0.8", default-features = false }
 indexmap = "1.0.1"
 lock_api = "0.4"
 log = "0.4.5"


### PR DESCRIPTION
crossbeam_utils is currently not used anywhere withing this crate so I propose to remove the dependency to (slightly) reduce compile times