### PR TITLE
Add -D warnings to clippy CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Format
         run: cargo fmt -- --check
       - name: Clippy
-        run: cargo clippy --workspace --all-features --all-targets
+        run: cargo clippy --workspace --all-features --all-targets -- -D warnings
       - name: Test
         run: cargo test --workspace --all-features --all-targets
       - name: Test docs


### PR DESCRIPTION
This will prevent clippy warnings collected un-noticed in main branch.