### PR TITLE
fix: Inconsistent behaviour with lifetime elision on tracked fn

### DIFF
--- a/tests/compile-fail/tracked_fn_incompatibles.rs
+++ b/tests/compile-fail/tracked_fn_incompatibles.rs
@@ -34,4 +34,38 @@ fn tracked_fn_with_too_many_arguments_for_specify(
 ) -> u32 {
 }
 
+#[salsa::interned]
+struct MyInterned<'db> {
+    field: u32,
+}
+
+#[salsa::tracked]
+fn tracked_fn_with_lt_param_and_elided_lt_on_db_arg1<'db>(
+    db: &dyn Db,
+    interned: MyInterned<'db>,
+) -> u32 {
+    interned.field(db) * 2
+}
+
+#[salsa::tracked]
+fn tracked_fn_with_lt_param_and_elided_lt_on_db_arg2<'db_lifetime>(
+    db: &dyn Db,
+    interned: MyInterned<'db_lifetime>,
+) -> u32 {
+    interned.field(db) * 2
+}
+
+#[salsa::tracked]
+fn tracked_fn_with_lt_param_and_elided_lt_on_input<'db>(
+    db: &'db dyn Db,
+    interned: MyInterned,
+) -> u32 {
+    interned.field(db) * 2
+}
+
+#[salsa::tracked]
+fn tracked_fn_with_multiple_lts<'db1, 'db2>(db: &'db1 dyn Db, interned: MyInterned<'db2>) -> u32 {
+    interned.field(db) * 2
+}
+
 fn main() {}

--- a/tests/compile-fail/tracked_fn_incompatibles.stderr
+++ b/tests/compile-fail/tracked_fn_incompatibles.stderr
@@ -28,6 +28,35 @@ error: only functions with a single salsa struct as their input can be specified
 29 | #[salsa::tracked(specify)]
    |                  ^^^^^^^
 
+error: must have a `'db` lifetime
+  --> tests/compile-fail/tracked_fn_incompatibles.rs:44:9
+   |
+44 |     db: &dyn Db,
+   |         ^
+
+error: must have a `'db_lifetime` lifetime
+  --> tests/compile-fail/tracked_fn_incompatibles.rs:52:9
+   |
+52 |     db: &dyn Db,
+   |         ^
+
+error: only a single lifetime parameter is accepted
+  --> tests/compile-fail/tracked_fn_incompatibles.rs:67:39
+   |
+67 | fn tracked_fn_with_multiple_lts<'db1, 'db2>(db: &'db1 dyn Db, interned: MyInterned<'db2>) -> u32 {
+   |                                       ^^^^
+
+error[E0106]: missing lifetime specifier
+  --> tests/compile-fail/tracked_fn_incompatibles.rs:61:15
+   |
+61 |     interned: MyInterned,
+   |               ^^^^^^^^^^ expected named lifetime parameter
+   |
+help: consider using the `'db` lifetime
+   |
+61 |     interned: MyInterned<'db>,
+   |                         +++++
+
 error[E0308]: mismatched types
   --> tests/compile-fail/tracked_fn_incompatibles.rs:24:46
    |

--- a/tests/tracked_fn_read_own_specify.rs
+++ b/tests/tracked_fn_read_own_specify.rs
@@ -22,7 +22,7 @@ fn tracked_fn(db: &dyn LogDatabase, input: MyInput) -> u32 {
 }
 
 #[salsa::tracked(specify)]
-fn tracked_fn_extra<'db>(db: &dyn LogDatabase, input: MyTracked<'db>) -> u32 {
+fn tracked_fn_extra<'db>(db: &'db dyn LogDatabase, input: MyTracked<'db>) -> u32 {
     db.push_log(format!("tracked_fn_extra({input:?})"));
     0
 }


### PR DESCRIPTION
Fixes #519

I think that there would be roughly two options for fixing this;

1. Returning error while proc macro expansion
2. Inserting a type alias like `type __T<'db> = DbInputArgType;` inside the expanded function's body so that the expanded code fails to compile

In this PR, I chose the first one because the second is little bit non-intuitive and the expanded code is slightly more bloated.
But the second one also has its own merit; It can utilize rustc's more detailed error message and is more consistent with the case that the other input parameter has an elided lifetime.
So, I'm okay to switch to the second one if I have to 😄 