### PR TITLE
Approximate sizes of `stack` and `visisted` when collecting accumulated values

### DIFF
--- a/src/function/accumulated.rs
+++ b/src/function/accumulated.rs
@@ -1,11 +1,11 @@
+use super::{Configuration, IngredientImpl};
+use crate::zalsa_local::QueryOrigin;
 use crate::{
     accumulator::{self, accumulated_map::AccumulatedMap},
     hash::FxHashSet,
     zalsa::ZalsaDatabase,
     AsDynDatabase, DatabaseKeyIndex, Id,
 };
-
-use super::{Configuration, IngredientImpl};
 
 impl<C> IngredientImpl<C>
 where
@@ -76,15 +76,9 @@ where
                 continue;
             };
 
-            let estimated_inputs = match &origin {
-                QueryOrigin::Assigned(_) | QueryOrigin::BaseInput => 0,
-                QueryOrigin::Derived(edges) | QueryOrigin::DerivedUntracked(edges) => {
-                    edges.input_outputs.len()
-                }
-            };
-
-            stack.reserve(estimated_inputs);
-            visited.reserve(estimated_inputs);
+            if let QueryOrigin::Derived(edges) | QueryOrigin::DerivedUntracked(edges) = &origin {
+                stack.reserve(edges.input_outputs.len());
+            }
 
             stack.extend(
                 origin


### PR DESCRIPTION
This PR uses the input-output length to approximate the number of items added to `stack` and reserves `stack.len()` additional items in `visited` to avoid costly resizes. This reduces the performance regression in https://github.com/astral-sh/ruff/pull/14760 from 10.3% to 9%, which seems worthwhile.

The downside is that it can result in a too large `stack` if a query has many outputs but only few outputs or in a too large `visited` set if many inputs are overlapping. I think this is acceptable, considering that the data structures are short-lived. 

## Performance

This shows a 9% performance improvement for the [accumulator benchmark](https://codspeed.io/salsa-rs/salsa/branches/MichaReiser%3Asmall-accumulator-perf?uri=benches%2Faccumulator.rs%3A%3Abenches%3A%3Aaccumulator%3A%3Aaccumulator).

