### PR TITLE
Include only identity fields by default in `DebugWithDb::debug` and add `DebugWithDb::debug_all`

### DIFF
--- a/calc-example/calc/src/parser.rs
+++ b/calc-example/calc/src/parser.rs
@@ -367,7 +367,7 @@ fn parse_string(source_text: &str) -> String {
     let accumulated = parse_statements::accumulated::<Diagnostics>(&db, source_program);
 
     // Format the result as a string and return it
-    format!("{:#?}", (statements.debug(&db), accumulated))
+    format!("{:#?}", (statements.debug_all(&db), accumulated))
 }
 // ANCHOR_END: parse_string
 

--- a/components/salsa-2022-macros/src/input.rs
+++ b/components/salsa-2022-macros/src/input.rs
@@ -1,4 +1,4 @@
-use crate::salsa_struct::{SalsaField, SalsaStruct};
+use crate::salsa_struct::{SalsaField, SalsaStruct, SalsaStructKind};
 use proc_macro2::{Literal, TokenStream};
 
 /// For an entity struct `Foo` with fields `f1: T1, ..., fN: TN`, we generate...
@@ -10,7 +10,9 @@ pub(crate) fn input(
     args: proc_macro::TokenStream,
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    match SalsaStruct::new(args, input).and_then(|el| InputStruct(el).generate_input()) {
+    match SalsaStruct::new(SalsaStructKind::Input, args, input)
+        .and_then(|el| InputStruct(el).generate_input())
+    {
         Ok(s) => s.into(),
         Err(err) => err.into_compile_error().into(),
     }

--- a/components/salsa-2022-macros/src/interned.rs
+++ b/components/salsa-2022-macros/src/interned.rs
@@ -1,4 +1,4 @@
-use crate::salsa_struct::SalsaStruct;
+use crate::salsa_struct::{SalsaStruct, SalsaStructKind};
 use proc_macro2::TokenStream;
 
 // #[salsa::interned(jar = Jar0, data = TyData0)]
@@ -13,7 +13,9 @@ pub(crate) fn interned(
     args: proc_macro::TokenStream,
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    match SalsaStruct::new(args, input).and_then(|el| InternedStruct(el).generate_interned()) {
+    match SalsaStruct::new(SalsaStructKind::Interned, args, input)
+        .and_then(|el| InternedStruct(el).generate_interned())
+    {
         Ok(s) => s.into(),
         Err(err) => err.into_compile_error().into(),
     }

--- a/components/salsa-2022-macros/src/salsa_struct.rs
+++ b/components/salsa-2022-macros/src/salsa_struct.rs
@@ -319,7 +319,7 @@ impl<A: AllowedOptions> SalsaStruct<A> {
                 let field_getter = field.get_name();
                 let field_ty = field.ty();
 
-                if self.is_identity_field(field){
+                if self.is_identity_field(field) {
                     parse_quote_spanned! {field.field.span() =>
                         debug_struct = debug_struct.field(
                             #field_name_string,
@@ -331,7 +331,7 @@ impl<A: AllowedOptions> SalsaStruct<A> {
                             )
                         );
                     }
-                }else{
+                } else {
                     parse_quote_spanned! {field.field.span() =>
                         if _include_all_fields {
                             debug_struct = debug_struct.field(

--- a/components/salsa-2022-macros/src/salsa_struct.rs
+++ b/components/salsa-2022-macros/src/salsa_struct.rs
@@ -319,34 +319,29 @@ impl<A: AllowedOptions> SalsaStruct<A> {
                 let field_getter = field.get_name();
                 let field_ty = field.ty();
 
+                let field_debug = quote_spanned! { field.field.span() =>
+                    debug_struct = debug_struct.field(
+                        #field_name_string,
+                        &::salsa::debug::helper::SalsaDebug::<#field_ty, #db_type>::salsa_debug(
+                            #[allow(clippy::needless_borrow)]
+                            &self.#field_getter(_db),
+                            _db,
+                            _include_all_fields
+                        )
+                    );
+                };
+
                 if self.is_identity_field(field) {
-                    parse_quote_spanned! {field.field.span() =>
-                        debug_struct = debug_struct.field(
-                            #field_name_string,
-                            &::salsa::debug::helper::SalsaDebug::<#field_ty, #db_type>::salsa_debug(
-                                #[allow(clippy::needless_borrow)]
-                                &self.#field_getter(_db),
-                                _db,
-                                _include_all_fields
-                            )
-                        );
+                    quote_spanned! { field.field.span() =>
+                        #field_debug
                     }
                 } else {
-                    parse_quote_spanned! {field.field.span() =>
+                    quote_spanned! { field.field.span() =>
                         if _include_all_fields {
-                            debug_struct = debug_struct.field(
-                                #field_name_string,
-                                &::salsa::debug::helper::SalsaDebug::<#field_ty, #db_type>::salsa_debug(
-                                    #[allow(clippy::needless_borrow)]
-                                    &self.#field_getter(_db),
-                                    _db,
-                                    true
-                                )
-                            );
+                            #field_debug
                         }
                     }
                 }
-
             })
             .collect::<TokenStream>();
 

--- a/components/salsa-2022-macros/src/tracked_struct.rs
+++ b/components/salsa-2022-macros/src/tracked_struct.rs
@@ -1,6 +1,6 @@
 use proc_macro2::{Literal, TokenStream};
 
-use crate::salsa_struct::{SalsaField, SalsaStruct};
+use crate::salsa_struct::{SalsaField, SalsaStruct, SalsaStructKind};
 
 /// For an tracked struct `Foo` with fields `f1: T1, ..., fN: TN`, we generate...
 ///
@@ -11,7 +11,8 @@ pub(crate) fn tracked(
     args: proc_macro::TokenStream,
     struct_item: syn::ItemStruct,
 ) -> syn::Result<TokenStream> {
-    SalsaStruct::with_struct(args, struct_item).and_then(|el| TrackedStruct(el).generate_tracked())
+    SalsaStruct::with_struct(SalsaStructKind::Tracked, args, struct_item)
+        .and_then(|el| TrackedStruct(el).generate_tracked())
 }
 
 struct TrackedStruct(SalsaStruct<Self>);

--- a/components/salsa-2022/src/debug.rs
+++ b/components/salsa-2022/src/debug.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
+    fmt,
     rc::Rc,
     sync::Arc,
 };
@@ -66,12 +67,7 @@ pub trait DebugWithDb<Db: ?Sized> {
         }
     }
 
-    fn fmt(
-        &self,
-        f: &mut std::fmt::Formatter<'_>,
-        db: &Db,
-        include_all_fields: bool,
-    ) -> std::fmt::Result;
+    fn fmt(&self, f: &mut fmt::Formatter<'_>, db: &Db, include_all_fields: bool) -> fmt::Result;
 }
 
 pub struct DebugWith<'me, Db: ?Sized> {
@@ -96,8 +92,8 @@ impl<T: ?Sized> std::ops::Deref for BoxRef<'_, T> {
     }
 }
 
-impl<D: ?Sized> std::fmt::Debug for DebugWith<'_, D> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<D: ?Sized> fmt::Debug for DebugWith<'_, D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         DebugWithDb::fmt(&*self.value, f, self.db, self.include_all_fields)
     }
 }
@@ -106,12 +102,7 @@ impl<Db: ?Sized, T: ?Sized> DebugWithDb<Db> for &T
 where
     T: DebugWithDb<Db>,
 {
-    fn fmt(
-        &self,
-        f: &mut std::fmt::Formatter<'_>,
-        db: &Db,
-        include_all_fields: bool,
-    ) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>, db: &Db, include_all_fields: bool) -> fmt::Result {
         T::fmt(self, f, db, include_all_fields)
     }
 }
@@ -120,12 +111,7 @@ impl<Db: ?Sized, T: ?Sized> DebugWithDb<Db> for Box<T>
 where
     T: DebugWithDb<Db>,
 {
-    fn fmt(
-        &self,
-        f: &mut std::fmt::Formatter<'_>,
-        db: &Db,
-        include_all_fields: bool,
-    ) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>, db: &Db, include_all_fields: bool) -> fmt::Result {
         T::fmt(self, f, db, include_all_fields)
     }
 }
