### PR TITLE
Add test tracing, fix up comments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ eyre = "0.6.8"
 notify-debouncer-mini = "0.4.1"
 ordered-float = "4.2.1"
 rustversion = "1.0"
-test-log = "0.2.11"
+test-log = { version ="0.2.11", features = ["trace"] }
 trybuild = "1.0"
 
 

--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -110,7 +110,7 @@ impl ActiveQuery {
     }
 
     /// Adds any dependencies from `other` into `self`.
-    /// Used during cycle recovery, see [`Runtime::create_cycle_error`].
+    /// Used during cycle recovery, see [`Runtime::unblock_cycle_and_maybe_throw`].
     pub(super) fn add_from(&mut self, other: &ActiveQuery) {
         self.changed_at = self.changed_at.max(other.changed_at);
         self.durability = self.durability.min(other.durability);
@@ -120,7 +120,7 @@ impl ActiveQuery {
     }
 
     /// Removes the participants in `cycle` from my dependencies.
-    /// Used during cycle recovery, see [`Runtime::create_cycle_error`].
+    /// Used during cycle recovery, see [`Runtime::unblock_cycle_and_maybe_throw`].
     pub(super) fn remove_cycle_participants(&mut self, cycle: &Cycle) {
         for p in cycle.participant_keys() {
             let p: DependencyIndex = p.into();
@@ -129,7 +129,7 @@ impl ActiveQuery {
     }
 
     /// Copy the changed-at, durability, and dependencies from `cycle_query`.
-    /// Used during cycle recovery, see [`Runtime::create_cycle_error`].
+    /// Used during cycle recovery, see [`Runtime::unblock_cycle_and_maybe_throw`].
     pub(crate) fn take_inputs_from(&mut self, cycle_query: &ActiveQuery) {
         self.changed_at = cycle_query.changed_at;
         self.durability = cycle_query.durability;

--- a/src/cycle.rs
+++ b/src/cycle.rs
@@ -94,17 +94,15 @@ impl std::fmt::Debug for Cycle {
 pub enum CycleRecoveryStrategy {
     /// Cannot recover from cycles: panic.
     ///
-    /// This is the default. It is also what happens if a cycle
-    /// occurs and the queries involved have different recovery
-    /// strategies.
+    /// This is the default.
     ///
     /// In the case of a failure due to a cycle, the panic
-    /// value will be XXX (FIXME).
+    /// value will be the `Cycle`.
     Panic,
 
     /// Recovers from cycles by storing a sentinel value.
     ///
-    /// This value is computed by the `QueryFunction::cycle_fallback`
+    /// This value is computed by the query's `recovery_fn`
     /// function.
     Fallback,
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -65,7 +65,7 @@ pub trait Configuration: Any {
     /// This invokes the function the user wrote.
     fn execute<'db>(db: &'db Self::DbView, input: Self::Input<'db>) -> Self::Output<'db>;
 
-    /// If the cycle strategy is `Recover`, then invoked when `key` is a participant
+    /// If the cycle strategy is `Fallback`, then invoked when `key` is a participant
     /// in a cycle to find out what value it should have.
     ///
     /// This invokes the recovery function given by the user.

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -109,7 +109,7 @@ impl ZalsaLocal {
         changed_at: Revision,
     ) {
         debug!(
-            "report_query_read_and_unwind_if_cycle_resulted(input={:?}, durability={:?}, changed_at={:?})",
+            "report_tracked_read(input={:?}, durability={:?}, changed_at={:?})",
             input, durability, changed_at
         );
         self.with_query_stack(|stack| {

--- a/tests/cycles.rs
+++ b/tests/cycles.rs
@@ -49,9 +49,6 @@ use salsa::Durability;
 // | Cross  | Fallback | N/A      | Tracked   | both     | parallel/parallel_cycle_mid_recover.rs |
 // | Cross  | Fallback | N/A      | Tracked   | both     | parallel/parallel_cycle_all_recover.rs |
 
-// TODO: The following test is not yet ported.
-// | Intra  | Fallback | Old      | Tracked   | direct   | cycle_disappears_durability |
-
 #[derive(PartialEq, Eq, Hash, Clone, Debug)]
 struct Error {
     cycle: Vec<String>,


### PR DESCRIPTION
This PR does two things:

1) Add the `trace` feature for the `test-log` dependency, which I've found very useful in trying to understand the cycle-handling code. It means that I can change `#[test]` to `#[test_log::test]` above a failing test of interest, and then if I run `cargo test` with e.g. `RUST_LOG=debug`, the failing test output will include all the debug traces from that test.

2) Fix up a bunch of comments and some debug traces I ran across in my exploration that looked out of date.

Happy to split this into two PRs if that's preferred.