### PR TITLE
Do not allocate input singleton data for non-singleton inputs

### DIFF
--- a/components/salsa-macro-rules/src/setup_input_struct.rs
+++ b/components/salsa-macro-rules/src/setup_input_struct.rs
@@ -72,7 +72,7 @@ macro_rules! setup_input_struct {
             impl $zalsa_struct::Configuration for $Configuration {
                 const DEBUG_NAME: &'static str = stringify!($Struct);
                 const FIELD_DEBUG_NAMES: &'static [&'static str] = &[$(stringify!($field_id)),*];
-                const IS_SINGLETON: bool = $is_singleton;
+                type Singleton = $zalsa::macro_if! {if $is_singleton {$zalsa::input::Singleton} else {$zalsa::input::NotSingleton}};
 
                 /// The input struct (which wraps an `Id`)
                 type Struct = $Struct;

--- a/src/input/singleton.rs
+++ b/src/input/singleton.rs
@@ -1,0 +1,55 @@
+use crossbeam::atomic::AtomicCell;
+use parking_lot::Mutex;
+
+use crate::{id::FromId, Id};
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+pub trait SingletonChoice: sealed::Sealed + Default {
+    fn with_lock(&self, cb: impl FnOnce() -> Id) -> Id;
+    fn index(&self) -> Option<Id>;
+}
+
+pub struct Singleton {
+    index: AtomicCell<Option<Id>>,
+    lock: Mutex<()>,
+}
+impl sealed::Sealed for Singleton {}
+impl SingletonChoice for Singleton {
+    fn with_lock(&self, cb: impl FnOnce() -> Id) -> Id {
+        let _guard = self.lock.lock();
+        if self.index.load().is_some() {
+            panic!("singleton struct may not be duplicated");
+        }
+        let id = cb();
+        self.index.store(Some(id));
+        drop(_guard);
+        id
+    }
+
+    fn index(&self) -> Option<Id> {
+        self.index.load().map(FromId::from_id)
+    }
+}
+
+impl Default for Singleton {
+    fn default() -> Self {
+        Self {
+            index: AtomicCell::new(None),
+            lock: Default::default(),
+        }
+    }
+}
+#[derive(Default)]
+pub struct NotSingleton;
+impl sealed::Sealed for NotSingleton {}
+impl SingletonChoice for NotSingleton {
+    fn with_lock(&self, cb: impl FnOnce() -> Id) -> Id {
+        cb()
+    }
+    fn index(&self) -> Option<Id> {
+        None
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,8 @@ pub mod plumbing {
     pub mod input {
         pub use crate::input::input_field::FieldIngredientImpl;
         pub use crate::input::setter::SetterImpl;
+        pub use crate::input::singleton::NotSingleton;
+        pub use crate::input::singleton::Singleton;
         pub use crate::input::Configuration;
         pub use crate::input::HasBuilder;
         pub use crate::input::IngredientImpl;


### PR DESCRIPTION
This does some type shenanigans (unfortunately can't gate on the previously used const as Rust's const story just isn't there yet), to swap the singleton field with `()` if it's not needed.