### PR TITLE
Add options to tracked funcitons for lru capacity 

### DIFF
--- a/components/salsa-2022-macros/src/accumulator.rs
+++ b/components/salsa-2022-macros/src/accumulator.rs
@@ -32,6 +32,8 @@ impl crate::options::AllowedOptions for Accumulator {
     const DB: bool = false;
 
     const RECOVERY_FN: bool = false;
+
+    const LRU: bool = false;
 }
 
 fn accumulator_contents(

--- a/components/salsa-2022-macros/src/jar.rs
+++ b/components/salsa-2022-macros/src/jar.rs
@@ -41,6 +41,8 @@ impl crate::options::AllowedOptions for Jar {
     const DB: bool = true;
 
     const RECOVERY_FN: bool = false;
+
+    const LRU: bool = false;
 }
 
 pub(crate) fn jar_struct_and_friends(

--- a/components/salsa-2022-macros/src/options.rs
+++ b/components/salsa-2022-macros/src/options.rs
@@ -46,6 +46,9 @@ pub(crate) struct Options<A: AllowedOptions> {
     /// If this is `Some`, the value is the `<ident>`.
     pub data: Option<syn::Ident>,
 
+    /// The `lru = <usize>` option is used to set the lru capacity for a tracked function.
+    /// 
+    /// If this is `Some`, the value is the `<usize>`.
     pub lru: Option<syn::LitInt>,
 
     /// Remember the `A` parameter, which plays no role after parsing.

--- a/components/salsa-2022-macros/src/salsa_struct.rs
+++ b/components/salsa-2022-macros/src/salsa_struct.rs
@@ -50,7 +50,7 @@ impl crate::options::AllowedOptions for SalsaStruct {
     const DB: bool = false;
 
     const RECOVERY_FN: bool = false;
-    
+
     const LRU: bool = false;
 }
 

--- a/components/salsa-2022-macros/src/salsa_struct.rs
+++ b/components/salsa-2022-macros/src/salsa_struct.rs
@@ -50,6 +50,8 @@ impl crate::options::AllowedOptions for SalsaStruct {
     const DB: bool = false;
 
     const RECOVERY_FN: bool = false;
+    
+    const LRU: bool = false;
 }
 
 const BANNED_FIELD_NAMES: &[&str] = &["from", "new"];

--- a/components/salsa-2022-macros/src/tracked_fn.rs
+++ b/components/salsa-2022-macros/src/tracked_fn.rs
@@ -72,6 +72,8 @@ impl crate::options::AllowedOptions for TrackedFn {
     const DB: bool = false;
 
     const RECOVERY_FN: bool = true;
+
+    const LRU: bool = true;
 }
 
 /// Returns the key type for this tracked function.

--- a/components/salsa-2022-macros/src/tracked_fn.rs
+++ b/components/salsa-2022-macros/src/tracked_fn.rs
@@ -31,6 +31,13 @@ fn tracked_fn(args: Args, item_fn: syn::ItemFn) -> syn::Result<TokenStream> {
                 "tracked functon takes too many argments to have its value set with `specify`",
             ));
         }
+
+        if args.lru.is_some() {
+            return Err(syn::Error::new(
+                s.span(),
+                "`specify` and `lru` cannot be used together",
+            ));
+        }
     }
 
     let struct_item = configuration_struct(&item_fn);

--- a/components/salsa-2022/src/function/lru.rs
+++ b/components/salsa-2022/src/function/lru.rs
@@ -18,7 +18,6 @@ impl Lru {
             return None;
         }
 
