### PR TITLE
Replace `orx-concurrent-vec` with `boxcar`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ description = "A generic framework for on-demand, incrementalized computation (e
 [dependencies]
 arc-swap = "1"
 boomphf = "0.6"
+boxcar = "0.2"
 crossbeam = "0.8"
 dashmap = "6"
 hashlink = "0.9"
 indexmap = "2"
-orx-concurrent-vec = "2"
 tracing = "0.1"
 parking_lot = "0.12"
 rustc-hash = "2"

--- a/src/views.rs
+++ b/src/views.rs
@@ -3,8 +3,6 @@ use std::{
     sync::Arc,
 };
 
-use orx_concurrent_vec::ConcurrentVec;
-
 use crate::Database;
 
 /// A `Views` struct is associated with some specific database type
@@ -26,7 +24,7 @@ use crate::Database;
 #[derive(Clone)]
 pub struct Views {
     source_type_id: TypeId,
-    view_casters: Arc<ConcurrentVec<ViewCaster>>,
+    view_casters: Arc<boxcar::Vec<ViewCaster>>,
 }
 
 /// A ViewCaster contains a trait object that can cast from the
@@ -104,7 +102,7 @@ impl Views {
         if self
             .view_casters
             .iter()
-            .any(|u| u.target_type_id == target_type_id)
+            .any(|(_, u)| u.target_type_id == target_type_id)
         {
             return;
         }
@@ -140,7 +138,7 @@ impl Views {
         assert_eq!(self.source_type_id, db_type_id, "database type mismatch");
 
         let view_type_id = TypeId::of::<DbView>();
-        for caster in self.view_casters.iter() {
+        for (_, caster) in self.view_casters.iter() {
             if caster.target_type_id == view_type_id {
                 // SAFETY: We have some function that takes a thin reference to the underlying
                 // database type `X` and returns a (potentially wide) reference to `View`.


### PR DESCRIPTION
This PR replaces `orx-concurrent-vec` with `boxcar` because:

* `boxcar` is a much smaller dependency 11.1KB without dependencies vs 90.9KB with a handful of dependencies
* `orx-concurrent-vec` [fails to build on 32bit](https://github.com/orxfun/orx-split-vec/pull/45) platforms (may be fixed soon)
* `boxcar` shows better performance
