### PR TITLE
add `synthetic_write`

### DIFF
--- a/calc-example/calc/src/db.rs
+++ b/calc-example/calc/src/db.rs
@@ -47,14 +47,6 @@ impl Default for Database {
 
 // ANCHOR: db_impl
 impl salsa::Database for Database {
-    fn salsa_runtime(&self) -> &salsa::Runtime {
-        self.storage.runtime()
-    }
-
-    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
-        self.storage.runtime_mut()
-    }
-
     fn salsa_event(&self, event: salsa::Event) {
         // Log interesting events, if logging is enabled
         if let Some(logs) = &self.logs {

--- a/calc-example/calc/src/db.rs
+++ b/calc-example/calc/src/db.rs
@@ -51,6 +51,10 @@ impl salsa::Database for Database {
         self.storage.runtime()
     }
 
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
+        self.storage.runtime_mut()
+    }
+
     fn salsa_event(&self, event: salsa::Event) {
         // Log interesting events, if logging is enabled
         if let Some(logs) = &self.logs {

--- a/components/salsa-2022-macros/src/db.rs
+++ b/components/salsa-2022-macros/src/db.rs
@@ -120,6 +120,10 @@ fn has_jars_dyn_impl(input: &syn::ItemStruct, storage: &syn::Ident) -> syn::Item
                 self.#storage.runtime()
             }
 
+            fn runtime_mut(&mut self) ->&mut salsa::Runtime {
+                self.#storage.runtime_mut()
+            }
+
             fn maybe_changed_after(
                 &self,
                 input: salsa::key::DependencyIndex,
@@ -159,9 +163,14 @@ fn has_jars_dyn_impl(input: &syn::ItemStruct, storage: &syn::Ident) -> syn::Item
                 let ingredient = self.#storage.ingredient(ingredient);
                 ingredient.salsa_struct_deleted(self, id);
             }
+
             fn fmt_index(&self, index: salsa::key::DependencyIndex, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 let ingredient = self.#storage.ingredient(index.ingredient_index());
                 ingredient.fmt_index(index.key_index(), fmt)
+            }
+
+            fn synthetic_write(&mut self, durability: salsa::Durability) {
+                self.runtime_mut().synthetic_write(durability);
             }
         }
     }

--- a/components/salsa-2022-macros/src/db.rs
+++ b/components/salsa-2022-macros/src/db.rs
@@ -168,10 +168,6 @@ fn has_jars_dyn_impl(input: &syn::ItemStruct, storage: &syn::Ident) -> syn::Item
                 let ingredient = self.#storage.ingredient(index.ingredient_index());
                 ingredient.fmt_index(index.key_index(), fmt)
             }
-
-            fn synthetic_write(&mut self, durability: salsa::Durability) {
-                self.runtime_mut().synthetic_write(durability);
-            }
         }
     }
 }

