### PR TITLE
Fix accumulated values for backdated queries

### DIFF
--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -12,7 +12,7 @@ use accumulated_map::AccumulatedMap;
 
 use crate::{
     cycle::CycleRecoveryStrategy,
-    ingredient::{fmt_index, Ingredient, Jar},
+    ingredient::{fmt_index, Ingredient, Jar, MaybeChangedAfter},
     plumbing::JarAux,
     zalsa::IngredientIndex,
     zalsa_local::QueryOrigin,
@@ -106,7 +106,7 @@ impl<A: Accumulator> Ingredient for IngredientImpl<A> {
         _db: &dyn Database,
         _input: Option<Id>,
         _revision: Revision,
-    ) -> bool {
+    ) -> MaybeChangedAfter {
         panic!("nothing should ever depend on an accumulator directly")
     }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -3,7 +3,7 @@ use std::{any::Any, fmt, sync::Arc};
 use crate::{
     accumulator::accumulated_map::AccumulatedMap,
     cycle::CycleRecoveryStrategy,
-    ingredient::fmt_index,
+    ingredient::{fmt_index, MaybeChangedAfter},
     key::DatabaseKeyIndex,
     plumbing::JarAux,
     salsa_struct::SalsaStructInDb,
@@ -194,7 +194,7 @@ where
         db: &dyn Database,
         input: Option<Id>,
         revision: Revision,
-    ) -> bool {
+    ) -> MaybeChangedAfter {
         let key = input.unwrap();
         let db = db.as_view::<C::DbView>();
         self.maybe_changed_after(db, key, revision)

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use crossbeam::atomic::AtomicCell;
 
+use crate::accumulator::accumulated_map::InputAccumulatedValues;
 use crate::zalsa_local::QueryOrigin;
 use crate::{
     key::DatabaseKeyIndex, zalsa::Zalsa, zalsa_local::QueryRevisions, Event, EventKind, Id,
@@ -143,6 +144,7 @@ impl<V> Memo<V> {
         db: &dyn crate::Database,
         revision_now: Revision,
         database_key_index: DatabaseKeyIndex,
+        accumulated: InputAccumulatedValues,
     ) {
         db.salsa_event(&|| Event {
             thread_id: std::thread::current().id(),
@@ -152,6 +154,7 @@ impl<V> Memo<V> {
         });
 
         self.verified_at.store(revision_now);
+        self.revisions.accumulated.set_inputs(accumulated);
     }
 
     pub(super) fn mark_outputs_as_verified(

--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -1,6 +1,7 @@
 use crossbeam::atomic::AtomicCell;
 
 use crate::{
+    accumulator::accumulated_map::InputAccumulatedValues,
     tracked_struct::TrackedStructInDb,
     zalsa::ZalsaDatabase,
     zalsa_local::{QueryOrigin, QueryRevisions},
@@ -127,6 +128,7 @@ where
             db.as_dyn_database(),
             zalsa.current_revision(),
             database_key_index,
+            InputAccumulatedValues::Empty,
         );
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -15,7 +15,7 @@ use crate::{
     accumulator::accumulated_map::InputAccumulatedValues,
     cycle::CycleRecoveryStrategy,
     id::{AsId, FromId},
-    ingredient::{fmt_index, Ingredient},
+    ingredient::{fmt_index, Ingredient, MaybeChangedAfter},
     key::{DatabaseKeyIndex, DependencyIndex},
     plumbing::{Jar, JarAux, Stamp},
     table::{memo::MemoTable, sync::SyncTable, Slot, Table},
@@ -222,10 +222,10 @@ impl<C: Configuration> Ingredient for IngredientImpl<C> {
         _db: &dyn Database,
         _input: Option<Id>,
         _revision: Revision,
-    ) -> bool {
+    ) -> MaybeChangedAfter {
         // Input ingredients are just a counter, they store no data, they are immortal.
         // Their *fields* are stored in function ingredients elsewhere.
-        false
+        MaybeChangedAfter::No(InputAccumulatedValues::Empty)
     }
 
     fn cycle_recovery_strategy(&self) -> CycleRecoveryStrategy {

--- a/src/input/input_field.rs
+++ b/src/input/input_field.rs
@@ -1,5 +1,5 @@
 use crate::cycle::CycleRecoveryStrategy;
-use crate::ingredient::{fmt_index, Ingredient};
+use crate::ingredient::{fmt_index, Ingredient, MaybeChangedAfter};
 use crate::input::Configuration;
 use crate::zalsa::IngredientIndex;
 use crate::zalsa_local::QueryOrigin;
@@ -54,11 +54,12 @@ where
         db: &dyn Database,
         input: Option<Id>,
         revision: Revision,
-    ) -> bool {
+    ) -> MaybeChangedAfter {
         let zalsa = db.zalsa();
         let input = input.unwrap();
         let value = <IngredientImpl<C>>::data(zalsa, input);
-        value.stamps[self.field_index].changed_at > revision
+
+        MaybeChangedAfter::from(value.stamps[self.field_index].changed_at > revision)
     }
 
     fn origin(&self, _db: &dyn Database, _key_index: Id) -> Option<QueryOrigin> {

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -1,7 +1,7 @@
 use crate::accumulator::accumulated_map::InputAccumulatedValues;
 use crate::durability::Durability;
 use crate::id::AsId;
-use crate::ingredient::fmt_index;
+use crate::ingredient::{fmt_index, MaybeChangedAfter};
 use crate::key::DependencyIndex;
 use crate::plumbing::{Jar, JarAux};
 use crate::table::memo::MemoTable;
@@ -225,8 +225,8 @@ where
         _db: &dyn Database,
         _input: Option<Id>,
         revision: Revision,
-    ) -> bool {
-        revision < self.reset_at
+    ) -> MaybeChangedAfter {
+        MaybeChangedAfter::from(revision < self.reset_at)
     }
 
     fn cycle_recovery_strategy(&self) -> crate::cycle::CycleRecoveryStrategy {

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,4 +1,7 @@
-use crate::{cycle::CycleRecoveryStrategy, zalsa::IngredientIndex, Database, Id};
+use crate::{
+    cycle::CycleRecoveryStrategy, ingredient::MaybeChangedAfter, zalsa::IngredientIndex, Database,
+    Id,
+};
 
 /// An integer that uniquely identifies a particular query instance within the
 /// database. Used to track dependencies between queries. Fully ordered and
@@ -51,7 +54,7 @@ impl DependencyIndex {
         &self,
         db: &dyn Database,
         last_verified_at: crate::Revision,
-    ) -> bool {
+    ) -> MaybeChangedAfter {
         db.zalsa()
             .lookup_ingredient(self.ingredient_index)
             .maybe_changed_after(db, self.key_index, last_verified_at)

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -6,7 +6,7 @@ use tracked_field::FieldIngredientImpl;
 use crate::{
     accumulator::accumulated_map::InputAccumulatedValues,
     cycle::CycleRecoveryStrategy,
-    ingredient::{fmt_index, Ingredient, Jar, JarAux},
+    ingredient::{fmt_index, Ingredient, Jar, JarAux, MaybeChangedAfter},
     key::{DatabaseKeyIndex, DependencyIndex},
     plumbing::ZalsaLocal,
     runtime::StampedValue,
@@ -587,8 +587,8 @@ where
         _db: &dyn Database,
         _input: Option<Id>,
         _revision: Revision,
-    ) -> bool {
-        false
+    ) -> MaybeChangedAfter {
+        MaybeChangedAfter::No(InputAccumulatedValues::Empty)
     }
 
     fn cycle_recovery_strategy(&self) -> CycleRecoveryStrategy {

--- a/src/tracked_struct/tracked_field.rs
+++ b/src/tracked_struct/tracked_field.rs
@@ -1,6 +1,10 @@
 use std::marker::PhantomData;
 
-use crate::{ingredient::Ingredient, zalsa::IngredientIndex, Database, Id};
+use crate::{
+    ingredient::{Ingredient, MaybeChangedAfter},
+    zalsa::IngredientIndex,
+    Database, Id,
+};
 
 use super::{Configuration, Value};
 
@@ -53,12 +57,12 @@ where
         db: &'db dyn Database,
         input: Option<Id>,
         revision: crate::Revision,
-    ) -> bool {
+    ) -> MaybeChangedAfter {
         let zalsa = db.zalsa();
         let id = input.unwrap();
         let data = <super::IngredientImpl<C>>::data(zalsa.table(), id);
         let field_changed_at = data.revisions[self.field_index];
-        field_changed_at > revision
+        MaybeChangedAfter::from(field_changed_at > revision)
     }
 
     fn origin(

--- a/tests/accumulated_backdate.rs
+++ b/tests/accumulated_backdate.rs
@@ -1,0 +1,77 @@
+//! Tests that accumulated values are correctly accounted for
+//! when backdating a value.
+
+mod common;
+use common::LogDatabase;
+
+use expect_test::expect;
+use salsa::{Accumulator, Setter};
+use test_log::test;
+
+#[salsa::input]
+struct File {
+    content: String,
+}
+
+#[salsa::accumulator]
+struct Log(#[allow(dead_code)] String);
+
+#[salsa::tracked]
+fn compile(db: &dyn LogDatabase, input: File) -> u32 {
+    parse(db, input)
+}
+
+#[salsa::tracked]
+fn parse(db: &dyn LogDatabase, input: File) -> u32 {
+    let value: Result<u32, _> = input.content(db).parse();
+
+    match value {
+        Ok(value) => value,
+        Err(error) => {
+            Log(error.to_string()).accumulate(db);
+            0
+        }
+    }
+}
+
+#[test]
+fn backdate() {
+    let mut db = common::LoggerDatabase::default();
+
+    let input = File::new(&db, "0".to_string());
+
+    let logs = compile::accumulated::<Log>(&db, input);
+    expect![[r#"[]"#]].assert_eq(&format!("{:#?}", logs));
+
+    input.set_content(&mut db).to("a".to_string());
+    let logs = compile::accumulated::<Log>(&db, input);
+
+    expect![[r#"
+        [
+            Log(
+                "invalid digit found in string",
+            ),
+        ]"#]]
+    .assert_eq(&format!("{:#?}", logs));
+}
+
+#[test]
+fn backdate_no_diagnostics() {
+    let mut db = common::LoggerDatabase::default();
+
+    let input = File::new(&db, "a".to_string());
+
+    let logs = compile::accumulated::<Log>(&db, input);
+    expect![[r#"
+        [
+            Log(
+                "invalid digit found in string",
+            ),
+        ]"#]]
+    .assert_eq(&format!("{:#?}", logs));
+
+    input.set_content(&mut db).to("0".to_string());
+    let logs = compile::accumulated::<Log>(&db, input);
+
+    expect![[r#"[]"#]].assert_eq(&format!("{:#?}", logs));
+}


### PR DESCRIPTION
As reported on [Zulip](https://salsa.zulipchat.com/#narrow/channel/333573-Contributing-to-Salsa/topic/Accumulator.20performance)

The optimization introduced in https://github.com/salsa-rs/salsa/pull/621 doesn't account for queries that get backdated but now have accumulated values (or had accumulated values and now no more). 

This PR fixes this regression but I think it needs some cleanup before it can be landed. Specifically, I think the refactor in https://github.com/salsa-rs/salsa/pull/636 that moves the `AccumulatedInputValues` to the memo would be an improvement. I'm happy to follow up on this sometime when I've a little more time or someone else takes it over from here.