### PR TITLE
Fix parallel_map::execute_cancellation test

### DIFF
--- a/tests/parallel/parallel_map.rs
+++ b/tests/parallel/parallel_map.rs
@@ -15,17 +15,18 @@ struct ParallelInput {
 fn tracked_fn(db: &dyn salsa::Database, input: ParallelInput) -> Vec<u32> {
     salsa::par_map(db, input.field(db), |_db, field| field + 1)
 }
+
 #[salsa::tracked]
 fn a1(db: &dyn KnobsDatabase, input: ParallelInput) -> Vec<u32> {
     db.signal(1);
     salsa::par_map(db, input.field(db), |db, field| {
         db.wait_for(2);
-        field + 1
+        field + dummy(db)
     })
 }
 
 #[salsa::tracked]
-fn dummy(_db: &dyn KnobsDatabase, _input: ParallelInput) -> ParallelInput {
+fn dummy(_db: &dyn KnobsDatabase) -> u32 {
     panic!("should never get here!")
 }
 

--- a/tests/parallel/signal.rs
+++ b/tests/parallel/signal.rs
@@ -8,8 +8,6 @@ pub(crate) struct Signal {
 
 impl Signal {
     pub(crate) fn signal(&self, stage: usize) {
-        dbg!(format!("signal({})", stage));
-
         // This check avoids acquiring the lock for things that will
         // clearly be a no-op. Not *necessary* but helps to ensure we
         // are more likely to encounter weird race conditions;
@@ -27,8 +25,6 @@ impl Signal {
     /// Waits until the given condition is true; the fn is invoked
     /// with the current stage.
     pub(crate) fn wait_for(&self, stage: usize) {
-        dbg!(format!("wait_for({})", stage));
-
         // As above, avoid lock if clearly a no-op.
         if stage > 0 {
             let mut v = self.value.lock();


### PR DESCRIPTION
As discovered in https://github.com/salsa-rs/salsa/pull/635, the test here is racy. After resolving the `wait_for` it never actually executes cancellable work and so it might just finish computation without cancelling (the only place where it was able to cancel was when calling the `input.field(db)` call. This brings the test more in line with how `parallel_execute` does it.