### PR TITLE
Allow `clippy::needless_lifetimes` on tracked method getters

### DIFF
--- a/components/salsa-2022-macros/src/tracked_fn.rs
+++ b/components/salsa-2022-macros/src/tracked_fn.rs
@@ -234,6 +234,12 @@ fn tracked_method(
 
     let (config_ty, fn_struct) = crate::tracked_fn::fn_struct(&args, &item_fn)?;
 
+    // we generate a `'db` lifetime that clippy
+    // sometimes doesn't like
+    item_method
+        .attrs
+        .push(syn::parse_quote! {#[allow(clippy::needless_lifetimes)]});
+
     item_method.block = getter_fn(
         &args,
         &mut item_method.sig,

--- a/salsa-2022-tests/tests/warnings/main.rs
+++ b/salsa-2022-tests/tests/warnings/main.rs
@@ -3,4 +3,5 @@
 #![deny(warnings)]
 
 mod needless_borrow;
+mod needless_lifetimes;
 mod unused_variable_db;

--- a/salsa-2022-tests/tests/warnings/needless_lifetimes.rs
+++ b/salsa-2022-tests/tests/warnings/needless_lifetimes.rs
@@ -1,0 +1,27 @@
+pub trait Db: salsa::DbWithJar<Jar> {}
+
+#[salsa::jar(db = Db)]
+pub struct Jar(SourceTree, SourceTree_all_items, use_tree);
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct Item {}
+
+#[salsa::tracked(jar = Jar)]
+pub struct SourceTree {}
+
+#[salsa::tracked(jar = Jar)]
+impl SourceTree {
+    #[salsa::tracked(return_ref)]
+    pub fn all_items(self, _db: &dyn Db) -> Vec<Item> {
+        todo!()
+    }
+}
+
+#[salsa::tracked(jar = Jar, return_ref)]
+fn use_tree(_db: &dyn Db, _tree: SourceTree) {}
+
+#[allow(unused)]
+fn use_it(db: &dyn Db, tree: SourceTree) {
+    tree.all_items(db);
+    use_tree(db, tree);
+}


### PR DESCRIPTION
The tracked method generation adds an extra `__db` lifetime to the signature, but clippy complains that this lifetime can be elided in some cases, so add an allow to silence this warning.

Unfortunately clippy doesn't lint inside of the warning tests, so those tests don't do anything to check that no clippy warnings are generated.