### PR TITLE
Remove blank book chapter on "How to use salsa"

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,7 +1,6 @@
 # Summary
 
 - [About salsa](./about_salsa.md)
-- [How to use Salsa](./how_to_use.md)
 - [How Salsa works](./how_salsa_works.md)
 - [Common patterns](./common_patterns.md)
   - [Selection](./common_patterns/selection.md)

--- a/book/src/how_to_use.md
+++ b/book/src/how_to_use.md
@@ -1,1 +1,0 @@
-# How to use Salsa


### PR DESCRIPTION
The chapter was blank. Fwiw, I think it's more
helpful to have only non-blank chapters.

When I first looked at the docs, the message
I got from seeing a blank "how to use" was
"oh, there is no guidance on how to use this thing".
However, there turns out to be plenty of guidance,
with detailled, runnable examples, some API documentation,
and RFCs.

If there is still an aspiration for a high-level
"how to use Salsa" that goes beyond the "Hello World"
example, I'd be happy to adapt that aspiration into a
GitHub issue.