### PR TITLE
Preserve durability when setting a new input-value

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -116,14 +116,14 @@ impl<C: Configuration> IngredientImpl<C> {
     /// * `runtime`, the salsa runtiem
     /// * `id`, id of the input struct
     /// * `field_index`, index of the field that will be changed
-    /// * `durability`, durability of the new value
+    /// * `durability`, durability of the new value. If omitted, uses the durability of the previous value.
     /// * `setter`, function that modifies the fields tuple; should only modify the element for `field_index`
     pub fn set_field<R>(
         &mut self,
         runtime: &mut Runtime,
         id: C::Struct,
         field_index: usize,
-        durability: Durability,
+        durability: Option<Durability>,
         setter: impl FnOnce(&mut C::Fields) -> R,
     ) -> R {
         let id: Id = id.as_id();
@@ -134,7 +134,7 @@ impl<C: Configuration> IngredientImpl<C> {
             runtime.report_tracked_write(stamp.durability);
         }
 
-        stamp.durability = durability;
+        stamp.durability = durability.unwrap_or(stamp.durability);
         stamp.changed_at = runtime.current_revision();
         setter(&mut r.fields)
     }

--- a/src/input/setter.rs
+++ b/src/input/setter.rs
@@ -15,7 +15,7 @@ pub struct SetterImpl<'setter, C: Configuration, S, F> {
     runtime: &'setter mut Runtime,
     id: C::Struct,
     ingredient: &'setter mut IngredientImpl<C>,
-    durability: Durability,
+    durability: Option<Durability>,
     field_index: usize,
     setter: S,
     phantom: PhantomData<fn(F)>,
@@ -38,7 +38,7 @@ where
             id,
             field_index,
             ingredient,
-            durability: Durability::LOW,
+            durability: None,
             setter,
             phantom: PhantomData,
         }
@@ -53,7 +53,7 @@ where
     type FieldTy = F;
 
     fn with_durability(mut self, durability: Durability) -> Self {
-        self.durability = durability;
+        self.durability = Some(durability);
         self
     }
 

--- a/tests/input_setter_preserves_durability.rs
+++ b/tests/input_setter_preserves_durability.rs
@@ -1,0 +1,34 @@
+use test_log::test;
+
+use salsa::plumbing::ZalsaDatabase;
+use salsa::{Durability, Setter};
+
+#[salsa::input]
+struct MyInput {
+    required_field: bool,
+
+    #[default]
+    optional_field: usize,
+}
+
+#[test]
+fn execute() {
+    let mut db = salsa::DatabaseImpl::new();
+
+    let input = MyInput::builder(true)
+        .required_field_durability(Durability::HIGH)
+        .new(&db);
+
+    // Change the field value. It should preserve high durability.
+    input.set_required_field(&mut db).to(false);
+
+    let last_high_revision = db.zalsa().last_changed_revision(Durability::HIGH);
+
+    // Changing the value again should **again** dump the high durability revision.
+    input.set_required_field(&mut db).to(false);
+
+    assert_ne!(
+        db.zalsa().last_changed_revision(Durability::HIGH),
+        last_high_revision
+    );
+}


### PR DESCRIPTION
This PR changes the `Setter` to preserve the existing durability instead of defaulting to `Low`. 

[Discussed on Zulip](https://salsa.zulipchat.com/#narrow/stream/333573-salsa-3.2E0/topic/durability/near/454842662)


