### PR TITLE
[breaking-salsa-2022] Debug with db: ignore deps, support customization

### DIFF
--- a/components/salsa-2022-macros/src/input.rs
+++ b/components/salsa-2022-macros/src/input.rs
@@ -1,4 +1,4 @@
-use crate::salsa_struct::{SalsaField, SalsaStruct, SalsaStructKind};
+use crate::salsa_struct::{SalsaField, SalsaStruct};
 use proc_macro2::{Literal, TokenStream};
 
 /// For an entity struct `Foo` with fields `f1: T1, ..., fN: TN`, we generate...
@@ -10,9 +10,7 @@ pub(crate) fn input(
     args: proc_macro::TokenStream,
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    match SalsaStruct::new(SalsaStructKind::Input, args, input)
-        .and_then(|el| InputStruct(el).generate_input())
-    {
+    match SalsaStruct::new(args, input).and_then(|el| InputStruct(el).generate_input()) {
         Ok(s) => s.into(),
         Err(err) => err.into_compile_error().into(),
     }

--- a/components/salsa-2022-macros/src/interned.rs
+++ b/components/salsa-2022-macros/src/interned.rs
@@ -1,4 +1,4 @@
-use crate::salsa_struct::{SalsaStruct, SalsaStructKind};
+use crate::salsa_struct::SalsaStruct;
 use proc_macro2::TokenStream;
 
 // #[salsa::interned(jar = Jar0, data = TyData0)]
@@ -13,9 +13,7 @@ pub(crate) fn interned(
     args: proc_macro::TokenStream,
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    match SalsaStruct::new(SalsaStructKind::Interned, args, input)
-        .and_then(|el| InternedStruct(el).generate_interned())
-    {
+    match SalsaStruct::new(args, input).and_then(|el| InternedStruct(el).generate_interned()) {
         Ok(s) => s.into(),
         Err(err) => err.into_compile_error().into(),
     }

--- a/components/salsa-2022-macros/src/salsa_struct.rs
+++ b/components/salsa-2022-macros/src/salsa_struct.rs
@@ -73,6 +73,8 @@ impl<A: AllowedOptions> SalsaStruct<A> {
             .iter()
             .map(|attr| {
                 if attr.path.is_ident("customize") {
+                    // FIXME: this should be a comma separated list but I couldn't
+                    // be bothered to remember how syn does this.
                     let args: syn::Ident = attr.parse_args()?;
                     if args.to_string() == "DebugWithDb" {
                         Ok(vec![Customization::DebugWithDb])

--- a/components/salsa-2022-macros/src/tracked_struct.rs
+++ b/components/salsa-2022-macros/src/tracked_struct.rs
@@ -1,6 +1,6 @@
 use proc_macro2::{Literal, Span, TokenStream};
 
-use crate::salsa_struct::{SalsaField, SalsaStruct, SalsaStructKind};
+use crate::salsa_struct::{SalsaField, SalsaStruct};
 
 /// For an tracked struct `Foo` with fields `f1: T1, ..., fN: TN`, we generate...
 ///
@@ -11,8 +11,7 @@ pub(crate) fn tracked(
     args: proc_macro::TokenStream,
     struct_item: syn::ItemStruct,
 ) -> syn::Result<TokenStream> {
-    SalsaStruct::with_struct(SalsaStructKind::Tracked, args, struct_item)
-        .and_then(|el| TrackedStruct(el).generate_tracked())
+    SalsaStruct::with_struct(args, struct_item).and_then(|el| TrackedStruct(el).generate_tracked())
 }
 
 struct TrackedStruct(SalsaStruct<Self>);

--- a/components/salsa-2022/src/event.rs
+++ b/components/salsa-2022/src/event.rs
@@ -28,15 +28,10 @@ impl<Db> DebugWithDb<Db> for Event
 where
     Db: ?Sized + Database,
 {
-    fn fmt(
-        &self,
-        f: &mut std::fmt::Formatter<'_>,
-        db: &Db,
-        include_all_fields: bool,
-    ) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>, db: &Db) -> std::fmt::Result {
         f.debug_struct("Event")
             .field("runtime_id", &self.runtime_id)
-            .field("kind", &self.kind.debug_with(db, include_all_fields))
+            .field("kind", &self.kind.debug(db))
             .finish()
     }
 }
@@ -154,19 +149,11 @@ impl<Db> DebugWithDb<Db> for EventKind
 where
     Db: ?Sized + Database,
 {
-    fn fmt(
-        &self,
-        fmt: &mut std::fmt::Formatter<'_>,
-        db: &Db,
-        include_all_fields: bool,
-    ) -> std::fmt::Result {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>, db: &Db) -> std::fmt::Result {
         match self {
             EventKind::DidValidateMemoizedValue { database_key } => fmt
                 .debug_struct("DidValidateMemoizedValue")
-                .field(
-                    "database_key",
-                    &database_key.debug_with(db, include_all_fields),
-                )
+                .field("database_key", &database_key.debug(db))
                 .finish(),
             EventKind::WillBlockOn {
                 other_runtime_id,
@@ -174,17 +161,11 @@ where
             } => fmt
                 .debug_struct("WillBlockOn")
                 .field("other_runtime_id", other_runtime_id)
-                .field(
-                    "database_key",
-                    &database_key.debug_with(db, include_all_fields),
-                )
+                .field("database_key", &database_key.debug(db))
                 .finish(),
             EventKind::WillExecute { database_key } => fmt
                 .debug_struct("WillExecute")
-                .field(
-                    "database_key",
-                    &database_key.debug_with(db, include_all_fields),
-                )
+                .field("database_key", &database_key.debug(db))
                 .finish(),
             EventKind::WillCheckCancellation => fmt.debug_struct("WillCheckCancellation").finish(),
             EventKind::WillDiscardStaleOutput {
@@ -192,29 +173,20 @@ where
                 output_key,
             } => fmt
                 .debug_struct("WillDiscardStaleOutput")
-                .field(
-                    "execute_key",
-                    &execute_key.debug_with(db, include_all_fields),
-                )
-                .field("output_key", &output_key.debug_with(db, include_all_fields))
+                .field("execute_key", &execute_key.debug(db))
+                .field("output_key", &output_key.debug(db))
                 .finish(),
             EventKind::DidDiscard { key } => fmt
                 .debug_struct("DidDiscard")
-                .field("key", &key.debug_with(db, include_all_fields))
+                .field("key", &key.debug(db))
                 .finish(),
             EventKind::DidDiscardAccumulated {
                 executor_key,
                 accumulator,
             } => fmt
                 .debug_struct("DidDiscardAccumulated")
-                .field(
-                    "executor_key",
-                    &executor_key.debug_with(db, include_all_fields),
-                )
-                .field(
-                    "accumulator",
-                    &accumulator.debug_with(db, include_all_fields),
-                )
+                .field("executor_key", &executor_key.debug(db))
+                .field("accumulator", &accumulator.debug(db))
                 .finish(),
         }
     }

--- a/components/salsa-2022/src/key.rs
+++ b/components/salsa-2022/src/key.rs
@@ -38,12 +38,7 @@ impl<Db> crate::debug::DebugWithDb<Db> for DependencyIndex
 where
     Db: ?Sized + Database,
 {
-    fn fmt(
-        &self,
-        f: &mut std::fmt::Formatter<'_>,
-        db: &Db,
-        _include_all_fields: bool,
-    ) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>, db: &Db) -> std::fmt::Result {
         db.fmt_index(*self, f)
     }
 }
@@ -73,14 +68,9 @@ impl<Db> crate::debug::DebugWithDb<Db> for DatabaseKeyIndex
 where
     Db: ?Sized + Database,
 {
-    fn fmt(
-        &self,
-        f: &mut std::fmt::Formatter<'_>,
-        db: &Db,
-        include_all_fields: bool,
-    ) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>, db: &Db) -> std::fmt::Result {
         let i: DependencyIndex = (*self).into();
-        DebugWithDb::fmt(&i, f, db, include_all_fields)
+        DebugWithDb::fmt(&i, f, db)
     }
 }
 

--- a/components/salsa-2022/src/runtime.rs
+++ b/components/salsa-2022/src/runtime.rs
@@ -104,6 +104,22 @@ impl Runtime {
         self.shared_state.empty_dependencies.clone()
     }
 
+    /// Executes `op` but ignores its effect on
+    /// the query dependencies; intended for use
+    /// by `DebugWithDb` only.
+    ///
+    /// # Danger: intended for debugging only
+    ///
+    /// This operation is intended for **debugging only**.
+    /// Misuse will cause Salsa to give incorrect results.
+    /// The expectation is that the type `R` produced will be
+    /// logged or printed out. **The type `R` that is produced
+    /// should not affect the result or other outputs
+    /// (such as accumulators) from the current Salsa query.**
+    pub fn debug_probe<R>(&self, op: impl FnOnce() -> R) -> R {
+        self.local_state.debug_probe(op)
+    }
+
     pub fn snapshot(&self) -> Self {
         if self.local_state.query_in_progress() {
             panic!("it is not legal to `snapshot` during a query (see salsa-rs/salsa#80)");

--- a/components/salsa-2022/src/runtime/local_state.rs
+++ b/components/salsa-2022/src/runtime/local_state.rs
@@ -174,6 +174,25 @@ impl LocalState {
         self.with_query_stack(|stack| !stack.is_empty())
     }
 
+    /// Dangerous operation: executes `op` but ignores its effect on
+    /// the query dependencies. Useful for debugging statements, but
+    /// otherwise not to be toyed with!
+    pub(super) fn debug_probe<R>(&self, op: impl FnOnce() -> R) -> R {
+        let saved_state: Option<_> =
+            self.with_query_stack(|stack| Some(stack.last()?.save_query_state()));
+
+        let result = op();
+
+        if let Some(saved_state) = saved_state {
+            self.with_query_stack(|stack| {
+                let active_query = stack.last_mut().expect("query stack not empty");
+                active_query.restore_query_state(saved_state);
+            });
+        }
+
+        result
+    }
+
     /// Returns the index of the active query along with its *current* durability/changed-at
     /// information. As the query continues to execute, naturally, that information may change.
     pub(super) fn active_query(&self) -> Option<(DatabaseKeyIndex, StampedValue<()>)> {

--- a/examples-2022/calc/src/parser.rs
+++ b/examples-2022/calc/src/parser.rs
@@ -367,7 +367,7 @@ fn parse_string(source_text: &str) -> String {
     let accumulated = parse_statements::accumulated::<Diagnostics>(&db, source_program);
 
     // Format the result as a string and return it
-    format!("{:#?}", (statements.debug_all(&db), accumulated))
+    format!("{:#?}", (statements.debug(&db), accumulated))
 }
 // ANCHOR_END: parse_string
 

--- a/salsa-2022-tests/tests/input_with_ids.rs
+++ b/salsa-2022-tests/tests/input_with_ids.rs
@@ -38,7 +38,7 @@ fn test_debug() {
     let input = MyInput::new(&mut db, 50, 10, Field {});
 
     let actual = format!("{:?}", input.debug(&db));
-    let expected = expect![[r#"MyInput { [salsa id]: 0, id_one: 50, id_two: 10 }"#]];
+    let expected = expect!["MyInput { [salsa id]: 0, id_one: 50, id_two: 10, field: Field }"];
     expected.assert_eq(&actual);
 }
 

--- a/salsa-2022-tests/tests/singleton.rs
+++ b/salsa-2022-tests/tests/singleton.rs
@@ -67,6 +67,6 @@ fn debug() {
     let db = Database::default();
     let input = MyInput::new(&db, 3, 4);
     let actual = format!("{:?}", input.debug(&db));
-    let expected = expect![[r#"MyInput { [salsa id]: 0, id_field: 4 }"#]];
+    let expected = expect!["MyInput { [salsa id]: 0, field: 3, id_field: 4 }"];
     expected.assert_eq(&actual);
 }

--- a/salsa-2022-tests/tests/tracked_fn_read_own_specify.rs
+++ b/salsa-2022-tests/tests/tracked_fn_read_own_specify.rs
@@ -55,7 +55,7 @@ fn execute() {
     assert_eq!(tracked_fn(&db, input), 2222);
     db.assert_logs(expect![[r#"
         [
-            "tracked_fn(MyInput { [salsa id]: 0 })",
+            "tracked_fn(MyInput { [salsa id]: 0, field: 22 })",
         ]"#]]);
 
     // A "synthetic write" causes the system to act *as though* some

--- a/salsa-2022-tests/tests/warnings/needless_borrow.rs
+++ b/salsa-2022-tests/tests/warnings/needless_borrow.rs
@@ -7,12 +7,7 @@ struct Jar(TokenTree);
 enum Token {}
 
 impl salsa::DebugWithDb<dyn Db + '_> for Token {
-    fn fmt(
-        &self,
-        _f: &mut std::fmt::Formatter<'_>,
-        _db: &dyn Db,
-        _include_all_fields: bool,
-    ) -> std::fmt::Result {
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>, _db: &dyn Db) -> std::fmt::Result {
         unreachable!()
     }
 }


### PR DESCRIPTION
This changes how `DebugWithDb` works:

* All field values are always included (useful) and thus the `include_all_fields` flag is removed (it was annoying).
* Dependencies from those field values are ignored by salsa (useful, but potentially dangerous).
* You can use `#[customize(DebugWithDb)]` to skip generating the impl for a given type.

I think overall this is an improvement, though it is a breaking change.