@@ -134,12 +120,7 @@ impl<Db: ?Sized, T> DebugWithDb<Db> for Rc<T>
 where
     T: DebugWithDb<Db>,
 {
-    fn fmt(
-        &self,
-        f: &mut std::fmt::Formatter<'_>,
-        db: &Db,
-        include_all_fields: bool,
-    ) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>, db: &Db, include_all_fields: bool) -> fmt::Result {
         T::fmt(self, f, db, include_all_fields)
     }
 }
@@ -148,12 +129,7 @@ impl<Db: ?Sized, T: ?Sized> DebugWithDb<Db> for Arc<T>
 where
     T: DebugWithDb<Db>,
 {
-    fn fmt(
-        &self,
-        f: &mut std::fmt::Formatter<'_>,
-        db: &Db,
-        include_all_fields: bool,
-    ) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>, db: &Db, include_all_fields: bool) -> fmt::Result {
         T::fmt(self, f, db, include_all_fields)
     }
 }
@@ -162,12 +138,7 @@ impl<Db: ?Sized, T> DebugWithDb<Db> for Vec<T>
 where
     T: DebugWithDb<Db>,
 {
-    fn fmt(
-        &self,
-        f: &mut std::fmt::Formatter<'_>,
-        db: &Db,
-        include_all_fields: bool,
-    ) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>, db: &Db, include_all_fields: bool) -> fmt::Result {
         let elements = self.iter().map(|e| e.debug_with(db, include_all_fields));
         f.debug_list().entries(elements).finish()
     }
