### PR TITLE
Reduce cloning of sets in `ActiveQuery` and `QueryRevisions`

### DIFF
--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -1,4 +1,5 @@
 use rustc_hash::FxHashMap;
+use std::sync::Arc;
 
 use crate::{
     durability::Durability,
@@ -98,11 +99,11 @@ impl ActiveQuery {
         self.input_outputs.contains(&(EdgeKind::Output, key))
     }
 
-    pub(crate) fn revisions(&self) -> QueryRevisions {
+    pub(crate) fn into_revisions(self) -> QueryRevisions {
         let input_outputs = if self.input_outputs.is_empty() {
             EMPTY_DEPENDENCIES.clone()
         } else {
-            self.input_outputs.iter().copied().collect()
+            Arc::from(self.input_outputs.into_boxed_slice())
         };
 
         let edges = QueryEdges::new(input_outputs);
@@ -117,7 +118,7 @@ impl ActiveQuery {
             changed_at: self.changed_at,
             origin,
             durability: self.durability,
-            tracked_struct_ids: self.tracked_struct_ids.clone(),
+            tracked_struct_ids: self.tracked_struct_ids,
         }
     }
 

--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -1,5 +1,4 @@
 use rustc_hash::FxHashMap;
-use std::sync::Arc;
 
 use crate::{
     durability::Durability,
@@ -103,7 +102,7 @@ impl ActiveQuery {
         let input_outputs = if self.input_outputs.is_empty() {
             EMPTY_DEPENDENCIES.clone()
         } else {
-            Arc::from(self.input_outputs.into_boxed_slice())
+            self.input_outputs.into_iter().collect()
         };
 
         let edges = QueryEdges::new(input_outputs);

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -84,18 +84,13 @@ where
             self.diff_outputs(db, database_key_index, old_memo, &revisions);
         }
 
-        let value = self
-            .insert_memo(
-                zalsa,
-                id,
-                Memo::new(Some(value), revision_now, revisions.clone()),
-            )
-            .unwrap();
-
-        let stamped_value = revisions.stamped_value(value);
-
         tracing::debug!("{database_key_index:?}: read_upgrade: result.revisions = {revisions:#?}");
 
-        stamped_value
+        let stamp_template = revisions.stamp_template();
+        let value = self
+            .insert_memo(zalsa, id, Memo::new(Some(value), revision_now, revisions))
+            .unwrap();
+
+        stamp_template.stamp(value)
     }
 }

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -3,7 +3,6 @@ use tracing::debug;
 
 use crate::active_query::ActiveQuery;
 use crate::durability::Durability;
-use crate::hash::FxIndexSet;
 use crate::key::DatabaseKeyIndex;
 use crate::key::DependencyIndex;
 use crate::runtime::StampedValue;
@@ -433,7 +432,7 @@ pub enum EdgeKind {
 }
 
 lazy_static::lazy_static! {
-    pub(crate) static ref EMPTY_DEPENDENCIES: Arc<indexmap::set::Slice<(EdgeKind, DependencyIndex)>> = Arc::from(FxIndexSet::default().into_boxed_slice());
+    pub(crate) static ref EMPTY_DEPENDENCIES: Arc<[(EdgeKind, DependencyIndex)]> = Arc::new([]);
 }
 
 /// The edges between a memoized value and other queries in the dependency graph.
@@ -455,7 +454,7 @@ pub struct QueryEdges {
     /// Important:
     ///
     /// * The inputs must be in **execution order** for the red-green algorithm to work.
-    pub input_outputs: Arc<indexmap::set::Slice<(EdgeKind, DependencyIndex)>>,
+    pub input_outputs: Arc<[(EdgeKind, DependencyIndex)]>,
 }
 
 impl QueryEdges {
@@ -480,9 +479,7 @@ impl QueryEdges {
     }
 
     /// Creates a new `QueryEdges`; the values given for each field must meet struct invariants.
-    pub(crate) fn new(
-        input_outputs: Arc<indexmap::set::Slice<(EdgeKind, DependencyIndex)>>,
-    ) -> Self {
+    pub(crate) fn new(input_outputs: Arc<[(EdgeKind, DependencyIndex)]>) -> Self {
         Self { input_outputs }
     }
 }


### PR DESCRIPTION
A small performance improvement to avoid cloning hash sets where we can consume the value instead.