### PR TITLE
Change the constructor of `salsa::Id` to const fn

### DIFF
--- a/components/salsa-2022/src/id.rs
+++ b/components/salsa-2022/src/id.rs
@@ -26,14 +26,16 @@ impl Id {
     /// but it can be useful if you are using the type as a general
     /// purpose "identifier" internally.
     #[track_caller]
-    pub fn from_u32(x: u32) -> Self {
-        assert!(x < Self::MAX_U32);
+    pub const fn from_u32(x: u32) -> Self {
         Id {
-            value: NonZeroU32::new(x + 1).unwrap(),
+            value: match NonZeroU32::new(x + 1) {
+                Some(v) => v,
+                None => panic!("given value is too large to be a `salsa::Id`"),
+            },
         }
     }
 
-    pub fn as_u32(self) -> u32 {
+    pub const fn as_u32(self) -> u32 {
         self.value.get() - 1
     }
 }

--- a/salsa-2022-tests/tests/compile-fail/get-set-on-private-field.stderr
+++ b/salsa-2022-tests/tests/compile-fail/get-set-on-private-field.stderr
@@ -1,17 +1,17 @@
-error[E0624]: associated function `field` is private
+error[E0624]: method `field` is private
   --> tests/compile-fail/get-set-on-private-field.rs:29:11
    |
 7  |     #[salsa::input(jar = Jar)]
-   |     -------------------------- private associated function defined here
+   |     -------------------------- private method defined here
 ...
 29 |     input.field(&db);
-   |           ^^^^^ private associated function
+   |           ^^^^^ private method
 
-error[E0624]: associated function `set_field` is private
+error[E0624]: method `set_field` is private
   --> tests/compile-fail/get-set-on-private-field.rs:30:11
    |
 7  |     #[salsa::input(jar = Jar)]
-   |     -------------------------- private associated function defined here
+   |     -------------------------- private method defined here
 ...
 30 |     input.set_field(&mut db).to(23);
-   |           ^^^^^^^^^ private associated function
+   |           ^^^^^^^^^ private method


### PR DESCRIPTION
This change is motivated to allow interned structs to have default const instances and prefill them in db initialization.

A specific example is managing symbols as a salsa interned struct in a compiler implementation. By declaring keywords as `const` symbols, we can handle keywords without going through their internal representation as rustc does (ref: [rustc_span::symbol](https://github.com/rust-lang/rust/blob/master/compiler/rustc_span/src/symbol.rs)). 
Conceptually, it'd look like the one below.

```rust
#[salsa::interned]
pub struct Symbol {
    data: String,
}

const SELF_SYM: Symbol = Symbol(salsa::Id::from_u32(1))
...

/// This function is called in db initialization.
fn prefill(db: &dyn HirDb) {
       Symbol::new(db, "self".to_string());
       ...
}
```