### PR TITLE
Have users of `SalsaStruct` specify allowed options

### DIFF
--- a/components/salsa-2022-macros/src/input.rs
+++ b/components/salsa-2022-macros/src/input.rs
@@ -17,14 +17,34 @@ pub(crate) fn input(
     }
 }
 
-struct InputStruct(SalsaStruct);
+struct InputStruct(SalsaStruct<Self>);
 
 impl std::ops::Deref for InputStruct {
-    type Target = SalsaStruct;
+    type Target = SalsaStruct<Self>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
+}
+
+impl crate::options::AllowedOptions for InputStruct {
+    const RETURN_REF: bool = false;
+
+    const SPECIFY: bool = false;
+
+    const NO_EQ: bool = false;
+
+    const JAR: bool = true;
+
+    const DATA: bool = true;
+
+    const DB: bool = false;
+
+    const RECOVERY_FN: bool = false;
+
+    const LRU: bool = false;
+
+    const CONSTRUCTOR_NAME: bool = true;
 }
 
 impl InputStruct {

--- a/components/salsa-2022-macros/src/interned.rs
+++ b/components/salsa-2022-macros/src/interned.rs
@@ -20,14 +20,34 @@ pub(crate) fn interned(
     }
 }
 
-struct InternedStruct(SalsaStruct);
+struct InternedStruct(SalsaStruct<Self>);
 
 impl std::ops::Deref for InternedStruct {
-    type Target = SalsaStruct;
+    type Target = SalsaStruct<Self>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
+}
+
+impl crate::options::AllowedOptions for InternedStruct {
+    const RETURN_REF: bool = false;
+
+    const SPECIFY: bool = false;
+
+    const NO_EQ: bool = false;
+
+    const JAR: bool = true;
+
+    const DATA: bool = true;
+
+    const DB: bool = false;
+
+    const RECOVERY_FN: bool = false;
+
+    const LRU: bool = false;
+
+    const CONSTRUCTOR_NAME: bool = true;
 }
 
 impl InternedStruct {

--- a/components/salsa-2022-macros/src/salsa_struct.rs
+++ b/components/salsa-2022-macros/src/salsa_struct.rs
@@ -29,7 +29,10 @@ use heck::ToUpperCamelCase;
 use proc_macro2::{Ident, Literal, Span, TokenStream};
 use syn::spanned::Spanned;
 
-use crate::{configuration, options::{Options, AllowedOptions}};
+use crate::{
+    configuration,
+    options::{AllowedOptions, Options},
+};
 
 pub(crate) struct SalsaStruct<A: AllowedOptions> {
     args: Options<A>,

--- a/components/salsa-2022-macros/src/salsa_struct.rs
+++ b/components/salsa-2022-macros/src/salsa_struct.rs
@@ -29,37 +29,17 @@ use heck::ToUpperCamelCase;
 use proc_macro2::{Ident, Literal, Span, TokenStream};
 use syn::spanned::Spanned;
 
-use crate::{configuration, options::Options};
+use crate::{configuration, options::{Options, AllowedOptions}};
 
-pub(crate) struct SalsaStruct {
-    args: Options<Self>,
+pub(crate) struct SalsaStruct<A: AllowedOptions> {
+    args: Options<A>,
     struct_item: syn::ItemStruct,
     fields: Vec<SalsaField>,
 }
 
-impl crate::options::AllowedOptions for SalsaStruct {
-    const RETURN_REF: bool = false;
-
-    const SPECIFY: bool = false;
-
-    const NO_EQ: bool = false;
-
-    const JAR: bool = true;
-
-    const DATA: bool = true;
-
-    const DB: bool = false;
-
-    const RECOVERY_FN: bool = false;
-
-    const LRU: bool = false;
-
-    const CONSTRUCTOR_NAME: bool = true;
-}
-
 const BANNED_FIELD_NAMES: &[&str] = &["from", "new"];
 
-impl SalsaStruct {
+impl<A: AllowedOptions> SalsaStruct<A> {
     pub(crate) fn new(
         args: proc_macro::TokenStream,
         input: proc_macro::TokenStream,

--- a/components/salsa-2022-macros/src/tracked_struct.rs
+++ b/components/salsa-2022-macros/src/tracked_struct.rs
@@ -19,14 +19,34 @@ pub(crate) fn tracked(
     }
 }
 
-struct TrackedStruct(SalsaStruct);
+struct TrackedStruct(SalsaStruct<Self>);
 
 impl std::ops::Deref for TrackedStruct {
-    type Target = SalsaStruct;
+    type Target = SalsaStruct<Self>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
+}
+
+impl crate::options::AllowedOptions for TrackedStruct {
+    const RETURN_REF: bool = false;
+
+    const SPECIFY: bool = false;
+
+    const NO_EQ: bool = false;
+
+    const JAR: bool = true;
+
+    const DATA: bool = true;
+
+    const DB: bool = false;
+
+    const RECOVERY_FN: bool = false;
+
+    const LRU: bool = false;
+
+    const CONSTRUCTOR_NAME: bool = true;
 }
 
 impl TrackedStruct {


### PR DESCRIPTION
This allows adding new options exclusively to `tracked`, `input`, `interned`, or any combination of them, without having to add support code to `SalsaStruct`.

The motivating example is #337, where `input` needs to accept a new `singleton` option, but `tracked` and `interned` should reject it.