### PR TITLE
Update expect test output to account for OrderedFloat changes

### DIFF
--- a/examples/calc/parser.rs
+++ b/examples/calc/parser.rs
@@ -399,9 +399,7 @@ fn parse_print() {
                                             end: 7,
                                         },
                                         data: Number(
-                                            OrderedFloat(
-                                                1.0,
-                                            ),
+                                            1.0,
                                         ),
                                     },
                                     Add,
@@ -412,9 +410,7 @@ fn parse_print() {
                                             end: 11,
                                         },
                                         data: Number(
-                                            OrderedFloat(
-                                                2.0,
-                                            ),
+                                            2.0,
                                         ),
                                     },
                                 ),
@@ -550,9 +546,7 @@ fn parse_example() {
                                                         end: 81,
                                                     },
                                                     data: Number(
-                                                        OrderedFloat(
-                                                            3.14,
-                                                        ),
+                                                        3.14,
                                                     ),
                                                 },
                                                 Multiply,
@@ -613,9 +607,7 @@ fn parse_example() {
                                                 end: 124,
                                             },
                                             data: Number(
-                                                OrderedFloat(
-                                                    3.0,
-                                                ),
+                                                3.0,
                                             ),
                                         },
                                         Expression {
@@ -625,9 +617,7 @@ fn parse_example() {
                                                 end: 127,
                                             },
                                             data: Number(
-                                                OrderedFloat(
-                                                    4.0,
-                                                ),
+                                                4.0,
                                             ),
                                         },
                                     ],
@@ -660,9 +650,7 @@ fn parse_example() {
                                                 end: 160,
                                             },
                                             data: Number(
-                                                OrderedFloat(
-                                                    1.0,
-                                                ),
+                                                1.0,
                                             ),
                                         },
                                     ],
@@ -691,9 +679,7 @@ fn parse_example() {
                                             end: 182,
                                         },
                                         data: Number(
-                                            OrderedFloat(
-                                                11.0,
-                                            ),
+                                            11.0,
                                         ),
                                     },
                                     Multiply,
@@ -704,9 +690,7 @@ fn parse_example() {
                                             end: 186,
                                         },
                                         data: Number(
-                                            OrderedFloat(
-                                                2.0,
-                                            ),
+                                            2.0,
                                         ),
                                     },
                                 ),
@@ -780,9 +764,7 @@ fn parse_precedence() {
                                                     end: 7,
                                                 },
                                                 data: Number(
-                                                    OrderedFloat(
-                                                        1.0,
-                                                    ),
+                                                    1.0,
                                                 ),
                                             },
                                             Add,
@@ -800,9 +782,7 @@ fn parse_precedence() {
                                                             end: 11,
                                                         },
                                                         data: Number(
-                                                            OrderedFloat(
-                                                                2.0,
-                                                            ),
+                                                            2.0,
                                                         ),
                                                     },
                                                     Multiply,
@@ -813,9 +793,7 @@ fn parse_precedence() {
                                                             end: 15,
                                                         },
                                                         data: Number(
-                                                            OrderedFloat(
-                                                                3.0,
-                                                            ),
+                                                            3.0,
                                                         ),
                                                     },
                                                 ),
@@ -830,9 +808,7 @@ fn parse_precedence() {
                                             end: 19,
                                         },
                                         data: Number(
-                                            OrderedFloat(
-                                                4.0,
-                                            ),
+                                            4.0,
                                         ),
                                     },
                                 ),


### PR DESCRIPTION
The `expect!` tests for the parser example are failing in main branch. This failure started with https://github.com/salsa-rs/salsa/commit/c50cefa71e24ccdd108576938dfa44139fc72c00 which upgraded the `ordered-float` dependency. It looks like the new version of ordered-float implements `Display` as a pass-through to the underlying float, and the old version did not, causing these test failures.

Generated by running `env UPDATE_EXPECT=1 cargo test --workspace --all-features --all-targets`.