--- a/components/salsa-2022/src/accumulator.rs
+++ b/components/salsa-2022/src/accumulator.rs
@@ -120,7 +120,7 @@ where
         output_key: Option<crate::Id>,
     ) {
         assert!(output_key.is_none());
-        let current_revision = db.salsa_runtime().current_revision();
+        let current_revision = db.runtime().current_revision();
         if let Some(mut v) = self.map.get_mut(&executor) {
             // The value is still valid in the new revision.
             v.produced_at = current_revision;
@@ -136,7 +136,7 @@ where
         assert!(stale_output_key.is_none());
         if self.map.remove(&executor).is_some() {
             db.salsa_event(Event {
-                runtime_id: db.salsa_runtime().id(),
+                runtime_id: db.runtime().id(),
                 kind: EventKind::DidDiscardAccumulated {
                     executor_key: executor,
                     accumulator: self.dependency_index(),

--- a/components/salsa-2022/src/database.rs
+++ b/components/salsa-2022/src/database.rs
@@ -22,6 +22,14 @@ pub trait Database: HasJarsDyn + AsSalsaDatabase {
     fn synthetic_write(&mut self, durability: Durability) {
         self.runtime_mut().synthetic_write(durability);
     }
+
+    /// Reports that the query depends on some state unknown to salsa.
+    ///
+    /// Queries which report untracked reads will be re-executed in the next
+    /// revision.
+    fn report_untracked_read(&self) {
+        self.runtime().report_untracked_read();
+    }
 }
 
 /// Indicates a database that also supports parallel query

--- a/components/salsa-2022/src/database.rs
+++ b/components/salsa-2022/src/database.rs
@@ -11,9 +11,9 @@ pub trait Database: HasJarsDyn + AsSalsaDatabase {
         log::debug!("salsa_event: {:?}", event.debug(self));
     }
 
-    fn salsa_runtime(&self) -> &Runtime;
-
-    fn salsa_runtime_mut(&mut self) -> &mut Runtime;
+    fn salsa_runtime(&self) -> &Runtime {
+        self.runtime()
+    }
 }
 
 /// Indicates a database that also supports parallel query

--- a/components/salsa-2022/src/database.rs
+++ b/components/salsa-2022/src/database.rs
@@ -12,6 +12,8 @@ pub trait Database: HasJarsDyn + AsSalsaDatabase {
     }
 
     fn salsa_runtime(&self) -> &Runtime;
+
+    fn salsa_runtime_mut(&mut self) -> &mut Runtime;
 }
 
 /// Indicates a database that also supports parallel query

--- a/components/salsa-2022/src/database.rs
+++ b/components/salsa-2022/src/database.rs
@@ -1,4 +1,4 @@
-use crate::{storage::HasJarsDyn, DebugWithDb, Event, Runtime};
+use crate::{storage::HasJarsDyn, DebugWithDb, Event};
 
 pub trait Database: HasJarsDyn + AsSalsaDatabase {
     /// This function is invoked at key points in the salsa
@@ -9,10 +9,6 @@ pub trait Database: HasJarsDyn + AsSalsaDatabase {
     /// the standard `log` facade.
     fn salsa_event(&self, event: Event) {
         log::debug!("salsa_event: {:?}", event.debug(self));
-    }
-
-    fn salsa_runtime(&self) -> &Runtime {
-        self.runtime()
     }
 }
 

--- a/components/salsa-2022/src/database.rs
+++ b/components/salsa-2022/src/database.rs
@@ -20,7 +20,7 @@ pub trait Database: HasJarsDyn + AsSalsaDatabase {
     /// will block until that snapshot is dropped -- if that snapshot
     /// is owned by the current thread, this could trigger deadlock.
     fn synthetic_write(&mut self, durability: Durability) {
-        self.runtime_mut().synthetic_write(durability);
+        self.runtime_mut().report_tracked_write(durability);
     }
 
     /// Reports that the query depends on some state unknown to salsa.

--- a/components/salsa-2022/src/event.rs
+++ b/components/salsa-2022/src/event.rs
@@ -56,7 +56,7 @@ pub enum EventKind {
     /// before they have answered us.
     ///
     /// (NB: you can find the `id` of the current thread via the
-    /// `salsa_runtime`)
+    /// `runtime`)
     WillBlockOn {
         /// The id of the runtime we will block on.
         other_runtime_id: RuntimeId,

--- a/components/salsa-2022/src/function.rs
+++ b/components/salsa-2022/src/function.rs
@@ -261,7 +261,7 @@ where
         if let Some(origin) = self.delete_memo(id) {
             let key = self.database_key_index(id);
             db.salsa_event(Event {
-                runtime_id: db.salsa_runtime().id(),
+                runtime_id: db.runtime().id(),
                 kind: EventKind::DidDiscard { key },
             });
 

--- a/components/salsa-2022/src/function/accumulated.rs
+++ b/components/salsa-2022/src/function/accumulated.rs
@@ -3,7 +3,7 @@ use crate::{
     key::DependencyIndex,
     runtime::local_state::QueryOrigin,
     storage::{HasJar, HasJarsDyn},
-    Database, DatabaseKeyIndex,
+    DatabaseKeyIndex,
 };
 
 use super::{Configuration, DynDb, FunctionIngredient};
@@ -26,7 +26,7 @@ where
         // Now walk over all the things that the value depended on
         // and find the values they accumulated into the given
         // accumulator:
-        let runtime = db.salsa_runtime();
+        let runtime = db.runtime();
         let mut result = vec![];
         let accumulator_ingredient = A::accumulator_ingredient(db);
         let mut stack = Stack::new(self.database_key_index(key));

--- a/components/salsa-2022/src/function/diff_outputs.rs
+++ b/components/salsa-2022/src/function/diff_outputs.rs
@@ -45,7 +45,7 @@ where
     }
 
     fn report_stale_output(db: &DynDb<'_, C>, key: DatabaseKeyIndex, output: DependencyIndex) {
-        let runtime_id = db.salsa_runtime().id();
+        let runtime_id = db.runtime().id();
         db.salsa_event(Event {
             runtime_id,
             kind: EventKind::WillDiscardStaleOutput {

--- a/components/salsa-2022/src/function/execute.rs
+++ b/components/salsa-2022/src/function/execute.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use crate::{
     debug::DebugWithDb,
     runtime::{local_state::ActiveQueryGuard, StampedValue},
+    storage::HasJarsDyn,
     Cycle, Database, Event, EventKind,
 };
 
@@ -27,7 +28,7 @@ where
         active_query: ActiveQueryGuard<'_>,
         opt_old_memo: Option<Arc<Memo<C::Value>>>,
     ) -> StampedValue<&C::Value> {
-        let runtime = db.salsa_runtime();
+        let runtime = db.runtime();
         let revision_now = runtime.current_revision();
         let database_key_index = active_query.database_key_index;
 

--- a/components/salsa-2022/src/function/fetch.rs
+++ b/components/salsa-2022/src/function/fetch.rs
@@ -1,6 +1,6 @@
 use arc_swap::Guard;
 
-use crate::{database::AsSalsaDatabase, runtime::StampedValue, AsId, Database};
+use crate::{database::AsSalsaDatabase, runtime::StampedValue, storage::HasJarsDyn, AsId};
 
 use super::{Configuration, DynDb, FunctionIngredient};
 
@@ -9,7 +9,7 @@ where
     C: Configuration,
 {
     pub fn fetch(&self, db: &DynDb<C>, key: C::Key) -> &C::Value {
-        let runtime = db.salsa_runtime();
+        let runtime = db.runtime();
 
         runtime.unwind_if_revision_cancelled(db);
 
@@ -23,7 +23,7 @@ where
             self.evict(AsId::from_id(evicted));
         }
 
-        db.salsa_runtime().report_tracked_read(
+        db.runtime().report_tracked_read(
             self.database_key_index(key).into(),
             durability,
             changed_at,
@@ -46,7 +46,7 @@ where
         let memo_guard = self.memo_map.get(key);
         if let Some(memo) = &memo_guard {
             if memo.value.is_some() {
-                let runtime = db.salsa_runtime();
+                let runtime = db.runtime();
                 if self.shallow_verify_memo(db, runtime, self.database_key_index(key), memo) {
                     let value = unsafe {
                         // Unsafety invariant: memo is present in memo_map
@@ -60,7 +60,7 @@ where
     }
 
     fn fetch_cold(&self, db: &DynDb<C>, key: C::Key) -> Option<StampedValue<&C::Value>> {
-        let runtime = db.salsa_runtime();
+        let runtime = db.runtime();
         let database_key_index = self.database_key_index(key);
 
         // Try to claim this query: if someone else has claimed it already, go back and start again.

--- a/components/salsa-2022/src/function/maybe_changed_after.rs
+++ b/components/salsa-2022/src/function/maybe_changed_after.rs
@@ -9,7 +9,7 @@ use crate::{
         StampedValue,
     },
     storage::HasJarsDyn,
-    Database, Revision, Runtime,
+    Revision, Runtime,
 };
 
 use super::{memo::Memo, Configuration, DynDb, FunctionIngredient};
@@ -24,7 +24,7 @@ where
         key: C::Key,
         revision: Revision,
     ) -> bool {
-        let runtime = db.salsa_runtime();
+        let runtime = db.runtime();
         runtime.unwind_if_revision_cancelled(db);
 
         loop {
@@ -61,7 +61,7 @@ where
         key_index: C::Key,
         revision: Revision,
     ) -> Option<bool> {
-        let runtime = db.salsa_runtime();
+        let runtime = db.runtime();
         let database_key_index = self.database_key_index(key_index);
 
         let _claim_guard = self
@@ -148,7 +148,7 @@ where
         old_memo: &Memo<C::Value>,
         active_query: &ActiveQueryGuard<'_>,
     ) -> bool {
-        let runtime = db.salsa_runtime();
+        let runtime = db.runtime();
         let database_key_index = active_query.database_key_index;
 
         log::debug!(

--- a/components/salsa-2022/src/function/specify.rs
+++ b/components/salsa-2022/src/function/specify.rs
@@ -3,8 +3,9 @@ use crossbeam::atomic::AtomicCell;
 use crate::{
     database::AsSalsaDatabase,
     runtime::local_state::{QueryOrigin, QueryRevisions},
+    storage::HasJarsDyn,
     tracked_struct::TrackedStructInDb,
-    Database, DatabaseKeyIndex, DebugWithDb,
+    DatabaseKeyIndex, DebugWithDb,
 };
 
 use super::{memo::Memo, Configuration, DynDb, FunctionIngredient};
@@ -25,7 +26,7 @@ where
     ) where
         C::Key: TrackedStructInDb<DynDb<'db, C>>,
     {
-        let runtime = db.salsa_runtime();
+        let runtime = db.runtime();
 
         let (active_query_key, current_deps) = match runtime.active_query() {
             Some(v) => v,
@@ -101,7 +102,7 @@ where
 
         // Record that the current query *specified* a value for this cell.
         let database_key_index = self.database_key_index(key);
-        db.salsa_runtime().add_output(database_key_index.into());
+        db.runtime().add_output(database_key_index.into());
     }
 
     /// Invoked when the query `executor` has been validated as having green inputs
@@ -114,7 +115,7 @@ where
         executor: DatabaseKeyIndex,
         key: C::Key,
     ) {
-        let runtime = db.salsa_runtime();
+        let runtime = db.runtime();
 
         let memo = match self.memo_map.get(key) {
             Some(m) => m,

--- a/components/salsa-2022/src/function/sync.rs
+++ b/components/salsa-2022/src/function/sync.rs
@@ -26,7 +26,7 @@ impl SyncMap {
         db: &'me dyn Database,
         database_key_index: DatabaseKeyIndex,
     ) -> Option<ClaimGuard<'me>> {
-        let runtime = db.salsa_runtime();
+        let runtime = db.runtime();
         match self.sync_map.entry(database_key_index.key_index) {
             dashmap::mapref::entry::Entry::Vacant(entry) => {
                 entry.insert(SyncState {

--- a/components/salsa-2022/src/runtime.rs
+++ b/components/salsa-2022/src/runtime.rs
@@ -144,6 +144,19 @@ impl Runtime {
         }
     }
 
+    /// A "synthetic write" causes the system to act *as though* some
+    /// input of durability `durability` has changed. This is mostly
+    /// useful for profiling scenarios.
+    ///
+    /// **WARNING:** Just like an ordinary write, this method triggers
+    /// cancellation. If you invoke it while a snapshot exists, it
+    /// will block until that snapshot is dropped -- if that snapshot
+    /// is owned by the current thread, this could trigger deadlock.
+    pub fn synthetic_write(&mut self, durability: Durability) {
+        self.new_revision();
+        self.report_tracked_write(durability)
+    }
+
     /// Adds `key` to the list of output created by the current query
     /// (if not already present).
     pub(crate) fn add_output(&self, key: DependencyIndex) {

--- a/components/salsa-2022/src/runtime.rs
+++ b/components/salsa-2022/src/runtime.rs
@@ -144,19 +144,6 @@ impl Runtime {
         }
     }
 
-    /// A "synthetic write" causes the system to act *as though* some
-    /// input of durability `durability` has changed. This is mostly
-    /// useful for profiling scenarios.
-    ///
-    /// **WARNING:** Just like an ordinary write, this method triggers
-    /// cancellation. If you invoke it while a snapshot exists, it
-    /// will block until that snapshot is dropped -- if that snapshot
-    /// is owned by the current thread, this could trigger deadlock.
-    pub fn synthetic_write(&mut self, durability: Durability) {
-        self.new_revision();
-        self.report_tracked_write(durability)
-    }
-
     /// Adds `key` to the list of output created by the current query
     /// (if not already present).
     pub(crate) fn add_output(&self, key: DependencyIndex) {

--- a/components/salsa-2022/src/storage.rs
+++ b/components/salsa-2022/src/storage.rs
@@ -93,6 +93,10 @@ where
         &self.runtime
     }
 
+    pub fn runtime_mut(&mut self) -> &mut Runtime {
+        &mut self.runtime
+    }
+
     // ANCHOR: jars_mut
     /// Gets mutable access to the jars. This will trigger a new revision
     /// and it will also cancel any ongoing work in the current revision.

--- a/components/salsa-2022/src/storage.rs
+++ b/components/salsa-2022/src/storage.rs
@@ -8,7 +8,7 @@ use crate::jar::Jar;
 use crate::key::DependencyIndex;
 use crate::runtime::local_state::QueryOrigin;
 use crate::runtime::Runtime;
-use crate::{Database, DatabaseKeyIndex, Id, IngredientIndex, Durability};
+use crate::{Database, DatabaseKeyIndex, Durability, Id, IngredientIndex};
 
 use super::routes::Routes;
 use super::{ParallelDatabase, Revision};
@@ -94,7 +94,7 @@ where
     }
 
     pub fn runtime_mut(&mut self) -> &mut Runtime {
-        &mut self.runtime
+        self.jars_mut().1
     }
 
     // ANCHOR: jars_mut

--- a/components/salsa-2022/src/storage.rs
+++ b/components/salsa-2022/src/storage.rs
@@ -8,7 +8,7 @@ use crate::jar::Jar;
 use crate::key::DependencyIndex;
 use crate::runtime::local_state::QueryOrigin;
 use crate::runtime::Runtime;
-use crate::{Database, DatabaseKeyIndex, Id, IngredientIndex};
+use crate::{Database, DatabaseKeyIndex, Id, IngredientIndex, Durability};
 
 use super::routes::Routes;
 use super::{ParallelDatabase, Revision};
@@ -203,6 +203,8 @@ pub trait HasJar<J> {
 pub trait HasJarsDyn {
     fn runtime(&self) -> &Runtime;
 
+    fn runtime_mut(&mut self) -> &mut Runtime;
+
     fn maybe_changed_after(&self, input: DependencyIndex, revision: Revision) -> bool;
 
     fn cycle_recovery_strategy(&self, input: IngredientIndex) -> CycleRecoveryStrategy;
@@ -226,6 +228,8 @@ pub trait HasJarsDyn {
     fn salsa_struct_deleted(&self, ingredient: IngredientIndex, id: Id);
 
     fn fmt_index(&self, index: DependencyIndex, fmt: &mut fmt::Formatter<'_>) -> fmt::Result;
+
+    fn synthetic_write(&mut self, durability: Durability);
 }
 // ANCHOR_END: HasJarsDyn
 

--- a/components/salsa-2022/src/storage.rs
+++ b/components/salsa-2022/src/storage.rs
@@ -228,8 +228,6 @@ pub trait HasJarsDyn {
     fn salsa_struct_deleted(&self, ingredient: IngredientIndex, id: Id);
 
     fn fmt_index(&self, index: DependencyIndex, fmt: &mut fmt::Formatter<'_>) -> fmt::Result;
-
-    fn synthetic_write(&mut self, durability: Durability);
 }
 // ANCHOR_END: HasJarsDyn
 

--- a/components/salsa-2022/src/storage.rs
+++ b/components/salsa-2022/src/storage.rs
@@ -8,7 +8,7 @@ use crate::jar::Jar;
 use crate::key::DependencyIndex;
 use crate::runtime::local_state::QueryOrigin;
 use crate::runtime::Runtime;
-use crate::{Database, DatabaseKeyIndex, Durability, Id, IngredientIndex};
+use crate::{Database, DatabaseKeyIndex, Id, IngredientIndex};
 
 use super::routes::Routes;
 use super::{ParallelDatabase, Revision};

--- a/components/salsa-2022/src/tracked_struct.rs
+++ b/components/salsa-2022/src/tracked_struct.rs
@@ -111,7 +111,7 @@ where
     /// discussion and important considerations.
     pub(crate) fn delete_entity(&self, db: &dyn crate::Database, id: Id) {
         db.salsa_event(Event {
-            runtime_id: db.salsa_runtime().id(),
+            runtime_id: db.runtime().id(),
             kind: crate::EventKind::DidDiscard {
                 key: self.database_key_index(id),
             },

--- a/salsa-2022-tests/tests/accumulate-from-tracked-fn.rs
+++ b/salsa-2022-tests/tests/accumulate-from-tracked-fn.rs
@@ -55,6 +55,10 @@ impl salsa::Database for Database {
     fn salsa_runtime(&self) -> &salsa::Runtime {
         self.storage.runtime()
     }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
+        self.storage.runtime_mut()
+    }
 }
 
 impl Db for Database {}

--- a/salsa-2022-tests/tests/accumulate-from-tracked-fn.rs
+++ b/salsa-2022-tests/tests/accumulate-from-tracked-fn.rs
@@ -51,14 +51,6 @@ struct Database {
 
 impl salsa::Database for Database {
     fn salsa_event(&self, _event: salsa::Event) {}
-
-    fn salsa_runtime(&self) -> &salsa::Runtime {
-        self.storage.runtime()
-    }
-
-    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
-        self.storage.runtime_mut()
-    }
 }
 
 impl Db for Database {}

--- a/salsa-2022-tests/tests/accumulate-reuse-workaround.rs
+++ b/salsa-2022-tests/tests/accumulate-reuse-workaround.rs
@@ -59,6 +59,10 @@ impl salsa::Database for Database {
     fn salsa_runtime(&self) -> &salsa::Runtime {
         self.storage.runtime()
     }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
+        self.storage.runtime_mut()
+    }
 }
 
 impl Db for Database {}

--- a/salsa-2022-tests/tests/accumulate-reuse-workaround.rs
+++ b/salsa-2022-tests/tests/accumulate-reuse-workaround.rs
@@ -55,14 +55,6 @@ struct Database {
 
 impl salsa::Database for Database {
     fn salsa_event(&self, _event: salsa::Event) {}
-
-    fn salsa_runtime(&self) -> &salsa::Runtime {
-        self.storage.runtime()
-    }
-
-    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
-        self.storage.runtime_mut()
-    }
 }
 
 impl Db for Database {}

--- a/salsa-2022-tests/tests/accumulate-reuse.rs
+++ b/salsa-2022-tests/tests/accumulate-reuse.rs
@@ -50,14 +50,6 @@ struct Database {
 
 impl salsa::Database for Database {
     fn salsa_event(&self, _event: salsa::Event) {}
-
-    fn salsa_runtime(&self) -> &salsa::Runtime {
-        self.storage.runtime()
-    }
-
-    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
-        self.storage.runtime_mut()
-    }
 }
 
 impl Db for Database {}

--- a/salsa-2022-tests/tests/accumulate-reuse.rs
+++ b/salsa-2022-tests/tests/accumulate-reuse.rs
@@ -54,6 +54,10 @@ impl salsa::Database for Database {
     fn salsa_runtime(&self) -> &salsa::Runtime {
         self.storage.runtime()
     }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
+        self.storage.runtime_mut()
+    }
 }
 
 impl Db for Database {}

--- a/salsa-2022-tests/tests/accumulate.rs
+++ b/salsa-2022-tests/tests/accumulate.rs
@@ -74,6 +74,10 @@ impl salsa::Database for Database {
     fn salsa_runtime(&self) -> &salsa::Runtime {
         self.storage.runtime()
     }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
+        self.storage.runtime_mut()
+    }
 }
 
 impl Db for Database {}

--- a/salsa-2022-tests/tests/accumulate.rs
+++ b/salsa-2022-tests/tests/accumulate.rs
@@ -70,14 +70,6 @@ struct Database {
 
 impl salsa::Database for Database {
     fn salsa_event(&self, _event: salsa::Event) {}
-
-    fn salsa_runtime(&self) -> &salsa::Runtime {
-        self.storage.runtime()
-    }
-
-    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
-        self.storage.runtime_mut()
-    }
 }
 
 impl Db for Database {}

--- a/salsa-2022-tests/tests/cycles.rs
+++ b/salsa-2022-tests/tests/cycles.rs
@@ -3,7 +3,6 @@
 use std::panic::{RefUnwindSafe, UnwindSafe};
 
 use expect_test::expect;
-use salsa::storage::HasJarsDyn;
 use salsa::Durability;
 
 // Axes:
@@ -99,13 +98,13 @@ fn memoized_b(db: &dyn Db, input: MyInput) {
 
 #[salsa::tracked(jar = Jar)]
 fn volatile_a(db: &dyn Db, input: MyInput) {
-    db.runtime().report_untracked_read();
+    db.report_untracked_read();
     volatile_b(db, input)
 }
 
 #[salsa::tracked(jar = Jar)]
 fn volatile_b(db: &dyn Db, input: MyInput) {
-    db.runtime().report_untracked_read();
+    db.report_untracked_read();
     volatile_a(db, input)
 }
 

--- a/salsa-2022-tests/tests/cycles.rs
+++ b/salsa-2022-tests/tests/cycles.rs
@@ -82,6 +82,10 @@ impl salsa::Database for Database {
     fn salsa_runtime(&self) -> &salsa::Runtime {
         self.storage.runtime()
     }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
+        self.storage.runtime_mut()
+    }
 }
 
 impl Db for Database {}

--- a/salsa-2022-tests/tests/cycles.rs
+++ b/salsa-2022-tests/tests/cycles.rs
@@ -78,17 +78,9 @@ struct Database {
     storage: salsa::Storage<Self>,
 }
 
-impl salsa::Database for Database {
-    fn salsa_runtime(&self) -> &salsa::Runtime {
-        self.storage.runtime()
-    }
-
-    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
-        self.storage.runtime_mut()
-    }
-}
-
 impl Db for Database {}
+
+impl salsa::Database for Database {}
 
 impl RefUnwindSafe for Database {}
 

--- a/salsa-2022-tests/tests/debug.rs
+++ b/salsa-2022-tests/tests/debug.rs
@@ -34,6 +34,10 @@ impl salsa::Database for Database {
     fn salsa_runtime(&self) -> &salsa::Runtime {
         self.storage.runtime()
     }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
+        self.storage.runtime_mut()
+    }
 }
 
 impl Db for Database {}

--- a/salsa-2022-tests/tests/debug.rs
+++ b/salsa-2022-tests/tests/debug.rs
@@ -30,15 +30,7 @@ struct Database {
     storage: salsa::Storage<Self>,
 }
 
-impl salsa::Database for Database {
-    fn salsa_runtime(&self) -> &salsa::Runtime {
-        self.storage.runtime()
-    }
-
-    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
-        self.storage.runtime_mut()
-    }
-}
+impl salsa::Database for Database {}
 
 impl Db for Database {}
 

--- a/salsa-2022-tests/tests/deletion-cascade.rs
+++ b/salsa-2022-tests/tests/deletion-cascade.rs
@@ -76,14 +76,6 @@ impl salsa::Database for Database {
             _ => {}
         }
     }
-
-    fn salsa_runtime(&self) -> &salsa::Runtime {
-        self.storage.runtime()
-    }
-
-    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
-        self.storage.runtime_mut()
-    }
 }
 
 impl Db for Database {}

--- a/salsa-2022-tests/tests/deletion-cascade.rs
+++ b/salsa-2022-tests/tests/deletion-cascade.rs
@@ -80,6 +80,10 @@ impl salsa::Database for Database {
     fn salsa_runtime(&self) -> &salsa::Runtime {
         self.storage.runtime()
     }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
+        self.storage.runtime_mut()
+    }
 }
 
 impl Db for Database {}

--- a/salsa-2022-tests/tests/deletion.rs
+++ b/salsa-2022-tests/tests/deletion.rs
@@ -73,6 +73,10 @@ impl salsa::Database for Database {
     fn salsa_runtime(&self) -> &salsa::Runtime {
         self.storage.runtime()
     }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
+        self.storage.runtime_mut()
+    }
 }
 
 impl Db for Database {}

--- a/salsa-2022-tests/tests/deletion.rs
+++ b/salsa-2022-tests/tests/deletion.rs
@@ -69,14 +69,6 @@ impl salsa::Database for Database {
             _ => {}
         }
     }
-
-    fn salsa_runtime(&self) -> &salsa::Runtime {
-        self.storage.runtime()
-    }
-
-    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
-        self.storage.runtime_mut()
-    }
 }
 
 impl Db for Database {}

--- a/salsa-2022-tests/tests/expect_reuse_field_x_of_a_tracked_struct_changes_but_fn_depends_on_field_y.rs
+++ b/salsa-2022-tests/tests/expect_reuse_field_x_of_a_tracked_struct_changes_but_fn_depends_on_field_y.rs
@@ -57,6 +57,10 @@ impl salsa::Database for Database {
     fn salsa_runtime(&self) -> &salsa::Runtime {
         self.storage.runtime()
     }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
+        self.storage.runtime_mut()
+    }
 }
 
 impl Db for Database {}

--- a/salsa-2022-tests/tests/expect_reuse_field_x_of_a_tracked_struct_changes_but_fn_depends_on_field_y.rs
+++ b/salsa-2022-tests/tests/expect_reuse_field_x_of_a_tracked_struct_changes_but_fn_depends_on_field_y.rs
@@ -53,15 +53,7 @@ struct Database {
     logger: Logger,
 }
 
-impl salsa::Database for Database {
-    fn salsa_runtime(&self) -> &salsa::Runtime {
-        self.storage.runtime()
-    }
-
-    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
-        self.storage.runtime_mut()
-    }
-}
+impl salsa::Database for Database {}
 
 impl Db for Database {}
 

--- a/salsa-2022-tests/tests/expect_reuse_field_x_of_an_input_changes_but_fn_depends_on_field_y.rs
+++ b/salsa-2022-tests/tests/expect_reuse_field_x_of_an_input_changes_but_fn_depends_on_field_y.rs
@@ -41,6 +41,10 @@ impl salsa::Database for Database {
     fn salsa_runtime(&self) -> &salsa::Runtime {
         self.storage.runtime()
     }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
+        self.storage.runtime_mut()
+    }
 }
 
 impl Db for Database {}

--- a/salsa-2022-tests/tests/expect_reuse_field_x_of_an_input_changes_but_fn_depends_on_field_y.rs
+++ b/salsa-2022-tests/tests/expect_reuse_field_x_of_an_input_changes_but_fn_depends_on_field_y.rs
@@ -37,15 +37,7 @@ struct Database {
     logger: Logger,
 }
 
-impl salsa::Database for Database {
-    fn salsa_runtime(&self) -> &salsa::Runtime {
-        self.storage.runtime()
-    }
-
-    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
-        self.storage.runtime_mut()
-    }
-}
+impl salsa::Database for Database {}
 
 impl Db for Database {}
 

--- a/salsa-2022-tests/tests/hello_world.rs
+++ b/salsa-2022-tests/tests/hello_world.rs
@@ -44,6 +44,10 @@ impl salsa::Database for Database {
     fn salsa_runtime(&self) -> &salsa::Runtime {
         self.storage.runtime()
     }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
+        self.storage.runtime_mut()
+    }
 }
 
 impl Db for Database {}

--- a/salsa-2022-tests/tests/hello_world.rs
+++ b/salsa-2022-tests/tests/hello_world.rs
@@ -40,15 +40,7 @@ struct Database {
     logger: Logger,
 }
 
-impl salsa::Database for Database {
-    fn salsa_runtime(&self) -> &salsa::Runtime {
-        self.storage.runtime()
-    }
-
-    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
-        self.storage.runtime_mut()
-    }
-}
+impl salsa::Database for Database {}
 
 impl Db for Database {}
 

--- a/salsa-2022-tests/tests/lru.rs
+++ b/salsa-2022-tests/tests/lru.rs
@@ -74,7 +74,6 @@ impl salsa::Database for DatabaseImpl {
     fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
         self.storage.runtime_mut()
     }
-    
 }
 
 impl Db for DatabaseImpl {}
@@ -184,7 +183,8 @@ fn lru_keeps_dependency_info() {
         assert_eq!(x as usize, i);
     }
 
-    db.salsa_runtime_mut().synthetic_write(salsa::Durability::HIGH);
+    db.salsa_runtime_mut()
+        .synthetic_write(salsa::Durability::HIGH);
 
     // We want to test that calls to `get_hot_potato2` are still considered
     // clean. Check that no new executions occur as we go here.

--- a/salsa-2022-tests/tests/lru.rs
+++ b/salsa-2022-tests/tests/lru.rs
@@ -55,7 +55,7 @@ fn get_hot_potato2(db: &dyn Db, input: MyInput) -> u32 {
 #[salsa::tracked(jar = Jar, lru = 32)]
 fn get_volatile(db: &dyn Db, _input: MyInput) -> usize {
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
-    db.salsa_runtime().report_untracked_read();
+    db.runtime().report_untracked_read();
     COUNTER.fetch_add(1, Ordering::SeqCst)
 }
 

--- a/salsa-2022-tests/tests/lru.rs
+++ b/salsa-2022-tests/tests/lru.rs
@@ -6,7 +6,7 @@ use std::sync::{
     Arc,
 };
 
-use salsa::storage::HasJarsDyn;
+use salsa::Database;
 use salsa_2022_tests::{HasLogger, Logger};
 use test_log::test;
 
@@ -61,16 +61,16 @@ fn get_volatile(db: &dyn Db, _input: MyInput) -> usize {
 
 #[salsa::db(Jar)]
 #[derive(Default)]
-struct Database {
+struct DatabaseImpl {
     storage: salsa::Storage<Self>,
     logger: Logger,
 }
 
-impl salsa::Database for Database {}
+impl salsa::Database for DatabaseImpl {}
 
-impl Db for Database {}
+impl Db for DatabaseImpl {}
 
-impl HasLogger for Database {
+impl HasLogger for DatabaseImpl {
     fn logger(&self) -> &Logger {
         &self.logger
     }
@@ -82,7 +82,7 @@ fn load_n_potatoes() -> usize {
 
 #[test]
 fn lru_works() {
-    let mut db = Database::default();
+    let mut db = DatabaseImpl::default();
     assert_eq!(load_n_potatoes(), 0);
 
     for i in 0..128u32 {
@@ -98,7 +98,7 @@ fn lru_works() {
 
 #[test]
 fn lru_doesnt_break_volatile_queries() {
-    let mut db = Database::default();
+    let mut db = DatabaseImpl::default();
 
     // Create all inputs first, so that there are no revision changes among calls to `get_volatile`
     let inputs: Vec<MyInput> = (0..128usize)
@@ -118,7 +118,7 @@ fn lru_doesnt_break_volatile_queries() {
 
 #[test]
 fn lru_can_be_changed_at_runtime() {
-    let mut db = Database::default();
+    let mut db = DatabaseImpl::default();
     assert_eq!(load_n_potatoes(), 0);
 
     let inputs: Vec<(u32, MyInput)> = (0..128).map(|i| (i, MyInput::new(&mut db, i))).collect();
@@ -161,7 +161,7 @@ fn lru_can_be_changed_at_runtime() {
 
 #[test]
 fn lru_keeps_dependency_info() {
-    let mut db = Database::default();
+    let mut db = DatabaseImpl::default();
     let capacity = 32;
 
     // Invoke `get_hot_potato2` 33 times. This will (in turn) invoke

--- a/salsa-2022-tests/tests/lru.rs
+++ b/salsa-2022-tests/tests/lru.rs
@@ -55,7 +55,7 @@ fn get_hot_potato2(db: &dyn Db, input: MyInput) -> u32 {
 #[salsa::tracked(jar = Jar, lru = 32)]
 fn get_volatile(db: &dyn Db, _input: MyInput) -> usize {
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
-    db.runtime().report_untracked_read();
+    db.report_untracked_read();
     COUNTER.fetch_add(1, Ordering::SeqCst)
 }
 

--- a/salsa-2022-tests/tests/lru.rs
+++ b/salsa-2022-tests/tests/lru.rs
@@ -6,9 +6,9 @@ use std::sync::{
     Arc,
 };
 
+use salsa::storage::HasJarsDyn;
 use salsa_2022_tests::{HasLogger, Logger};
 use test_log::test;
-use salsa::storage::HasJarsDyn;
 
 #[salsa::jar(db = Db)]
 struct Jar(MyInput, get_hot_potato, get_hot_potato2, get_volatile);

--- a/salsa-2022-tests/tests/lru.rs
+++ b/salsa-2022-tests/tests/lru.rs
@@ -66,15 +66,7 @@ struct Database {
     logger: Logger,
 }
 
-impl salsa::Database for Database {
-    fn salsa_runtime(&self) -> &salsa::Runtime {
-        self.storage.runtime()
-    }
-
-    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
-        self.storage.runtime_mut()
-    }
-}
+impl salsa::Database for Database {}
 
 impl Db for Database {}
 

--- a/salsa-2022-tests/tests/mutate_in_place.rs
+++ b/salsa-2022-tests/tests/mutate_in_place.rs
@@ -26,6 +26,10 @@ impl salsa::Database for Database {
     fn salsa_runtime(&self) -> &salsa::Runtime {
         self.storage.runtime()
     }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
+        self.storage.runtime_mut()
+    }
 }
 
 impl Db for Database {}

--- a/salsa-2022-tests/tests/mutate_in_place.rs
+++ b/salsa-2022-tests/tests/mutate_in_place.rs
@@ -22,15 +22,7 @@ struct Database {
     logger: Logger,
 }
 
-impl salsa::Database for Database {
-    fn salsa_runtime(&self) -> &salsa::Runtime {
-        self.storage.runtime()
-    }
-
-    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
-        self.storage.runtime_mut()
-    }
-}
+impl salsa::Database for Database {}
 
 impl Db for Database {}
 

--- a/salsa-2022-tests/tests/override_new_get_set.rs
+++ b/salsa-2022-tests/tests/override_new_get_set.rs
@@ -72,15 +72,7 @@ fn execute() {
         storage: salsa::Storage<Self>,
     }
 
-    impl salsa::Database for Database {
-        fn salsa_runtime(&self) -> &salsa::Runtime {
-            self.storage.runtime()
-        }
-
-        fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
-            self.storage.runtime_mut()
-        }
-    }
+    impl salsa::Database for Database {}
 
     impl Db for Database {}
 

--- a/salsa-2022-tests/tests/override_new_get_set.rs
+++ b/salsa-2022-tests/tests/override_new_get_set.rs
@@ -76,6 +76,10 @@ fn execute() {
         fn salsa_runtime(&self) -> &salsa::Runtime {
             self.storage.runtime()
         }
+
+        fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
+            self.storage.runtime_mut()
+        }
     }
 
     impl Db for Database {}

--- a/salsa-2022-tests/tests/parallel/setup.rs
+++ b/salsa-2022-tests/tests/parallel/setup.rs
@@ -38,18 +38,10 @@ pub(crate) struct Database {
 }
 
 impl salsa::Database for Database {
-    fn salsa_runtime(&self) -> &salsa::Runtime {
-        self.storage.runtime()
-    }
-
     fn salsa_event(&self, event: salsa::Event) {
         if let salsa::EventKind::WillBlockOn { .. } = event.kind {
             self.signal(self.knobs().signal_on_will_block.get());
         }
-    }
-
-    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
-        self.storage.runtime_mut()
     }
 }
 

--- a/salsa-2022-tests/tests/parallel/setup.rs
+++ b/salsa-2022-tests/tests/parallel/setup.rs
@@ -47,6 +47,10 @@ impl salsa::Database for Database {
             self.signal(self.knobs().signal_on_will_block.get());
         }
     }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
+        self.storage.runtime_mut()
+    }
 }
 
 impl salsa::ParallelDatabase for Database {

--- a/salsa-2022-tests/tests/specify_tracked_fn_in_rev_1_but_not_2.rs
+++ b/salsa-2022-tests/tests/specify_tracked_fn_in_rev_1_but_not_2.rs
@@ -76,6 +76,10 @@ impl salsa::Database for Database {
         self.storage.runtime()
     }
 
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
+        self.storage.runtime_mut()
+    }
+
     fn salsa_event(&self, event: salsa::Event) {
         self.push_log(format!("{:?}", event.debug(self)));
     }

--- a/salsa-2022-tests/tests/specify_tracked_fn_in_rev_1_but_not_2.rs
+++ b/salsa-2022-tests/tests/specify_tracked_fn_in_rev_1_but_not_2.rs
@@ -72,14 +72,6 @@ struct Database {
 }
 
 impl salsa::Database for Database {
-    fn salsa_runtime(&self) -> &salsa::Runtime {
-        self.storage.runtime()
-    }
-
-    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
-        self.storage.runtime_mut()
-    }
-
     fn salsa_event(&self, event: salsa::Event) {
         self.push_log(format!("{:?}", event.debug(self)));
     }

--- a/salsa-2022-tests/tests/tracked_fn_on_input.rs
+++ b/salsa-2022-tests/tests/tracked_fn_on_input.rs
@@ -25,15 +25,7 @@ fn execute() {
         storage: salsa::Storage<Self>,
     }
 
-    impl salsa::Database for Database {
-        fn salsa_runtime(&self) -> &salsa::Runtime {
-            self.storage.runtime()
-        }
-
-        fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
-            self.storage.runtime_mut()
-        }
-    }
+    impl salsa::Database for Database {}
 
     impl Db for Database {}
 

--- a/salsa-2022-tests/tests/tracked_fn_on_input.rs
+++ b/salsa-2022-tests/tests/tracked_fn_on_input.rs
@@ -29,6 +29,10 @@ fn execute() {
         fn salsa_runtime(&self) -> &salsa::Runtime {
             self.storage.runtime()
         }
+
+        fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
+            self.storage.runtime_mut()
+        }
     }
 
     impl Db for Database {}

--- a/salsa-2022-tests/tests/tracked_fn_on_tracked.rs
+++ b/salsa-2022-tests/tests/tracked_fn_on_tracked.rs
@@ -27,15 +27,7 @@ struct Database {
     storage: salsa::Storage<Self>,
 }
 
-impl salsa::Database for Database {
-    fn salsa_runtime(&self) -> &salsa::Runtime {
-        self.storage.runtime()
-    }
-
-    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
-        self.storage.runtime_mut()
-    }
-}
+impl salsa::Database for Database {}
 
 impl Db for Database {}
 

--- a/salsa-2022-tests/tests/tracked_fn_on_tracked.rs
+++ b/salsa-2022-tests/tests/tracked_fn_on_tracked.rs
@@ -31,6 +31,10 @@ impl salsa::Database for Database {
     fn salsa_runtime(&self) -> &salsa::Runtime {
         self.storage.runtime()
     }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
+        self.storage.runtime_mut()
+    }
 }
 
 impl Db for Database {}

--- a/salsa-2022-tests/tests/tracked_fn_on_tracked_specify.rs
+++ b/salsa-2022-tests/tests/tracked_fn_on_tracked_specify.rs
@@ -41,6 +41,10 @@ impl salsa::Database for Database {
     fn salsa_runtime(&self) -> &salsa::Runtime {
         self.storage.runtime()
     }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
+        self.storage.runtime_mut()
+    }
 }
 
 impl Db for Database {}

--- a/salsa-2022-tests/tests/tracked_fn_on_tracked_specify.rs
+++ b/salsa-2022-tests/tests/tracked_fn_on_tracked_specify.rs
@@ -37,15 +37,7 @@ struct Database {
     storage: salsa::Storage<Self>,
 }
 
-impl salsa::Database for Database {
-    fn salsa_runtime(&self) -> &salsa::Runtime {
-        self.storage.runtime()
-    }
-
-    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
-        self.storage.runtime_mut()
-    }
-}
+impl salsa::Database for Database {}
 
 impl Db for Database {}
 

--- a/salsa-2022-tests/tests/tracked_fn_read_own_entity.rs
+++ b/salsa-2022-tests/tests/tracked_fn_read_own_entity.rs
@@ -41,15 +41,7 @@ struct Database {
     logger: Logger,
 }
 
-impl salsa::Database for Database {
-    fn salsa_runtime(&self) -> &salsa::Runtime {
-        self.storage.runtime()
-    }
-
-    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
-        self.storage.runtime_mut()
-    }
-}
+impl salsa::Database for Database {}
 
 impl Db for Database {}
 

--- a/salsa-2022-tests/tests/tracked_fn_read_own_entity.rs
+++ b/salsa-2022-tests/tests/tracked_fn_read_own_entity.rs
@@ -45,6 +45,10 @@ impl salsa::Database for Database {
     fn salsa_runtime(&self) -> &salsa::Runtime {
         self.storage.runtime()
     }
+
+    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime {
+        self.storage.runtime_mut()
+    }
 }
 
 impl Db for Database {}


### PR DESCRIPTION
fixes #364 

add `synthetic_write` and use it in test `lru_keeps_dependency_info`, the test will now be broken. We can use `lru_keeps_dependency_info` as a test for https://github.com/salsa-rs/salsa/issues/365, which already has a pr https://github.com/salsa-rs/salsa/pull/371.