### PR TITLE
Replace unnecessary `Arc` by `Box`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ rustc-hash = "2"
 salsa-macro-rules = { version = "0.1.0", path = "components/salsa-macro-rules" }
 salsa-macros = { path = "components/salsa-macros" }
 smallvec = "1"
-lazy_static = "1"
 rayon = "1.10.0"
 
 [dev-dependencies]

--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -61,7 +61,7 @@ pub struct IngredientImpl<A: Accumulator> {
 }
 
 impl<A: Accumulator> IngredientImpl<A> {
-    /// Find the accumulator ingrediate for `A` in the database, if any.
+    /// Find the accumulator ingredient for `A` in the database, if any.
     pub fn from_db<Db>(db: &Db) -> Option<&Self>
     where
         Db: ?Sized + Database,

--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -8,7 +8,6 @@ use crate::{
     hash::FxIndexSet,
     key::{DatabaseKeyIndex, DependencyIndex},
     tracked_struct::{Disambiguator, Identity},
-    zalsa_local::EMPTY_DEPENDENCIES,
     Cycle, Id, Revision,
 };
 
@@ -108,7 +107,7 @@ impl ActiveQuery {
 
     pub(crate) fn into_revisions(self) -> QueryRevisions {
         let input_outputs = if self.input_outputs.is_empty() {
-            EMPTY_DEPENDENCIES.clone()
+            Box::default()
         } else {
             self.input_outputs.into_iter().collect()
         };

--- a/src/function/accumulated.rs
+++ b/src/function/accumulated.rs
@@ -53,8 +53,9 @@ where
                 continue;
             }
 
+            let ingredient = zalsa.lookup_ingredient(k.ingredient_index);
             // Extend `output` with any values accumulated by `k`.
-            if let Some(accumulated_map) = k.accumulated(db) {
+            if let Some(accumulated_map) = ingredient.accumulated(db, k.key_index) {
                 accumulated_map.extend_with_accumulated(accumulator.index(), &mut output);
 
                 // Skip over the inputs because we know that the entire sub-graph has no accumulated values
@@ -69,10 +70,7 @@ where
             // output vector, we want to push in execution order, so reverse order to
             // ensure the first child that was executed will be the first child popped
             // from the stack.
-            let Some(origin) = zalsa
-                .lookup_ingredient(k.ingredient_index)
-                .origin(db, k.key_index)
-            else {
+            let Some(origin) = ingredient.origin(db, k.key_index) else {
                 continue;
             };
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,7 +1,4 @@
-use crate::{
-    accumulator::accumulated_map::AccumulatedMap, cycle::CycleRecoveryStrategy,
-    zalsa::IngredientIndex, Database, Id,
-};
+use crate::{cycle::CycleRecoveryStrategy, zalsa::IngredientIndex, Database, Id};
 
 /// An integer that uniquely identifies a particular query instance within the
 /// database. Used to track dependencies between queries. Fully ordered and
@@ -98,12 +95,6 @@ impl DatabaseKeyIndex {
 
     pub(crate) fn cycle_recovery_strategy(self, db: &dyn Database) -> CycleRecoveryStrategy {
         self.ingredient_index.cycle_recovery_strategy(db)
-    }
-
-    pub(crate) fn accumulated(self, db: &dyn Database) -> Option<&AccumulatedMap> {
-        db.zalsa()
-            .lookup_ingredient(self.ingredient_index)
-            .accumulated(db, self.key_index)
     }
 }
 

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -194,11 +194,9 @@ impl MemoTable {
         unsafe { Self::from_dummy::<M>(arc_swap.swap(Self::to_dummy(memo))) };
     }
 
-    pub(crate) fn into_memos(
-        mut self,
-    ) -> impl Iterator<Item = (MemoIngredientIndex, Arc<dyn Memo>)> {
-        let memos = std::mem::take(self.memos.get_mut());
-        memos
+    pub(crate) fn into_memos(self) -> impl Iterator<Item = (MemoIngredientIndex, Arc<dyn Memo>)> {
+        self.memos
+            .into_inner()
             .into_iter()
             .zip(0..)
             .filter_map(|(mut memo, index)| memo.data.take().map(|d| (d, index)))

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -163,6 +163,37 @@ impl MemoTable {
         unsafe { Some(Self::from_dummy(arc_swap.load_full())) }
     }
 
+    /// Calls `f` on the memo at `memo_ingredient_index` and replaces the memo with the result of `f`.
+    /// If the memo is not present, `f` is not called.
+    pub(crate) fn map_memo<M: Memo>(
+        &self,
+        memo_ingredient_index: MemoIngredientIndex,
+        f: impl FnOnce(Arc<M>) -> Arc<M>,
+    ) {
+        // If the memo slot is already occupied, it must already have the
+        // right type info etc, and we only need the read-lock.
+        let memos = self.memos.read();
+        let Some(MemoEntry {
+            data:
+                Some(MemoEntryData {
+                    type_id,
+                    to_dyn_fn: _,
+                    arc_swap,
+                }),
+        }) = memos.get(memo_ingredient_index.as_usize())
+        else {
+            return;
+        };
+        assert_eq!(
+            *type_id,
+            TypeId::of::<M>(),
+            "inconsistent type-id for `{memo_ingredient_index:?}`"
+        );
+        // SAFETY: type_id check asserted above
+        let memo = f(unsafe { Self::from_dummy(arc_swap.load_full()) });
+        unsafe { Self::from_dummy::<M>(arc_swap.swap(Self::to_dummy(memo))) };
+    }
+
     pub(crate) fn into_memos(
         mut self,
     ) -> impl Iterator<Item = (MemoIngredientIndex, Arc<dyn Memo>)> {


### PR DESCRIPTION
`QueryEdges` were `Arc`ed before, but we only ever clone them for LRU evictions (and there the original one will drop right after eviction), this is a rare occurence. Additionally to save on constantly allocating an empty `Arc` in the case where no deps exist, we needed a `lazy_static`. Instead, we `Box` the slice now, dropping the need for ref-counting as well as the `lazy_static` as an empty slice never allocates in a `Box`. 

Another improvement we should make is use a `ThinBox` once that's a thing, we don't really make use of the length directly and it would shave off 4/8 bytes for Memo/QueryRevisions.