### PR TITLE
Make storage fields of #nameGroupStorage private

### DIFF
--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -310,10 +310,8 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
         }
 
         // A field for the storage struct
-        //
-        // FIXME(#120): the pub should not be necessary once we complete the transition
         storage_fields.extend(quote! {
-            pub #fn_name: std::sync::Arc<<#qt as salsa::Query>::Storage>,
+            #fn_name: std::sync::Arc<<#qt as salsa::Query>::Storage>,
         });
     }
 


### PR DESCRIPTION
This change resolves a fixme that referenced #120.

This change breaks no tests, and, if I understand
correctly, does not affect user-facing API.

Here is the difference for the `HelloWorldGroupStorage__` struct
generated from macros in the `hello_world` example:

**Before:**

```rs
struct HelloWorldGroupStorage__ {
    pub input_string:std::sync::Arc<<InputStringQuery as salsa::Query> ::Storage> ,pub length:std::sync::Arc<<LengthQuery as salsa::Query> ::Storage> ,
}
```

**After:**

```rs
struct HelloWorldGroupStorage__ {
    input_string:std::sync::Arc<<InputStringQuery as salsa::Query> ::Storage> ,length:std::sync::Arc<<LengthQuery as salsa::Query> ::Storage> ,
}
```