### PR TITLE
internal: add dhat to several `tracked_fn` tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ ordered-float = "4.2.1"
 rustversion = "1.0"
 test-log = { version ="0.2.11", features = ["trace"] }
 trybuild = "1.0"
+dhat = "0.3"
 
 [[bench]]
 name = "compare"

--- a/tests/tracked_fn_on_input.rs
+++ b/tests/tracked_fn_on_input.rs
@@ -1,6 +1,13 @@
-//! Test that a `tracked` fn on a `salsa::input`
-//! compiles and executes successfully.
+//! Tests that:
+//! - `tracked` fn on a `salsa::input`
+//!   compiles and executes successfully.
+//! - The size and number of allocations
+//!   made by Salsa while executing a `tracked` fn
+//!   with a `salsa::input`.
 #![allow(warnings)]
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
 
 #[salsa::input]
 struct MyInput {
@@ -14,7 +21,13 @@ fn tracked_fn(db: &dyn salsa::Database, input: MyInput) -> u32 {
 
 #[test]
 fn execute() {
+    let _profiler = dhat::Profiler::builder().testing().build();
+
     let mut db = salsa::DatabaseImpl::new();
     let input = MyInput::new(&db, 22);
     assert_eq!(tracked_fn(&db, input), 44);
+
+    let stats = dhat::HeapStats::get();
+    dhat::assert_eq!(stats.total_blocks, 26);
+    dhat::assert_eq!(stats.total_bytes, 95164);
 }


### PR DESCRIPTION
I'm investigating allocations in rust-analyzer. I'm pretty sure that the primary, remaining regression we have in rust-analyzer's memory usage can be attributed to #599 ([discussion on Zulip](https://rust-lang.zulipchat.com/#narrow/channel/185405-t-compiler.2Frust-analyzer/topic/Porting.20to.20Salsa.203.2E0/near/490944779)). I figured I'd establish some baselines, hence the changes and additions to these tests.