### PR TITLE
Fix assertion for same DB in `DbGuard`

### DIFF
--- a/src/local_state.rs
+++ b/src/local_state.rs
@@ -86,7 +86,7 @@ impl LocalState {
                     let new_db = NonNull::from(db);
 
                     // Already attached? Assert that the database has not changed.
-                    // NOTE: It's important to use `addr_eq` here because `NonNull` not only compares the address but also the type's metadata.
+                    // NOTE: It's important to use `addr_eq` here because `NonNull::eq` not only compares the address but also the type's metadata.
                     if !std::ptr::addr_eq(current_db.as_ptr(), new_db.as_ptr()) {
                         panic!(
                             "Cannot change database mid-query. current: {current_db:?}, new: {new_db:?}",


### PR DESCRIPTION
Working on https://github.com/salsa-rs/salsa/pull/529 I ran into the issue that the assertion in `DbGuard` asserting that the DB is unchanged consistently fails. 

The underlying problem is that `NonNull::eq` not only compares the pointer but also the metadata which is unreliable for trait object pointers

> When comparing wide pointers, both the address and the metadata are tested for equality. However, note that comparing trait object pointers (*const dyn Trait) is unreliable: pointers to values of the same underlying type can compare inequal (because vtables are duplicated in multiple codegen units), and pointers to values of different underlying type can compare equal (since identical vtables can be deduplicated within a codegen unit).
[source](https://doc.rust-lang.org/std/ptr/fn.eq.html)

This PR changes the assertion to use `std::ptr::addr_eq` which only compares the address without the metadata.

Fixes https://github.com/salsa-rs/salsa/issues/536 
