### PR TITLE
Added destructors to inputs

### DIFF
--- a/components/salsa-2022-macros/src/accumulator.rs
+++ b/components/salsa-2022-macros/src/accumulator.rs
@@ -38,6 +38,8 @@ impl crate::options::AllowedOptions for Accumulator {
     const LRU: bool = false;
 
     const CONSTRUCTOR_NAME: bool = false;
+
+    const DESTRUCTOR_NAME: bool = false;
 }
 
 fn accumulator_contents(

--- a/components/salsa-2022-macros/src/interned.rs
+++ b/components/salsa-2022-macros/src/interned.rs
@@ -51,6 +51,8 @@ impl crate::options::AllowedOptions for InternedStruct {
     const LRU: bool = false;
 
     const CONSTRUCTOR_NAME: bool = true;
+
+    const DESTRUCTOR_NAME: bool = false;
 }
 
 impl InternedStruct {

--- a/components/salsa-2022-macros/src/jar.rs
+++ b/components/salsa-2022-macros/src/jar.rs
@@ -47,6 +47,8 @@ impl crate::options::AllowedOptions for Jar {
     const LRU: bool = false;
 
     const CONSTRUCTOR_NAME: bool = false;
+
+    const DESTRUCTOR_NAME: bool = false;
 }
 
 pub(crate) fn jar_struct_and_friends(

--- a/components/salsa-2022-macros/src/salsa_struct.rs
+++ b/components/salsa-2022-macros/src/salsa_struct.rs
@@ -217,6 +217,14 @@ impl<A: AllowedOptions> SalsaStruct<A> {
         }
     }
 
+    /// Returns the `destructor_name` in `Options` if it is `Some`, else `new`
+    pub(crate) fn destructor_name(&self) -> syn::Ident {
+        match self.args.destructor_name.clone() {
+            Some(name) => name,
+            None => Ident::new("delete", Span::call_site()),
+        }
+    }
+
     /// For each of the fields passed as an argument,
     /// generate a struct named `Ident_Field` and an impl
     /// of `salsa::function::Configuration` for that struct.

--- a/components/salsa-2022-macros/src/tracked_fn.rs
+++ b/components/salsa-2022-macros/src/tracked_fn.rs
@@ -78,6 +78,8 @@ impl crate::options::AllowedOptions for TrackedFn {
     const LRU: bool = true;
 
     const CONSTRUCTOR_NAME: bool = false;
+
+    const DESTRUCTOR_NAME: bool = false;
 }
 
 type ImplArgs = Options<TrackedImpl>;
@@ -180,6 +182,8 @@ impl crate::options::AllowedOptions for TrackedImpl {
     const CONSTRUCTOR_NAME: bool = false;
 
     const SINGLETON: bool = false;
+
+    const DESTRUCTOR_NAME: bool = false;
 }
 
 fn tracked_method(

--- a/components/salsa-2022-macros/src/tracked_struct.rs
+++ b/components/salsa-2022-macros/src/tracked_struct.rs
@@ -45,6 +45,8 @@ impl crate::options::AllowedOptions for TrackedStruct {
     const LRU: bool = false;
 
     const CONSTRUCTOR_NAME: bool = true;
+
+    const DESTRUCTOR_NAME: bool = false;
 }
 
 impl TrackedStruct {

--- a/salsa-2022-tests/tests/input_deletion.rs
+++ b/salsa-2022-tests/tests/input_deletion.rs
@@ -1,0 +1,71 @@
+//! Test input deletion
+
+use salsa::DebugWithDb;
+use salsa_2022_tests::{HasLogger, Logger};
+
+use expect_test::expect;
+use test_log::test;
+
+#[salsa::jar(db = Db)]
+struct Jar(MyInput, final_result);
+
+trait Db: salsa::DbWithJar<Jar> + HasLogger {}
+
+#[salsa::input]
+struct MyInput {
+    field: u32,
+}
+
+#[salsa::tracked]
+fn final_result(db: &dyn Db, input: MyInput) -> u32 {
+    db.push_log(format!("final_result({:?})", input));
+    input.field(db) + 1
+}
+
+#[salsa::db(Jar)]
+#[derive(Default)]
+struct Database {
+    storage: salsa::Storage<Self>,
+    logger: Logger,
+}
+
+impl salsa::Database for Database {
+    fn salsa_event(&self, event: salsa::Event) {
+        match event.kind {
+            salsa::EventKind::WillDiscardStaleOutput { .. }
+            | salsa::EventKind::DidDiscard { .. } => {
+                self.push_log(format!("salsa_event({:?})", event.kind.debug(self)));
+            }
+            _ => {}
+        }
+    }
+}
+
+impl Db for Database {}
+
+impl HasLogger for Database {
+    fn logger(&self) -> &Logger {
+        &self.logger
+    }
+}
+
+#[test]
+fn basic() {
+    let mut db = Database::default();
+
+    // Creates 3 tracked structs
+    let input = MyInput::new(&db, 3);
+    assert_eq!(final_result(&db, input), 4);
+    db.assert_logs(expect![[r#"
+        [
+            "final_result(MyInput(Id { value: 1 }))",
+        ]"#]]);
+
+    let result = input.delete(&db);
+    assert_eq!(result, Some((3,)));
+    db.assert_logs(expect![[r#"
+        [
+            "salsa_event(DidDiscard { key: field(0) })",
+            "salsa_event(DidDiscard { key: final_result(0) })",
+        ]"#]]);
+}


### PR DESCRIPTION
This is about the simplest way to solve this problem. Note that I do not do anything regarding making input structs non-`Copy`. Instead, you can handle free-after-free by using the Option return result.

I am not familiar enough with the codebase to know if this is likely to bork things elsewhere. I also don't know enough about our thread safety guarantees to be certain that the strategy of deleting each input ingredient in turn won't cause race conditions.

Resolves #345. 