### PR TITLE
Update `dashmap`, `hashlink`, and `rustc-hash`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ description = "A generic framework for on-demand, incrementalized computation (e
 arc-swap = "1.6.0"
 boomphf = "0.6.0"
 crossbeam = "0.8.1"
-dashmap = "5.3.4"
-hashlink = "0.8.0"
+dashmap = "6.0.1"
+hashlink = "0.9.1"
 indexmap = "2"
 log = "0.4.5"
 orx-concurrent-vec = "1.10.0"
 parking_lot = "0.12.1"
-rustc-hash = "1.1.0"
+rustc-hash = "2.0.0"
 salsa-macro-rules = { version = "0.1.0", path = "components/salsa-macro-rules" }
 salsa-macros = { path = "components/salsa-macros" }
 smallvec = "1.0.0"

--- a/src/tracked_struct/struct_map.rs
+++ b/src/tracked_struct/struct_map.rs
@@ -6,11 +6,7 @@ use std::{
 use crossbeam::queue::SegQueue;
 use dashmap::mapref::one::RefMut;
 
-use crate::{
-    alloc::Alloc,
-    hash::{FxDashMap, FxHasher},
-    Id, Runtime,
-};
+use crate::{alloc::Alloc, hash::FxDashMap, Id, Runtime};
 
 use super::{Configuration, KeyStruct, Value};
 
@@ -251,7 +247,7 @@ pub(crate) struct UpdateRef<'db, C>
 where
     C: Configuration,
 {
-    guard: RefMut<'db, Id, Alloc<Value<C>>, FxHasher>,
+    guard: RefMut<'db, Id, Alloc<Value<C>>>,
 }
 
 impl<'db, C> UpdateRef<'db, C>


### PR DESCRIPTION
Update `dashmap`, `hashlink` and `rustc-hash` to the most recent major version.

**dashmap**

> This release contains performance optimizations, most notably 10-40% gains on Apple Silicon but also 5-10% gains when measured in Intel Sapphire Rapids. This work was accomplished in:

It's a major because there's a slight API change. 

**hashlink**

> API incompatible change: Don't panic in reserve and try_reserve in cases where a rehash is needed. Previously would panic, adds the proper bounds on reserve methods to do a rehash (previously bounds were missing, and reserve would result in panics). (Thank you cuviper!)

I think that's fine

**rustc-hash**

> Replace hash with faster and better finalized hash. This replaces the previous "fxhash" algorithm originating in Firefox with a custom hasher designed and implemented by Orson Peters ([orlp](https://github.com/orlp)). It was measured to have slightly better performance for rustc, has better theoretical properties and also includes a signficantly better string hasher.