### PR TITLE
Add required book deploy permissions and add concurrency group

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -40,6 +40,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: book
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    concurrency:
+      group: github-pages
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Follow-up of #507, fixes `Error: Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable` and limits concurrency of deploy jobs.