### PR TITLE
Allow interned values as tracked function arguments

### DIFF
--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -93,6 +93,12 @@ macro_rules! setup_interned_struct {
                 }
             }
 
+            impl<$db_lt> $zalsa::LookupId<$db_lt> for $Struct<$db_lt> {
+                fn lookup_id(id: salsa::Id, db: &$db_lt dyn $zalsa::Database) -> Self {
+                    $Configuration::ingredient(db).interned_value(id)
+                }
+            }
+
             unsafe impl Send for $Struct<'_> {}
 
             unsafe impl Sync for $Struct<'_> {}

--- a/tests/compile-fail/specify-does-not-work-if-the-key-is-a-salsa-interned.stderr
+++ b/tests/compile-fail/specify-does-not-work-if-the-key-is-a-salsa-interned.stderr
@@ -1,13 +1,3 @@
-error[E0277]: the trait bound `MyInterned<'_>: LookupId<'_>` is not satisfied
-  --> tests/compile-fail/specify-does-not-work-if-the-key-is-a-salsa-interned.rs:15:1
-   |
-15 | #[salsa::tracked(specify)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromId` is not implemented for `MyInterned<'_>`, which is required by `MyInterned<'_>: LookupId<'_>`
-   |
-   = help: the trait `LookupId<'db>` is implemented for `MyTracked<'db>`
-   = note: required for `MyInterned<'_>` to implement `LookupId<'_>`
-   = note: this error originates in the macro `salsa::plumbing::setup_tracked_fn` which comes from the expansion of the attribute macro `salsa::tracked` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0277]: the trait bound `MyInterned<'_>: TrackedStructInDb` is not satisfied
   --> tests/compile-fail/specify-does-not-work-if-the-key-is-a-salsa-interned.rs:15:1
    |

--- a/tests/tracked_fn_on_interned.rs
+++ b/tests/tracked_fn_on_interned.rs
@@ -1,0 +1,29 @@
+//! Test that a `tracked` fn on a `salsa::interned`
+//! compiles and executes successfully.
+
+#[salsa::interned]
+struct Name<'db> {
+    name: String,
+}
+
+#[salsa::tracked]
+fn tracked_fn<'db>(db: &'db dyn salsa::Database, name: Name<'db>) -> String {
+    name.name(db).clone()
+}
+
+#[salsa::db]
+#[derive(Default)]
+struct Database {
+    storage: salsa::Storage<Self>,
+}
+
+#[salsa::db]
+impl salsa::Database for Database {}
+
+#[test]
+fn execute() {
+    let db = Database::default();
+    let name = Name::new(&db, "Salsa".to_string());
+
+    assert_eq!(tracked_fn(&db, name), "Salsa");
+}


### PR DESCRIPTION
This fixes the second part of https://github.com/salsa-rs/salsa/issues/521 where tracked functions didn't accept interned values
