### PR TITLE
avoid warnings in generated code

### DIFF
--- a/components/salsa-2022-macros/src/salsa_struct.rs
+++ b/components/salsa-2022-macros/src/salsa_struct.rs
@@ -310,14 +310,15 @@ impl<A: AllowedOptions> SalsaStruct<A> {
 
                     impl<Everything, Db: ?Sized, T: ::core::fmt::Debug> Fallback<T, Db> for Everything {}
 
-                    &Test::<#field_ty, #db_type>::salsa_debug(&self.#field_getter(db), db)
+                    #[allow(clippy::needless_borrow)]
+                    &Test::<#field_ty, #db_type>::salsa_debug(&self.#field_getter(_db), _db)
                 })
             }
         }).collect::<Vec<TokenStream>>();
 
         parse_quote_spanned! {ident.span()=>
             impl ::salsa::DebugWithDb<#db_type> for #ident {
-                fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>, db: &#db_type) -> ::std::fmt::Result {
+                fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>, _db: &#db_type) -> ::std::fmt::Result {
                     f.debug_struct(#ident_string)
                         .field("[salsa id]", &self.0.as_u32())
                         #(#fields)*

--- a/salsa-2022-tests/tests/warnings/main.rs
+++ b/salsa-2022-tests/tests/warnings/main.rs
@@ -1,0 +1,6 @@
+//! Test that macros don't generate code with warnings
+
+#![deny(warnings)]
+
+mod needless_borrow;
+mod unused_variable_db;

--- a/salsa-2022-tests/tests/warnings/needless_borrow.rs
+++ b/salsa-2022-tests/tests/warnings/needless_borrow.rs
@@ -1,0 +1,19 @@
+trait Db: salsa::DbWithJar<Jar> {}
+
+#[salsa::jar(db = Db)]
+struct Jar(TokenTree);
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+enum Token {}
+
+impl salsa::DebugWithDb<dyn Db + '_> for Token {
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>, _db: &dyn Db) -> std::fmt::Result {
+        unreachable!()
+    }
+}
+
+#[salsa::tracked(jar = Jar)]
+struct TokenTree {
+    #[return_ref]
+    tokens: Vec<Token>,
+}

--- a/salsa-2022-tests/tests/warnings/unused_variable_db.rs
+++ b/salsa-2022-tests/tests/warnings/unused_variable_db.rs
@@ -1,0 +1,7 @@
+trait Db: salsa::DbWithJar<Jar> {}
+
+#[salsa::jar(db = Db)]
+struct Jar(Keywords);
+
+#[salsa::interned(jar = Jar)]
+struct Keywords {}


### PR DESCRIPTION
Addresses a couple of warnings that appear when I tried to use current master in https://github.com/dada-lang/dada.

Also added tests that will fail to compile if the macros generate warnings.