### PR TITLE
Fix mdbook warning re "Potential incomplete link"

### DIFF
--- a/book/src/cycles.md
+++ b/book/src/cycles.md
@@ -1,3 +1,3 @@
 # Cycle handling
 
-By default, when Salsa detects a cycle in the computation graph, Salsa will panic with a [`salsa::Cycle`] as the panic value. The [`salsa::Cycle`] structure that describes the cycle, which can be useful for diagnosing what went wrong. 
+By default, when Salsa detects a cycle in the computation graph, Salsa will panic with a `salsa::Cycle` as the panic value. The `salsa::Cycle` structure that describes the cycle, which can be useful for diagnosing what went wrong. 


### PR DESCRIPTION
In cycle.md, change `[salsa::Cycle]` to `salsa::Cycle` so mdbook doesn't get confused
and think there is a broken Markdown link ("warning: Potential incomplete link").

After fixing this problem, there are no more mdbook warnings when
running `mdbook build` in the "book" directory.

