### PR TITLE
Add benchmark for query with many tracked structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ smallvec = "1.0.0"
 
 [dev-dependencies]
 annotate-snippets = "0.11.4"
+criterion = "0.5.1"
 derive-new = "0.5.9"
 expect-test = "1.4.0"
 eyre = "0.6.8"
@@ -33,5 +34,10 @@ rustversion = "1.0"
 test-log = "0.2.11"
 trybuild = "1.0"
 
+
+[[bench]]
+name = "incremental"
+harness = false
+
 [workspace]
-members = [ "components/salsa-macro-rules","components/salsa-macros"]
+members = ["components/salsa-macro-rules", "components/salsa-macros"]

--- a/benches/incremental.rs
+++ b/benches/incremental.rs
@@ -1,0 +1,54 @@
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use salsa::Setter;
+
+#[salsa::input]
+struct Input {
+    field: usize,
+}
+
+#[salsa::tracked]
+struct Tracked<'db> {
+    number: usize,
+}
+
+#[salsa::tracked(return_ref)]
+fn index<'db>(db: &'db dyn salsa::Database, input: Input) -> Vec<Tracked<'db>> {
+    (0..input.field(db)).map(|i| Tracked::new(db, i)).collect()
+}
+
+#[salsa::tracked]
+fn root(db: &dyn salsa::Database, input: Input) -> usize {
+    let index = index(db, input);
+    index.len()
+}
+
+fn many_tracked_structs(criterion: &mut Criterion) {
+    criterion.bench_function("many_tracked_structs", |b| {
+        b.iter_batched_ref(
+            || {
+                let db = salsa::default_database();
+
+                let input = Input::new(&db, 1_000);
+                let input2 = Input::new(&db, 1);
+
+                // prewarm cache
+                let _ = root(&db, input);
+                let _ = root(&db, input2);
+
+                (db, input, input2)
+            },
+            |(db, input, input2)| {
+                // Make a change, but fetch the result for the other input
+                input2.set_field(db).to(2);
+
+                let result = root(db, *input);
+
+                assert_eq!(result, 1_000);
+            },
+            BatchSize::LargeInput,
+        );
+    });
+}
+
+criterion_group!(benches, many_tracked_structs);
+criterion_main!(benches);


### PR DESCRIPTION
This PR adds a micro-benchmark that measures the cost of validating many tracked structs that are all unaffected by the input change. 

The benchmark is emulating a scenario where a root query creates a large number of tracked structs, e.g., a `program.check` call. Now, a single file changes that invalidates a very small subset of ingredients, but `program.check` still pays the cost of marking unchanged ingredients as "validated".

## Testing

I back-ported the benchmark to before *beautiful Salsa*. See https://github.com/salsa-rs/salsa/pull/530. 

Running the benchmark on the current version takes around 14us whereas the pre-rewrite version only takes 12us on my machine. 

This benchmark covers https://salsa.zulipchat.com/#narrow/stream/333573-salsa-3.2E0/topic/Beautiful.20Salsa.20perf.20incremental.20checking.20perf.20regression


 