### PR TITLE
Fix query invalidation when high durability input changes

### DIFF
--- a/components/salsa-macro-rules/src/setup_input_struct.rs
+++ b/components/salsa-macro-rules/src/setup_input_struct.rs
@@ -86,13 +86,13 @@ macro_rules! setup_input_struct {
                     })
                 }
 
-                pub fn ingredient_mut(db: &mut dyn $zalsa::Database) -> (&mut $zalsa_struct::IngredientImpl<Self>, $zalsa::Revision) {
+                pub fn ingredient_mut(db: &mut dyn $zalsa::Database) -> (&mut $zalsa_struct::IngredientImpl<Self>, &mut $zalsa::Runtime) {
                     let zalsa_mut = db.zalsa_mut();
                     let index = zalsa_mut.add_or_lookup_jar_by_type(&<$zalsa_struct::JarImpl<$Configuration>>::default());
                     let current_revision = zalsa_mut.current_revision();
-                    let ingredient = zalsa_mut.lookup_ingredient_mut(index);
+                    let (ingredient, runtime) = zalsa_mut.lookup_ingredient_mut(index);
                     let ingredient = ingredient.assert_type_mut::<$zalsa_struct::IngredientImpl<Self>>();
-                    (ingredient, current_revision)
+                    (ingredient, runtime)
                 }
             }
 

--- a/src/input/setter.rs
+++ b/src/input/setter.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use crate::input::{Configuration, IngredientImpl};
-use crate::{Durability, Revision};
+use crate::{Durability, Runtime};
 
 /// Setter for a field of an input.
 pub trait Setter: Sized {
@@ -12,7 +12,7 @@ pub trait Setter: Sized {
 
 #[must_use]
 pub struct SetterImpl<'setter, C: Configuration, S, F> {
-    current_revision: Revision,
+    runtime: &'setter mut Runtime,
     id: C::Struct,
     ingredient: &'setter mut IngredientImpl<C>,
     durability: Durability,
@@ -27,14 +27,14 @@ where
     S: FnOnce(&mut C::Fields, F) -> F,
 {
     pub fn new(
-        current_revision: Revision,
+        runtime: &'setter mut Runtime,
         id: C::Struct,
         field_index: usize,
         ingredient: &'setter mut IngredientImpl<C>,
         setter: S,
     ) -> Self {
         SetterImpl {
-            current_revision,
+            runtime,
             id,
             field_index,
             ingredient,
@@ -59,7 +59,7 @@ where
 
     fn to(self, value: F) -> F {
         let Self {
-            current_revision,
+            runtime,
             id,
             ingredient,
             durability,
@@ -68,7 +68,7 @@ where
             phantom: _,
         } = self;
 
-        ingredient.set_field(current_revision, id, field_index, durability, |tuple| {
+        ingredient.set_field(runtime, id, field_index, durability, |tuple| {
             setter(tuple, value)
         })
     }

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -172,8 +172,14 @@ impl Zalsa {
     }
 
     /// **NOT SEMVER STABLE**
-    pub fn lookup_ingredient_mut(&mut self, index: IngredientIndex) -> &mut dyn Ingredient {
-        &mut **self.ingredients_vec.get_mut(index.as_usize()).unwrap()
+    pub fn lookup_ingredient_mut(
+        &mut self,
+        index: IngredientIndex,
+    ) -> (&mut dyn Ingredient, &mut Runtime) {
+        (
+            &mut **self.ingredients_vec.get_mut(index.as_usize()).unwrap(),
+            &mut self.runtime,
+        )
     }
 
     /// **NOT SEMVER STABLE**

--- a/tests/tracked_fn_high_durability_dependency.rs
+++ b/tests/tracked_fn_high_durability_dependency.rs
@@ -1,0 +1,36 @@
+#![allow(warnings)]
+
+use salsa::plumbing::HasStorage;
+use salsa::{Database, Durability, Setter};
+
+mod common;
+#[salsa::input]
+struct MyInput {
+    field: u32,
+}
+
+#[salsa::tracked]
+fn tracked_fn(db: &dyn salsa::Database, input: MyInput) -> u32 {
+    input.field(db) * 2
+}
+
+#[test]
+fn execute() {
+    let mut db = salsa::DatabaseImpl::default();
+
+    let input_high = MyInput::new(&mut db, 0);
+    input_high
+        .set_field(&mut db)
+        .with_durability(Durability::HIGH)
+        .to(2200);
+
+    assert_eq!(tracked_fn(&db, input_high), 4400);
+
+    // Changing the value should re-execute the query
+    input_high
+        .set_field(&mut db)
+        .with_durability(Durability::HIGH)
+        .to(2201);
+
+    assert_eq!(tracked_fn(&db, input_high), 4402);
+}


### PR DESCRIPTION
This PR fixes a bug in Salsa where changing the value of a high durability field did not invalidate any queries with `durability > LOW` 

I had to re-expose `&mut Runtime` again when calling `ingredient_mut` to call `runtime.report_tracked_write` in `SetterImpl`
