### PR TITLE
Accumulators

### DIFF
--- a/components/salsa-2022-macros/src/db.rs
+++ b/components/salsa-2022-macros/src/db.rs
@@ -141,12 +141,12 @@ fn has_jars_dyn_impl(input: &syn::ItemStruct, storage: &syn::Ident) -> syn::Item
                 ingredient.origin(index.key_index())
             }
 
-            fn mark_validated_output(&self, executor: salsa::DatabaseKeyIndex, output: salsa::key::DatabaseKeyIndex) {
+            fn mark_validated_output(&self, executor: salsa::DatabaseKeyIndex, output: salsa::key::DependencyIndex) {
                 let ingredient = self.#storage.ingredient(output.ingredient_index());
                 ingredient.mark_validated_output(self, executor, output.key_index());
             }
 
-            fn remove_stale_output(&self, executor: salsa::DatabaseKeyIndex, stale_output: salsa::key::DatabaseKeyIndex) {
+            fn remove_stale_output(&self, executor: salsa::DatabaseKeyIndex, stale_output: salsa::key::DependencyIndex) {
                 let ingredient = self.#storage.ingredient(stale_output.ingredient_index());
                 ingredient.remove_stale_output(self, executor, stale_output.key_index());
             }

--- a/components/salsa-2022/src/accumulator.rs
+++ b/components/salsa-2022/src/accumulator.rs
@@ -1,11 +1,13 @@
+//! Basic test of accumulator functionality.
+
 use crate::{
     cycle::CycleRecoveryStrategy,
     hash::FxDashMap,
     ingredient::{Ingredient, IngredientRequiresReset},
     key::DependencyIndex,
-    runtime::{local_state::QueryOrigin, StampedValue},
+    runtime::local_state::QueryOrigin,
     storage::HasJar,
-    DatabaseKeyIndex, Durability, IngredientIndex, Revision, Runtime,
+    DatabaseKeyIndex, Event, EventKind, IngredientIndex, Revision, Runtime,
 };
 
 pub trait Accumulator {
@@ -16,36 +18,53 @@ pub trait Accumulator {
     where
         Db: ?Sized + HasJar<Self::Jar>;
 }
-
 pub struct AccumulatorIngredient<Data: Clone> {
-    map: FxDashMap<DatabaseKeyIndex, StampedValue<Vec<Data>>>,
+    index: IngredientIndex,
+    map: FxDashMap<DatabaseKeyIndex, AccumulatedValues<Data>>,
+}
+
+struct AccumulatedValues<Data> {
+    produced_at: Revision,
+    values: Vec<Data>,
 }
 
 impl<Data: Clone> AccumulatorIngredient<Data> {
-    pub fn new(_index: IngredientIndex) -> Self {
+    pub fn new(index: IngredientIndex) -> Self {
         Self {
             map: FxDashMap::default(),
+            index,
+        }
+    }
+
+    fn dependency_index(&self) -> DependencyIndex {
+        DependencyIndex {
+            ingredient_index: self.index,
+            key_index: None,
         }
     }
 
     pub fn push(&self, runtime: &Runtime, value: Data) {
-        let (active_query, active_inputs) = match runtime.active_query() {
+        let current_revision = runtime.current_revision();
+        let (active_query, _) = match runtime.active_query() {
             Some(pair) => pair,
             None => {
                 panic!("cannot accumulate values outside of an active query")
             }
         };
 
-        let mut stamped_value = self.map.entry(active_query).or_insert(StampedValue {
-            value: vec![],
-            durability: Durability::MAX,
-            changed_at: Revision::start(),
+        let mut accumulated_values = self.map.entry(active_query).or_insert(AccumulatedValues {
+            values: vec![],
+            produced_at: current_revision,
         });
 
-        stamped_value.value.push(value);
-        stamped_value
-            .value_mut()
-            .merge_revision_info(&active_inputs);
+        // This is the first push in a new revision. Reset.
+        if accumulated_values.produced_at != current_revision {
+            accumulated_values.values.truncate(0);
+            accumulated_values.produced_at = current_revision;
+        }
+
+        runtime.add_output(self.dependency_index());
+        accumulated_values.values.push(value);
     }
 
     pub(crate) fn produced_by(
@@ -54,20 +73,28 @@ impl<Data: Clone> AccumulatorIngredient<Data> {
         query: DatabaseKeyIndex,
         output: &mut Vec<Data>,
     ) {
+        let current_revision = runtime.current_revision();
         if let Some(v) = self.map.get(&query) {
-            let StampedValue {
-                value,
-                durability,
-                changed_at,
+            // FIXME: We don't currently have a good way to identify the value that was read.
+            // You can't report is as a tracked read of `query`, because the return value of query is not being read here --
+            // instead it is the set of values accumuated by `query`.
+            runtime.report_untracked_read();
+
+            let AccumulatedValues {
+                values,
+                produced_at,
             } = v.value();
-            runtime.report_tracked_read(query.into(), *durability, *changed_at);
-            output.extend(value.iter().cloned());
+
+            if *produced_at == current_revision {
+                output.extend(values.iter().cloned());
+            }
         }
     }
 }
 
 impl<DB: ?Sized, Data> Ingredient<DB> for AccumulatorIngredient<Data>
 where
+    DB: crate::Database,
     Data: Clone,
 {
     fn maybe_changed_after(&self, _db: &DB, _input: DependencyIndex, _revision: Revision) -> bool {
@@ -84,22 +111,34 @@ where
 
     fn mark_validated_output(
         &self,
-        _db: &DB,
+        db: &DB,
         executor: DatabaseKeyIndex,
         output_key: Option<crate::Id>,
     ) {
-        // FIXME
-        drop((executor, output_key));
+        assert!(output_key.is_none());
+        let current_revision = db.salsa_runtime().current_revision();
+        if let Some(mut v) = self.map.get_mut(&executor) {
+            // The value is still valid in the new revision.
+            v.produced_at = current_revision;
+        }
     }
 
     fn remove_stale_output(
         &self,
-        _db: &DB,
+        db: &DB,
         executor: DatabaseKeyIndex,
         stale_output_key: Option<crate::Id>,
     ) {
-        // FIXME
-        drop((executor, stale_output_key));
+        assert!(stale_output_key.is_none());
+        if self.map.remove(&executor).is_some() {
+            db.salsa_event(Event {
+                runtime_id: db.salsa_runtime().id(),
+                kind: EventKind::DidDiscardAccumulated {
+                    executor_key: executor,
+                    accumulator: self.dependency_index(),
+                },
+            })
+        }
     }
 
     fn reset_for_new_revision(&mut self) {

--- a/components/salsa-2022/src/accumulator.rs
+++ b/components/salsa-2022/src/accumulator.rs
@@ -82,7 +82,12 @@ where
         None
     }
 
-    fn mark_validated_output(&self, _db: &DB, executor: DatabaseKeyIndex, output_key: crate::Id) {
+    fn mark_validated_output(
+        &self,
+        _db: &DB,
+        executor: DatabaseKeyIndex,
+        output_key: Option<crate::Id>,
+    ) {
         // FIXME
         drop((executor, output_key));
     }
@@ -91,7 +96,7 @@ where
         &self,
         _db: &DB,
         executor: DatabaseKeyIndex,
-        stale_output_key: crate::Id,
+        stale_output_key: Option<crate::Id>,
     ) {
         // FIXME
         drop((executor, stale_output_key));

--- a/components/salsa-2022/src/event.rs
+++ b/components/salsa-2022/src/event.rs
@@ -91,6 +91,15 @@ pub enum EventKind {
         /// Value being discarded.
         key: DatabaseKeyIndex,
     },
+
+    /// Discarded accumulated data from a given fn
+    DidDiscardAccumulated {
+        /// The key of the fn that accumulated results
+        executor_key: DatabaseKeyIndex,
+
+        /// Accumulator that was accumulated into
+        accumulator: DependencyIndex,
+    },
 }
 
 impl fmt::Debug for EventKind {
@@ -124,6 +133,14 @@ impl fmt::Debug for EventKind {
             EventKind::DidDiscard { key } => {
                 fmt.debug_struct("DidDiscard").field("key", &key).finish()
             }
+            EventKind::DidDiscardAccumulated {
+                executor_key,
+                accumulator,
+            } => fmt
+                .debug_struct("DidDiscardAccumulated")
+                .field("executor_key", executor_key)
+                .field("accumulator", accumulator)
+                .finish(),
         }
     }
 }
@@ -162,6 +179,14 @@ where
             EventKind::DidDiscard { key } => fmt
                 .debug_struct("DidDiscard")
                 .field("key", &key.debug(db))
+                .finish(),
+            EventKind::DidDiscardAccumulated {
+                executor_key,
+                accumulator,
+            } => fmt
+                .debug_struct("DidDiscardAccumulated")
+                .field("executor_key", &executor_key.debug(db))
+                .field("accumulator", &accumulator.debug(db))
                 .finish(),
         }
     }

--- a/components/salsa-2022/src/event.rs
+++ b/components/salsa-2022/src/event.rs
@@ -1,4 +1,6 @@
-use crate::{debug::DebugWithDb, runtime::RuntimeId, Database, DatabaseKeyIndex};
+use crate::{
+    debug::DebugWithDb, key::DatabaseKeyIndex, key::DependencyIndex, runtime::RuntimeId, Database,
+};
 use std::fmt;
 
 /// The `Event` struct identifies various notable things that can
@@ -81,7 +83,7 @@ pub enum EventKind {
         execute_key: DatabaseKeyIndex,
 
         /// Key for the query that is no longer output
-        output_key: DatabaseKeyIndex,
+        output_key: DependencyIndex,
     },
 
     /// Tracked structs or memoized data were discarded (freed).

--- a/components/salsa-2022/src/function.rs
+++ b/components/salsa-2022/src/function.rs
@@ -225,8 +225,13 @@ where
         self.origin(key)
     }
 
-    fn mark_validated_output(&self, db: &DB, executor: DatabaseKeyIndex, output_key: crate::Id) {
-        let output_key = C::key_from_id(output_key);
+    fn mark_validated_output(
+        &self,
+        db: &DB,
+        executor: DatabaseKeyIndex,
+        output_key: Option<crate::Id>,
+    ) {
+        let output_key = C::key_from_id(output_key.unwrap());
         self.validate_specified_value(db.as_jar_db(), executor, output_key);
     }
 
@@ -234,7 +239,7 @@ where
         &self,
         _db: &DB,
         _executor: DatabaseKeyIndex,
-        _stale_output_key: crate::Id,
+        _stale_output_key: Option<crate::Id>,
     ) {
         // This function is invoked when a query Q specifies the value for `stale_output_key` in rev 1,
         // but not in rev 2. We don't do anything in this case, we just leave the (now stale) memo.

--- a/components/salsa-2022/src/function/diff_outputs.rs
+++ b/components/salsa-2022/src/function/diff_outputs.rs
@@ -1,6 +1,6 @@
 use crate::{
-    runtime::local_state::QueryRevisions, storage::HasJarsDyn, Database, DatabaseKeyIndex, Event,
-    EventKind,
+    key::DependencyIndex, runtime::local_state::QueryRevisions, storage::HasJarsDyn, Database,
+    DatabaseKeyIndex, Event, EventKind,
 };
 
 use super::{memo::Memo, Configuration, DynDb, FunctionIngredient};
@@ -44,7 +44,7 @@ where
         }
     }
 
-    fn report_stale_output(db: &DynDb<'_, C>, key: DatabaseKeyIndex, output: DatabaseKeyIndex) {
+    fn report_stale_output(db: &DynDb<'_, C>, key: DatabaseKeyIndex, output: DependencyIndex) {
         let runtime_id = db.salsa_runtime().id();
         db.salsa_event(Event {
             runtime_id,

--- a/components/salsa-2022/src/function/specify.rs
+++ b/components/salsa-2022/src/function/specify.rs
@@ -101,7 +101,7 @@ where
 
         // Record that the current query *specified* a value for this cell.
         let database_key_index = self.database_key_index(key);
-        db.salsa_runtime().add_output(database_key_index);
+        db.salsa_runtime().add_output(database_key_index.into());
     }
 
     /// Invoked when the query `executor` has been validated as having green inputs

--- a/components/salsa-2022/src/ingredient.rs
+++ b/components/salsa-2022/src/ingredient.rs
@@ -26,13 +26,18 @@ pub trait Ingredient<DB: ?Sized> {
 
     /// Invoked when the value `output_key` should be marked as valid in the current revision.
     /// This occurs because the value for `executor`, which generated it, was marked as valid in the current revision.
-    fn mark_validated_output(&self, db: &DB, executor: DatabaseKeyIndex, output_key: Id);
+    fn mark_validated_output(&self, db: &DB, executor: DatabaseKeyIndex, output_key: Option<Id>);
 
     /// Invoked when the value `stale_output` was output by `executor` in a previous
     /// revision, but was NOT output in the current revision.
     ///
     /// This hook is used to clear out the stale value so others cannot read it.
-    fn remove_stale_output(&self, db: &DB, executor: DatabaseKeyIndex, stale_output_key: Id);
+    fn remove_stale_output(
+        &self,
+        db: &DB,
+        executor: DatabaseKeyIndex,
+        stale_output_key: Option<Id>,
+    );
 
     /// Informs the ingredient `self` that the salsa struct with id `id` has been deleted.
     /// This gives `self` a chance to remove any memoized data dependent on `id`.

--- a/components/salsa-2022/src/input.rs
+++ b/components/salsa-2022/src/input.rs
@@ -62,7 +62,12 @@ where
         None
     }
 
-    fn mark_validated_output(&self, _db: &DB, executor: DatabaseKeyIndex, output_key: crate::Id) {
+    fn mark_validated_output(
+        &self,
+        _db: &DB,
+        executor: DatabaseKeyIndex,
+        output_key: Option<crate::Id>,
+    ) {
         unreachable!(
             "mark_validated_output({:?}, {:?}): input cannot be the output of a tracked function",
             executor, output_key
@@ -73,7 +78,7 @@ where
         &self,
         _db: &DB,
         executor: DatabaseKeyIndex,
-        stale_output_key: crate::Id,
+        stale_output_key: Option<crate::Id>,
     ) {
         unreachable!(
             "remove_stale_output({:?}, {:?}): input cannot be the output of a tracked function",

--- a/components/salsa-2022/src/input_field.rs
+++ b/components/salsa-2022/src/input_field.rs
@@ -90,9 +90,21 @@ where
         None
     }
 
-    fn mark_validated_output(&self, _db: &DB, _executor: DatabaseKeyIndex, _output_key: Id) {}
+    fn mark_validated_output(
+        &self,
+        _db: &DB,
+        _executor: DatabaseKeyIndex,
+        _output_key: Option<Id>,
+    ) {
+    }
 
-    fn remove_stale_output(&self, _db: &DB, _executor: DatabaseKeyIndex, _stale_output_key: Id) {}
+    fn remove_stale_output(
+        &self,
+        _db: &DB,
+        _executor: DatabaseKeyIndex,
+        _stale_output_key: Option<Id>,
+    ) {
+    }
 
     fn salsa_struct_deleted(&self, _db: &DB, _id: Id) {
         panic!("unexpected call: input fields are never deleted");

--- a/components/salsa-2022/src/interned.rs
+++ b/components/salsa-2022/src/interned.rs
@@ -200,7 +200,12 @@ where
         None
     }
 
-    fn mark_validated_output(&self, _db: &DB, executor: DatabaseKeyIndex, output_key: crate::Id) {
+    fn mark_validated_output(
+        &self,
+        _db: &DB,
+        executor: DatabaseKeyIndex,
+        output_key: Option<crate::Id>,
+    ) {
         unreachable!(
             "mark_validated_output({:?}, {:?}): input cannot be the output of a tracked function",
             executor, output_key
@@ -211,7 +216,7 @@ where
         &self,
         _db: &DB,
         executor: DatabaseKeyIndex,
-        stale_output_key: crate::Id,
+        stale_output_key: Option<crate::Id>,
     ) {
         unreachable!(
             "remove_stale_output({:?}, {:?}): interned ids are not outputs",

--- a/components/salsa-2022/src/runtime.rs
+++ b/components/salsa-2022/src/runtime.rs
@@ -146,7 +146,7 @@ impl Runtime {
 
     /// Adds `key` to the list of output created by the current query
     /// (if not already present).
-    pub(crate) fn add_output(&self, key: DatabaseKeyIndex) {
+    pub(crate) fn add_output(&self, key: DependencyIndex) {
         self.local_state.add_output(key);
     }
 

--- a/components/salsa-2022/src/runtime/active_query.rs
+++ b/components/salsa-2022/src/runtime/active_query.rs
@@ -44,7 +44,7 @@ pub(super) struct ActiveQuery {
     ///
     /// We use a btree-set because we want to be able to
     /// extract the keys in sorted order.
-    pub(super) outputs: BTreeSet<DatabaseKeyIndex>,
+    pub(super) outputs: BTreeSet<DependencyIndex>,
 }
 
 impl ActiveQuery {
@@ -85,12 +85,13 @@ impl ActiveQuery {
     }
 
     /// Adds a key to our list of outputs.
-    pub(super) fn add_output(&mut self, key: DatabaseKeyIndex) {
+    pub(super) fn add_output(&mut self, key: DependencyIndex) {
         self.outputs.insert(key);
     }
 
     /// True if the given key was output by this query.
     pub(super) fn is_output(&self, key: DatabaseKeyIndex) -> bool {
+        let key: DependencyIndex = key.into();
         self.outputs.contains(&key)
     }
 

--- a/components/salsa-2022/src/runtime/local_state.rs
+++ b/components/salsa-2022/src/runtime/local_state.rs
@@ -132,9 +132,6 @@ impl QueryEdges {
     /// Creates a new `QueryEdges`; the values given for each field must meet struct invariants.
     pub(crate) fn new(separator: usize, input_outputs: Arc<[DependencyIndex]>) -> Self {
         debug_assert!(separator <= input_outputs.len());
-        debug_assert!(input_outputs[separator..]
-            .iter()
-            .all(|&dep_index| DatabaseKeyIndex::try_from(dep_index).is_ok()));
         Self {
             separator: u32::try_from(separator).unwrap(),
             input_outputs,
@@ -192,10 +189,10 @@ impl LocalState {
         })
     }
 
-    pub(super) fn add_output(&self, entity: DatabaseKeyIndex) {
+    pub(super) fn add_output(&self, entity: DependencyIndex) {
         self.with_query_stack(|stack| {
             if let Some(top_query) = stack.last_mut() {
-                top_query.add_output(entity.into())
+                top_query.add_output(entity)
             }
         })
     }

--- a/components/salsa-2022/src/runtime/local_state.rs
+++ b/components/salsa-2022/src/runtime/local_state.rs
@@ -81,7 +81,7 @@ pub enum QueryOrigin {
 
 impl QueryOrigin {
     /// Indices for queries *written* by this query (or `&[]` if its value was assigned).
-    pub(crate) fn outputs(&self) -> impl Iterator<Item = DatabaseKeyIndex> + '_ {
+    pub(crate) fn outputs(&self) -> impl Iterator<Item = DependencyIndex> + '_ {
         let slice = match self {
             QueryOrigin::Derived(edges) | QueryOrigin::DerivedUntracked(edges) => {
                 &edges.input_outputs[edges.separator as usize..]
@@ -89,11 +89,7 @@ impl QueryOrigin {
             QueryOrigin::Assigned(_) | QueryOrigin::BaseInput | QueryOrigin::Field => &[],
         };
 
-        // the `QueryEdges` repr. invariant guarantees all tracked outputs are full  'dependency index' values,
-        // so we can safely unwrap result of `try_from` here
-        slice
-            .iter()
-            .map(|&dep_index| DatabaseKeyIndex::try_from(dep_index).unwrap())
+        slice.iter().copied()
     }
 }
 
@@ -119,7 +115,6 @@ pub struct QueryEdges {
     ///
     /// * The inputs must be in **execution order** for the red-green algorithm to work.
     /// * The outputs must be in **sorted order** so that we can easily "diff" them between revisions.
-    /// * All outputs must have a `Some` value for `key_index`.
     input_outputs: Arc<[DependencyIndex]>,
 
     /// The index that separates inputs from outputs in the `tracked` field.
@@ -200,7 +195,7 @@ impl LocalState {
     pub(super) fn add_output(&self, entity: DatabaseKeyIndex) {
         self.with_query_stack(|stack| {
             if let Some(top_query) = stack.last_mut() {
-                top_query.add_output(entity)
+                top_query.add_output(entity.into())
             }
         })
     }
@@ -208,7 +203,7 @@ impl LocalState {
     pub(super) fn is_output(&self, entity: DatabaseKeyIndex) -> bool {
         self.with_query_stack(|stack| {
             if let Some(top_query) = stack.last_mut() {
-                top_query.is_output(entity)
+                top_query.is_output(entity.into())
             } else {
                 false
             }

--- a/components/salsa-2022/src/storage.rs
+++ b/components/salsa-2022/src/storage.rs
@@ -180,12 +180,12 @@ pub trait HasJarsDyn {
 
     fn origin(&self, input: DatabaseKeyIndex) -> Option<QueryOrigin>;
 
-    fn mark_validated_output(&self, executor: DatabaseKeyIndex, output: DatabaseKeyIndex);
+    fn mark_validated_output(&self, executor: DatabaseKeyIndex, output: DependencyIndex);
 
     /// Invoked when `executor` used to output `stale_output` but no longer does.
     /// This method routes that into a call to the [`remove_stale_output`](`crate::ingredient::Ingredient::remove_stale_output`)
     /// method on the ingredient for `stale_output`.
-    fn remove_stale_output(&self, executor: DatabaseKeyIndex, stale_output: DatabaseKeyIndex);
+    fn remove_stale_output(&self, executor: DatabaseKeyIndex, stale_output: DependencyIndex);
 
     /// Informs `ingredient` that the salsa struct with id `id` has been deleted.
     /// This means that `id` will not be used in this revision and hence

--- a/components/salsa-2022/src/tracked_struct.rs
+++ b/components/salsa-2022/src/tracked_struct.rs
@@ -144,7 +144,12 @@ where
         None
     }
 
-    fn mark_validated_output(&self, _db: &DB, executor: DatabaseKeyIndex, output_key: crate::Id) {
+    fn mark_validated_output(
+        &self,
+        _db: &DB,
+        executor: DatabaseKeyIndex,
+        output_key: Option<crate::Id>,
+    ) {
         // FIXME
         drop((executor, output_key));
     }
@@ -153,13 +158,13 @@ where
         &self,
         db: &DB,
         _executor: DatabaseKeyIndex,
-        stale_output_key: crate::Id,
+        stale_output_key: Option<crate::Id>,
     ) {
         // This method is called when, in prior revisions,
         // `executor` creates a tracked struct `salsa_output_key`,
         // but it did not in the current revision.
         // In that case, we can delete `stale_output_key` and any data associated with it.
-        let stale_output_key: Id = Id::from_id(stale_output_key);
+        let stale_output_key: Id = Id::from_id(stale_output_key.unwrap());
         self.delete_entity(db.as_salsa_database(), stale_output_key);
     }
 

--- a/components/salsa-2022/src/tracked_struct.rs
+++ b/components/salsa-2022/src/tracked_struct.rs
@@ -86,7 +86,7 @@ where
             data,
         };
         let result = self.interned.intern(runtime, entity_key);
-        runtime.add_output(self.database_key_index(result));
+        runtime.add_output(self.database_key_index(result).into());
         result
     }
 

--- a/salsa-2022-tests/tests/accumulate-and-reuse.rs
+++ b/salsa-2022-tests/tests/accumulate-and-reuse.rs
@@ -1,0 +1,180 @@
+//! Basic deletion test:
+//!
+//! * entities not created in a revision are deleted, as is any memoized data keyed on them.
+
+use salsa::DebugWithDb;
+use salsa_2022_tests::{HasLogger, Logger};
+
+use expect_test::expect;
+use test_log::test;
+
+#[salsa::jar(db = Db)]
+struct Jar(MyInput, Logs, push_logs, push_a_logs, push_b_logs);
+
+trait Db: salsa::DbWithJar<Jar> + HasLogger {}
+
+#[salsa::input]
+struct MyInput {
+    field_a: u32,
+    field_b: u32,
+}
+
+#[salsa::accumulator]
+struct Logs(String);
+
+#[salsa::tracked]
+#[allow(dead_code)]
+fn push_logs(db: &dyn Db, input: MyInput) {
+    db.push_log(format!(
+        "push_logs(a = {}, b = {})",
+        input.field_a(db),
+        input.field_b(db)
+    ));
+
+    // We don't invoke `push_a_logs` (or `push_b_logs`) with a value of 1 or less.
+    // This allows us to test what happens a change in inputs causes a function not to be called at all.
+    if input.field_a(db) > 1 {
+        push_a_logs(db, input);
+    }
+
+    if input.field_b(db) > 1 {
+        push_b_logs(db, input);
+    }
+}
+
+#[salsa::tracked]
+fn push_a_logs(db: &dyn Db, input: MyInput) {
+    let field_a = input.field_a(db);
+    db.push_log(format!("push_a_logs({})", field_a));
+
+    for i in 0..field_a {
+        Logs::push(db, format!("log_a({} of {})", i, field_a));
+    }
+}
+
+#[salsa::tracked]
+fn push_b_logs(db: &dyn Db, input: MyInput) {
+    let field_a = input.field_b(db);
+    db.push_log(format!("push_b_logs({})", field_a));
+
+    for i in 0..field_a {
+        Logs::push(db, format!("log_b({} of {})", i, field_a));
+    }
+}
+
+#[salsa::db(Jar)]
+#[derive(Default)]
+struct Database {
+    storage: salsa::Storage<Self>,
+    logger: Logger,
+}
+
+impl salsa::Database for Database {
+    fn salsa_event(&self, event: salsa::Event) {}
+
+    fn salsa_runtime(&self) -> &salsa::Runtime {
+        self.storage.runtime()
+    }
+}
+
+impl Db for Database {}
+
+impl HasLogger for Database {
+    fn logger(&self) -> &Logger {
+        &self.logger
+    }
+}
+
+#[test]
+fn accumulate_once() {
+    let mut db = Database::default();
+
+    // Just call accumulate on a base input to see what happens.
+    let input = MyInput::new(&mut db, 2, 3);
+    let logs = push_logs::accumulated::<Logs>(&db, input);
+    expect![[r#"
+        [
+            "log_b(0 of 3)",
+            "log_b(1 of 3)",
+            "log_b(2 of 3)",
+            "log_a(0 of 2)",
+            "log_a(1 of 2)",
+        ]"#]]
+    .assert_eq(&format!("{:#?}", logs));
+    db.assert_logs(expect![[r#"
+        [
+            "push_logs(a = 2, b = 3)",
+            "push_a_logs(2)",
+            "push_b_logs(3)",
+        ]"#]])
+}
+
+#[test]
+fn change_a_and_reaccumulate() {
+    let mut db = Database::default();
+
+    // Accumulate logs for `a = 2` and `b = 3`
+    let input = MyInput::new(&mut db, 2, 3);
+    let logs = push_logs::accumulated::<Logs>(&db, input);
+    expect![[r#"
+        [
+            "log_b(0 of 3)",
+            "log_b(1 of 3)",
+            "log_b(2 of 3)",
+            "log_a(0 of 2)",
+            "log_a(1 of 2)",
+        ]"#]]
+    .assert_eq(&format!("{:#?}", logs));
+    db.assert_logs(expect![[r#"
+        [
+            "push_logs(a = 2, b = 3)",
+            "push_a_logs(2)",
+            "push_b_logs(3)",
+        ]"#]]);
+
+    // Change to `a = 1`, which means `push_logs` does not call `push_a_logs` at all
+    input.set_field_a(&mut db, 1);
+    let logs = push_logs::accumulated::<Logs>(&db, input);
+    expect![[r#"
+        [
+            "log_b(0 of 3)",
+            "log_b(1 of 3)",
+            "log_b(2 of 3)",
+        ]"#]]
+    .assert_eq(&format!("{:#?}", logs));
+    db.assert_logs(expect![[r#"
+        [
+            "push_logs(a = 1, b = 3)",
+        ]"#]]);
+}
+
+#[test]
+fn get_a_logs_after_changing_b() {
+    let mut db = Database::default();
+
+    // Invoke `push_a_logs` with `a = 2` and `b = 3` (but `b` doesn't matter)
+    let input = MyInput::new(&mut db, 2, 3);
+    let logs = push_a_logs::accumulated::<Logs>(&db, input);
+    expect![[r#"
+        [
+            "log_a(0 of 2)",
+            "log_a(1 of 2)",
+        ]"#]]
+    .assert_eq(&format!("{:#?}", logs));
+    db.assert_logs(expect![[r#"
+        [
+            "push_a_logs(2)",
+        ]"#]]);
+
+    // Changing `b` does not cause `push_a_logs` to re-execute
+    // and we still get the same result
+    input.set_field_b(&mut db, 5);
+    let logs = push_a_logs::accumulated::<Logs>(&db, input);
+    expect![[r#"
+        [
+            "log_a(0 of 2)",
+            "log_a(1 of 2)",
+        ]"#]]
+    .assert_eq(&format!("{:#?}", logs));
+    db.assert_logs(expect!["[]"]);
+}

--- a/salsa-2022-tests/tests/accumulate-from-tracked-fn.rs
+++ b/salsa-2022-tests/tests/accumulate-from-tracked-fn.rs
@@ -1,0 +1,93 @@
+//! Accumulate values from within a tracked function.
+//! Then mutate the values so that the tracked function re-executes.
+//! Check that we accumulate the appropriate, new values.
+
+use salsa_2022_tests::{HasLogger, Logger};
+
+use expect_test::expect;
+use test_log::test;
+
+#[salsa::jar(db = Db)]
+struct Jar(List, Integers, compute);
+
+trait Db: salsa::DbWithJar<Jar> + HasLogger {}
+
+#[salsa::input]
+struct List {
+    value: u32,
+    next: Option<List>,
+}
+
+#[salsa::accumulator]
+struct Integers(u32);
+
+#[salsa::tracked]
+fn compute(db: &dyn Db, input: List) {
+    eprintln!(
+        "{:?}(value={:?}, next={:?})",
+        input,
+        input.value(db),
+        input.next(db)
+    );
+    let result = if let Some(next) = input.next(db) {
+        let next_integers = compute::accumulated::<Integers>(db, next);
+        eprintln!("{:?}", next_integers);
+        let v = input.value(db) + next_integers.iter().sum::<u32>();
+        eprintln!("input={:?} v={:?}", input.value(db), v);
+        v
+    } else {
+        input.value(db)
+    };
+    Integers::push(db, result);
+    eprintln!("pushed result {:?}", result);
+}
+
+#[salsa::db(Jar)]
+#[derive(Default)]
+struct Database {
+    storage: salsa::Storage<Self>,
+    logger: Logger,
+}
+
+impl salsa::Database for Database {
+    fn salsa_event(&self, _event: salsa::Event) {}
+
+    fn salsa_runtime(&self) -> &salsa::Runtime {
+        self.storage.runtime()
+    }
+}
+
+impl Db for Database {}
+
+impl HasLogger for Database {
+    fn logger(&self) -> &Logger {
+        &self.logger
+    }
+}
+
+#[test]
+fn test1() {
+    let mut db = Database::default();
+
+    let l0 = List::new(&mut db, 1, None);
+    let l1 = List::new(&mut db, 10, Some(l0));
+
+    compute(&db, l1);
+    expect![[r#"
+        [
+            11,
+            1,
+        ]
+    "#]]
+    .assert_debug_eq(&compute::accumulated::<Integers>(&db, l1));
+
+    l0.set_value(&mut db, 2);
+    compute(&db, l1);
+    expect![[r#"
+        [
+            12,
+            2,
+        ]
+    "#]]
+    .assert_debug_eq(&compute::accumulated::<Integers>(&db, l1));
+}

--- a/salsa-2022-tests/tests/accumulate-reuse-workaround.rs
+++ b/salsa-2022-tests/tests/accumulate-reuse-workaround.rs
@@ -1,0 +1,97 @@
+//! Demonstrates the workaround of wrapping calls to
+//! `accumulated` in a tracked function to get better
+//! reuse.
+
+use salsa_2022_tests::{HasLogger, Logger};
+
+use expect_test::expect;
+use test_log::test;
+
+#[salsa::jar(db = Db)]
+struct Jar(List, Integers, compute, accumulated);
+
+trait Db: salsa::DbWithJar<Jar> + HasLogger {}
+
+#[salsa::input]
+struct List {
+    value: u32,
+    next: Option<List>,
+}
+
+#[salsa::accumulator]
+struct Integers(u32);
+
+#[salsa::tracked]
+fn compute(db: &dyn Db, input: List) -> u32 {
+    db.push_log(format!("compute({:?})", input,));
+
+    // always pushes 0
+    Integers::push(db, 0);
+
+    let result = if let Some(next) = input.next(db) {
+        let next_integers = accumulated(db, next);
+        let v = input.value(db) + next_integers.iter().sum::<u32>();
+        v
+    } else {
+        input.value(db)
+    };
+
+    // return value changes
+    result
+}
+
+#[salsa::tracked(return_ref)]
+fn accumulated(db: &dyn Db, input: List) -> Vec<u32> {
+    db.push_log(format!("accumulated({:?})", input,));
+    compute::accumulated::<Integers>(db, input)
+}
+
+#[salsa::db(Jar)]
+#[derive(Default)]
+struct Database {
+    storage: salsa::Storage<Self>,
+    logger: Logger,
+}
+
+impl salsa::Database for Database {
+    fn salsa_event(&self, _event: salsa::Event) {}
+
+    fn salsa_runtime(&self) -> &salsa::Runtime {
+        self.storage.runtime()
+    }
+}
+
+impl Db for Database {}
+
+impl HasLogger for Database {
+    fn logger(&self) -> &Logger {
+        &self.logger
+    }
+}
+
+#[test]
+fn test1() {
+    let mut db = Database::default();
+
+    let l1 = List::new(&mut db, 1, None);
+    let l2 = List::new(&mut db, 2, Some(l1));
+
+    assert_eq!(compute(&db, l2), 2);
+    db.assert_logs(expect![[r#"
+        [
+            "compute(List(Id { value: 2 }))",
+            "accumulated(List(Id { value: 1 }))",
+            "compute(List(Id { value: 1 }))",
+        ]"#]]);
+
+    // When we mutate `l1`, we should re-execute `compute` for `l1`,
+    // and we re-execute accumulated for `l1`, but we do NOT re-execute
+    // `compute` for `l2`.
+    l1.set_value(&mut db, 2);
+    assert_eq!(compute(&db, l2), 2);
+    db.assert_logs(expect![[r#"
+        [
+            "accumulated(List(Id { value: 1 }))",
+            "compute(List(Id { value: 1 }))",
+        ]"#]]);
+}

--- a/salsa-2022-tests/tests/accumulate-reuse.rs
+++ b/salsa-2022-tests/tests/accumulate-reuse.rs
@@ -1,0 +1,92 @@
+//! Accumulator re-use test.
+//!
+//! Tests behavior when a query's only inputs
+//! are the accumulated values from another query.
+
+use salsa_2022_tests::{HasLogger, Logger};
+
+use expect_test::expect;
+use test_log::test;
+
+#[salsa::jar(db = Db)]
+struct Jar(List, Integers, compute);
+
+trait Db: salsa::DbWithJar<Jar> + HasLogger {}
+
+#[salsa::input]
+struct List {
+    value: u32,
+    next: Option<List>,
+}
+
+#[salsa::accumulator]
+struct Integers(u32);
+
+#[salsa::tracked]
+fn compute(db: &dyn Db, input: List) -> u32 {
+    db.push_log(format!("compute({:?})", input,));
+
+    // always pushes 0
+    Integers::push(db, 0);
+
+    let result = if let Some(next) = input.next(db) {
+        let next_integers = compute::accumulated::<Integers>(db, next);
+        let v = input.value(db) + next_integers.iter().sum::<u32>();
+        v
+    } else {
+        input.value(db)
+    };
+
+    // return value changes
+    result
+}
+
+#[salsa::db(Jar)]
+#[derive(Default)]
+struct Database {
+    storage: salsa::Storage<Self>,
+    logger: Logger,
+}
+
+impl salsa::Database for Database {
+    fn salsa_event(&self, _event: salsa::Event) {}
+
+    fn salsa_runtime(&self) -> &salsa::Runtime {
+        self.storage.runtime()
+    }
+}
+
+impl Db for Database {}
+
+impl HasLogger for Database {
+    fn logger(&self) -> &Logger {
+        &self.logger
+    }
+}
+
+#[test]
+fn test1() {
+    let mut db = Database::default();
+
+    let l1 = List::new(&mut db, 1, None);
+    let l2 = List::new(&mut db, 2, Some(l1));
+
+    assert_eq!(compute(&db, l2), 2);
+    db.assert_logs(expect![[r#"
+        [
+            "compute(List(Id { value: 2 }))",
+            "compute(List(Id { value: 1 }))",
+        ]"#]]);
+
+    // When we mutate `l1`, we should re-execute `compute` for `l1`,
+    // but we should not have to re-execute `compute` for `l2`.
+    // The only inpout for `compute(l1)` is the accumulated values from `l1`,
+    // which have not changed.
+    l1.set_value(&mut db, 2);
+    assert_eq!(compute(&db, l2), 2);
+    db.assert_logs(expect![[r#"
+        [
+            "compute(List(Id { value: 2 }))",
+            "compute(List(Id { value: 1 }))",
+        ]"#]]);
+}

--- a/salsa-2022-tests/tests/accumulate.rs
+++ b/salsa-2022-tests/tests/accumulate.rs
@@ -175,6 +175,6 @@ fn get_a_logs_after_changing_b() {
             "log_a(0 of 2)",
             "log_a(1 of 2)",
         ]"#]]
-    .assert_eq(&format!("{:#?}", logs));
+        .assert_debug_eq(&logs);
     db.assert_logs(expect!["[]"]);
 }

--- a/salsa-2022-tests/tests/accumulate.rs
+++ b/salsa-2022-tests/tests/accumulate.rs
@@ -175,6 +175,6 @@ fn get_a_logs_after_changing_b() {
             "log_a(0 of 2)",
             "log_a(1 of 2)",
         ]"#]]
-        .assert_debug_eq(&logs);
+    .assert_debug_eq(&logs);
     db.assert_logs(expect!["[]"]);
 }


### PR DESCRIPTION
This branch fixes accumulators so they have the right *behavior* -- the implementation leaves something to be desired, though, in that you don't get very good re-use if you are using accumulators from inside tracked functions. Right now that is treated as an untracked read, so if you want to get good re-use you need a workaround like this one...

```rust
#[salsa::tracked(return_ref)]
fn accumulated_values(db: &dyn Db) -> Vec<T> {
    some_query::accumulated::<SomeAccumulator>(db)
}
```

...which would track and compare the new vs old vector and detect when they've changed.


Despite this limitation, this PR makes accumulators behave correctly with respect to the value taht gets returned and is good enough to Fix #313 in my opinion. I'll file an issue for the remaining improvements.