### PR TITLE
feat: Re-add volatile queries

### DIFF
--- a/components/salsa-macros/src/query_group.rs
+++ b/components/salsa-macros/src/query_group.rs
@@ -59,6 +59,10 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
                         storage = QueryStorage::Dependencies;
                         num_storages += 1;
                     }
+                    "volatile" => {
+                        storage = QueryStorage::Volatile;
+                        num_storages += 1;
+                    }
                     "input" => {
                         storage = QueryStorage::Input;
                         num_storages += 1;
@@ -277,7 +281,7 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
                 specific durability instead of the default of
                 `Durability::LOW`. You can use `Durability::MAX`
                 to promise that its value will never change again.
- 
+
                 See `{fn_name}` for details.
 
                 *Note:* Setting values will trigger cancellation
@@ -400,6 +404,9 @@ pub(crate) fn query_group(args: TokenStream, input: TokenStream) -> TokenStream 
             QueryStorage::Memoized => quote!(salsa::plumbing::MemoizedStorage<Self>),
             QueryStorage::Dependencies => {
                 quote!(salsa::plumbing::DependencyStorage<Self>)
+            }
+            QueryStorage::Volatile => {
+                quote!(salsa::plumbing::VolatileStorage<Self>)
             }
             QueryStorage::Input => quote!(salsa::plumbing::InputStorage<Self>),
             QueryStorage::Interned => quote!(salsa::plumbing::InternedStorage<Self>),
@@ -747,6 +754,7 @@ enum QueryStorage {
     Interned,
     InternedLookup { intern_query_type: Ident },
     Transparent,
+    Volatile,
 }
 
 impl QueryStorage {
@@ -757,7 +765,7 @@ impl QueryStorage {
             | QueryStorage::Interned
             | QueryStorage::InternedLookup { .. }
             | QueryStorage::Transparent => false,
-            QueryStorage::Memoized | QueryStorage::Dependencies => true,
+            QueryStorage::Memoized | QueryStorage::Dependencies | QueryStorage::Volatile => true,
         }
     }
 }

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -34,6 +34,11 @@ pub type MemoizedStorage<Q> = DerivedStorage<Q, AlwaysMemoizeValue>;
 /// storage requirements.
 pub type DependencyStorage<Q> = DerivedStorage<Q, NeverMemoizeValue>;
 
+/// "Volatile" quries stores the value but always updates the value when recomputed,
+/// forcing any dependent queries to also be recomputed. No `Eq` constraint is required
+/// for the value stored.
+pub type VolatileStorage<Q> = DerivedStorage<Q, VolatileMemoizeValue>;
+
 /// Handles storage where the value is 'derived' by executing a
 /// function (in contrast to "inputs").
 pub struct DerivedStorage<Q, MP>
@@ -95,6 +100,20 @@ where
 
     fn memoized_value_eq(_old_value: &Q::Value, _new_value: &Q::Value) -> bool {
         panic!("cannot reach since we never memoize")
+    }
+}
+
+pub enum VolatileMemoizeValue {}
+impl<Q> MemoizationPolicy<Q> for VolatileMemoizeValue
+where
+    Q: QueryFunction,
+{
+    fn should_memoize_value(_key: &Q::Key) -> bool {
+        true
+    }
+
+    fn memoized_value_eq(_old_value: &Q::Value, _new_value: &Q::Value) -> bool {
+        false
     }
 }
 

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 
 pub use crate::derived::DependencyStorage;
 pub use crate::derived::MemoizedStorage;
+pub use crate::derived::VolatileStorage;
 pub use crate::input::InputStorage;
 pub use crate::interned::InternedStorage;
 pub use crate::interned::LookupInternedStorage;


### PR DESCRIPTION
I have some values which I would like store but which do not implement `Eq`, `volatile` queries, which used to exist, avoid this requirement by simply assuming that the value always changes and therefore do not need to compare it.

An alternative to this which is mentioned in #218 is that we might allow the equality check to be customized via, say `#[salsa::eq(my_eq)]`. It seems slightly more complicated though so I just went with this as a start (since the storage assumes it can use `#[derive(Default)]` to construct right now so some codegen changes are needed).

cc #56 #218