### PR TITLE
Fix `DebugWithDb` in multi-crate Salsa projects

### DIFF
--- a/components/salsa-macros/src/debug_with_db.rs
+++ b/components/salsa-macros/src/debug_with_db.rs
@@ -9,6 +9,12 @@ pub(crate) fn debug_with_db(input: syn::DeriveInput) -> syn::Result<proc_macro2:
         ));
     }
 
+    // This hardcodes the convention of placing the Jar at the crate root (since that's what generates
+    // the re-export __salsa_crate_Db).
+    // That's not great and should be fixed but we'd have to add a custom attribute and I am too lazy.
+    #[allow(non_snake_case)]
+    let DbTrait: syn::Path = parse_quote!(crate::__salsa_crate_Db);
+
     let structure: synstructure::Structure = synstructure::Structure::new(&input);
 
     let fmt = syn::Ident::new("fmt", Span::call_site());
@@ -64,7 +70,7 @@ pub(crate) fn debug_with_db(input: syn::DeriveInput) -> syn::Result<proc_macro2:
         .collect();
 
     let tokens = structure.gen_impl(quote! {
-        gen impl<DB: ?Sized + crate::__salsa_crate_Db> ::salsa::debug::DebugWithDb<DB> for @Self {
+        gen impl<DB: ?Sized + #DbTrait> ::salsa::debug::DebugWithDb<DB> for @Self {
             fn fmt(&self, #fmt: &mut std::fmt::Formatter<'_>, #db: &DB) -> std::fmt::Result {
                 use ::salsa::debug::helper::Fallback as _;
                 match self {

--- a/components/salsa-macros/src/jar.rs
+++ b/components/salsa-macros/src/jar.rs
@@ -59,6 +59,7 @@ pub(crate) fn jar_struct_and_friends(
     let output_struct = jar_struct(input);
 
     let jar_struct = &input.ident;
+    let vis = &input.vis;
 
     // for each field, we need to generate an impl of `HasIngredientsFor`
     let has_ingredients_for_impls: Vec<_> = input
@@ -72,6 +73,9 @@ pub(crate) fn jar_struct_and_friends(
 
     quote! {
         #output_struct
+
+        #[doc(hidden)]
+        #vis use #jar_trait as __salsa_crate_Db;
 
         #(#has_ingredients_for_impls)*
 

--- a/components/salsa-macros/src/options.rs
+++ b/components/salsa-macros/src/options.rs
@@ -111,6 +111,28 @@ impl<A: AllowedOptions> Options<A> {
         parse_quote! {crate::Jar}
     }
 
+    /// Returns the module containing the [`Self::jar_ty`].
+    pub(crate) fn jar_mod(&self) -> syn::Path {
+        let ty = self.jar_ty();
+        let syn::Type::Path(qpath) = ty else {
+            panic!("unexpected jar type (only plain paths allowed)")
+        };
+        let syn::TypePath {
+            qself: None,
+            mut path,
+        } = qpath
+        else {
+            panic!("unexpected jar type (no assoc types allowed)")
+        };
+        path.segments.pop();
+        path.segments.pop_punct();
+        if path.segments.is_empty() {
+            parse_quote!(self)
+        } else {
+            path
+        }
+    }
+
     pub(crate) fn should_backdate(&self) -> bool {
         self.no_eq.is_none()
     }

--- a/components/salsa-macros/src/salsa_struct.rs
+++ b/components/salsa-macros/src/salsa_struct.rs
@@ -275,6 +275,10 @@ impl<A: AllowedOptions> SalsaStruct<A> {
         self.args.jar_ty()
     }
 
+    pub(crate) fn jar_mod(&self) -> syn::Path {
+        self.args.jar_mod()
+    }
+
     /// checks if the "singleton" flag was set
     pub(crate) fn is_isingleton(&self) -> bool {
         self.args.singleton.is_some()
@@ -494,12 +498,13 @@ impl<A: AllowedOptions> SalsaStruct<A> {
         }
 
         let jar_ty = self.jar_ty();
+        let jar_mod = self.jar_mod();
         let ident = self.the_ident();
         let (_, type_generics, where_clause) = self.struct_item.generics.split_for_impl();
         let mut local_generics = self.struct_item.generics.clone();
         local_generics
             .params
-            .push(parse_quote_spanned!(ident.span() => DB: ?Sized + crate::__salsa_crate_Db));
+            .push(parse_quote_spanned!(ident.span() => DB: ?Sized + #jar_mod::__salsa_crate_Db));
         let (impl_generics, _, _) = local_generics.split_for_impl();
 
         let ident_string = ident.to_string();

--- a/tests/compile-fail/get-set-on-private-field.rs
+++ b/tests/compile-fail/get-set-on-private-field.rs
@@ -2,9 +2,7 @@
 pub struct Jar(a::MyInput);
 
 mod a {
-    use crate::Jar;
-
-    #[salsa::input(jar = Jar)]
+    #[salsa::input(jar = crate::Jar)]
     pub struct MyInput {
         field: u32,
     }

--- a/tests/compile-fail/get-set-on-private-field.stderr
+++ b/tests/compile-fail/get-set-on-private-field.stderr
@@ -1,17 +1,10 @@
-error[E0624]: method `field` is private
-  --> tests/compile-fail/get-set-on-private-field.rs:29:11
-   |
-9  |         field: u32,
-   |         ---------- private method defined here
-...
-29 |     input.field(&db);
-   |           ^^^^^ private method
-
-error[E0624]: method `set_field` is private
-  --> tests/compile-fail/get-set-on-private-field.rs:30:11
-   |
-9  |         field: u32,
-   |         ----- private method defined here
-...
-30 |     input.set_field(&mut db).to(23);
-   |           ^^^^^^^^^ private method
+error[E0405]: cannot find trait `__salsa_crate_Db` in module `self`
+ --> tests/compile-fail/get-set-on-private-field.rs:8:16
+  |
+8 |     pub struct MyInput {
+  |                ^^^^^^^ not found in `self`
+  |
+help: consider importing this trait through its public re-export
+  |
+5 +     use crate::__salsa_crate_Db;
+  |

--- a/tests/compile-fail/get-set-on-private-field.stderr
+++ b/tests/compile-fail/get-set-on-private-field.stderr
@@ -1,10 +1,17 @@
-error[E0405]: cannot find trait `__salsa_crate_Db` in module `self`
- --> tests/compile-fail/get-set-on-private-field.rs:8:16
-  |
-8 |     pub struct MyInput {
-  |                ^^^^^^^ not found in `self`
-  |
-help: consider importing this trait through its public re-export
-  |
-5 +     use crate::__salsa_crate_Db;
-  |
+error[E0624]: method `field` is private
+  --> tests/compile-fail/get-set-on-private-field.rs:27:11
+   |
+7  |         field: u32,
+   |         ---------- private method defined here
+...
+27 |     input.field(&db);
+   |           ^^^^^ private method
+
+error[E0624]: method `set_field` is private
+  --> tests/compile-fail/get-set-on-private-field.rs:28:11
+   |
+7  |         field: u32,
+   |         ----- private method defined here
+...
+28 |     input.set_field(&mut db).to(23);
+   |           ^^^^^^^^^ private method

--- a/tests/compile-fail/jars_incompatibles.stderr
+++ b/tests/compile-fail/jars_incompatibles.stderr
@@ -52,13 +52,8 @@ error[E0412]: cannot find type `Jar1` in this scope
 26 | #[salsa::input(jar = Jar1)]
    |                      ^^^^ not found in this scope
 
-error[E0412]: cannot find type `Jar1` in this scope
-  --> tests/compile-fail/jars_incompatibles.rs:26:22
+error[E0405]: cannot find trait `__salsa_crate_Db` in module `self`
+  --> tests/compile-fail/jars_incompatibles.rs:27:8
    |
-26 | #[salsa::input(jar = Jar1)]
-   |                      ^^^^ not found in this scope
-   |
-help: you might be missing a type parameter
-   |
-27 | struct MyInput<Jar1> {
-   |               ++++++
+27 | struct MyInput {
+   |        ^^^^^^^ not found in `self`

--- a/tests/derived-debugwithdb-is-generic.rs
+++ b/tests/derived-debugwithdb-is-generic.rs
@@ -1,0 +1,44 @@
+//! Tests that the impls of `DebugWithDb` in `derive`s and for Salsa structs
+//! is fully generic, rather than using dyn trait.
+
+use salsa::database::AsSalsaDatabase;
+use salsa::DbWithJar;
+use salsa::DebugWithDb;
+
+use std::marker::PhantomData;
+
+#[salsa::jar(db = Db)]
+struct Jar(MyInputStruct, MyTrackedStruct<'_>, MyInternedStruct<'_>);
+
+trait Db: salsa::DbWithJar<Jar> {}
+impl<DB> Db for DB where DB: ?Sized + salsa::DbWithJar<Jar> {}
+
+#[salsa::input]
+struct MyInputStruct {}
+
+#[salsa::tracked]
+struct MyTrackedStruct<'db> {}
+
+#[salsa::interned]
+struct MyInternedStruct<'db> {}
+
+#[derive(salsa::DebugWithDb)]
+struct MyDerivedStruct<'db> {
+    _phantom: PhantomData<&'db ()>,
+}
+
+fn ensure_generic<DB: ?Sized + AsSalsaDatabase + DbWithJar<Jar>, S: DebugWithDb<DB>>() {}
+
+#[allow(unused)]
+fn test_all<'db, DB: ?Sized + AsSalsaDatabase + DbWithJar<Jar>>() {
+    ensure_generic::<DB, MyInputStruct>();
+    ensure_generic::<DB, MyTrackedStruct<'db>>();
+    ensure_generic::<DB, MyInternedStruct<'db>>();
+    ensure_generic::<DB, MyDerivedStruct<'db>>();
+}
+
+#[test]
+fn execute() {
+    // We just need to make sure this test compiles.
+    // No need to actually run it.
+}


### PR DESCRIPTION
Previously, the auto-generated impls hard-coded the database's type to
be `&dyn Db`, with `Db` being the local crate's database. Due to
limitations of trait upcasting, this meant that Salsa structs containing
Salsa structs from multiple different crates would not be printed
properly. They would fallback to the plain `std::fmt::Debug` impl, which
just prints an ID -- not very useful.

Now, the impls are generic over the database type. Any database that
implements the local database trait will be accepted.

For more background, see [this Zulip conversation][1].

[1]: https://salsa.zulipchat.com/#narrow/stream/145099-general/topic/recursive.20DebugWithDb.3F

r? @nikomatsakis
