### PR TITLE
Remove `bors.toml` and update GitHub Actions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -3,38 +3,37 @@ name: Book
 on:
   push:
     branches:
-    - master
-    - staging
-    - trying
+      - master
   pull_request:
     paths:
-    - 'book/**'
-    - '.github/workflows/book.yml'
+      - "book/**"
+      - ".github/workflows/book.yml"
+  merge_group:
 
 jobs:
   book:
     name: Book
     runs-on: ubuntu-latest
     env:
-      MDBOOK_VERSION: '0.4.12'
-      MDBOOK_LINKCHECK_VERSION: '0.7.4'
-      MDBOOK_MERMAID_VERSION: '0.8.3'
+      MDBOOK_VERSION: "0.4.40"
+      MDBOOK_LINKCHECK_VERSION: "0.7.7"
+      MDBOOK_MERMAID_VERSION: "0.13.0"
     steps:
-    - uses: actions/checkout@v2
-    - name: Install mdbook
-      run: |
-        curl -L https://github.com/rust-lang/mdBook/releases/download/v$MDBOOK_VERSION/mdbook-v$MDBOOK_VERSION-x86_64-unknown-linux-gnu.tar.gz | tar xz -C ~/.cargo/bin
-        curl -L https://github.com/badboy/mdbook-mermaid/releases/download/v$MDBOOK_MERMAID_VERSION/mdbook-mermaid-v$MDBOOK_MERMAID_VERSION-x86_64-unknown-linux-gnu.tar.gz | tar xz -C ~/.cargo/bin
-        curl -L https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v$MDBOOK_LINKCHECK_VERSION/mdbook-linkcheck.v$MDBOOK_LINKCHECK_VERSION.x86_64-unknown-linux-gnu.zip -O
-        unzip mdbook-linkcheck.v$MDBOOK_LINKCHECK_VERSION.x86_64-unknown-linux-gnu.zip -d ~/.cargo/bin
-        chmod +x ~/.cargo/bin/mdbook-linkcheck
-    - name: Build
-      run: mdbook build
-      working-directory: book
-    - uses: actions/upload-artifact@v2
-      with:
-        name: book
-        path: book/book/html
+      - uses: actions/checkout@v4
+      - name: Install mdbook
+        run: |
+          curl -L https://github.com/rust-lang/mdBook/releases/download/v$MDBOOK_VERSION/mdbook-v$MDBOOK_VERSION-x86_64-unknown-linux-gnu.tar.gz | tar xz -C ~/.cargo/bin
+          curl -L https://github.com/badboy/mdbook-mermaid/releases/download/v$MDBOOK_MERMAID_VERSION/mdbook-mermaid-v$MDBOOK_MERMAID_VERSION-x86_64-unknown-linux-gnu.tar.gz | tar xz -C ~/.cargo/bin
+          curl -L https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v$MDBOOK_LINKCHECK_VERSION/mdbook-linkcheck.x86_64-unknown-linux-gnu.zip -O
+          unzip mdbook-linkcheck.x86_64-unknown-linux-gnu.zip -d ~/.cargo/bin
+          chmod +x ~/.cargo/bin/mdbook-linkcheck
+      - name: Build
+        run: mdbook build
+        working-directory: book
+      - uses: actions/upload-artifact@v4
+        with:
+          name: book
+          path: book/book/html
 
   deploy:
     name: Deploy
@@ -42,10 +41,11 @@ jobs:
     needs: book
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
-    - uses: actions/download-artifact@v2
-      with:
-        name: book
-    - uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: .
+      - uses: actions/download-artifact@v4
+        with:
+          name: book
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+      - uses: actions/deploy-pages@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,13 +4,11 @@ on:
   push:
     branches:
       - master
-      - staging
-      - trying
   pull_request:
     paths:
       - "**.rs"
       - "**/Cargo.*"
-      - ".github/workflows/**.yml"
+      - ".github/workflows/test.yml"
       - "tests/compile-fail/**.stderr"
   merge_group:
 
@@ -31,51 +29,62 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
+        id: rust-toolchain
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
-          default: true
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
+            ${{ runner.os }}-cargo-
       - name: Format
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
+        run: cargo fmt -- --check
       - name: Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features --all-targets --workspace
+        run: cargo clippy --workspace --all-features --all-targets
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features --all-targets --workspace
+        run: cargo test --workspace --all-features --all-targets
       - name: Test docs
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --doc
+        run: cargo test --workspace --all-features --doc
       - name: Check (without default features)
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --no-default-features
+        run: cargo check --workspace --no-default-features
 
   miri:
     name: Miri
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Install Miri
-        run: |
-          rustup toolchain install nightly --component miri
-          rustup override set nightly
-          cargo miri setup
+        uses: dtolnay/rust-toolchain@miri
+        id: rust-toolchain
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-miri-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-miri-
+            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
+            ${{ runner.os }}-cargo-
+      - name: Setup Miri
+        run: cargo miri setup
       - name: Test with Miri
-        run: cargo miri test --no-fail-fast
+        run: cargo miri test --no-fail-fast --all-features
       - name: Run examples with Miri
         run: |
           cargo miri run --example calc

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,0 @@
-status = [
-    "Test (stable, false)",
-    "Book"
-]
-delete_merged_branches = true
-timeout_sec = 1200 # 20 min


### PR DESCRIPTION
Another follow-up of #501. 

Removes `bors.toml`, because it's no longer used/needed (it seems salsa is using a merge queue now). Also removes the empty `rustfmt.toml`.

Updates some GitHub Actions to the latest, removes the `bors` branch push triggers, and removes the use of the unmaintained `actions-rs` actions. Also bumps the `mdbook` versions to the latest and adds cacheing for the rust build jobs.