### PR TITLE
Make with_incremented_revision take FnOnce

### DIFF
--- a/src/derived.rs
+++ b/src/derived.rs
@@ -229,7 +229,7 @@ where
         Q::Key: Borrow<S>,
     {
         db.salsa_runtime_mut()
-            .with_incremented_revision(&mut |new_revision| {
+            .with_incremented_revision(|new_revision| {
                 let map_read = self.slot_map.read();
 
                 if let Some(slot) = map_read.get(key) {

--- a/src/input.rs
+++ b/src/input.rs
@@ -202,9 +202,8 @@ where
         // keys, we only need a new revision if the key used to
         // exist. But we may add such methods in the future and this
         // case doesn't generally seem worth optimizing for.
-        let mut value = Some(value);
         db.salsa_runtime_mut()
-            .with_incremented_revision(&mut |next_revision| {
+            .with_incremented_revision(|next_revision| {
                 let mut slots = self.slots.write();
 
                 // Do this *after* we acquire the lock, so that we are not
@@ -212,7 +211,7 @@ where
                 // (Otherwise, someone else might write a *newer* revision
                 // into the same cell while we block on the lock.)
                 let stamped_value = StampedValue {
-                    value: value.take().unwrap(),
+                    value,
                     durability,
                     changed_at: next_revision,
                 };

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -97,7 +97,7 @@ impl Runtime {
     /// will block until that snapshot is dropped -- if that snapshot
     /// is owned by the current thread, this could trigger deadlock.
     pub fn synthetic_write(&mut self, durability: Durability) {
-        self.with_incremented_revision(&mut |_next_revision| Some(durability));
+        self.with_incremented_revision(|_next_revision| Some(durability));
     }
 
     /// The unique identifier attached to this `SalsaRuntime`. Each
@@ -165,10 +165,10 @@ impl Runtime {
     ///
     /// Note that, given our writer model, we can assume that only one thread is
     /// attempting to increment the global revision at a time.
-    pub(crate) fn with_incremented_revision(
-        &mut self,
-        op: &mut dyn FnMut(Revision) -> Option<Durability>,
-    ) {
+    pub(crate) fn with_incremented_revision<F>(&mut self, op: F)
+    where
+        F: FnOnce(Revision) -> Option<Durability>,
+    {
         log::debug!("increment_revision()");
 
         if !self.permits_increment() {


### PR DESCRIPTION
Removes a bug vector, since this function would
panic if the closure is used more than once.

iuc, the code opted out of the compiler's checks
before via a clever `.take()`.

Another change is to take the closure by value
rather than by reference. The monomorphization
seems harmless, since `with_incremented_revision`
is only called from two places.