### PR TITLE
Reduce tracing output of memo

### DIFF
--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -72,6 +72,7 @@ where
         tracing::debug!(
             "{database_key_index:?}: maybe_changed_after_cold, successful claim, \
                 revision = {revision:?}, old_memo = {old_memo:#?}",
+            old_memo = old_memo.tracing_debug()
         );
 
         // Check if the inputs are still valid and we can just compare `changed_at`.
@@ -105,7 +106,10 @@ where
         let verified_at = memo.verified_at.load();
         let revision_now = zalsa.current_revision();
 
-        tracing::debug!("{database_key_index:?}: shallow_verify_memo(memo = {memo:#?})",);
+        tracing::debug!(
+            "{database_key_index:?}: shallow_verify_memo(memo = {memo:#?})",
+            memo = memo.tracing_debug()
+        );
 
         if verified_at == revision_now {
             // Already verified.
@@ -140,7 +144,10 @@ where
         let zalsa = db.zalsa();
         let database_key_index = active_query.database_key_index;
 
-        tracing::debug!("{database_key_index:?}: deep_verify_memo(old_memo = {old_memo:#?})",);
+        tracing::debug!(
+            "{database_key_index:?}: deep_verify_memo(old_memo = {old_memo:#?})",
+            old_memo = old_memo.tracing_debug()
+        );
 
         if self.shallow_verify_memo(db, zalsa, database_key_index, old_memo) {
             return true;

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -1,3 +1,4 @@
+use std::fmt::Formatter;
 use std::sync::Arc;
 
 use arc_swap::{ArcSwap, Guard};
@@ -167,5 +168,30 @@ impl<V> Memo<V> {
         for output in self.revisions.origin.outputs() {
             output.mark_validated_output(db, database_key_index);
         }
+    }
+
+    pub(super) fn tracing_debug(&self) -> impl std::fmt::Debug + '_ {
+        struct TracingDebug<'a, T> {
+            memo: &'a Memo<T>,
+        }
+
+        impl<T> std::fmt::Debug for TracingDebug<'_, T> {
+            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                f.debug_struct("Memo")
+                    .field(
+                        "value",
+                        if self.memo.value.is_some() {
+                            &"Some(<value>)"
+                        } else {
+                            &"None"
+                        },
+                    )
+                    .field("verified_at", &self.memo.verified_at)
+                    .field("revisions", &self.memo.revisions)
+                    .finish()
+            }
+        }
+
+        TracingDebug { memo: self }
     }
 }

--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -81,7 +81,11 @@ where
             revisions,
         };
 
-        tracing::debug!("specify: about to add memo {:#?} for key {:?}", memo, key);
+        tracing::debug!(
+            "specify: about to add memo {:#?} for key {:?}",
+            memo.tracing_debug(),
+            key
+        );
         self.insert_memo(db, key, memo);
 
         // Record that the current query *specified* a value for this cell.


### PR DESCRIPTION
This PR reduces the verbosity of Salsa's tracing output. 

Salsa used to include the `Memo` value in the tracing output. If the value is large (imagine a file's source text or AST), this can lead to very verbose traces.

This PR introduces a new `tracing_debug` function on `Memo` that omits `value` and only includes whether the `Memo`'s value is `Some` or `None`.

I considered chagning `Memo`'s `Debug` implementation but I can see cases where it might be useful to debug print a `Memo` including its value when debugging a Salsa issue. 

The output of `Memo.revisions` can still be long if a query has many dependencies but seeing the outputs is useful when debugging Salsa

## Test plan

I used a field-level tracing filter in Ruff and the Salsa output looks very manageable now.

```
RED_KNOT_LOG=[{name=bar.baz}] cargo run --bin red_knot -- --current-directory=../test -vvv
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.12s
     Running `target/debug/red_knot --current-directory=../test -vvv`
22┐red_knot_module_resolver::resolver::resolve_module{name=child.a}
22┘
22┐red_knot_module_resolver::resolver::resolve_module{name=typing}
22┘
22┐red_knot_module_resolver::resolver::resolve_module{name=builtins}
22┘
22┐red_knot_module_resolver::resolver::resolve_module{name=b}
22┘
22┐red_knot_module_resolver::resolver::resolve_module{name=bar.baz}
22├─   0.059225s   0ms DEBUG salsa::function::maybe_changed_after module_resolution_settings(0): shallow_verify_memo(memo = Memo {
22│     value: "Some(<value>)",
22│     verified_at: AtomicCell {
22│         value: R1,
22│     },
22│     revisions: QueryRevisions {
22│         changed_at: R1,
22│         durability: Durability(
22│             2,
22│         ),
22│         origin: Derived(
22│             QueryEdges {
22│                 input_outputs: [
22│                     (
22│                         Input,
22│                         search_paths(0),
22│                     ),
22│                     (
22│                         Input,
22│                         target_version(0),
22│                     ),
22│                 ],
22│             },
22│         ),
22│     },
22│ })
22├─   0.059288s   0ms DEBUG salsa::zalsa_local report_tracked_read(input=module_resolution_settings(0), durability=Durability(2), changed_at=R1)
22├─   0.059327s   0ms DEBUG salsa::zalsa_local report_tracked_read(input=status(10), durability=Durability(0), changed_at=R1)
22├─   0.059361s   0ms TRACE ruff_db::files Adding file /home/micha/astral/test/bar/baz
22├─   0.059399s   0ms DEBUG salsa::zalsa_local report_tracked_read(input=status(29), durability=Durability(0), changed_at=R1)
22├─   0.059434s   0ms TRACE ruff_db::files Adding file /home/micha/astral/test/bar/baz.pyi
22├─   0.059466s   0ms DEBUG salsa::zalsa_local report_tracked_read(input=status(30), durability=Durability(0), changed_at=R1)
22├─   0.059502s   0ms DEBUG salsa::zalsa_local report_tracked_read(input=status(9), durability=Durability(0), changed_at=R1)
22├─   0.059531s   0ms DEBUG salsa::zalsa_local report_tracked_read(input=path(9), durability=Durability(0), changed_at=R1)
22├─   0.059552s   0ms DEBUG red_knot_module_resolver::resolver Resolved module 'bar.baz' to '/home/micha/astral/test/bar/baz.py'.
22┘
22┐red_knot_module_resolver::resolver::resolve_module{name=a}
22┘
22┐red_knot_module_resolver::resolver::resolve_module{name=a_alias}
22┘
22┐red_knot_module_resolver::resolver::resolve_module{name=random}
22┘
22┐red_knot_module_resolver::resolver::resolve_module{name=x}
22┘
22┐red_knot_module_resolver::resolver::resolve_module{name=_typeshed}
22┘
```