@@ -177,14 +148,9 @@ impl<Db: ?Sized, T> DebugWithDb<Db> for Option<T>
 where
     T: DebugWithDb<Db>,
 {
-    fn fmt(
-        &self,
-        f: &mut std::fmt::Formatter<'_>,
-        db: &Db,
-        include_all_fields: bool,
-    ) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>, db: &Db, include_all_fields: bool) -> fmt::Result {
         let me = self.as_ref().map(|v| v.debug_with(db, include_all_fields));
-        std::fmt::Debug::fmt(&me, f)
+        fmt::Debug::fmt(&me, f)
     }
 }
 
@@ -193,12 +159,7 @@ where
     K: DebugWithDb<Db>,
     V: DebugWithDb<Db>,
 {
-    fn fmt(
-        &self,
-        f: &mut std::fmt::Formatter<'_>,
-        db: &Db,
-        include_all_fields: bool,
-    ) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>, db: &Db, include_all_fields: bool) -> fmt::Result {
         let elements = self.iter().map(|(k, v)| {
             (
                 k.debug_with(db, include_all_fields),
@@ -214,12 +175,7 @@ where
     A: DebugWithDb<Db>,
     B: DebugWithDb<Db>,
 {
-    fn fmt(
-        &self,
-        f: &mut std::fmt::Formatter<'_>,
-        db: &Db,
-        include_all_fields: bool,
-    ) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>, db: &Db, include_all_fields: bool) -> fmt::Result {
         f.debug_tuple("")
             .field(&self.0.debug_with(db, include_all_fields))
             .field(&self.1.debug_with(db, include_all_fields))
@@ -233,12 +189,7 @@ where
     B: DebugWithDb<Db>,
     C: DebugWithDb<Db>,
 {
-    fn fmt(
-        &self,
-        f: &mut std::fmt::Formatter<'_>,
-        db: &Db,
-        include_all_fields: bool,
-    ) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>, db: &Db, include_all_fields: bool) -> fmt::Result {
         f.debug_tuple("")
             .field(&self.0.debug_with(db, include_all_fields))
             .field(&self.1.debug_with(db, include_all_fields))
@@ -251,12 +202,7 @@ impl<Db: ?Sized, V, S> DebugWithDb<Db> for HashSet<V, S>
 where
     V: DebugWithDb<Db>,
 {
-    fn fmt(
-        &self,
-        f: &mut std::fmt::Formatter<'_>,
-        db: &Db,
-        include_all_fields: bool,
-    ) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>, db: &Db, include_all_fields: bool) -> fmt::Result {
         let elements = self.iter().map(|e| e.debug_with(db, include_all_fields));
         f.debug_list().entries(elements).finish()
     }

--- a/components/salsa-2022/src/debug.rs
+++ b/components/salsa-2022/src/debug.rs
@@ -16,6 +16,9 @@ pub trait DebugWithDb<Db: ?Sized> {
         }
     }
 
+    /// Be careful when using this method inside a tracked function,
+    /// because the default macro generated implementation will read all fields,
+    /// maybe introducing undesired dependencies.
     fn debug_all<'me, 'db>(&'me self, db: &'me Db) -> DebugWith<'me, Db>
     where
         Self: Sized + 'me,
@@ -38,6 +41,9 @@ pub trait DebugWithDb<Db: ?Sized> {
         }
     }
 
+    /// Be careful when using this method inside a tracked function,
+    /// because the default macro generated implementation will read all fields,
+    /// maybe introducing undesired dependencies.
     fn into_debug_all<'me, 'db>(self, db: &'me Db) -> DebugWith<'me, Db>
     where
         Self: Sized + 'me,
@@ -49,8 +55,13 @@ pub trait DebugWithDb<Db: ?Sized> {
         }
     }
 
+    /// Should only read fields that are part of the identity, which means:
+    ///     - for [#\[salsa::input\]](salsa_2022_macros::input) no fields
+    ///     - for [#\[salsa::tracked\]](salsa_2022_macros::tracked) only fields with `#[id]` attribute
+    ///     - for [#\[salsa::interned\]](salsa_2022_macros::interned) any field
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>, db: &Db) -> std::fmt::Result;
 
+    /// Unlike [DebugWithDb::fmt], may read any field.
     fn fmt_all(&self, f: &mut std::fmt::Formatter<'_>, db: &Db) -> std::fmt::Result {
         self.fmt(f, db)
     }

--- a/components/salsa-2022/src/debug.rs
+++ b/components/salsa-2022/src/debug.rs
@@ -67,6 +67,10 @@ pub trait DebugWithDb<Db: ?Sized> {
         }
     }
 
+    /// if `include_all_fields` is `false` only identity fields should be read, which means:
+    ///     - for [#\[salsa::input\]](salsa_2022_macros::input) no fields
+    ///     - for [#\[salsa::tracked\]](salsa_2022_macros::tracked) only fields with `#[id]` attribute
+    ///     - for [#\[salsa::interned\]](salsa_2022_macros::interned) any field
     fn fmt(&self, f: &mut fmt::Formatter<'_>, db: &Db, include_all_fields: bool) -> fmt::Result;
 }
 

--- a/components/salsa-2022/src/event.rs
+++ b/components/salsa-2022/src/event.rs
@@ -28,10 +28,15 @@ impl<Db> DebugWithDb<Db> for Event
 where
     Db: ?Sized + Database,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>, db: &Db) -> std::fmt::Result {
+    fn fmt(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+        db: &Db,
+        include_all_fields: bool,
+    ) -> std::fmt::Result {
         f.debug_struct("Event")
             .field("runtime_id", &self.runtime_id)
-            .field("kind", &self.kind.debug(db))
+            .field("kind", &self.kind.debug_with(db, include_all_fields))
             .finish()
     }
 }
@@ -149,11 +154,19 @@ impl<Db> DebugWithDb<Db> for EventKind
 where
     Db: ?Sized + Database,
 {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>, db: &Db) -> std::fmt::Result {
+    fn fmt(
+        &self,
+        fmt: &mut std::fmt::Formatter<'_>,
+        db: &Db,
+        include_all_fields: bool,
+    ) -> std::fmt::Result {
         match self {
             EventKind::DidValidateMemoizedValue { database_key } => fmt
                 .debug_struct("DidValidateMemoizedValue")
-                .field("database_key", &database_key.debug(db))
+                .field(
+                    "database_key",
+                    &database_key.debug_with(db, include_all_fields),
+                )
                 .finish(),
             EventKind::WillBlockOn {
                 other_runtime_id,
@@ -161,11 +174,17 @@ where
             } => fmt
                 .debug_struct("WillBlockOn")
                 .field("other_runtime_id", other_runtime_id)
-                .field("database_key", &database_key.debug(db))
+                .field(
+                    "database_key",
+                    &database_key.debug_with(db, include_all_fields),
+                )
                 .finish(),
             EventKind::WillExecute { database_key } => fmt
                 .debug_struct("WillExecute")
-                .field("database_key", &database_key.debug(db))
+                .field(
+                    "database_key",
+                    &database_key.debug_with(db, include_all_fields),
+                )
                 .finish(),
             EventKind::WillCheckCancellation => fmt.debug_struct("WillCheckCancellation").finish(),
             EventKind::WillDiscardStaleOutput {
@@ -173,20 +192,29 @@ where
                 output_key,
             } => fmt
                 .debug_struct("WillDiscardStaleOutput")
-                .field("execute_key", &execute_key.debug(db))
-                .field("output_key", &output_key.debug(db))
+                .field(
+                    "execute_key",
+                    &execute_key.debug_with(db, include_all_fields),
+                )
+                .field("output_key", &output_key.debug_with(db, include_all_fields))
                 .finish(),
             EventKind::DidDiscard { key } => fmt
                 .debug_struct("DidDiscard")
-                .field("key", &key.debug(db))
+                .field("key", &key.debug_with(db, include_all_fields))
                 .finish(),
             EventKind::DidDiscardAccumulated {
                 executor_key,
                 accumulator,
             } => fmt
                 .debug_struct("DidDiscardAccumulated")
-                .field("executor_key", &executor_key.debug(db))
-                .field("accumulator", &accumulator.debug(db))
+                .field(
+                    "executor_key",
+                    &executor_key.debug_with(db, include_all_fields),
+                )
+                .field(
+                    "accumulator",
+                    &accumulator.debug_with(db, include_all_fields),
+                )
                 .finish(),
         }
     }

--- a/components/salsa-2022/src/key.rs
+++ b/components/salsa-2022/src/key.rs
@@ -38,7 +38,12 @@ impl<Db> crate::debug::DebugWithDb<Db> for DependencyIndex
 where
     Db: ?Sized + Database,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>, db: &Db) -> std::fmt::Result {
+    fn fmt(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+        db: &Db,
+        _include_all_fields: bool,
+    ) -> std::fmt::Result {
         db.fmt_index(*self, f)
     }
 }
@@ -68,9 +73,14 @@ impl<Db> crate::debug::DebugWithDb<Db> for DatabaseKeyIndex
 where
     Db: ?Sized + Database,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>, db: &Db) -> std::fmt::Result {
+    fn fmt(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+        db: &Db,
+        include_all_fields: bool,
+    ) -> std::fmt::Result {
         let i: DependencyIndex = (*self).into();
-        DebugWithDb::fmt(&i, f, db)
+        DebugWithDb::fmt(&i, f, db, include_all_fields)
     }
 }
 

