### PR TITLE
add a link to the older version of Salsa in the document

### DIFF
--- a/book/_redirects
+++ b/book/_redirects
@@ -1,0 +1,2 @@
+# Redirects from what the browser requests to what we serve
+/                /salsa2022

--- a/book/netlify.sh
+++ b/book/netlify.sh
@@ -13,4 +13,34 @@ curl -L https://github.com/badboy/mdbook-mermaid/releases/download/v$MDBOOK_MERM
 curl -L https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v$MDBOOK_LINKCHECK_VERSION/mdbook-linkcheck.v$MDBOOK_LINKCHECK_VERSION.x86_64-unknown-linux-gnu.zip -O
 unzip mdbook-linkcheck.v$MDBOOK_LINKCHECK_VERSION.x86_64-unknown-linux-gnu.zip -d ~/.cargo/bin
 chmod +x ~/.cargo/bin/mdbook-linkcheck
-mdbook build
+
+# ======================================================================
+# The following script automates the deployment of both the latest and a
+# specified older version of the 'salsa' documentation using mdbook
+
+# Store the current branch or commit
+original_branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$original_branch" == "HEAD" ]; then
+  original_branch=$(git rev-parse HEAD)
+fi
+
+mkdir -p versions  # Create a root directory for all versions
+
+# Declare an associative array to map commits to custom version directory names
+declare -A commit_to_version=( ["$original_branch"]="salsa2022" ["754eea8b5f8a31b1100ba313d59e41260b494225"]="salsa" )
+
+# Loop over the keys (commit hashes or branch names) in the associative array
+for commit in "${!commit_to_version[@]}"; do
+  git checkout $commit
+  mdbook build
+  version_dir="versions/${commit_to_version[$commit]}"
+  mkdir -p $version_dir
+  mv book/html/* $version_dir
+  rm -rf book
+done
+
+# Return to the original branch or commit
+git checkout $original_branch
+
+# Copy _redirects to the root directory
+cp _redirects versions

--- a/book/src/caveat.md
+++ b/book/src/caveat.md
@@ -1,3 +1,5 @@
 > ⚠️ **IN-PROGRESS VERSION OF SALSA.** ⚠️
 >
 > This page describes the unreleased "Salsa 2022" version, which is a major departure from older versions of salsa. The code here works but is only available on github and from the `salsa-2022` crate.
+>
+> If you are looking for the older version of salsa, simply visit [this link](https://old-salsa-rs.netlify.app/)

--- a/book/src/caveat.md
+++ b/book/src/caveat.md
@@ -2,4 +2,4 @@
 >
 > This page describes the unreleased "Salsa 2022" version, which is a major departure from older versions of salsa. The code here works but is only available on github and from the `salsa-2022` crate.
 >
-> If you are looking for the older version of salsa, simply visit [this link](https://old-salsa-rs.netlify.app/)
+> If you are looking for the older version of salsa, simply visit [this link](https://salsa-rs.netlify.app/salsa)


### PR DESCRIPTION
related to #448 

As Salsa-2022 is no yet complete and it is still unstable, there are some users who continue to use the old version of Salsa, or prefer using it due to its more stable API. Therefore, I think it is necessary to re-deploy the book for the older version of Salsa.

I have deployed the book for the older version from commit [754eea8b5f8a31b1100ba313d59e41260b494225](https://github.com/salsa-rs/salsa/commit/754eea8b5f8a31b1100ba313d59e41260b494225)  of Salsa on https://old-salsa-rs.netlify.app/