### PR TITLE
Remove `Implementing the Default trait` book section

### DIFF
--- a/book/src/tutorial/db.md
+++ b/book/src/tutorial/db.md
@@ -35,14 +35,6 @@ If you want to permit accessing your database from multiple threads at once, the
 {{#include ../../../examples-2022/calc/src/db.rs:par_db_impl}}
 ```
 
-## Implementing the `Default` trait
-
-It's not required, but implementing the `Default` trait is often a convenient way to let users instantiate your database:
-
-```rust
-{{#include ../../../examples-2022/calc/src/db.rs:default_impl}}
-```
-
 ## Implementing the traits for each jar
 
 The `Database` struct also needs to implement the [database traits for each jar](./jar.md#database-trait-for-the-jar).


### PR DESCRIPTION
https://github.com/salsa-rs/salsa/commit/73102b1e8ed4f373fbd02f28dc7884b3d9de96b3 removed `ANCHOR: default_impl` from https://github.com/salsa-rs/salsa/blob/master/examples-2022/calc/src/db.rs, but it still in the book, which results in an confusing empty code block: https://salsa-rs.github.io/salsa/tutorial/db.html#implementing-the-default-trait

The struct is already has `#[derive(Default)]`, so at this point the section is not very useful. Maybe it is better without it?