--- a/salsa-2022-tests/tests/debug.rs
+++ b/salsa-2022-tests/tests/debug.rs
@@ -51,6 +51,8 @@ fn input() {
 
     // all fields
     let actual = format!("{:?}", complex_struct.debug_all(&db));
-    let expected = expect![[r#"ComplexStruct { [salsa id]: 0, my_input: MyInput { [salsa id]: 0, field: 22 }, not_salsa: NotSalsa { field: "it's salsa time" } }"#]];
+    let expected = expect![[
+        r#"ComplexStruct { [salsa id]: 0, my_input: MyInput { [salsa id]: 0, field: 22 }, not_salsa: NotSalsa { field: "it's salsa time" } }"#
+    ]];
     expected.assert_eq(&actual);
 }

--- a/salsa-2022-tests/tests/debug.rs
+++ b/salsa-2022-tests/tests/debug.rs
@@ -44,9 +44,15 @@ fn input() {
     };
     let complex_struct = ComplexStruct::new(&mut db, input, not_salsa);
 
+    // default debug only includes identity fields
     let actual = format!("{:?}", complex_struct.debug(&db));
+    let expected = expect!["ComplexStruct { [salsa id]: 0 }"];
+    expected.assert_eq(&actual);
+
+    // all fields
+    let actual = format!("{:?}", complex_struct.debug_all(&db));
     let expected = expect![[
-        r#"ComplexStruct { [salsa id]: 0, my_input: MyInput { [salsa id]: 0, field: 22 }, not_salsa: NotSalsa { field: "it's salsa time" } }"#
+        r#"ComplexStruct { [salsa id]: 0, my_input: MyInput { [salsa id]: 0 }, not_salsa: NotSalsa { field: "it's salsa time" } }"#
     ]];
     expected.assert_eq(&actual);
 }

--- a/salsa-2022-tests/tests/debug.rs
+++ b/salsa-2022-tests/tests/debug.rs
@@ -51,8 +51,6 @@ fn input() {
 
     // all fields
     let actual = format!("{:?}", complex_struct.debug_all(&db));
-    let expected = expect![[
-        r#"ComplexStruct { [salsa id]: 0, my_input: MyInput { [salsa id]: 0 }, not_salsa: NotSalsa { field: "it's salsa time" } }"#
-    ]];
+    let expected = expect![[r#"ComplexStruct { [salsa id]: 0, my_input: MyInput { [salsa id]: 0, field: 22 }, not_salsa: NotSalsa { field: "it's salsa time" } }"#]];
     expected.assert_eq(&actual);
 }

--- a/salsa-2022-tests/tests/warnings/needless_borrow.rs
+++ b/salsa-2022-tests/tests/warnings/needless_borrow.rs
@@ -7,7 +7,12 @@ struct Jar(TokenTree);
 enum Token {}
 
 impl salsa::DebugWithDb<dyn Db + '_> for Token {
-    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>, _db: &dyn Db) -> std::fmt::Result {
+    fn fmt(
+        &self,
+        _f: &mut std::fmt::Formatter<'_>,
+        _db: &dyn Db,
+        _include_all_fields: bool,
+    ) -> std::fmt::Result {
         unreachable!()
     }
 }


### PR DESCRIPTION
This addresses a couple of items of #397 

I initially added a separate `DebugWithDb::fmt_all` method but then changed it to an extra parameter to make it easier to propagate to inner fields. Also tried introducing something like:
```rust
pub struct FormatterWithDb<'me, 'f, Db: ?Sized>{
  fmt: &'me mut std::fmt::Formatter<'f>,
  db: &'me Db,
  include_all_fields: bool
}
```
to pass to `fmt`, but I gave up because the lifetimes got a bit unwieldy.