### PR TITLE
Bump revision in `db.synthetic_write`

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -21,7 +21,9 @@ pub trait Database: DatabaseGen {
     /// will block until that snapshot is dropped -- if that snapshot
     /// is owned by the current thread, this could trigger deadlock.
     fn synthetic_write(&mut self, durability: Durability) {
-        self.runtime_mut().report_tracked_write(durability);
+        let runtime = self.runtime_mut();
+        runtime.new_revision();
+        runtime.report_tracked_write(durability);
     }
 
     /// Reports that the query depends on some state unknown to salsa.

--- a/tests/synthetic_write.rs
+++ b/tests/synthetic_write.rs
@@ -1,0 +1,73 @@
+//! Test that a constant `tracked` fn (has no inputs)
+//! compiles and executes successfully.
+#![allow(warnings)]
+
+mod common;
+
+use common::{HasLogger, Logger};
+use expect_test::expect;
+use salsa::{Database as _, Durability, Event, EventKind};
+
+#[salsa::db]
+trait Db: salsa::Database + HasLogger {}
+
+#[salsa::input]
+struct MyInput {
+    field: u32,
+}
+
+#[salsa::tracked]
+fn tracked_fn(db: &dyn Db, input: MyInput) -> u32 {
+    input.field(db) * 2
+}
+
+#[salsa::db]
+#[derive(Default)]
+struct Database {
+    storage: salsa::Storage<Self>,
+    logger: Logger,
+}
+
+#[salsa::db]
+impl salsa::Database for Database {
+    fn salsa_event(&self, event: Event) {
+        if let EventKind::WillExecute { .. } | EventKind::DidValidateMemoizedValue { .. } =
+            event.kind
+        {
+            self.push_log(format!("{:?}", event.kind));
+        }
+    }
+}
+
+impl HasLogger for Database {
+    fn logger(&self) -> &Logger {
+        &self.logger
+    }
+}
+
+#[salsa::db]
+impl Db for Database {}
+
+#[test]
+fn execute() {
+    let mut db = Database::default();
+
+    let input = MyInput::new(&db, 22);
+    assert_eq!(tracked_fn(&db, input), 44);
+
+    db.assert_logs(expect![[r#"
+        [
+            "WillExecute { database_key: tracked_fn(0) }",
+        ]"#]]);
+
+    // Bumps the revision
+    db.synthetic_write(Durability::LOW);
+
+    // Query should re-run
+    assert_eq!(tracked_fn(&db, input), 44);
+
+    db.assert_logs(expect![[r#"
+        [
+            "DidValidateMemoizedValue { database_key: tracked_fn(0) }",
+        ]"#]]);
+}


### PR DESCRIPTION
This PR fixes `db.synthetic_write` by bumping the `runtime.revision`. 

This wasn't needed before because `runtime_mut` went through `jars_mut` which increments the revision. 
Since this is no longer the case, bump the revision manually. 

I verified that the test failed *before* making the change.