### PR TITLE
Implement self-referential/subset key interning 

### DIFF
--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -165,7 +165,7 @@ macro_rules! setup_interned_struct {
                 {
                     let current_revision = $zalsa::current_revision(db);
                     $Configuration::ingredient(db).intern(db.as_dyn_database(),
-                        StructKey::<$db_lt>($($field_id,)* std::marker::PhantomData::default()))
+                        StructKey::<$db_lt>($($field_id,)* std::marker::PhantomData::default()), |_, data| ($($zalsa::interned::Lookup::into_owned(data.$field_index),)*))
                 }
 
                 $(

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -249,7 +249,7 @@ macro_rules! setup_tracked_fn {
                     use salsa::plumbing as $zalsa;
                     let key = $zalsa::macro_if! {
                         if $needs_interner {
-                            $Configuration::intern_ingredient($db).intern_id($db.as_dyn_database(), ($($input_id),*))
+                            $Configuration::intern_ingredient($db).intern_id($db.as_dyn_database(), ($($input_id),*), |_, data| data)
                         } else {
                             $zalsa::AsId::as_id(&($($input_id),*))
                         }
@@ -285,7 +285,7 @@ macro_rules! setup_tracked_fn {
                 let result = $zalsa::macro_if! {
                     if $needs_interner {
                         {
-                            let key = $Configuration::intern_ingredient($db).intern_id($db.as_dyn_database(), ($($input_id),*));
+                            let key = $Configuration::intern_ingredient($db).intern_id($db.as_dyn_database(), ($($input_id),*), |_, data| data);
                             $Configuration::fn_ingredient($db).fetch($db, key)
                         }
                     } else {

--- a/src/input.rs
+++ b/src/input.rs
@@ -117,7 +117,7 @@ impl<C: Configuration> IngredientImpl<C> {
             None
         };
 
-        let id = zalsa_local.allocate(zalsa.table(), self.ingredient_index, || Value::<C> {
+        let id = zalsa_local.allocate(zalsa.table(), self.ingredient_index, |_| Value::<C> {
             fields,
             stamps,
             memos: Default::default(),

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -154,9 +154,7 @@ where
             InputAccumulatedValues::Empty,
         );
 
-        // Optimisation to only get read lock on the map if the data has already
-        // been interned.
-        // We need to use the raw API for this lookup. See the [`Lookup`][] trait definition for an explanation of why.
+        // Optimization to only get read lock on the map if the data has already been interned.
         let data_hash = self.key_map.hasher().hash_one(&key);
         let shard = self.key_map.determine_shard(data_hash as _);
         let eq = |(a, _): &_| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,7 @@ pub mod plumbing {
 
     pub mod interned {
         pub use crate::interned::Configuration;
+        pub use crate::interned::HashEqLike;
         pub use crate::interned::IngredientImpl;
         pub use crate::interned::JarImpl;
         pub use crate::interned::Lookup;

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -320,7 +320,7 @@ where
         current_deps: &StampedValue<()>,
         fields: C::Fields<'db>,
     ) -> Id {
-        let value = || Value {
+        let value = |_| Value {
             updated_at: AtomicCell::new(Some(current_revision)),
             durability: current_deps.durability,
             fields: unsafe { self.to_static(fields) },
@@ -339,7 +339,7 @@ where
             // Overwrite the free-list entry. Use `*foo = ` because the entry
             // has been previously initialized and we want to free the old contents.
             unsafe {
-                *data_raw = value();
+                *data_raw = value(id);
             }
 
             id

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -58,7 +58,7 @@ impl ZalsaLocal {
         &self,
         table: &Table,
         ingredient: IngredientIndex,
-        mut value: impl FnOnce() -> T,
+        mut value: impl FnOnce(Id) -> T,
     ) -> Id {
         // Find the most recent page, pushing a page if needed
         let mut page = *self
@@ -71,7 +71,7 @@ impl ZalsaLocal {
             // Try to allocate an entry on that page
             let page_ref = table.page::<T>(page);
             match page_ref.allocate(page, value) {
-                // If succesful, return
+                // If succesfull, return
                 Ok(id) => return id,
 
                 // Otherwise, create a new page and try again

--- a/tests/interned-structs_self_ref.rs
+++ b/tests/interned-structs_self_ref.rs
@@ -109,7 +109,13 @@ const _: () = {
             Self::default_debug_fmt(*self, f)
         }
     }
-    impl zalsa_::SalsaStructInDb for InternedString<'_> {}
+    impl zalsa_::SalsaStructInDb for InternedString<'_> {
+        fn lookup_ingredient_index(
+            aux: &dyn zalsa_::JarAux,
+        ) -> core::option::Option<zalsa_::IngredientIndex> {
+            aux.lookup_jar_by_type(&<zalsa_struct_::JarImpl<Configuration_>>::default())
+        }
+    }
 
     unsafe impl zalsa_::Update for InternedString<'_> {
         unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {

--- a/tests/interned-structs_self_ref.rs
+++ b/tests/interned-structs_self_ref.rs
@@ -1,0 +1,176 @@
+//! Test that a `tracked` fn on a `salsa::input`
+//! compiles and executes successfully.
+
+use std::convert::identity;
+
+use test_log::test;
+
+#[test]
+fn interning_returns_equal_keys_for_equal_data() {
+    let db = salsa::DatabaseImpl::new();
+    let s1 = InternedString::new(&db, "Hello, ".to_string(), identity);
+    let s2 = InternedString::new(&db, "World, ".to_string(), |_| s1);
+    let s1_2 = InternedString::new(&db, "Hello, ", identity);
+    let s2_2 = InternedString::new(&db, "World, ", |_| s2);
+    assert_eq!(s1, s1_2);
+    assert_eq!(s2, s2_2);
+}
+// Recursive expansion of interned macro
+// #[salsa::interned]
+// struct InternedString<'db> {
+//     data: String,
+//     other: InternedString<'db>,
+// }
+// ======================================
+
+#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+struct InternedString<'db>(
+    salsa::Id,
+    std::marker::PhantomData<&'db salsa::plumbing::interned::Value<InternedString<'static>>>,
+);
+
+#[allow(warnings)]
+const _: () = {
+    use salsa::plumbing as zalsa_;
+    use zalsa_::interned as zalsa_struct_;
+    type Configuration_ = InternedString<'static>;
+    #[derive(Clone)]
+    struct StructData<'db>(String, InternedString<'db>);
+
+    impl<'db> Eq for StructData<'db> {}
+    impl<'db> PartialEq for StructData<'db> {
+        fn eq(&self, other: &Self) -> bool {
+            self.0 == other.0
+        }
+    }
+
+    impl<'db> std::hash::Hash for StructData<'db> {
+        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+            self.0.hash(state);
+        }
+    }
+
+    #[doc = r" Key to use during hash lookups. Each field is some type that implements `Lookup<T>`"]
+    #[doc = r" for the owned type. This permits interning with an `&str` when a `String` is required and so forth."]
+    #[derive(Hash)]
+    struct StructKey<'db, T0>(T0, std::marker::PhantomData<&'db ()>);
+
+    impl<'db, T0> zalsa_::interned::HashEqLike<StructKey<'db, T0>> for StructData<'db>
+    where
+        String: zalsa_::interned::HashEqLike<T0>,
+    {
+        fn hash<H: std::hash::Hasher>(&self, h: &mut H) {
+            zalsa_::interned::HashEqLike::<T0>::hash(&self.0, &mut *h);
+        }
+        fn eq(&self, data: &StructKey<'db, T0>) -> bool {
+            (zalsa_::interned::HashEqLike::<T0>::eq(&self.0, &data.0) && true)
+        }
+    }
+    impl zalsa_struct_::Configuration for Configuration_ {
+        const DEBUG_NAME: &'static str = "InternedString";
+        type Data<'a> = StructData<'a>;
+        type Struct<'a> = InternedString<'a>;
+        fn struct_from_id<'db>(id: salsa::Id) -> Self::Struct<'db> {
+            InternedString(id, std::marker::PhantomData)
+        }
+        fn deref_struct(s: Self::Struct<'_>) -> salsa::Id {
+            s.0
+        }
+    }
+    impl Configuration_ {
+        pub fn ingredient<Db>(db: &Db) -> &zalsa_struct_::IngredientImpl<Self>
+        where
+            Db: ?Sized + zalsa_::Database,
+        {
+            static CACHE: zalsa_::IngredientCache<zalsa_struct_::IngredientImpl<Configuration_>> =
+                zalsa_::IngredientCache::new();
+            CACHE.get_or_create(db.as_dyn_database(), || {
+                db.zalsa()
+                    .add_or_lookup_jar_by_type(&<zalsa_struct_::JarImpl<Configuration_>>::default())
+            })
+        }
+    }
+    impl zalsa_::AsId for InternedString<'_> {
+        fn as_id(&self) -> salsa::Id {
+            self.0
+        }
+    }
+    impl zalsa_::FromId for InternedString<'_> {
+        fn from_id(id: salsa::Id) -> Self {
+            Self(id, std::marker::PhantomData)
+        }
+    }
+    unsafe impl Send for InternedString<'_> {}
+
+    unsafe impl Sync for InternedString<'_> {}
+
+    impl std::fmt::Debug for InternedString<'_> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            Self::default_debug_fmt(*self, f)
+        }
+    }
+    impl zalsa_::SalsaStructInDb for InternedString<'_> {}
+
+    unsafe impl zalsa_::Update for InternedString<'_> {
+        unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
+            if unsafe { *old_pointer } != new_value {
+                unsafe { *old_pointer = new_value };
+                true
+            } else {
+                false
+            }
+        }
+    }
+    impl<'db> InternedString<'db> {
+        pub fn new<Db_, T0: zalsa_::interned::Lookup<String> + std::hash::Hash>(
+            db: &'db Db_,
+            data: T0,
+            other: impl FnOnce(InternedString<'db>) -> InternedString<'db>,
+        ) -> Self
+        where
+            Db_: ?Sized + salsa::Database,
+            String: zalsa_::interned::HashEqLike<T0>,
+        {
+            let current_revision = zalsa_::current_revision(db);
+            Configuration_::ingredient(db).intern(
+                db.as_dyn_database(),
+                StructKey::<'db>(data, std::marker::PhantomData::default()),
+                |id, data| {
+                    StructData(
+                        zalsa_::interned::Lookup::into_owned(data.0),
+                        other(zalsa_::FromId::from_id(id)),
+                    )
+                },
+            )
+        }
+        fn data<Db_>(self, db: &'db Db_) -> String
+        where
+            Db_: ?Sized + zalsa_::Database,
+        {
+            let fields = Configuration_::ingredient(db).fields(db.as_dyn_database(), self);
+            std::clone::Clone::clone((&fields.0))
+        }
+        fn other<Db_>(self, db: &'db Db_) -> InternedString<'db>
+        where
+            Db_: ?Sized + zalsa_::Database,
+        {
+            let fields = Configuration_::ingredient(db).fields(db.as_dyn_database(), self);
+            std::clone::Clone::clone((&fields.1))
+        }
+        #[doc = r" Default debug formatting for this struct (may be useful if you define your own `Debug` impl)"]
+        pub fn default_debug_fmt(this: Self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            zalsa_::with_attached_database(|db| {
+                let fields = Configuration_::ingredient(db).fields(db.as_dyn_database(), this);
+                let mut f = f.debug_struct("InternedString");
+                let f = f.field("data", &fields.0);
+                let f = f.field("other", &fields.1);
+                f.finish()
+            })
+            .unwrap_or_else(|| {
+                f.debug_tuple("InternedString")
+                    .field(&zalsa_::AsId::as_id(&this))
+                    .finish()
+            })
+        }
+    }
+};


### PR DESCRIPTION
This lacks a user facing API via the macro but I could not be bothered implementing that as it takes way too much effort with the decl macro quoting unfortunately (and I did not feel like cloning the entire macro for this either). This is enough for rust-analyzer's needs for the time being though as there is only one usage which we have handwritten for now.