### PR TITLE
Require Debug for C::Stamps

### DIFF
--- a/examples/calc/parser.rs
+++ b/examples/calc/parser.rs
@@ -399,9 +399,7 @@ fn parse_print() {
                                             end: 7,
                                         },
                                         data: Number(
-                                            OrderedFloat(
-                                                1.0,
-                                            ),
+                                            1.0,
                                         ),
                                     },
                                     Add,
@@ -412,9 +410,7 @@ fn parse_print() {
                                             end: 11,
                                         },
                                         data: Number(
-                                            OrderedFloat(
-                                                2.0,
-                                            ),
+                                            2.0,
                                         ),
                                     },
                                 ),
@@ -550,9 +546,7 @@ fn parse_example() {
                                                         end: 81,
                                                     },
                                                     data: Number(
-                                                        OrderedFloat(
-                                                            3.14,
-                                                        ),
+                                                        3.14,
                                                     ),
                                                 },
                                                 Multiply,
@@ -613,9 +607,7 @@ fn parse_example() {
                                                 end: 124,
                                             },
                                             data: Number(
-                                                OrderedFloat(
-                                                    3.0,
-                                                ),
+                                                3.0,
                                             ),
                                         },
                                         Expression {
@@ -625,9 +617,7 @@ fn parse_example() {
                                                 end: 127,
                                             },
                                             data: Number(
-                                                OrderedFloat(
-                                                    4.0,
-                                                ),
+                                                4.0,
                                             ),
                                         },
                                     ],
@@ -660,9 +650,7 @@ fn parse_example() {
                                                 end: 160,
                                             },
                                             data: Number(
-                                                OrderedFloat(
-                                                    1.0,
-                                                ),
+                                                1.0,
                                             ),
                                         },
                                     ],
@@ -691,9 +679,7 @@ fn parse_example() {
                                             end: 182,
                                         },
                                         data: Number(
-                                            OrderedFloat(
-                                                11.0,
-                                            ),
+                                            11.0,
                                         ),
                                     },
                                     Multiply,
@@ -704,9 +690,7 @@ fn parse_example() {
                                             end: 186,
                                         },
                                         data: Number(
-                                            OrderedFloat(
-                                                2.0,
-                                            ),
+                                            2.0,
                                         ),
                                     },
                                 ),
@@ -780,9 +764,7 @@ fn parse_precedence() {
                                                     end: 7,
                                                 },
                                                 data: Number(
-                                                    OrderedFloat(
-                                                        1.0,
-                                                    ),
+                                                    1.0,
                                                 ),
                                             },
                                             Add,
@@ -800,9 +782,7 @@ fn parse_precedence() {
                                                             end: 11,
                                                         },
                                                         data: Number(
-                                                            OrderedFloat(
-                                                                2.0,
-                                                            ),
+                                                            2.0,
                                                         ),
                                                     },
                                                     Multiply,
@@ -813,9 +793,7 @@ fn parse_precedence() {
                                                             end: 15,
                                                         },
                                                         data: Number(
-                                                            OrderedFloat(
-                                                                3.0,
-                                                            ),
+                                                            3.0,
                                                         ),
                                                     },
                                                 ),
@@ -830,9 +808,7 @@ fn parse_precedence() {
                                             end: 19,
                                         },
                                         data: Number(
-                                            OrderedFloat(
-                                                4.0,
-                                            ),
+                                            4.0,
                                         ),
                                     },
                                 ),

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,6 +1,7 @@
+use std::fmt::Debug;
 use std::ops::{Deref, DerefMut};
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct Array<T, const N: usize> {
     data: [T; N],
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -36,7 +36,7 @@ pub trait Configuration: Any {
     type Fields: Send + Sync;
 
     /// A array of [`StampedValue<()>`](`StampedValue`) tuples, one per each of the value fields.
-    type Stamps: Send + Sync + DerefMut<Target = [Stamp]>;
+    type Stamps: Send + Sync + fmt::Debug + DerefMut<Target = [Stamp]>;
 }
 
 pub struct JarImpl<C: Configuration> {


### PR DESCRIPTION
I found this really useful in debugging durability issues; it allows sprinkling a `dbg!(&data.stamps)` in some key places to see what the field durabilities and changed-at values are for the fields.