### PR TITLE
feature: Add support for dumping database contents

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,11 @@ salsa-macros = { path = "components/salsa-macros" }
 smallvec = "1"
 rayon = "1.10.0"
 
+[features]
+# FIXME: remove this as a default feature before 1.0.
+default = ["salsa_unstable"]
+salsa_unstable = []
+
 [dev-dependencies]
 annotate-snippets = "0.11.5"
 derive-new = "0.6.0"
@@ -33,7 +38,7 @@ eyre = "0.6.8"
 notify-debouncer-mini = "0.4.1"
 ordered-float = "4.2.1"
 rustversion = "1.0"
-test-log = { version ="0.2.11", features = ["trace"] }
+test-log = { version = "0.2.11", features = ["trace"] }
 trybuild = "1.0"
 
 [[bench]]

--- a/components/salsa-macro-rules/src/setup_input_struct.rs
+++ b/components/salsa-macro-rules/src/setup_input_struct.rs
@@ -67,7 +67,7 @@ macro_rules! setup_input_struct {
             use salsa::plumbing as $zalsa;
             use $zalsa::input as $zalsa_struct;
 
-            struct $Configuration;
+            type $Configuration = $Struct;
 
             impl $zalsa_struct::Configuration for $Configuration {
                 const DEBUG_NAME: &'static str = stringify!($Struct);

--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -120,7 +120,7 @@ macro_rules! setup_interned_struct {
 
             impl salsa::plumbing::interned::Configuration for $StructWithStatic {
                 const DEBUG_NAME: &'static str = stringify!($Struct);
-                type Data<'a> = $StructDataIdent<'a>;
+                type Fields<'a> = $StructDataIdent<'a>;
                 type Struct<'db> = $Struct< $($db_lt_arg)? >;
                 fn struct_from_id<'db>(id: salsa::Id) -> Self::Struct<'db> {
                     use salsa::plumbing::FromId;

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -107,7 +107,7 @@ macro_rules! setup_tracked_fn {
                     impl $zalsa::interned::Configuration for $Configuration {
                         const DEBUG_NAME: &'static str = "Configuration";
 
-                        type Data<$db_lt> = ($($input_ty),*);
+                        type Fields<$db_lt> = ($($input_ty),*);
 
                         type Struct<$db_lt> = $InternedData<$db_lt>;
 

--- a/src/database_impl.rs
+++ b/src/database_impl.rs
@@ -13,6 +13,10 @@ impl DatabaseImpl {
     pub fn new() -> Self {
         Self::default()
     }
+
+    pub fn storage(&self) -> &Storage<Self> {
+        &self.storage
+    }
 }
 
 #[salsa::db]

--- a/src/input.rs
+++ b/src/input.rs
@@ -272,8 +272,10 @@ pub struct Value<C>
 where
     C: Configuration,
 {
-    /// Fields of this input struct. They can change across revisions,
-    /// but they do not change within a particular revision.
+    /// Fields of this input struct.
+    ///
+    /// They can change across revisions, but they do not change within
+    /// a particular revision.
     fields: C::Fields,
 
     /// The revision and durability information for each field: when did this field last change.
@@ -284,6 +286,19 @@ where
 
     /// Syncs
     syncs: SyncTable,
+}
+
+impl<C> Value<C>
+where
+    C: Configuration,
+{
+    /// Fields of this tracked struct.
+    ///
+    /// They can change across revisions, but they do not change within
+    /// a particular revision.
+    pub fn fields(&self) -> &C::Fields {
+        &self.fields
+    }
 }
 
 pub trait HasBuilder {

--- a/src/input.rs
+++ b/src/input.rs
@@ -296,6 +296,7 @@ where
     ///
     /// They can change across revisions, but they do not change within
     /// a particular revision.
+    #[cfg(feature = "salsa_unstable")]
     pub fn fields(&self) -> &C::Fields {
         &self.fields
     }

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -84,6 +84,7 @@ where
     C: Configuration,
 {
     /// Fields of this interned struct.
+    #[cfg(feature = "salsa_unstable")]
     pub fn fields(&self) -> &C::Fields<'static> {
         &self.fields
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,7 @@ pub mod plumbing {
         pub use crate::input::HasBuilder;
         pub use crate::input::IngredientImpl;
         pub use crate::input::JarImpl;
+        pub use crate::input::Value;
     }
 
     pub mod interned {

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -735,6 +735,7 @@ where
     ///
     /// They can change across revisions, but they do not change within
     /// a particular revision.
+    #[cfg(feature = "salsa_unstable")]
     pub fn fields(&self) -> &C::Fields<'static> {
         &self.fields
     }

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -731,6 +731,14 @@ impl<C> Value<C>
 where
     C: Configuration,
 {
+    /// Fields of this tracked struct.
+    ///
+    /// They can change across revisions, but they do not change within
+    /// a particular revision.
+    pub fn fields(&self) -> &C::Fields<'static> {
+        &self.fields
+    }
+
     fn take_memo_table(&mut self) -> MemoTable {
         // This fn is only called after `updated_at` has been set to `None`;
         // this ensures that there is no concurrent access

--- a/tests/debug_db_contents.rs
+++ b/tests/debug_db_contents.rs
@@ -1,0 +1,58 @@
+#[salsa::interned]
+struct InternedStruct<'db> {
+    name: String,
+}
+
+#[salsa::input]
+struct InputStruct {
+    field: u32,
+}
+
+#[salsa::tracked]
+struct TrackedStruct<'db> {
+    field: u32,
+}
+
+#[salsa::tracked]
+fn tracked_fn(db: &dyn salsa::Database, input: InputStruct) -> TrackedStruct<'_> {
+    TrackedStruct::new(db, input.field(db) * 2)
+}
+
+#[test]
+fn execute() {
+    let db = salsa::DatabaseImpl::new();
+
+    let _ = InternedStruct::new(&db, "Salsa".to_string());
+    let _ = InternedStruct::new(&db, "Salsa2".to_string());
+
+    // test interned structs
+    let interned = db
+        .storage()
+        .debug_interned_entries::<InternedStruct>()
+        .collect::<Vec<_>>();
+
+    assert_eq!(interned.len(), 2);
+    assert_eq!(interned[0].fields().0, "Salsa");
+    assert_eq!(interned[1].fields().0, "Salsa2");
+
+    // test input structs
+    let input = InputStruct::new(&db, 22);
+    let inputs = db
+        .storage()
+        .debug_input_entries::<InputStruct>()
+        .collect::<Vec<_>>();
+
+    assert_eq!(inputs.len(), 1);
+    assert_eq!(inputs[0].fields().0, 22);
+
+    // test tracked structs
+    let computed = tracked_fn(&db, input).field(&db);
+    assert_eq!(computed, 44);
+    let tracked = db
+        .storage()
+        .debug_tracked_entries::<TrackedStruct>()
+        .collect::<Vec<_>>();
+
+    assert_eq!(tracked.len(), 1);
+    assert_eq!(tracked[0].fields().0, computed);
+}

--- a/tests/interned-structs_self_ref.rs
+++ b/tests/interned-structs_self_ref.rs
@@ -68,7 +68,7 @@ const _: () = {
     }
     impl zalsa_struct_::Configuration for Configuration_ {
         const DEBUG_NAME: &'static str = "InternedString";
-        type Data<'a> = StructData<'a>;
+        type Fields<'a> = StructData<'a>;
         type Struct<'a> = InternedString<'a>;
         fn struct_from_id<'db>(id: salsa::Id) -> Self::Struct<'db> {
             InternedString(id, std::marker::PhantomData)


### PR DESCRIPTION
As discussed in [this HackMD](https://hackmd.io/3Mpv0fa7Rm6cn9-EH5ejkw), we want to dump the contents of a Salsa database in order to debug what rust-analyzer and Salsa are doing. The original Salsa had a [`DebugQueryTable`](https://github.com/rust-lang/rust-analyzer/blob/fa4a40bbe867ed54f5a7c905b591fd7d60ba35eb/crates/ra-salsa/src/debug.rs#L9-L29) that we'd use [like this](https://github.com/rust-lang/rust-analyzer/blob/0a706f7d2ac093985eae317781200689cfd48b78/crates/rust-analyzer/src/cli/analysis_stats.rs#L274-L286):

```rust
let mut total_file_size = Bytes::default();
for e in ide_db::base_db::ParseQuery.in_db(db).entries::<Vec<_>>() {
    total_file_size += syntax_len(db.parse(e.key).syntax_node())
}

let mut total_macro_file_size = Bytes::default();
for e in hir::db::ParseMacroExpansionQuery.in_db(db).entries::<Vec<_>>() {
    let val = db.parse_macro_expansion(e.key).value.0;
    total_macro_file_size += syntax_len(val.syntax_node())
}
eprintln!("source files: {total_file_size}, macro files: {total_macro_file_size}");
```

(`ParseQuery` and `ParseMacroExpansionQuery` [were generated](https://github.com/rust-lang/rust-analyzer/blob/59bc7b49d0ad319de8c477c63da552cbc8a05e4c/crates/ra-salsa/ra-salsa-macros/src/query_group.rs#L43-L44) from [`SourceDatabase::parse`](https://github.com/rust-lang/rust-analyzer/blob/59bc7b49d0ad319de8c477c63da552cbc8a05e4c/crates/base-db/src/lib.rs#L69C8-L69C13) and [`ExpandDatabase::parse_macro_expansion`](https://github.com/rust-lang/rust-analyzer/blob/59bc7b49d0ad319de8c477c63da552cbc8a05e4c/crates/hir-expand/src/db.rs#L69-L73), respectively.)

This PR takes a slightly different approach: instead of generating a `Query` struct corresponding to a tracked function or Salsa struct, this PR simply exposes the underlying pages on `salsa::Storage` via the `debug_input_entries`, `debug_input_entries`, and `debug_interned_entries` methods. This results in the following API:

```rust
let _ = InternedStruct::new(&db, "Hello, world!".to_string());

// test interned structs
let interned = db
    .storage()
    .debug_interned_entries::<InternedStruct>()
    .collect::<Vec<_>>();
    
assert_eq!(interned[0].data.0, "Hello, world!");
```

Few notes:
- I don't see any obvious way to make these methods generic over the underlying Salsa struct, but I'm not sure it's desirable in the first place.
- I'm not _entirely_ happy with the name or API, so suggestions to improve it would be welcome. I don't know if I want to expose this debug information on the Salsa structs themselves, but I'd be happy to hear arguments in favor.
- This approach requires exposing parts of `{interned, tracked, input}::Value` publicly, which _feels_ suboptimal, but we're all friends here, right?