### PR TITLE
Exhaustive macros test

### DIFF
--- a/salsa-2022-tests/tests/compile-fail/accumulator_fields_incompatibles.rs
+++ b/salsa-2022-tests/tests/compile-fail/accumulator_fields_incompatibles.rs
@@ -1,0 +1,17 @@
+#[salsa::jar(db = Db)]
+struct Jar(AccTwoUnnamedFields, AccNamedField);
+
+trait Db: salsa::DbWithJar<Jar> {}
+
+// accumulator with more than one unnamed fields
+#[salsa::accumulator(jar = Jar)]
+struct AccTwoUnnamedFields (u32, u32);
+
+
+// accumulator with named fields
+#[salsa::accumulator(jar = Jar)]
+struct AccNamedField {
+    field: u32,
+}
+
+fn main() {}

--- a/salsa-2022-tests/tests/compile-fail/accumulator_fields_incompatibles.stderr
+++ b/salsa-2022-tests/tests/compile-fail/accumulator_fields_incompatibles.stderr
@@ -1,0 +1,23 @@
+error: accumulator structs should have only one anonymous field
+ --> tests/compile-fail/accumulator_fields_incompatibles.rs:8:8
+  |
+8 | struct AccTwoUnnamedFields (u32, u32);
+  |        ^^^^^^^^^^^^^^^^^^^
+
+error: accumulator structs should have only one anonymous field
+  --> tests/compile-fail/accumulator_fields_incompatibles.rs:13:8
+   |
+13 | struct AccNamedField {
+   |        ^^^^^^^^^^^^^
+
+error[E0412]: cannot find type `AccTwoUnnamedFields` in this scope
+ --> tests/compile-fail/accumulator_fields_incompatibles.rs:2:12
+  |
+2 | struct Jar(AccTwoUnnamedFields, AccNamedField);
+  |            ^^^^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `AccNamedField` in this scope
+ --> tests/compile-fail/accumulator_fields_incompatibles.rs:2:33
+  |
+2 | struct Jar(AccTwoUnnamedFields, AccNamedField);
+  |                                 ^^^^^^^^^^^^^ not found in this scope

--- a/salsa-2022-tests/tests/compile-fail/accumulator_incompatibles.rs
+++ b/salsa-2022-tests/tests/compile-fail/accumulator_incompatibles.rs
@@ -1,0 +1,30 @@
+#[salsa::jar(db = Db)]
+struct Jar(AccWithRetRef, AccWithSpecify, AccWithNoEq, AccWithData, AcWithcDb, AccWithRecover, AccWithLru, AccWithConstructor);
+
+trait Db: salsa::DbWithJar<Jar> {}
+
+#[salsa::accumulator(jar = Jar, return_ref)]
+struct AccWithRetRef (u32);
+
+#[salsa::accumulator(jar = Jar, specify)]
+struct AccWithSpecify (u32);
+
+#[salsa::accumulator(jar = Jar, no_eq)]
+struct AccWithNoEq (u32);
+
+#[salsa::accumulator(jar = Jar, data = MyAcc)]
+struct AccWithData (u32);
+
+#[salsa::accumulator(jar = Jar, db = Db)]
+struct AcWithcDb (u32);
+
+#[salsa::accumulator(jar = Jar, recover_fn = recover)]
+struct AccWithRecover (u32);
+
+#[salsa::accumulator(jar = Jar, lru =12)]
+struct AccWithLru (u32);
+
+#[salsa::accumulator(jar = Jar, constructor = Constructor)]
+struct AccWithConstructor (u32);
+
+fn main() {}

--- a/salsa-2022-tests/tests/compile-fail/accumulator_incompatibles.stderr
+++ b/salsa-2022-tests/tests/compile-fail/accumulator_incompatibles.stderr
@@ -1,0 +1,95 @@
+error: `return_ref` option not allowed here
+ --> tests/compile-fail/accumulator_incompatibles.rs:6:33
+  |
+6 | #[salsa::accumulator(jar = Jar, return_ref)]
+  |                                 ^^^^^^^^^^
+
+error: `specify` option not allowed here
+ --> tests/compile-fail/accumulator_incompatibles.rs:9:33
+  |
+9 | #[salsa::accumulator(jar = Jar, specify)]
+  |                                 ^^^^^^^
+
+error: `no_eq` option not allowed here
+  --> tests/compile-fail/accumulator_incompatibles.rs:12:33
+   |
+12 | #[salsa::accumulator(jar = Jar, no_eq)]
+   |                                 ^^^^^
+
+error: `data` option not allowed here
+  --> tests/compile-fail/accumulator_incompatibles.rs:15:33
+   |
+15 | #[salsa::accumulator(jar = Jar, data = MyAcc)]
+   |                                 ^^^^
+
+error: `db` option not allowed here
+  --> tests/compile-fail/accumulator_incompatibles.rs:18:33
+   |
+18 | #[salsa::accumulator(jar = Jar, db = Db)]
+   |                                 ^^
+
+error: unrecognized option `recover_fn`
+  --> tests/compile-fail/accumulator_incompatibles.rs:21:33
+   |
+21 | #[salsa::accumulator(jar = Jar, recover_fn = recover)]
+   |                                 ^^^^^^^^^^
+
+error: `lru` option not allowed here
+  --> tests/compile-fail/accumulator_incompatibles.rs:24:33
+   |
+24 | #[salsa::accumulator(jar = Jar, lru =12)]
+   |                                 ^^^
+
+error: `constructor` option not allowed here
+  --> tests/compile-fail/accumulator_incompatibles.rs:27:33
+   |
+27 | #[salsa::accumulator(jar = Jar, constructor = Constructor)]
+   |                                 ^^^^^^^^^^^
+
+error[E0412]: cannot find type `AccWithRetRef` in this scope
+ --> tests/compile-fail/accumulator_incompatibles.rs:2:12
+  |
+2 | struct Jar(AccWithRetRef, AccWithSpecify, AccWithNoEq, AccWithData, AcWithcDb, AccWithRecover, AccWithLru, AccWithConstructor);
+  |            ^^^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `AccWithSpecify` in this scope
+ --> tests/compile-fail/accumulator_incompatibles.rs:2:27
+  |
+2 | struct Jar(AccWithRetRef, AccWithSpecify, AccWithNoEq, AccWithData, AcWithcDb, AccWithRecover, AccWithLru, AccWithConstructor);
+  |                           ^^^^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `AccWithNoEq` in this scope
+ --> tests/compile-fail/accumulator_incompatibles.rs:2:43
+  |
+2 | struct Jar(AccWithRetRef, AccWithSpecify, AccWithNoEq, AccWithData, AcWithcDb, AccWithRecover, AccWithLru, AccWithConstructor);
+  |                                           ^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `AccWithData` in this scope
+ --> tests/compile-fail/accumulator_incompatibles.rs:2:56
+  |
+2 | struct Jar(AccWithRetRef, AccWithSpecify, AccWithNoEq, AccWithData, AcWithcDb, AccWithRecover, AccWithLru, AccWithConstructor);
+  |                                                        ^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `AcWithcDb` in this scope
+ --> tests/compile-fail/accumulator_incompatibles.rs:2:69
+  |
+2 | struct Jar(AccWithRetRef, AccWithSpecify, AccWithNoEq, AccWithData, AcWithcDb, AccWithRecover, AccWithLru, AccWithConstructor);
+  |                                                                     ^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `AccWithRecover` in this scope
+ --> tests/compile-fail/accumulator_incompatibles.rs:2:80
+  |
+2 | struct Jar(AccWithRetRef, AccWithSpecify, AccWithNoEq, AccWithData, AcWithcDb, AccWithRecover, AccWithLru, AccWithConstructor);
+  |                                                                                ^^^^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `AccWithLru` in this scope
+ --> tests/compile-fail/accumulator_incompatibles.rs:2:96
+  |
+2 | struct Jar(AccWithRetRef, AccWithSpecify, AccWithNoEq, AccWithData, AcWithcDb, AccWithRecover, AccWithLru, AccWithConstructor);
+  |                                                                                                ^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `AccWithConstructor` in this scope
+ --> tests/compile-fail/accumulator_incompatibles.rs:2:108
+  |
+2 | struct Jar(AccWithRetRef, AccWithSpecify, AccWithNoEq, AccWithData, AcWithcDb, AccWithRecover, AccWithLru, AccWithConstructor);
+  |                                                                                                            ^^^^^^^^^^^^^^^^^^ not found in this scope

--- a/salsa-2022-tests/tests/compile-fail/input_struct_incompatibles.rs
+++ b/salsa-2022-tests/tests/compile-fail/input_struct_incompatibles.rs
@@ -1,0 +1,24 @@
+#[salsa::jar(db = Db)]
+struct Jar(InputWithRetRef, InputWithSpecify, InputNoWithEq, InputWithDb, InputWithRecover, InputWithLru);
+
+trait Db: salsa::DbWithJar<Jar> {}
+
+#[salsa::input(jar = Jar, return_ref)]
+struct InputWithRetRef (u32);
+
+#[salsa::input(jar = Jar, specify)]
+struct InputWithSpecify (u32);
+
+#[salsa::input(jar = Jar, no_eq)]
+struct InputNoWithEq (u32);
+
+#[salsa::input(jar = Jar, db = Db)]
+struct InputWithDb (u32);
+
+#[salsa::input(jar = Jar, recover_fn = recover)]
+struct InputWithRecover (u32);
+
+#[salsa::input(jar = Jar, lru =12)]
+struct InputWithLru (u32);
+
+fn main() {}

--- a/salsa-2022-tests/tests/compile-fail/input_struct_incompatibles.stderr
+++ b/salsa-2022-tests/tests/compile-fail/input_struct_incompatibles.stderr
@@ -1,0 +1,71 @@
+error: `return_ref` option not allowed here
+ --> tests/compile-fail/input_struct_incompatibles.rs:6:27
+  |
+6 | #[salsa::input(jar = Jar, return_ref)]
+  |                           ^^^^^^^^^^
+
+error: `specify` option not allowed here
+ --> tests/compile-fail/input_struct_incompatibles.rs:9:27
+  |
+9 | #[salsa::input(jar = Jar, specify)]
+  |                           ^^^^^^^
+
+error: `no_eq` option not allowed here
+  --> tests/compile-fail/input_struct_incompatibles.rs:12:27
+   |
+12 | #[salsa::input(jar = Jar, no_eq)]
+   |                           ^^^^^
+
+error: `db` option not allowed here
+  --> tests/compile-fail/input_struct_incompatibles.rs:15:27
+   |
+15 | #[salsa::input(jar = Jar, db = Db)]
+   |                           ^^
+
+error: unrecognized option `recover_fn`
+  --> tests/compile-fail/input_struct_incompatibles.rs:18:27
+   |
+18 | #[salsa::input(jar = Jar, recover_fn = recover)]
+   |                           ^^^^^^^^^^
+
+error: `lru` option not allowed here
+  --> tests/compile-fail/input_struct_incompatibles.rs:21:27
+   |
+21 | #[salsa::input(jar = Jar, lru =12)]
+   |                           ^^^
+
+error[E0412]: cannot find type `InputWithRetRef` in this scope
+ --> tests/compile-fail/input_struct_incompatibles.rs:2:12
+  |
+2 | struct Jar(InputWithRetRef, InputWithSpecify, InputNoWithEq, InputWithDb, InputWithRecover, InputWithLru);
+  |            ^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `InputWithSpecify` in this scope
+ --> tests/compile-fail/input_struct_incompatibles.rs:2:29
+  |
+2 | struct Jar(InputWithRetRef, InputWithSpecify, InputNoWithEq, InputWithDb, InputWithRecover, InputWithLru);
+  |                             ^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `InputNoWithEq` in this scope
+ --> tests/compile-fail/input_struct_incompatibles.rs:2:47
+  |
+2 | struct Jar(InputWithRetRef, InputWithSpecify, InputNoWithEq, InputWithDb, InputWithRecover, InputWithLru);
+  |                                               ^^^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `InputWithDb` in this scope
+ --> tests/compile-fail/input_struct_incompatibles.rs:2:62
+  |
+2 | struct Jar(InputWithRetRef, InputWithSpecify, InputNoWithEq, InputWithDb, InputWithRecover, InputWithLru);
+  |                                                              ^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `InputWithRecover` in this scope
+ --> tests/compile-fail/input_struct_incompatibles.rs:2:75
+  |
+2 | struct Jar(InputWithRetRef, InputWithSpecify, InputNoWithEq, InputWithDb, InputWithRecover, InputWithLru);
+  |                                                                           ^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `InputWithLru` in this scope
+ --> tests/compile-fail/input_struct_incompatibles.rs:2:93
+  |
+2 | struct Jar(InputWithRetRef, InputWithSpecify, InputNoWithEq, InputWithDb, InputWithRecover, InputWithLru);
+  |                                                                                             ^^^^^^^^^^^^ not found in this scope

--- a/salsa-2022-tests/tests/compile-fail/interned_struct_incompatibles.rs
+++ b/salsa-2022-tests/tests/compile-fail/interned_struct_incompatibles.rs
@@ -1,0 +1,36 @@
+#[salsa::jar(db = Db)]
+struct Jar(InternedWithRetRef, InternedWithSpecify, InternedWithNoEq, InternedWithDb, InternedWithRecover, InternedWithLru);
+
+trait Db: salsa::DbWithJar<Jar> {}
+
+
+#[salsa::interned(jar = Jar, return_ref)]
+struct InternedWithRetRef {
+    field: u32,    
+}
+
+#[salsa::interned(jar = Jar, specify)]
+struct InternedWithSpecify {
+    field: u32,    
+}
+
+#[salsa::interned(jar = Jar, no_eq)]
+struct InternedWithNoEq {
+    field: u32,    
+}
+
+#[salsa::interned(jar = Jar, db = Db)]
+struct InternedWithDb {
+    field: u32,    
+}
+
+#[salsa::interned(jar = Jar, recover_fn = recover)]
+struct InternedWithRecover {
+    field: u32,    
+}
+
+#[salsa::interned(jar = Jar, lru =12)]
+struct InternedWithLru {
+    field: u32,    
+}
+fn main() {}

--- a/salsa-2022-tests/tests/compile-fail/interned_struct_incompatibles.stderr
+++ b/salsa-2022-tests/tests/compile-fail/interned_struct_incompatibles.stderr
@@ -1,0 +1,71 @@
+error: `return_ref` option not allowed here
+ --> tests/compile-fail/interned_struct_incompatibles.rs:7:30
+  |
+7 | #[salsa::interned(jar = Jar, return_ref)]
+  |                              ^^^^^^^^^^
+
+error: `specify` option not allowed here
+  --> tests/compile-fail/interned_struct_incompatibles.rs:12:30
+   |
+12 | #[salsa::interned(jar = Jar, specify)]
+   |                              ^^^^^^^
+
+error: `no_eq` option not allowed here
+  --> tests/compile-fail/interned_struct_incompatibles.rs:17:30
+   |
+17 | #[salsa::interned(jar = Jar, no_eq)]
+   |                              ^^^^^
+
+error: `db` option not allowed here
+  --> tests/compile-fail/interned_struct_incompatibles.rs:22:30
+   |
+22 | #[salsa::interned(jar = Jar, db = Db)]
+   |                              ^^
+
+error: unrecognized option `recover_fn`
+  --> tests/compile-fail/interned_struct_incompatibles.rs:27:30
+   |
+27 | #[salsa::interned(jar = Jar, recover_fn = recover)]
+   |                              ^^^^^^^^^^
+
+error: `lru` option not allowed here
+  --> tests/compile-fail/interned_struct_incompatibles.rs:32:30
+   |
+32 | #[salsa::interned(jar = Jar, lru =12)]
+   |                              ^^^
+
+error[E0412]: cannot find type `InternedWithRetRef` in this scope
+ --> tests/compile-fail/interned_struct_incompatibles.rs:2:12
+  |
+2 | struct Jar(InternedWithRetRef, InternedWithSpecify, InternedWithNoEq, InternedWithDb, InternedWithRecover, InternedWithLru);
+  |            ^^^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `InternedWithSpecify` in this scope
+ --> tests/compile-fail/interned_struct_incompatibles.rs:2:32
+  |
+2 | struct Jar(InternedWithRetRef, InternedWithSpecify, InternedWithNoEq, InternedWithDb, InternedWithRecover, InternedWithLru);
+  |                                ^^^^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `InternedWithNoEq` in this scope
+ --> tests/compile-fail/interned_struct_incompatibles.rs:2:53
+  |
+2 | struct Jar(InternedWithRetRef, InternedWithSpecify, InternedWithNoEq, InternedWithDb, InternedWithRecover, InternedWithLru);
+  |                                                     ^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `InternedWithDb` in this scope
+ --> tests/compile-fail/interned_struct_incompatibles.rs:2:71
+  |
+2 | struct Jar(InternedWithRetRef, InternedWithSpecify, InternedWithNoEq, InternedWithDb, InternedWithRecover, InternedWithLru);
+  |                                                                       ^^^^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `InternedWithRecover` in this scope
+ --> tests/compile-fail/interned_struct_incompatibles.rs:2:87
+  |
+2 | struct Jar(InternedWithRetRef, InternedWithSpecify, InternedWithNoEq, InternedWithDb, InternedWithRecover, InternedWithLru);
+  |                                                                                       ^^^^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `InternedWithLru` in this scope
+ --> tests/compile-fail/interned_struct_incompatibles.rs:2:108
+  |
+2 | struct Jar(InternedWithRetRef, InternedWithSpecify, InternedWithNoEq, InternedWithDb, InternedWithRecover, InternedWithLru);
+  |                                                                                                            ^^^^^^^^^^^^^^^ not found in this scope

--- a/salsa-2022-tests/tests/compile-fail/jars_incompatibles.rs
+++ b/salsa-2022-tests/tests/compile-fail/jars_incompatibles.rs
@@ -1,0 +1,33 @@
+#[salsa::jar(db = Db, return_ref)]
+struct JarWithRetRef(MyInput);
+
+#[salsa::jar(db = Db, specify)]
+struct JarWithDb(MyInput);
+
+
+#[salsa::jar(db = Db, no_eq)]
+struct JarWithNoEq(MyInput);
+
+#[salsa::jar(db = Db, jar = Jar)]
+struct JarWithJar(MyInput);
+
+#[salsa::jar(db = Db, data = Data)]
+struct JarWithData(MyInput);
+
+#[salsa::jar(db = Db, recovery_fn = recover)]
+struct JarWithRecover(MyInput);
+
+#[salsa::jar(db = Db, lru = 32)]
+struct JarWithLru(MyInput);
+
+#[salsa::jar(db = Db, constructor = JarConstructor)]
+struct JarWithConstructor(MyInput);
+
+#[salsa::input(jar = Jar1)]
+struct MyInput {
+    field: u32,
+}
+
+fn main() {
+
+}

--- a/salsa-2022-tests/tests/compile-fail/jars_incompatibles.stderr
+++ b/salsa-2022-tests/tests/compile-fail/jars_incompatibles.stderr
@@ -1,0 +1,61 @@
+error: `return_ref` option not allowed here
+ --> tests/compile-fail/jars_incompatibles.rs:1:23
+  |
+1 | #[salsa::jar(db = Db, return_ref)]
+  |                       ^^^^^^^^^^
+
+error: `specify` option not allowed here
+ --> tests/compile-fail/jars_incompatibles.rs:4:23
+  |
+4 | #[salsa::jar(db = Db, specify)]
+  |                       ^^^^^^^
+
+error: `no_eq` option not allowed here
+ --> tests/compile-fail/jars_incompatibles.rs:8:23
+  |
+8 | #[salsa::jar(db = Db, no_eq)]
+  |                       ^^^^^
+
+error: `jar` option not allowed here
+  --> tests/compile-fail/jars_incompatibles.rs:11:23
+   |
+11 | #[salsa::jar(db = Db, jar = Jar)]
+   |                       ^^^
+
+error: `data` option not allowed here
+  --> tests/compile-fail/jars_incompatibles.rs:14:23
+   |
+14 | #[salsa::jar(db = Db, data = Data)]
+   |                       ^^^^
+
+error: `recovery_fn` option not allowed here
+  --> tests/compile-fail/jars_incompatibles.rs:17:23
+   |
+17 | #[salsa::jar(db = Db, recovery_fn = recover)]
+   |                       ^^^^^^^^^^^
+
+error: `lru` option not allowed here
+  --> tests/compile-fail/jars_incompatibles.rs:20:23
+   |
+20 | #[salsa::jar(db = Db, lru = 32)]
+   |                       ^^^
+
+error: `constructor` option not allowed here
+  --> tests/compile-fail/jars_incompatibles.rs:23:23
+   |
+23 | #[salsa::jar(db = Db, constructor = JarConstructor)]
+   |                       ^^^^^^^^^^^
+
+error[E0412]: cannot find type `Jar1` in this scope
+  --> tests/compile-fail/jars_incompatibles.rs:26:22
+   |
+26 | #[salsa::input(jar = Jar1)]
+   |                      ^^^^ not found in this scope
+
+error[E0412]: cannot find type `Jar1` in this scope
+  --> tests/compile-fail/jars_incompatibles.rs:26:22
+   |
+26 | #[salsa::input(jar = Jar1)]
+   |                      ^^^^ not found in this scope
+27 | struct MyInput {
+   |               - help: you might be missing a type parameter: `<Jar1>`

--- a/salsa-2022-tests/tests/compile-fail/salsa_fields_incompatibles.rs
+++ b/salsa-2022-tests/tests/compile-fail/salsa_fields_incompatibles.rs
@@ -1,0 +1,19 @@
+#[salsa::jar(db = Db)]
+struct Jar(InputWithBannedName1, InputWithBannedName2);
+
+// Banned field name: `from`
+#[salsa::input]
+struct InputWithBannedName1 {
+    from: u32,
+}
+
+// Banned field name: `new`
+#[salsa::input]
+struct InputWithBannedName2 {
+    new: u32,
+}
+
+trait Db: salsa::DbWithJar<Jar> {}
+
+
+fn main() {}

--- a/salsa-2022-tests/tests/compile-fail/salsa_fields_incompatibles.stderr
+++ b/salsa-2022-tests/tests/compile-fail/salsa_fields_incompatibles.stderr
@@ -1,0 +1,23 @@
+error: the field name `from` is disallowed in salsa structs
+ --> tests/compile-fail/salsa_fields_incompatibles.rs:7:5
+  |
+7 |     from: u32,
+  |     ^^^^
+
+error: the field name `new` is disallowed in salsa structs
+  --> tests/compile-fail/salsa_fields_incompatibles.rs:13:5
+   |
+13 |     new: u32,
+   |     ^^^
+
+error[E0412]: cannot find type `InputWithBannedName1` in this scope
+ --> tests/compile-fail/salsa_fields_incompatibles.rs:2:12
+  |
+2 | struct Jar(InputWithBannedName1, InputWithBannedName2);
+  |            ^^^^^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `InputWithBannedName2` in this scope
+ --> tests/compile-fail/salsa_fields_incompatibles.rs:2:34
+  |
+2 | struct Jar(InputWithBannedName1, InputWithBannedName2);
+  |                                  ^^^^^^^^^^^^^^^^^^^^ not found in this scope

--- a/salsa-2022-tests/tests/compile-fail/tracked_fn_incompatibles.rs
+++ b/salsa-2022-tests/tests/compile-fail/tracked_fn_incompatibles.rs
@@ -1,0 +1,47 @@
+#[salsa::jar(db = Db)]
+struct Jar(MyInput, tracked_fn_with_data, tracked_fn_with_db, tracked_fn_with_constructor, tracked_fn_with_one_input, tracked_fn_with_receiver_not_applied_to_impl_block);
+
+trait Db: salsa::DbWithJar<Jar> {}
+
+#[salsa::input(jar = Jar)]
+struct MyInput {
+    field: u32,
+}
+
+
+#[salsa::tracked(jar = Jar, data = Data)]
+fn tracked_fn_with_data(db: &dyn Db, input: MyInput) -> u32 {
+    input.field(db) * 2
+}
+
+#[salsa::tracked(jar = Jar, db = Db)]
+fn tracked_fn_with_db(db: &dyn Db, input: MyInput) -> u32 {
+    input.field(db) * 2
+}
+
+#[salsa::tracked(jar = Jar, constructor = TrackedFn3)]
+fn tracked_fn_with_constructor(db: &dyn Db, input: MyInput) -> u32 {
+    input.field(db) * 2
+}
+
+
+#[salsa::tracked(jar = Jar)]
+fn tracked_fn_with_one_input(db: &dyn Db) -> u32 {
+}
+
+
+#[salsa::tracked(jar = Jar)]
+fn tracked_fn_with_receiver_not_applied_to_impl_block(&self, db: &dyn Db) -> u32 {
+}
+
+#[salsa::tracked(jar = Jar, specify)]
+fn tracked_fn_with_receiver_not_applied_to_impl_block(db: &dyn Db, input: MyInput, input: MyInput) -> u32 {
+}
+
+
+
+
+
+
+
+fn main() {}

--- a/salsa-2022-tests/tests/compile-fail/tracked_fn_incompatibles.stderr
+++ b/salsa-2022-tests/tests/compile-fail/tracked_fn_incompatibles.stderr
@@ -16,12 +16,6 @@ error: `constructor` option not allowed here
 22 | #[salsa::tracked(jar = Jar, constructor = TrackedFn3)]
    |                             ^^^^^^^^^^^
 
-error: tracked functions must have at least a database and salsa struct argument
-  --> tests/compile-fail/tracked_fn_incompatibles.rs:29:4
-   |
-29 | fn tracked_fn_with_one_input(db: &dyn Db) -> u32 {
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error: #[salsa::tracked] must also be applied to the impl block for tracked methods
   --> tests/compile-fail/tracked_fn_incompatibles.rs:34:55
    |
@@ -47,19 +41,24 @@ error[E0412]: cannot find type `tracked_fn_with_db` in this scope
   |                                           ^^^^^^^^^^^^^^^^^^ not found in this scope
 
 error[E0412]: cannot find type `tracked_fn_with_constructor` in this scope
- --> tests/compile-fail/tracked_fn_incompatibles.rs:2:63
-  |
-2 | struct Jar(MyInput, tracked_fn_with_data, tracked_fn_with_db, tracked_fn_with_constructor, tracked_fn_with_one_input, tracked_fn_with_rec...
-  |                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
-
-error[E0412]: cannot find type `tracked_fn_with_one_input` in this scope
- --> tests/compile-fail/tracked_fn_incompatibles.rs:2:92
-  |
-2 | ..._fn_with_db, tracked_fn_with_constructor, tracked_fn_with_one_input, tracked_fn_with_receiver_not_applied_to_impl_block);
-  |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
+  --> tests/compile-fail/tracked_fn_incompatibles.rs:2:63
+   |
+2  | struct Jar(MyInput, tracked_fn_with_data, tracked_fn_with_db, tracked_fn_with_constructor, tracked_fn_with_one_input, tracked_fn_with_rec...
+   |                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `tracked_fn_with_one_input`
+...
+28 | #[salsa::tracked(jar = Jar)]
+   | ---------------------------- similarly named struct `tracked_fn_with_one_input` defined here
 
 error[E0412]: cannot find type `tracked_fn_with_receiver_not_applied_to_impl_block` in this scope
  --> tests/compile-fail/tracked_fn_incompatibles.rs:2:119
   |
 2 | ...r, tracked_fn_with_one_input, tracked_fn_with_receiver_not_applied_to_impl_block);
   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0308]: mismatched types
+  --> tests/compile-fail/tracked_fn_incompatibles.rs:29:46
+   |
+29 | fn tracked_fn_with_one_input(db: &dyn Db) -> u32 {
+   |    -------------------------                 ^^^ expected `u32`, found `()`
+   |    |
+   |    implicitly returns `()` as its body has no tail or `return` expression

--- a/salsa-2022-tests/tests/compile-fail/tracked_fn_incompatibles.stderr
+++ b/salsa-2022-tests/tests/compile-fail/tracked_fn_incompatibles.stderr
@@ -1,0 +1,65 @@
+error: `data` option not allowed here
+  --> tests/compile-fail/tracked_fn_incompatibles.rs:12:29
+   |
+12 | #[salsa::tracked(jar = Jar, data = Data)]
+   |                             ^^^^
+
+error: `db` option not allowed here
+  --> tests/compile-fail/tracked_fn_incompatibles.rs:17:29
+   |
+17 | #[salsa::tracked(jar = Jar, db = Db)]
+   |                             ^^
+
+error: `constructor` option not allowed here
+  --> tests/compile-fail/tracked_fn_incompatibles.rs:22:29
+   |
+22 | #[salsa::tracked(jar = Jar, constructor = TrackedFn3)]
+   |                             ^^^^^^^^^^^
+
+error: tracked functions must have at least a database and salsa struct argument
+  --> tests/compile-fail/tracked_fn_incompatibles.rs:29:4
+   |
+29 | fn tracked_fn_with_one_input(db: &dyn Db) -> u32 {
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: #[salsa::tracked] must also be applied to the impl block for tracked methods
+  --> tests/compile-fail/tracked_fn_incompatibles.rs:34:55
+   |
+34 | fn tracked_fn_with_receiver_not_applied_to_impl_block(&self, db: &dyn Db) -> u32 {
+   |                                                       ^
+
+error: tracked function takes too many arguments to have its value set with `specify`
+  --> tests/compile-fail/tracked_fn_incompatibles.rs:37:29
+   |
+37 | #[salsa::tracked(jar = Jar, specify)]
+   |                             ^^^^^^^
+
+error[E0412]: cannot find type `tracked_fn_with_data` in this scope
+ --> tests/compile-fail/tracked_fn_incompatibles.rs:2:21
+  |
+2 | struct Jar(MyInput, tracked_fn_with_data, tracked_fn_with_db, tracked_fn_with_constructor, tracked_fn_with_one_input, tracked_fn_with_rec...
+  |                     ^^^^^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `tracked_fn_with_db` in this scope
+ --> tests/compile-fail/tracked_fn_incompatibles.rs:2:43
+  |
+2 | struct Jar(MyInput, tracked_fn_with_data, tracked_fn_with_db, tracked_fn_with_constructor, tracked_fn_with_one_input, tracked_fn_with_rec...
+  |                                           ^^^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `tracked_fn_with_constructor` in this scope
+ --> tests/compile-fail/tracked_fn_incompatibles.rs:2:63
+  |
+2 | struct Jar(MyInput, tracked_fn_with_data, tracked_fn_with_db, tracked_fn_with_constructor, tracked_fn_with_one_input, tracked_fn_with_rec...
+  |                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `tracked_fn_with_one_input` in this scope
+ --> tests/compile-fail/tracked_fn_incompatibles.rs:2:92
+  |
+2 | ..._fn_with_db, tracked_fn_with_constructor, tracked_fn_with_one_input, tracked_fn_with_receiver_not_applied_to_impl_block);
+  |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `tracked_fn_with_receiver_not_applied_to_impl_block` in this scope
+ --> tests/compile-fail/tracked_fn_incompatibles.rs:2:119
+  |
+2 | ...r, tracked_fn_with_one_input, tracked_fn_with_receiver_not_applied_to_impl_block);
+  |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope

--- a/salsa-2022-tests/tests/compile-fail/tracked_impl_incompatibles.rs
+++ b/salsa-2022-tests/tests/compile-fail/tracked_impl_incompatibles.rs
@@ -1,0 +1,74 @@
+#[salsa::jar(db = Db)]
+struct Jar(MyTracked);
+
+
+#[salsa::tracked]
+struct MyTracked {
+    field: u32,
+}
+
+#[salsa::tracked(return_ref)]
+impl std::default::Default for MyTracked {
+    fn default() -> Self {
+
+    }
+}
+#[salsa::tracked(specify)]
+impl std::default::Default for MyTracked {
+    fn default() -> Self {
+
+    }
+}
+
+#[salsa::tracked(no_eq)]
+impl std::default::Default for MyTracked {
+    fn default() -> Self {
+
+    }
+}
+
+#[salsa::tracked(data = Data)]
+impl std::default::Default for MyTracked {
+    fn default() -> Self {
+
+    }
+}
+
+#[salsa::tracked(db = Db)]
+impl std::default::Default for MyTracked {
+    fn default() -> Self {
+
+    }
+}
+
+#[salsa::tracked(recover_fn = recover)]
+impl std::default::Default for MyTracked {
+    fn default() -> Self {
+
+    }
+}
+
+#[salsa::tracked(lru = 32)]
+impl std::default::Default for MyTracked {
+    fn default() -> Self {
+
+    }
+}
+
+#[salsa::tracked(constructor = Constructor)]
+impl std::default::Default for MyTracked {
+    fn default() -> Self {
+
+    }
+}
+#[salsa::tracked]
+impl std::default::Default for [MyTracked; 12] {
+    fn default() -> Self {
+
+    }
+}
+
+
+trait Db: salsa::DbWithJar<Jar> {}
+
+fn main() {}

--- a/salsa-2022-tests/tests/compile-fail/tracked_impl_incompatibles.stderr
+++ b/salsa-2022-tests/tests/compile-fail/tracked_impl_incompatibles.stderr
@@ -1,0 +1,53 @@
+error: `return_ref` option not allowed here
+  --> tests/compile-fail/tracked_impl_incompatibles.rs:10:18
+   |
+10 | #[salsa::tracked(return_ref)]
+   |                  ^^^^^^^^^^
+
+error: `specify` option not allowed here
+  --> tests/compile-fail/tracked_impl_incompatibles.rs:16:18
+   |
+16 | #[salsa::tracked(specify)]
+   |                  ^^^^^^^
+
+error: `no_eq` option not allowed here
+  --> tests/compile-fail/tracked_impl_incompatibles.rs:23:18
+   |
+23 | #[salsa::tracked(no_eq)]
+   |                  ^^^^^
+
+error: `data` option not allowed here
+  --> tests/compile-fail/tracked_impl_incompatibles.rs:30:18
+   |
+30 | #[salsa::tracked(data = Data)]
+   |                  ^^^^
+
+error: `db` option not allowed here
+  --> tests/compile-fail/tracked_impl_incompatibles.rs:37:18
+   |
+37 | #[salsa::tracked(db = Db)]
+   |                  ^^
+
+error: unrecognized option `recover_fn`
+  --> tests/compile-fail/tracked_impl_incompatibles.rs:44:18
+   |
+44 | #[salsa::tracked(recover_fn = recover)]
+   |                  ^^^^^^^^^^
+
+error: `lru` option not allowed here
+  --> tests/compile-fail/tracked_impl_incompatibles.rs:51:18
+   |
+51 | #[salsa::tracked(lru = 32)]
+   |                  ^^^
+
+error: `constructor` option not allowed here
+  --> tests/compile-fail/tracked_impl_incompatibles.rs:58:18
+   |
+58 | #[salsa::tracked(constructor = Constructor)]
+   |                  ^^^^^^^^^^^
+
+error: #[salsa::tracked] can only be applied to salsa structs
+  --> tests/compile-fail/tracked_impl_incompatibles.rs:65:32
+   |
+65 | impl std::default::Default for [MyTracked; 12] {
+   |                                ^^^^^^^^^^^^^^^

--- a/salsa-2022-tests/tests/compile-fail/tracked_method_incompatibles.rs
+++ b/salsa-2022-tests/tests/compile-fail/tracked_method_incompatibles.rs
@@ -1,0 +1,21 @@
+#[salsa::jar(db = Db)]
+struct Jar(Tracked);
+
+
+#[salsa::tracked(jar = Jar)]
+struct Tracked {
+    field: u32,    
+}
+
+
+impl Tracked {
+    #[salsa::tracked]
+    fn use_tracked(&self) {
+
+    }
+}
+
+trait Db: salsa::DbWithJar<Jar> {}
+
+
+fn main() {}

--- a/salsa-2022-tests/tests/compile-fail/tracked_method_incompatibles.stderr
+++ b/salsa-2022-tests/tests/compile-fail/tracked_method_incompatibles.stderr
@@ -1,0 +1,5 @@
+error: tracked functions must have at least a database and salsa struct argument
+  --> tests/compile-fail/tracked_method_incompatibles.rs:13:8
+   |
+13 |     fn use_tracked(&self) {
+   |        ^^^^^^^^^^^

--- a/salsa-2022-tests/tests/compile-fail/tracked_method_incompatibles.stderr
+++ b/salsa-2022-tests/tests/compile-fail/tracked_method_incompatibles.stderr
@@ -1,5 +1,5 @@
-error: tracked functions must have at least a database and salsa struct argument
-  --> tests/compile-fail/tracked_method_incompatibles.rs:13:8
+error: #[salsa::tracked] must also be applied to the impl block for tracked methods
+  --> tests/compile-fail/tracked_method_incompatibles.rs:13:20
    |
 13 |     fn use_tracked(&self) {
-   |        ^^^^^^^^^^^
+   |                    ^

--- a/salsa-2022-tests/tests/compile-fail/tracked_struct_incompatibles.rs
+++ b/salsa-2022-tests/tests/compile-fail/tracked_struct_incompatibles.rs
@@ -1,0 +1,36 @@
+#[salsa::jar(db = Db)]
+struct Jar(TrackedWithRetRef, TrackedSructWithSpecify, TrackedStructWithNoEq, TrackedStructWithDb, TrackedStructWithRecover, TrackedStructWithLru);
+
+trait Db: salsa::DbWithJar<Jar> {}
+
+
+#[salsa::tracked(jar = Jar, return_ref)]
+struct TrackedWithRetRef {
+    field: u32,    
+}
+
+#[salsa::tracked(jar = Jar, specify)]
+struct TrackedSructWithSpecify {
+    field: u32,    
+}
+
+#[salsa::tracked(jar = Jar, no_eq)]
+struct TrackedStructWithNoEq {
+    field: u32,    
+}
+
+#[salsa::tracked(jar = Jar, db = Db)]
+struct TrackedStructWithDb {
+    field: u32,    
+}
+
+#[salsa::tracked(jar = Jar, recover_fn = recover)]
+struct TrackedStructWithRecover {
+    field: u32,    
+}
+
+#[salsa::tracked(jar = Jar, lru =12)]
+struct TrackedStructWithLru {
+    field: u32,    
+}
+fn main() {}

--- a/salsa-2022-tests/tests/compile-fail/tracked_struct_incompatibles.stderr
+++ b/salsa-2022-tests/tests/compile-fail/tracked_struct_incompatibles.stderr
@@ -1,0 +1,71 @@
+error: `return_ref` option not allowed here
+ --> tests/compile-fail/tracked_struct_incompatibles.rs:7:29
+  |
+7 | #[salsa::tracked(jar = Jar, return_ref)]
+  |                             ^^^^^^^^^^
+
+error: `specify` option not allowed here
+  --> tests/compile-fail/tracked_struct_incompatibles.rs:12:29
+   |
+12 | #[salsa::tracked(jar = Jar, specify)]
+   |                             ^^^^^^^
+
+error: `no_eq` option not allowed here
+  --> tests/compile-fail/tracked_struct_incompatibles.rs:17:29
+   |
+17 | #[salsa::tracked(jar = Jar, no_eq)]
+   |                             ^^^^^
+
+error: `db` option not allowed here
+  --> tests/compile-fail/tracked_struct_incompatibles.rs:22:29
+   |
+22 | #[salsa::tracked(jar = Jar, db = Db)]
+   |                             ^^
+
+error: unrecognized option `recover_fn`
+  --> tests/compile-fail/tracked_struct_incompatibles.rs:27:29
+   |
+27 | #[salsa::tracked(jar = Jar, recover_fn = recover)]
+   |                             ^^^^^^^^^^
+
+error: `lru` option not allowed here
+  --> tests/compile-fail/tracked_struct_incompatibles.rs:32:29
+   |
+32 | #[salsa::tracked(jar = Jar, lru =12)]
+   |                             ^^^
+
+error[E0412]: cannot find type `TrackedWithRetRef` in this scope
+ --> tests/compile-fail/tracked_struct_incompatibles.rs:2:12
+  |
+2 | struct Jar(TrackedWithRetRef, TrackedSructWithSpecify, TrackedStructWithNoEq, TrackedStructWithDb, TrackedStructWithRecover, TrackedStruc...
+  |            ^^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `TrackedSructWithSpecify` in this scope
+ --> tests/compile-fail/tracked_struct_incompatibles.rs:2:31
+  |
+2 | struct Jar(TrackedWithRetRef, TrackedSructWithSpecify, TrackedStructWithNoEq, TrackedStructWithDb, TrackedStructWithRecover, TrackedStruc...
+  |                               ^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `TrackedStructWithNoEq` in this scope
+ --> tests/compile-fail/tracked_struct_incompatibles.rs:2:56
+  |
+2 | struct Jar(TrackedWithRetRef, TrackedSructWithSpecify, TrackedStructWithNoEq, TrackedStructWithDb, TrackedStructWithRecover, TrackedStruc...
+  |                                                        ^^^^^^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `TrackedStructWithDb` in this scope
+ --> tests/compile-fail/tracked_struct_incompatibles.rs:2:79
+  |
+2 | struct Jar(TrackedWithRetRef, TrackedSructWithSpecify, TrackedStructWithNoEq, TrackedStructWithDb, TrackedStructWithRecover, TrackedStruc...
+  |                                                                               ^^^^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `TrackedStructWithRecover` in this scope
+ --> tests/compile-fail/tracked_struct_incompatibles.rs:2:100
+  |
+2 | ...rackedStructWithNoEq, TrackedStructWithDb, TrackedStructWithRecover, TrackedStructWithLru);
+  |                                               ^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `TrackedStructWithLru` in this scope
+ --> tests/compile-fail/tracked_struct_incompatibles.rs:2:126
+  |
+2 | ...ackedStructWithDb, TrackedStructWithRecover, TrackedStructWithLru);
+  |                                                 ^^^^^^^^^^^^^^^^^^^^ not found in this scope


### PR DESCRIPTION
### What
Used `trybuild` to verify that incompatible options with salsa structs will not compile

Ref: #354 

### How:
I created a `.rs` file for each salsa struct. I decided not to create one for each incompatible option, as this would only greatly increase the number of files. 