### PR TITLE
Improve assert message when creating a tracked struct outside of a tracked function

### DIFF
--- a/components/salsa-2022/src/runtime/local_state.rs
+++ b/components/salsa-2022/src/runtime/local_state.rs
@@ -291,7 +291,10 @@ impl LocalState {
 
     #[track_caller]
     pub(crate) fn disambiguate(&self, data_hash: u64) -> (DatabaseKeyIndex, Disambiguator) {
-        assert!(self.query_in_progress());
+        assert!(
+            self.query_in_progress(),
+            "cannot create a tracked struct disambiguator outside of a tracked function"
+        );
         self.with_query_stack(|stack| {
             let top_query = stack.last_mut().unwrap();
             let disambiguator = top_query.disambiguate(data_hash);

--- a/salsa-2022-tests/tests/panic-when-creating-tracked-struct-outside-of-tracked-fn.rs
+++ b/salsa-2022-tests/tests/panic-when-creating-tracked-struct-outside-of-tracked-fn.rs
@@ -1,0 +1,31 @@
+//! Test that creating a tracked struct outside of a
+//! tracked function panics with an assert message.
+
+#[salsa::jar(db = Db)]
+struct Jar(MyTracked);
+
+trait Db: salsa::DbWithJar<Jar> {}
+
+#[salsa::tracked(jar = Jar)]
+struct MyTracked {
+    field: u32,
+}
+
+#[salsa::db(Jar)]
+#[derive(Default)]
+struct Database {
+    storage: salsa::Storage<Self>,
+}
+
+impl salsa::Database for Database {}
+
+impl Db for Database {}
+
+#[test]
+#[should_panic(
+    expected = "cannot create a tracked struct disambiguator outside of a tracked function"
+)]
+fn execute() {
+    let db = Database::default();
+    MyTracked::new(&db, 0);
+}


### PR DESCRIPTION
Fixes #441 