### PR TITLE
Add Handle::into_inner method

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -60,6 +60,16 @@ impl<Db: HasStorage> Handle<Db> {
         Arc::get_mut(self.db_mut()).expect("other threads remain active despite cancellation")
     }
 
+    /// Returns the inner database, consuming the handle.
+    ///
+    /// If other handles are active, this method sets the cancellation flag
+    /// and blocks until they are dropped.
+    pub fn into_inner(mut self) -> Db {
+        self.cancel_others();
+        Arc::into_inner(self.db.take().unwrap())
+            .expect("other threads remain active despite cancellation")
+    }
+
     // ANCHOR: cancel_other_workers
     /// Sets cancellation flag and blocks until all other workers with access
     /// to this storage have completed.


### PR DESCRIPTION
This PR adds a `into_inner` function to `Handle`. 

Being able to go back to the database can be useful for methods that take a `Database` as argument but have to create a `Handle` because they run concurrent code. 
It is then desired that the method can return a `Database` to avoid that the entire code base has to use a `Handle<Db>`. 

Example:

```rust
    #[allow(clippy::print_stderr)]
    fn run(mut self, db: RootDatabase) -> RootDatabase {
        // Schedule the first check.
        let mut db = salsa::Handle::new(db);
        self.sender.send(MainLoopMessage::CheckWorkspace).unwrap();
        let mut revision = 0usize;

        while let Ok(message) = self.receiver.recv() {
            tracing::trace!("Main Loop: Tick");

            match message {
                MainLoopMessage::CheckWorkspace => {
                    let db = db.clone();
                    let sender = self.sender.clone();

                    // Spawn a new task that checks the workspace. This needs to be done in a separate thread
                    // to prevent blocking the main loop here.
                    rayon::spawn(move || {
                        if let Ok(result) = db.check() {
                            // Send the result back to the main loop for printing.
                            sender
                                .send(MainLoopMessage::CheckCompleted { result, revision })
                                .ok();
                        }
                    });
                }

                MainLoopMessage::CheckCompleted {
                    result,
                    revision: check_revision,
                } => {
                    if check_revision == revision {
                        eprintln!("{}", result.join("\n"));

                        if self.verbosity == Some(VerbosityLevel::Trace) {
                            eprintln!("{}", countme::get_all());
                        }
                    }

                    if self.watcher.is_none() {
                        return db.into_inner();
                    }
                }

                MainLoopMessage::ApplyChanges(changes) => {
                    revision += 1;
                    // Automatically cancels any pending queries and waits for them to complete.
                    db.get_mut().apply_changes(changes);
                    if let Some(watcher) = self.watcher.as_mut() {
                        watcher.update(&db);
                    }

                    self.sender.send(MainLoopMessage::CheckWorkspace).unwrap();
                }
                MainLoopMessage::Exit => {
                    return db.into_inner();
                }
            }
        }

        db.into_inner()
    }
```

## Why not just pass in a `Handle`

This is a possibility but it leaks that the function uses concurrency internally and one also has to be careful to pass in a `&mut Handle<T>` and to not clone it on the call-site (which I did) because it then results in a dead lock when calling `get_mut`. 


