### PR TITLE
Add missing `syn` feature requirement

### DIFF
--- a/components/salsa-2022-macros/Cargo.toml
+++ b/components/salsa-2022-macros/Cargo.toml
@@ -11,5 +11,5 @@ heck = "0.4"
 proc-macro2 = "1.0"
 quote = "1.0"
 eyre = "0.6.5"
-syn = { version = "2.0.64", features = ["visit-mut"] }
+syn = { version = "2.0.64", features = ["full", "visit-mut"] }
 synstructure = "0.13.1"


### PR DESCRIPTION
With the latest commit (283ccda), any project that uses Salsa hits tons
of internal errors within Salsa. That's because Salsa needs syn's `full`
feature, which was removed from the Cargo.toml as part of the Salsa 3.0
mega-PR. Because Salsa 1.0 still has the `full` feature in its
Cargo.toml, Cargo implicitly still enables `full` for Salsa 2022, and
thus the Salsa 2022 example projects compile fine -- even though any
external code using Salsa does not.
