### PR TITLE
Update doc in macro about query.in_db for dyn db

### DIFF
--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -269,9 +269,11 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
 
             let set_constant_fn_docs = format!(
                 "
-                Set the value of the `{fn_name}` input and promise
-                that its value will never change again.
-
+                Set the value of the `{fn_name}` input with a
+                specific durability instead of the default of
+                `Durability::LOW`. You can use `Durability::MAX`
+                to promise that its value will never change again.
+ 
                 See `{fn_name}` for details.
 
                 *Note:* Setting values will trigger cancellation
@@ -393,9 +395,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
         output.extend(quote! {
             impl #qt {
                 /// Get access to extra methods pertaining to this query.
-                /// You can also use it to invoke this query, though
-                /// it's more common to use the trait method on the database
-                /// itself.
+                /// You can also use it to invoke this query.
                 #trait_vis fn in_db(self, db: &#dyn_db) -> salsa::QueryTable<'_, Self>
                 {
                     salsa::plumbing::get_query_table::<#qt>(db)


### PR DESCRIPTION
Update the macro for `query_group` so the comment
on `fn in_db` no longer says that it is more common
to use the trait method on `db`.

Afaict, the trait methods referred to were removed
when dyn database were introduced in RFC0006:
./book/src/rfcs/RFC0006-Dynamic-Databases.md, as
described in the section
"Instead of `db.query(Q)`, you write `Q.in_db(&db)`"