### PR TITLE
Remove ': salsa::Database' bound from two examples

### DIFF
--- a/examples/compiler/interner.rs
+++ b/examples/compiler/interner.rs
@@ -1,7 +1,7 @@
 use crate::values::*;
 
 #[salsa::query_group(InternerDatabase)]
-pub trait Interner: salsa::Database {
+pub trait Interner {
     #[salsa::interned]
     fn intern_field(&self, field: FieldData) -> Field;
 

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 // trait for that query group as a supertrait.
 // ANCHOR:trait
 #[salsa::query_group(HelloWorldStorage)]
-trait HelloWorld: salsa::Database {
+trait HelloWorld {
     // For each query, we give the name, some input keys (here, we
     // have one key, `()`) and the output type `Arc<String>`. We can
     // use attributes to give other configuration:


### PR DESCRIPTION
Two examples had a superfluous bound
': salsa::Database' that wasn't present
in the `compiler` example and doesn't seem to be needed.

The `query_group` macro adds this bound
automatically.

This change can lead to a trailing `+` in
the bounds list. I verified this is OK by
running the examples and verifying that the production
is allowed
[per the Rust Reference](https://doc.rust-lang.org/reference/trait-bounds.html)