### PR TITLE
Permit renaming constructors, getters and setters

### DIFF
--- a/components/salsa-2022-macros/src/accumulator.rs
+++ b/components/salsa-2022-macros/src/accumulator.rs
@@ -34,6 +34,8 @@ impl crate::options::AllowedOptions for Accumulator {
     const RECOVERY_FN: bool = false;
 
     const LRU: bool = false;
+
+    const CONSTRUCTOR_NAME: bool = false;
 }
 
 fn accumulator_contents(

--- a/components/salsa-2022-macros/src/input.rs
+++ b/components/salsa-2022-macros/src/input.rs
@@ -64,13 +64,14 @@ impl InputStruct {
         let input_index = self.input_index();
 
         let field_indices = self.all_field_indices();
-        let field_names: Vec<_> = self.all_field_names();
+        let field_names = self.all_field_names();
         let field_tys: Vec<_> = self.all_field_tys();
         let field_clones: Vec<_> = self.all_fields().map(SalsaField::is_clone_field).collect();
-        let field_getters: Vec<syn::ImplItemMethod> = field_indices.iter().zip(&field_names).zip(&field_tys).zip(&field_clones).map(|(((field_index, field_name), field_ty), is_clone_field)|
+        let get_field_names: Vec<_> = self.all_get_field_names();
+        let field_getters: Vec<syn::ImplItemMethod> = field_indices.iter().zip(&get_field_names).zip(&field_tys).zip(&field_clones).map(|(((field_index, get_field_name), field_ty), is_clone_field)|
             if !*is_clone_field {
                 parse_quote! {
-                    pub fn #field_name<'db>(self, __db: &'db #db_dyn_ty) -> &'db #field_ty
+                    pub fn #get_field_name<'db>(self, __db: &'db #db_dyn_ty) -> &'db #field_ty
                     {
                         let (__jar, __runtime) = <_ as salsa::storage::HasJar<#jar_ty>>::jar(__db);
                         let __ingredients = <#jar_ty as salsa::storage::HasIngredientsFor< #ident >>::ingredient(__jar);
@@ -79,7 +80,7 @@ impl InputStruct {
                 }
             } else {
                 parse_quote! {
-                    pub fn #field_name<'db>(self, __db: &'db #db_dyn_ty) -> #field_ty
+                    pub fn #get_field_name<'db>(self, __db: &'db #db_dyn_ty) -> #field_ty
                     {
                         let (__jar, __runtime) = <_ as salsa::storage::HasJar<#jar_ty>>::jar(__db);
                         let __ingredients = <#jar_ty as salsa::storage::HasIngredientsFor< #ident >>::ingredient(__jar);
@@ -90,8 +91,8 @@ impl InputStruct {
         )
         .collect();
 
-        let field_setters: Vec<syn::ImplItemMethod> = field_indices.iter().zip(&field_names).zip(&field_tys).map(|((field_index, field_name), field_ty)| {
-            let set_field_name = syn::Ident::new(&format!("set_{}", field_name), field_name.span());
+        let set_field_names = self.all_set_field_names();
+        let field_setters: Vec<syn::ImplItemMethod> = field_indices.iter().zip(&set_field_names).zip(&field_tys).map(|((field_index, set_field_name), field_ty)| {
             parse_quote! {
                 pub fn #set_field_name<'db>(self, __db: &'db mut #db_dyn_ty, __value: #field_ty) -> #field_ty
                 {

--- a/components/salsa-2022-macros/src/input.rs
+++ b/components/salsa-2022-macros/src/input.rs
@@ -103,9 +103,10 @@ impl InputStruct {
         })
         .collect();
 
+        let constructor_name = self.constructor_name();
         parse_quote! {
             impl #ident {
-                pub fn new(__db: &mut #db_dyn_ty, #(#field_names: #field_tys,)*) -> Self
+                pub fn #constructor_name(__db: &mut #db_dyn_ty, #(#field_names: #field_tys,)*) -> Self
                 {
                     let (__jar, __runtime) = <_ as salsa::storage::HasJar<#jar_ty>>::jar_mut(__db);
                     let __ingredients = <#jar_ty as salsa::storage::HasIngredientsFor< #ident >>::ingredient_mut(__jar);

--- a/components/salsa-2022-macros/src/interned.rs
+++ b/components/salsa-2022-macros/src/interned.rs
@@ -91,8 +91,9 @@ impl InternedStruct {
         let field_names = self.all_field_names();
         let field_tys = self.all_field_tys();
         let data_ident = self.data_ident();
+        let constructor_name = self.constructor_name();
         let new_method: syn::ImplItemMethod = parse_quote! {
-            #vis fn new(
+            #vis fn #constructor_name(
                 db: &#db_dyn_ty,
                 #(#field_names: #field_tys,)*
             ) -> Self {

--- a/components/salsa-2022-macros/src/interned.rs
+++ b/components/salsa-2022-macros/src/interned.rs
@@ -68,9 +68,10 @@ impl InternedStruct {
             .map(|field| {
                 let field_name = field.name();
                 let field_ty = field.ty();
+                let field_get_name = field.get_name();
                 if field.is_clone_field() {
                     parse_quote! {
-                        #vis fn #field_name(self, db: &#db_dyn_ty) -> #field_ty {
+                        #vis fn #field_get_name(self, db: &#db_dyn_ty) -> #field_ty {
                             let (jar, runtime) = <_ as salsa::storage::HasJar<#jar_ty>>::jar(db);
                             let ingredients = <#jar_ty as salsa::storage::HasIngredientsFor< #id_ident >>::ingredient(jar);
                             std::clone::Clone::clone(&ingredients.data(runtime, self).#field_name)
@@ -78,7 +79,7 @@ impl InternedStruct {
                     }
                 } else {
                     parse_quote! {
-                        #vis fn #field_name<'db>(self, db: &'db #db_dyn_ty) -> &'db #field_ty {
+                        #vis fn #field_get_name<'db>(self, db: &'db #db_dyn_ty) -> &'db #field_ty {
                             let (jar, runtime) = <_ as salsa::storage::HasJar<#jar_ty>>::jar(db);
                             let ingredients = <#jar_ty as salsa::storage::HasIngredientsFor< #id_ident >>::ingredient(jar);
                             &ingredients.data(runtime, self).#field_name

--- a/components/salsa-2022-macros/src/jar.rs
+++ b/components/salsa-2022-macros/src/jar.rs
@@ -43,6 +43,8 @@ impl crate::options::AllowedOptions for Jar {
     const RECOVERY_FN: bool = false;
 
     const LRU: bool = false;
+
+    const CONSTRUCTOR_NAME: bool = false;
 }
 
 pub(crate) fn jar_struct_and_friends(

--- a/components/salsa-2022-macros/src/salsa_struct.rs
+++ b/components/salsa-2022-macros/src/salsa_struct.rs
@@ -26,7 +26,7 @@
 //!     * this could be optimized, particularly for interned fields
 
 use heck::CamelCase;
-use proc_macro2::Literal;
+use proc_macro2::{Ident, Literal, Span};
 
 use crate::{configuration, options::Options};
 
@@ -195,6 +195,14 @@ impl SalsaStruct {
         &self.struct_item.vis
     }
 
+    /// Returns the `constructor_name` in `Options` if it is `Some`, else `new`
+    pub(crate) fn constructor_name(&self) -> syn::Ident {
+        match self.args.constructor_name.clone() {
+            Some(name) => name,
+            None => Ident::new("new", Span::call_site()),
+        }
+    }
+
     /// For each of the fields passed as an argument,
     /// generate a struct named `Ident_Field` and an impl
     /// of `salsa::function::Configuration` for that struct.
@@ -343,12 +351,12 @@ impl SalsaField {
         Ok(result)
     }
 
-    /// The name of this field (all `EntityField` instances are named).
+    /// The name of this field (all `SalsaField` instances are named).
     pub(crate) fn name(&self) -> &syn::Ident {
         self.field.ident.as_ref().unwrap()
     }
 
-    /// The type of this field (all `EntityField` instances are named).
+    /// The type of this field (all `SalsaField` instances are named).
     pub(crate) fn ty(&self) -> &syn::Type {
         &self.field.ty
     }

--- a/components/salsa-2022-macros/src/salsa_struct.rs
+++ b/components/salsa-2022-macros/src/salsa_struct.rs
@@ -52,6 +52,8 @@ impl crate::options::AllowedOptions for SalsaStruct {
     const RECOVERY_FN: bool = false;
 
     const LRU: bool = false;
+
+    const CONSTRUCTOR_NAME: bool = true;
 }
 
 const BANNED_FIELD_NAMES: &[&str] = &["from", "new"];

--- a/components/salsa-2022-macros/src/tracked_fn.rs
+++ b/components/salsa-2022-macros/src/tracked_fn.rs
@@ -81,6 +81,8 @@ impl crate::options::AllowedOptions for TrackedFn {
     const RECOVERY_FN: bool = true;
 
     const LRU: bool = true;
+
+    const CONSTRUCTOR_NAME: bool = false;
 }
 
 /// Returns the key type for this tracked function.

--- a/components/salsa-2022-macros/src/tracked_struct.rs
+++ b/components/salsa-2022-macros/src/tracked_struct.rs
@@ -67,12 +67,13 @@ impl TrackedStruct {
 
         let id_field_indices: Vec<_> = self.id_field_indices();
         let id_field_names: Vec<_> = self.id_fields().map(SalsaField::name).collect();
+        let id_field_get_names: Vec<_> = self.id_fields().map(SalsaField::get_name).collect();
         let id_field_tys: Vec<_> = self.id_fields().map(SalsaField::ty).collect();
         let id_field_clones: Vec<_> = self.id_fields().map(SalsaField::is_clone_field).collect();
-        let id_field_getters: Vec<syn::ImplItemMethod> = id_field_indices.iter().zip(&id_field_names).zip(&id_field_tys).zip(&id_field_clones).map(|(((field_index, field_name), field_ty), is_clone_field)|
+        let id_field_getters: Vec<syn::ImplItemMethod> = id_field_indices.iter().zip(&id_field_get_names).zip(&id_field_tys).zip(&id_field_clones).map(|(((field_index, field_get_name), field_ty), is_clone_field)|
             if !*is_clone_field {
                 parse_quote! {
-                    pub fn #field_name<'db>(self, __db: &'db #db_dyn_ty) -> &'db #field_ty
+                    pub fn #field_get_name<'db>(self, __db: &'db #db_dyn_ty) -> &'db #field_ty
                     {
                         let (__jar, __runtime) = <_ as salsa::storage::HasJar<#jar_ty>>::jar(__db);
                         let __ingredients = <#jar_ty as salsa::storage::HasIngredientsFor< #ident >>::ingredient(__jar);
@@ -81,7 +82,7 @@ impl TrackedStruct {
                 }
             } else {
                 parse_quote! {
-                    pub fn #field_name<'db>(self, __db: &'db #db_dyn_ty) -> #field_ty
+                    pub fn #field_get_name<'db>(self, __db: &'db #db_dyn_ty) -> #field_ty
                     {
                         let (__jar, __runtime) = <_ as salsa::storage::HasJar<#jar_ty>>::jar(__db);
                         let __ingredients = <#jar_ty as salsa::storage::HasIngredientsFor< #ident >>::ingredient(__jar);
@@ -95,14 +96,15 @@ impl TrackedStruct {
         let value_field_indices = self.value_field_indices();
         let value_field_names: Vec<_> = self.value_fields().map(SalsaField::name).collect();
         let value_field_tys: Vec<_> = self.value_fields().map(SalsaField::ty).collect();
+        let value_field_get_names: Vec<_> = self.value_fields().map(SalsaField::get_name).collect();
         let value_field_clones: Vec<_> = self
             .value_fields()
             .map(SalsaField::is_clone_field)
             .collect();
-        let value_field_getters: Vec<syn::ImplItemMethod> = value_field_indices.iter().zip(&value_field_names).zip(&value_field_tys).zip(&value_field_clones).map(|(((field_index, field_name), field_ty), is_clone_field)|
+        let value_field_getters: Vec<syn::ImplItemMethod> = value_field_indices.iter().zip(&value_field_get_names).zip(&value_field_tys).zip(&value_field_clones).map(|(((field_index, field_get_name), field_ty), is_clone_field)|
             if !*is_clone_field {
                 parse_quote! {
-                    pub fn #field_name<'db>(self, __db: &'db #db_dyn_ty) -> &'db #field_ty
+                    pub fn #field_get_name<'db>(self, __db: &'db #db_dyn_ty) -> &'db #field_ty
                     {
                         let (__jar, __runtime) = <_ as salsa::storage::HasJar<#jar_ty>>::jar(__db);
                         let __ingredients = <#jar_ty as salsa::storage::HasIngredientsFor< #ident >>::ingredient(__jar);
@@ -111,7 +113,7 @@ impl TrackedStruct {
                 }
             } else {
                 parse_quote! {
-                    pub fn #field_name<'db>(self, __db: &'db #db_dyn_ty) -> #field_ty
+                    pub fn #field_get_name<'db>(self, __db: &'db #db_dyn_ty) -> #field_ty
                     {
                         let (__jar, __runtime) = <_ as salsa::storage::HasJar<#jar_ty>>::jar(__db);
                         let __ingredients = <#jar_ty as salsa::storage::HasIngredientsFor< #ident >>::ingredient(__jar);

--- a/components/salsa-2022-macros/src/tracked_struct.rs
+++ b/components/salsa-2022-macros/src/tracked_struct.rs
@@ -124,10 +124,11 @@ impl TrackedStruct {
 
         let all_field_names = self.all_field_names();
         let all_field_tys = self.all_field_tys();
+        let constructor_name = self.constructor_name();
 
         parse_quote! {
             impl #ident {
-                pub fn new(__db: &#db_dyn_ty, #(#all_field_names: #all_field_tys,)*) -> Self
+                pub fn #constructor_name(__db: &#db_dyn_ty, #(#all_field_names: #all_field_tys,)*) -> Self
                 {
                     let (__jar, __runtime) = <_ as salsa::storage::HasJar<#jar_ty>>::jar(__db);
                     let __ingredients = <#jar_ty as salsa::storage::HasIngredientsFor< #ident >>::ingredient(__jar);

--- a/salsa-2022-tests/tests/override_new_get_set.rs
+++ b/salsa-2022-tests/tests/override_new_get_set.rs
@@ -1,0 +1,84 @@
+//! Test that the `constructor` macro overrides
+//! the `new` method's name and `get` and `set`
+//! change the name of the getter and setter of the fields.
+#![allow(warnings)]
+
+use std::fmt::Display;
+
+#[salsa::jar(db = Db)]
+struct Jar(MyInput, MyInterned, MyTracked);
+
+trait Db: salsa::DbWithJar<Jar> {}
+
+#[salsa::input(jar = Jar, constructor = from_string)]
+struct MyInput {
+    #[get(text)]
+    #[set(set_text)]
+    field: String,
+}
+
+impl MyInput {
+    pub fn new(db: &mut dyn Db, s: impl Display) -> MyInput {
+        MyInput::from_string(db, s.to_string())
+    }
+
+    pub fn field(self, db: &dyn Db) -> String {
+        self.text(db)
+    }
+
+    pub fn set_field(self, db: &mut dyn Db, id: String) {
+        self.set_text(db, id);
+    }
+}
+
+#[salsa::interned(constructor = from_string)]
+struct MyInterned {
+    #[get(text)]
+    #[return_ref]
+    field: String,
+}
+
+impl MyInterned {
+    pub fn new(db: &dyn Db, s: impl Display) -> MyInterned {
+        MyInterned::from_string(db, s.to_string())
+    }
+
+    pub fn field(self, db: &dyn Db) -> &str {
+        &self.text(db)
+    }
+}
+
+#[salsa::tracked(constructor = from_string)]
+struct MyTracked {
+    #[get(text)]
+    field: String,
+}
+
+impl MyTracked {
+    pub fn new(db: &dyn Db, s: impl Display) -> MyTracked {
+        MyTracked::from_string(db, s.to_string())
+    }
+
+    pub fn field(self, db: &dyn Db) -> String {
+        self.text(db)
+    }
+}
+
+#[test]
+fn execute() {
+    #[salsa::db(Jar)]
+    #[derive(Default)]
+    struct Database {
+        storage: salsa::Storage<Self>,
+    }
+
+    impl salsa::Database for Database {
+        fn salsa_runtime(&self) -> &salsa::Runtime {
+            self.storage.runtime()
+        }
+    }
+
+    impl Db for Database {}
+
+    let mut db = Database::default();
+}


### PR DESCRIPTION
The goal is to add an option `constructor_name` to `#[salsa::input]`, `#[salsa::interned]` and `#[salsa::tracked]` that allows changing the name of the generated constructor. After that add attributes `get` and `set` to the fields which allow overriding the names of the getters and setters. In the end the following snippet should compile and work:
```rust
#[salsa::interned(constructor = from_string)]
struct MyInterned {
    #[get(text)] #[set(set_text)] #[return_ref]
    field: String,
}

impl MyInterned {
    pub fn new(db: &dyn Db, s: impl Display) -> MyInterned {
        MyInterned::from_string(db, s.to_string())
    }

    pub fn field(self, db: &dyn Db) -> &str {
        self.text(db)
    }

    pub fn set_field(self, db: &mut dyn Db, id: String) {
        self.set_text(&mut db, id)
    }
}
```

resolves #332 