### PR TITLE
fix misleading type in salsa book example

### DIFF
--- a/book/src/common_patterns/on_demand_inputs.md
+++ b/book/src/common_patterns/on_demand_inputs.md
@@ -25,7 +25,7 @@ trait FileWatcher {
     fn did_change_file(&mut self, path: &Path);
 }
 
-fn read(db: &dyn salsa::Database, path: PathBuf) -> String {
+fn read(db: &dyn VfsDatabase, path: PathBuf) -> String {
     db.salsa_runtime()
         .report_synthetic_read(salsa::Durability::LOW);
     db.watch(&path);


### PR DESCRIPTION
fix misleading type in salsa book example