### PR TITLE
Add CodSpeed Benchmarks to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,3 +89,43 @@ jobs:
       - name: Run examples with Miri
         run: |
           cargo miri run --example calc
+
+  benchmarks:
+    name: Benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        id: rust-toolchain
+        with:
+          toolchain: stable
+
+      - name: "Setup codspeed"
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-codspeed
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
+            ${{ runner.os }}-cargo-
+
+      - name: "Build benchmarks"
+        run: cargo codspeed build
+
+      - name: "Run benchmarks"
+        uses: CodSpeedHQ/action@v2
+        with:
+          run: cargo codspeed run
+          token: ${{ secrets.CODSPEED_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ smallvec = "1.0.0"
 
 [dev-dependencies]
 annotate-snippets = "0.11.4"
-criterion = "0.5.1"
+codspeed-criterion-compat = { version = "2.6.0", default-features = false }
 derive-new = "0.5.9"
 expect-test = "1.4.0"
 eyre = "0.6.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ smallvec = "1.0.0"
 
 [dev-dependencies]
 annotate-snippets = "0.11.4"
+criterion = "0.5.1"
 derive-new = "0.5.9"
 expect-test = "1.4.0"
 eyre = "0.6.8"
@@ -33,5 +34,10 @@ rustversion = "1.0"
 test-log = "0.2.11"
 trybuild = "1.0"
 
+
+[[bench]]
+name = "incremental"
+harness = false
+
 [workspace]
-members = [ "components/salsa-macro-rules","components/salsa-macros"]
+members = ["components/salsa-macro-rules", "components/salsa-macros"]

--- a/benches/incremental.rs
+++ b/benches/incremental.rs
@@ -1,0 +1,54 @@
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use salsa::Setter;
+
+#[salsa::input]
+struct Input {
+    field: usize,
+}
+
+#[salsa::tracked]
+struct Tracked<'db> {
+    number: usize,
+}
+
+#[salsa::tracked(return_ref)]
+fn index<'db>(db: &'db dyn salsa::Database, input: Input) -> Vec<Tracked<'db>> {
+    (0..input.field(db)).map(|i| Tracked::new(db, i)).collect()
+}
+
+#[salsa::tracked]
+fn root(db: &dyn salsa::Database, input: Input) -> usize {
+    let index = index(db, input);
+    index.len()
+}
+
+fn many_tracked_structs(criterion: &mut Criterion) {
+    criterion.bench_function("many_tracked_structs", |b| {
+        b.iter_batched_ref(
+            || {
+                let db = salsa::default_database();
+
+                let input = Input::new(&db, 1_000);
+                let input2 = Input::new(&db, 1);
+
+                // prewarm cache
+                let _ = root(&db, input);
+                let _ = root(&db, input2);
+
+                (db, input, input2)
+            },
+            |(db, input, input2)| {
+                // Make a change, but fetch the result for the other input
+                input2.set_field(db).to(2);
+
+                let result = root(db, *input);
+
+                assert_eq!(result, 1_000);
+            },
+            BatchSize::LargeInput,
+        );
+    });
+}
+
+criterion_group!(benches, many_tracked_structs);
+criterion_main!(benches);

--- a/benches/incremental.rs
+++ b/benches/incremental.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use codspeed_criterion_compat::{criterion_group, criterion_main, BatchSize, Criterion};
 use salsa::Setter;
 
 #[salsa::input]


### PR DESCRIPTION
This PR is based on https://github.com/salsa-rs/salsa/pull/529

This PR adds a CI step to run the benchmarks with codspeed. This gives us a similar experience to https://github.com/astral-sh/ruff/pull/12406#issuecomment-2241067701

I don't have the necessary permissions to finish the setup myself. 

1. [Add the repository to codspeed](https://docs.codspeed.io/importing-repositories)
2. [Add the access token](https://docs.codspeed.io/ci/github-actions) (named `CODSPEED_TOKEN`)

We'll need to create a access token and add it. I don't have the necessary permissions. See 