### PR TITLE
Fix panic when recreating tracked struct that was deleted in previous revision

### DIFF
--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -6,7 +6,7 @@ use crate::{
     key::{DatabaseKeyIndex, DependencyIndex},
     tracked_struct::{Disambiguator, KeyStruct},
     zalsa_local::EMPTY_DEPENDENCIES,
-    Cycle, Id, Revision,
+    Cycle, Revision,
 };
 
 use super::zalsa_local::{EdgeKind, QueryEdges, QueryOrigin, QueryRevisions};
@@ -48,7 +48,7 @@ pub(crate) struct ActiveQuery {
 
     /// Map from tracked struct keys (which include the hash + disambiguator) to their
     /// final id.
-    pub(crate) tracked_struct_ids: FxHashMap<KeyStruct, Id>,
+    pub(crate) tracked_struct_ids: FxHashMap<KeyStruct, DatabaseKeyIndex>,
 }
 
 impl ActiveQuery {

--- a/src/function.rs
+++ b/src/function.rs
@@ -165,7 +165,7 @@ where
         zalsa: &'db Zalsa,
         id: Id,
         memo: memo::Memo<C::Output<'db>>,
-    ) -> Option<&C::Output<'db>> {
+    ) -> Option<&'db C::Output<'db>> {
         let memo = Arc::new(memo);
         let value = unsafe {
             // Unsafety conditions: memo must be in the map (it's not yet, but it will be by the time this

--- a/src/function/diff_outputs.rs
+++ b/src/function/diff_outputs.rs
@@ -1,5 +1,4 @@
 use super::{memo::Memo, Configuration, IngredientImpl};
-use crate::tracked_struct::KeyStruct;
 use crate::{
     hash::FxHashSet, key::DependencyIndex, zalsa_local::QueryRevisions, AsDynDatabase as _,
     DatabaseKeyIndex, Event, EventKind,

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -81,7 +81,7 @@ where
         // old value.
         if let Some(old_memo) = &opt_old_memo {
             self.backdate_if_appropriate(old_memo, &mut revisions, &value);
-            self.diff_outputs(db, database_key_index, old_memo, &revisions);
+            self.diff_outputs(db, database_key_index, old_memo, &mut revisions);
         }
 
         tracing::debug!("{database_key_index:?}: read_upgrade: result.revisions = {revisions:#?}");

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -25,7 +25,7 @@ where
         db: &'db C::DbView,
         active_query: ActiveQueryGuard<'_>,
         opt_old_memo: Option<Arc<Memo<C::Output<'_>>>>,
-    ) -> StampedValue<&C::Output<'db>> {
+    ) -> StampedValue<&'db C::Output<'db>> {
         let zalsa = db.zalsa();
         let revision_now = zalsa.current_revision();
         let database_key_index = active_query.database_key_index;

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -6,7 +6,7 @@ impl<C> IngredientImpl<C>
 where
     C: Configuration,
 {
-    pub fn fetch<'db>(&'db self, db: &'db C::DbView, id: Id) -> &C::Output<'db> {
+    pub fn fetch<'db>(&'db self, db: &'db C::DbView, id: Id) -> &'db C::Output<'db> {
         let (zalsa, zalsa_local) = db.zalsas();
         zalsa_local.unwind_if_revision_cancelled(db.as_dyn_database());
 

--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -73,7 +73,7 @@ where
 
         if let Some(old_memo) = self.get_memo_from_table_for(zalsa, key) {
             self.backdate_if_appropriate(&old_memo, &mut revisions, &value);
-            self.diff_outputs(db, database_key_index, &old_memo, &revisions);
+            self.diff_outputs(db, database_key_index, &old_memo, &mut revisions);
         }
 
         let memo = Memo {

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -277,8 +277,9 @@ where
             None => {
                 // This is a new tracked struct, so create an entry in the struct map.
                 let id = self.allocate(zalsa, zalsa_local, current_revision, &current_deps, fields);
-                zalsa_local.add_output(self.database_key_index(id).into());
-                zalsa_local.store_tracked_struct_id(key_struct, id);
+                let key = self.database_key_index(id);
+                zalsa_local.add_output(key.into());
+                zalsa_local.store_tracked_struct_id(key_struct, key);
                 C::struct_from_id(id)
             }
         }

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -353,7 +353,12 @@ pub(crate) struct QueryRevisions {
 
     /// The ids of tracked structs created by this query.
     /// This is used to seed the next round if the query is
-    /// re-executed.
+    /// re-executed. This ensures that tracked structs
+    /// have the same id across revisions.
+    ///
+    /// [`diff_outputs`] removes tracked structs that were created
+    /// in a previous revision but no longer exist
+    /// in the new revision.
     pub(super) tracked_struct_ids: FxHashMap<KeyStruct, DatabaseKeyIndex>,
 }
 

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -361,13 +361,22 @@ pub(crate) struct QueryRevisions {
     pub(crate) origin: QueryOrigin,
 
     /// The ids of tracked structs created by this query.
-    /// This is used to seed the next round if the query is
-    /// re-executed. This ensures that tracked structs
-    /// have the same id across revisions.
     ///
-    /// [`diff_outputs`] removes tracked structs that were created
-    /// in a previous revision but no longer exist
-    /// in the new revision.
+    /// This table plays an important role when queries are
+    /// re-executed:
+    /// * A clone of this field is used as the initial set of
+    ///   `TrackedStructId`s for the query on the next execution.
+    /// * The query will thus re-use the same ids if it creates
+    ///   tracked structs with the same `KeyStruct` as before.
+    ///   It may also create new tracked structs.
+    /// * One tricky case involves deleted structs. If
+    ///   the old revision created a struct S but the new
+    ///   revision did not, there will still be a map entry
+    ///   for S. This is because queries only ever grow the map
+    ///   and they start with the same entries as from the
+    ///   previous revision. To handle this, `diff_outputs` compares
+    ///   the structs from the old/new revision and retains
+    ///   only entries that appeared in the new revision.
     pub(super) tracked_struct_ids: FxHashMap<KeyStruct, DatabaseKeyIndex>,
 
     pub(super) accumulated: AccumulatedMap,

--- a/tests/tracked_struct_recreate_new_revision.rs
+++ b/tests/tracked_struct_recreate_new_revision.rs
@@ -1,4 +1,5 @@
-//! Test that a `tracked` struct on a `salsa::input` doesn't panic when recreating a new revision.
+//! Test that re-creating a `tracked` struct after it was deleted in a previous
+//! revision doesn't panic.
 #![allow(warnings)]
 
 use salsa::Setter;
@@ -10,7 +11,6 @@ struct MyInput {
 
 #[salsa::tracked]
 struct TrackedStruct<'db> {
-    #[id]
     field: u32,
 }
 

--- a/tests/tracked_struct_recreate_new_revision.rs
+++ b/tests/tracked_struct_recreate_new_revision.rs
@@ -1,0 +1,35 @@
+//! Test that a `tracked` struct on a `salsa::input` doesn't panic when recreating a new revision.
+#![allow(warnings)]
+
+use salsa::Setter;
+
+#[salsa::input]
+struct MyInput {
+    field: u32,
+}
+
+#[salsa::tracked]
+struct TrackedStruct<'db> {
+    #[id]
+    field: u32,
+}
+
+#[salsa::tracked]
+fn tracked_fn(db: &dyn salsa::Database, input: MyInput) -> Option<TrackedStruct<'_>> {
+    if input.field(db) == 1 {
+        Some(TrackedStruct::new(db, 1))
+    } else {
+        None
+    }
+}
+
+#[test]
+fn execute() {
+    let mut db = salsa::DatabaseImpl::new();
+    let input = MyInput::new(&db, 1);
+    assert!(tracked_fn(&db, input).is_some());
+    input.set_field(&mut db).to(0);
+    assert_eq!(tracked_fn(&db, input), None);
+    input.set_field(&mut db).to(1);
+    assert!(tracked_fn(&db, input).is_some());
+}


### PR DESCRIPTION
Edited by @MichaReiser 

This is an error that surfaced when working on Ruff's LSP. The scenario is:

* Revision 0: Query `Q` creates a tracked struct `S`
* Revision 1: Query `Q` no longer creates a tracked struct
* Revision 2: Query `Q` again creates a tracked struct `S`

The real world scenario is Ruff's semantic index that creates a tracked struct `Scope` for every function. Deleting a function and then creating a new function resulted in a panic `two concurrent writers to {id:?}, should not be possible`.

The root cause of the panic is that a removed entity is added to an ingredients-free list, but the ID is never removed from the `tracked_struct_ids`, resulting in Revision 2 re-using the struct from the free list. 

