### PR TITLE
add from impls for u32/usize

### DIFF
--- a/components/salsa-2022/src/id.rs
+++ b/components/salsa-2022/src/id.rs
@@ -38,6 +38,19 @@ impl Id {
     }
 }
 
+impl From<u32> for Id {
+    fn from(n: u32) -> Self {
+        Id::from_u32(n)
+    }
+}
+
+impl From<usize> for Id {
+    fn from(n: usize) -> Self {
+        assert!(n < Id::MAX_USIZE);
+        Id::from_u32(n as u32)
+    }
+}
+
 impl From<Id> for u32 {
     fn from(n: Id) -> Self {
         n.as_u32()


### PR DESCRIPTION
Make it easy to create an `Id`, especially from a `usize`