### PR TITLE
Update trybuild tests

### DIFF
--- a/salsa-2022-tests/tests/compile-fail/jars_incompatibles.stderr
+++ b/salsa-2022-tests/tests/compile-fail/jars_incompatibles.stderr
@@ -57,5 +57,8 @@ error[E0412]: cannot find type `Jar1` in this scope
    |
 26 | #[salsa::input(jar = Jar1)]
    |                      ^^^^ not found in this scope
-27 | struct MyInput {
-   |               - help: you might be missing a type parameter: `<Jar1>`
+   |
+help: you might be missing a type parameter
+   |
+27 | struct MyInput<Jar1> {
+   |               ++++++


### PR DESCRIPTION
Rust 1.68 changed how the help suggestion text renders, and shows a diff for the suggested change.