### PR TITLE
Cargo updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ env_logger = "0.9"
 linked-hash-map = "0.5.2"
 rand = "0.8"
 rand_distr = "0.4.3"
-test-env-log = "0.2.7"
+test-log = "0.2.11"
 insta = "1.8.0"
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,10 @@ salsa-macros = { version = "0.17.0-pre.2", path = "components/salsa-macros" }
 
 [dev-dependencies]
 diff = "0.1.0"
-env_logger = "0.7"
+env_logger = "0.9"
 linked-hash-map = "0.5.2"
-rand = "0.7"
-rand_distr = "0.2.1"
+rand = "0.8"
+rand_distr = "0.4.3"
 test-env-log = "0.2.7"
 insta = "1.8.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ description = "A generic framework for on-demand, incrementalized computation (e
 [dependencies]
 arc-swap = "1.4.0"
 crossbeam-utils = { version = "0.8", default-features = false }
-dashmap = "4.0.2"
-hashlink = "0.7.0"
+dashmap = "5.3.4"
+hashlink = "0.8.0"
 indexmap = "1.0.1"
 lock_api = "0.4.7"
 log = "0.4.5"
@@ -36,5 +36,5 @@ members = [
     "components/salsa-2022",
     "components/salsa-2022-macros",
     "calc-example/calc",
-    "salsa-2022-tests"
+    "salsa-2022-tests",
 ]

--- a/components/salsa-2022-macros/Cargo.toml
+++ b/components/salsa-2022-macros/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
-heck = "0.3"
+heck = "0.4"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full", "extra-traits"] }

--- a/components/salsa-2022-macros/src/salsa_struct.rs
+++ b/components/salsa-2022-macros/src/salsa_struct.rs
@@ -25,7 +25,7 @@
 //! * data method `impl Foo { fn data(&self, db: &dyn crate::Db) -> FooData { FooData { f: self.f(db), ... } } }`
 //!     * this could be optimized, particularly for interned fields
 
-use heck::CamelCase;
+use heck::ToUpperCamelCase;
 use proc_macro2::{Ident, Literal, Span};
 
 use crate::{configuration, options::Options};
@@ -231,7 +231,7 @@ impl SalsaStruct {
                 let config_name = syn::Ident::new(
                     &format!(
                         "__{}",
-                        format!("{}_{}", ident, value_field_name).to_camel_case()
+                        format!("{}_{}", ident, value_field_name).to_upper_camel_case()
                     ),
                     value_field_name.span(),
                 );

--- a/components/salsa-2022/Cargo.toml
+++ b/components/salsa-2022/Cargo.toml
@@ -14,6 +14,6 @@ hashlink = "0.7.0"
 arc-swap = "1.4.0"
 crossbeam-utils = { version = "0.8", default-features = false }
 log = "0.4.5"
-parking_lot = "0.11.0"
+parking_lot = "0.12.1"
 smallvec = "1.0.0"
 salsa-2022-macros = { path = "../salsa-2022-macros" }

--- a/components/salsa-2022/Cargo.toml
+++ b/components/salsa-2022/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 
 [dependencies]
 crossbeam = "0.8.1"
-dashmap = "4.0.2"
+dashmap = "5.3.4"
 rustc-hash = "1.1.0"
 indexmap = "1.7.0"
-hashlink = "0.7.0"
+hashlink = "0.8.0"
 arc-swap = "1.4.0"
 crossbeam-utils = { version = "0.8", default-features = false }
 log = "0.4.5"

--- a/components/salsa-macros/Cargo.toml
+++ b/components/salsa-macros/Cargo.toml
@@ -11,7 +11,7 @@ description = "Procedural macros for the salsa crate"
 proc-macro = true
 
 [dependencies]
-heck = "0.3"
+heck = "0.4"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full", "extra-traits"] }

--- a/components/salsa-macros/src/database_storage.rs
+++ b/components/salsa-macros/src/database_storage.rs
@@ -1,4 +1,4 @@
-use heck::SnakeCase;
+use heck::ToSnakeCase;
 use proc_macro::TokenStream;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;

--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 
 use crate::parenthesized::Parenthesized;
-use heck::CamelCase;
+use heck::ToUpperCamelCase;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::ToTokens;
@@ -43,7 +43,8 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
             let mut cycle = None;
             let mut invoke = None;
 
-            let mut query_type = format_ident!("{}Query", query_name.to_string().to_camel_case());
+            let mut query_type =
+                format_ident!("{}Query", query_name.to_string().to_upper_camel_case());
             let mut num_storages = 0;
 
             // Extract attributes.
@@ -163,8 +164,10 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
             //
             //     fn lookup_foo(&self, x: u32) -> (Key1, Key2)
             let lookup_query = if let QueryStorage::Interned = storage {
-                let lookup_query_type =
-                    format_ident!("{}LookupQuery", query_name.to_string().to_camel_case());
+                let lookup_query_type = format_ident!(
+                    "{}LookupQuery",
+                    query_name.to_string().to_upper_camel_case()
+                );
                 let lookup_fn_name = format_ident!("lookup_{}", query_name);
                 let keys = keys.iter().map(|(_, ty)| ty);
                 let lookup_value: Type = parse_quote!((#(#keys),*));

--- a/tests/cycles.rs
+++ b/tests/cycles.rs
@@ -1,7 +1,7 @@
 use std::panic::UnwindSafe;
 
 use salsa::{Durability, ParallelDatabase, Snapshot};
-use test_env_log::test;
+use test_log::test;
 
 // Axes:
 //

--- a/tests/incremental/memoized_volatile.rs
+++ b/tests/incremental/memoized_volatile.rs
@@ -1,6 +1,6 @@
 use crate::implementation::{TestContext, TestContextImpl};
 use salsa::{Database, Durability};
-use test_env_log::test;
+use test_log::test;
 
 #[salsa::query_group(MemoizedVolatile)]
 pub(crate) trait MemoizedVolatileContext: TestContext {

--- a/tests/parallel/parallel_cycle_all_recover.rs
+++ b/tests/parallel/parallel_cycle_all_recover.rs
@@ -4,7 +4,7 @@
 
 use crate::setup::{Knobs, ParDatabaseImpl};
 use salsa::ParallelDatabase;
-use test_env_log::test;
+use test_log::test;
 
 // Recover cycle test:
 //

--- a/tests/parallel/parallel_cycle_mid_recover.rs
+++ b/tests/parallel/parallel_cycle_mid_recover.rs
@@ -4,7 +4,7 @@
 
 use crate::setup::{Knobs, ParDatabaseImpl};
 use salsa::ParallelDatabase;
-use test_env_log::test;
+use test_log::test;
 
 // Recover cycle test:
 //

--- a/tests/parallel/parallel_cycle_none_recover.rs
+++ b/tests/parallel/parallel_cycle_none_recover.rs
@@ -4,7 +4,7 @@
 
 use crate::setup::{Knobs, ParDatabaseImpl};
 use salsa::ParallelDatabase;
-use test_env_log::test;
+use test_log::test;
 
 #[test]
 fn parallel_cycle_none_recover() {

--- a/tests/parallel/parallel_cycle_one_recovers.rs
+++ b/tests/parallel/parallel_cycle_one_recovers.rs
@@ -4,7 +4,7 @@
 
 use crate::setup::{Knobs, ParDatabaseImpl};
 use salsa::ParallelDatabase;
-use test_env_log::test;
+use test_log::test;
 
 // Recover cycle test:
 //


### PR DESCRIPTION
- Unify `parking_log` versions
- `test-env-log` has been renamed
- Update `heck`, `dashmap` and `hashlink` to theirs latest versions

With this `cargo tree --workspace --duplicates` now doesn't return anything, when in master it returned:
```
env_logger v0.7.1
[dev-dependencies]
└── salsa v0.17.0-pre.2 (/home/berni/Documents/src/salsa)

env_logger v0.9.0
└── salsa-2022-tests v0.1.0 (/home/berni/Documents/src/salsa/salsa-2022-tests)

getrandom v0.1.16
├── rand v0.7.3
│   └── rand_distr v0.2.2
│       [dev-dependencies]
│       └── salsa v0.17.0-pre.2 (/home/berni/Documents/src/salsa)
│   [dev-dependencies]
│   └── salsa v0.17.0-pre.2 (/home/berni/Documents/src/salsa)
└── rand_core v0.5.1
    ├── rand v0.7.3 (*)
    └── rand_chacha v0.2.2
        └── rand v0.7.3 (*)

getrandom v0.2.7
└── ahash v0.7.6
    └── hashbrown v0.11.2
        └── hashlink v0.7.0
            ├── salsa v0.17.0-pre.2 (/home/berni/Documents/src/salsa)
            └── salsa-2022 v0.1.0 (/home/berni/Documents/src/salsa/components/salsa-2022)
                ├── calc v0.1.0 (/home/berni/Documents/src/salsa/calc-example/calc)
                └── salsa-2022-tests v0.1.0 (/home/berni/Documents/src/salsa/salsa-2022-tests)

hashbrown v0.11.2 (*)

hashbrown v0.12.3
└── indexmap v1.9.1
    ├── salsa v0.17.0-pre.2 (/home/berni/Documents/src/salsa)
    └── salsa-2022 v0.1.0 (/home/berni/Documents/src/salsa/components/salsa-2022) (*)

humantime v1.3.0
└── env_logger v0.7.1 (*)

humantime v2.1.0
└── env_logger v0.9.0 (*)
```