-
         let mut set = self.set.lock();
         set.insert(index);
         if set.len() > capacity {

--- a/components/salsa-2022/src/function/lru.rs
+++ b/components/salsa-2022/src/function/lru.rs
@@ -18,6 +18,7 @@ impl Lru {
             return None;
         }
 
+
         let mut set = self.set.lock();
         set.insert(index);
         if set.len() > capacity {

--- a/salsa-2022-tests/tests/lru.rs
+++ b/salsa-2022-tests/tests/lru.rs
@@ -1,15 +1,14 @@
-//! Test that a `tracked` fn on a `salsa::input`
+//! Test that a `tracked` fn with lru options
 //! compiles and executes successfully.
 
 use std::sync::{atomic::{AtomicUsize, Ordering}, Arc};
 
 use salsa_2022_tests::{HasLogger, Logger};
 
-use expect_test::expect;
 use test_log::test;
 
 #[salsa::jar(db = Db)]
-struct Jar(MyInput, get_hot_potato, EmptyInput);
+struct Jar(MyInput, get_hot_potato, EmptyInput, get_volatile);
 
 trait Db: salsa::DbWithJar<Jar> + HasLogger {}
 
@@ -43,6 +42,13 @@ fn get_hot_potato(db: &dyn Db, input: MyInput) -> Arc<HotPotato> {
     Arc::new(HotPotato::new(input.field(db)))
 }
 
+#[salsa::tracked(jar = Jar, lru = 32)]
+fn get_volatile(db: &dyn Db, _input: MyInput) -> usize {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    db.salsa_runtime().report_untracked_read();
+    COUNTER.fetch_add(1, Ordering::SeqCst)
+}
+
 #[salsa::input(jar = Jar)]
 struct EmptyInput {}
 
@@ -72,7 +78,7 @@ fn load_n_potatoes() -> usize {
 }
 
 #[test]
-fn execute() {
+fn lru_works() {
     let mut db = Database::default();
     assert_eq!(load_n_potatoes(), 0);
 
@@ -81,6 +87,26 @@ fn execute() {
         let p = get_hot_potato(&db, input);
         assert_eq!(p.0, i)
     }
-    EmptyInput::new(&mut db);
+
+    // Create a new input to change the revision, and trigger the GC
+    MyInput::new(&mut db, 0);
     assert_eq!(load_n_potatoes(), 32);
+}
+
+#[test]
+fn lru_doesnt_break_volatile_queries() {
+    let mut db = Database::default();
+
+    // Create all inputs first, so that there are no revision changes among calls to `get_volatile`
+    let inputs: Vec<MyInput> = (0..128usize).map(|i| MyInput::new(&mut db, i as u32)).collect();
+
+    // Here, we check that we execute each volatile query at most once, despite
+    // LRU. That does mean that we have more values in DB than the LRU capacity,
+    // but it's much better than inconsistent results from volatile queries!
+    for _ in 0..3 {
+        for (i, input) in inputs.iter().enumerate() {
+            let x = get_volatile(&db, *input);
+            assert_eq!(x, i);
+        }
+    }
 }

--- a/salsa-2022-tests/tests/lru.rs
+++ b/salsa-2022-tests/tests/lru.rs
@@ -8,7 +8,7 @@ use salsa_2022_tests::{HasLogger, Logger};
 use test_log::test;
 
 #[salsa::jar(db = Db)]
-struct Jar(MyInput, get_hot_potato, EmptyInput, get_volatile);
+struct Jar(MyInput, get_hot_potato, get_volatile);
 
 trait Db: salsa::DbWithJar<Jar> + HasLogger {}
 
@@ -48,9 +48,6 @@ fn get_volatile(db: &dyn Db, _input: MyInput) -> usize {
     db.salsa_runtime().report_untracked_read();
     COUNTER.fetch_add(1, Ordering::SeqCst)
 }
-
-#[salsa::input(jar = Jar)]
-struct EmptyInput {}
 
 #[salsa::db(Jar)]
 #[derive(Default)]

--- a/salsa-2022-tests/tests/lru.rs
+++ b/salsa-2022-tests/tests/lru.rs
@@ -9,7 +9,7 @@ use expect_test::expect;
 use test_log::test;
 
 #[salsa::jar(db = Db)]
-struct Jar(MyInput, get_hot_potato);
+struct Jar(MyInput, get_hot_potato, EmptyInput);
 
 trait Db: salsa::DbWithJar<Jar> + HasLogger {}
 
@@ -42,6 +42,9 @@ struct MyInput {
 fn get_hot_potato(db: &dyn Db, input: MyInput) -> Arc<HotPotato> {
     Arc::new(HotPotato::new(input.field(db)))
 }
+
+#[salsa::input(jar = Jar)]
+struct EmptyInput {}
 
 #[salsa::db(Jar)]
 #[derive(Default)]
@@ -78,7 +81,6 @@ fn execute() {
         let p = get_hot_potato(&db, input);
         assert_eq!(p.0, i)
     }
+    EmptyInput::new(&mut db);
     assert_eq!(load_n_potatoes(), 32);
-
-
 }

--- a/salsa-2022-tests/tests/lru.rs
+++ b/salsa-2022-tests/tests/lru.rs
@@ -1,0 +1,84 @@
+//! Test that a `tracked` fn on a `salsa::input`
+//! compiles and executes successfully.
+
+use std::sync::{atomic::{AtomicUsize, Ordering}, Arc};
+
+use salsa_2022_tests::{HasLogger, Logger};
+
+use expect_test::expect;
+use test_log::test;
+
+#[salsa::jar(db = Db)]
+struct Jar(MyInput, get_hot_potato);
+
+trait Db: salsa::DbWithJar<Jar> + HasLogger {}
+
+#[derive(Debug, PartialEq, Eq)]
+struct HotPotato(u32);
+
+thread_local! {
+    static N_POTATOES: AtomicUsize = AtomicUsize::new(0)
+}
+
+impl HotPotato {
+    fn new(id: u32) -> HotPotato {
+        N_POTATOES.with(|n| n.fetch_add(1, Ordering::SeqCst));
+        HotPotato(id)
+    }
+}
+
+impl Drop for HotPotato {
+    fn drop(&mut self) {
+        N_POTATOES.with(|n| n.fetch_sub(1, Ordering::SeqCst));
+    }
+}
+
+#[salsa::input(jar = Jar)]
+struct MyInput {
+    field: u32,
+}
+
+#[salsa::tracked(jar = Jar, lru = 32)]
+fn get_hot_potato(db: &dyn Db, input: MyInput) -> Arc<HotPotato> {
+    Arc::new(HotPotato::new(input.field(db)))
+}
+
+#[salsa::db(Jar)]
+#[derive(Default)]
+struct Database {
+    storage: salsa::Storage<Self>,
+    logger: Logger,
+}
+
+impl salsa::Database for Database {
+    fn salsa_runtime(&self) -> &salsa::Runtime {
+        self.storage.runtime()
+    }
+}
+
+impl Db for Database {}
+
+impl HasLogger for Database {
+    fn logger(&self) -> &Logger {
+        &self.logger
+    }
+}
+
+fn load_n_potatoes() -> usize {
+    N_POTATOES.with(|n| n.load(Ordering::SeqCst))
+}
+
+#[test]
+fn execute() {
+    let mut db = Database::default();
+    assert_eq!(load_n_potatoes(), 0);
+
+    for i in 0..128u32 {
+        let input = MyInput::new(&mut db, i);
+        let p = get_hot_potato(&db, input);
+        assert_eq!(p.0, i)
+    }
+    assert_eq!(load_n_potatoes(), 32);
+
+
+}

--- a/salsa-2022-tests/tests/mutate_in_place.rs
+++ b/salsa-2022-tests/tests/mutate_in_place.rs
@@ -3,7 +3,6 @@
 
 use salsa_2022_tests::{HasLogger, Logger};
 
-use expect_test::expect;
 use test_log::test;
 
 #[salsa::jar(db = Db)]


### PR DESCRIPTION
fixes #344 

Now we can write something like the following to set the lru capacity of tracked functions  
```rust
#[salsa::tracked(lru=32)]
fn my_tracked_fn(db: &dyn crate::Db, ...) { }
```

some details:  
* lru should not be combined with specify. We will report an error if people do #[salsa::tracked(lru = 32, specify)]
* set 0 as default capacity to disable LRU (Because I think doing this would make the code simpler when implementing `create_ingredients` of tracked functions).
* old salsa support to change lru capacity at runtime, [as noted here](https://salsa-rs.github.io/salsa/rfcs/RFC0004-LRU.html?highlight=change#reference-guide), but we do not support this now