### PR TITLE
Remove unreachable unwraps via typing

### DIFF
--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -122,7 +122,7 @@ impl<A: Accumulator> Ingredient for IngredientImpl<A> {
         &self,
         _db: &dyn Database,
         _executor: DatabaseKeyIndex,
-        _output_key: Option<crate::Id>,
+        _output_key: crate::Id,
     ) {
     }
 
@@ -130,7 +130,7 @@ impl<A: Accumulator> Ingredient for IngredientImpl<A> {
         &self,
         _db: &dyn Database,
         _executor: DatabaseKeyIndex,
-        _stale_output_key: Option<crate::Id>,
+        _stale_output_key: crate::Id,
     ) {
     }
 

--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -1,13 +1,14 @@
 use rustc_hash::FxHashMap;
 
 use super::zalsa_local::{QueryEdges, QueryOrigin, QueryRevisions};
+use crate::key::OutputDependencyIndex;
 use crate::tracked_struct::IdentityHash;
 use crate::zalsa_local::QueryEdge;
 use crate::{
     accumulator::accumulated_map::{AccumulatedMap, InputAccumulatedValues},
     durability::Durability,
     hash::FxIndexSet,
-    key::{DatabaseKeyIndex, DependencyIndex},
+    key::{DatabaseKeyIndex, InputDependencyIndex},
     tracked_struct::{Disambiguator, Identity},
     Cycle, Id, Revision,
 };
@@ -73,7 +74,7 @@ impl ActiveQuery {
 
     pub(super) fn add_read(
         &mut self,
-        input: DependencyIndex,
+        input: InputDependencyIndex,
         durability: Durability,
         revision: Revision,
         accumulated: InputAccumulatedValues,
@@ -97,12 +98,12 @@ impl ActiveQuery {
     }
 
     /// Adds a key to our list of outputs.
-    pub(super) fn add_output(&mut self, key: DependencyIndex) {
+    pub(super) fn add_output(&mut self, key: OutputDependencyIndex) {
         self.input_outputs.insert(QueryEdge::Output(key));
     }
 
     /// True if the given key was output by this query.
-    pub(super) fn is_output(&self, key: DependencyIndex) -> bool {
+    pub(super) fn is_output(&self, key: OutputDependencyIndex) -> bool {
         self.input_outputs.contains(&QueryEdge::Output(key))
     }
 
@@ -137,7 +138,7 @@ impl ActiveQuery {
     /// Used during cycle recovery, see [`Runtime::unblock_cycle_and_maybe_throw`].
     pub(super) fn remove_cycle_participants(&mut self, cycle: &Cycle) {
         for p in cycle.participant_keys() {
-            let p: DependencyIndex = p.into();
+            let p: InputDependencyIndex = p.into();
             self.input_outputs.shift_remove(&QueryEdge::Input(p));
         }
     }

--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -78,7 +78,7 @@ impl ActiveQuery {
         revision: Revision,
         accumulated: InputAccumulatedValues,
     ) {
-        self.input_outputs.insert(QueryEdge::input(input));
+        self.input_outputs.insert(QueryEdge::Input(input));
         self.durability = self.durability.min(durability);
         self.changed_at = self.changed_at.max(revision);
         self.accumulated.add_input(accumulated);
@@ -98,12 +98,12 @@ impl ActiveQuery {
 
     /// Adds a key to our list of outputs.
     pub(super) fn add_output(&mut self, key: DependencyIndex) {
-        self.input_outputs.insert(QueryEdge::output(key));
+        self.input_outputs.insert(QueryEdge::Output(key));
     }
 
     /// True if the given key was output by this query.
     pub(super) fn is_output(&self, key: DependencyIndex) -> bool {
-        self.input_outputs.contains(&QueryEdge::output(key))
+        self.input_outputs.contains(&QueryEdge::Output(key))
     }
 
     pub(crate) fn into_revisions(self) -> QueryRevisions {
@@ -138,7 +138,7 @@ impl ActiveQuery {
     pub(super) fn remove_cycle_participants(&mut self, cycle: &Cycle) {
         for p in cycle.participant_keys() {
             let p: DependencyIndex = p.into();
-            self.input_outputs.shift_remove(&QueryEdge::input(p));
+            self.input_outputs.shift_remove(&QueryEdge::Input(p));
         }
     }
 

--- a/src/cycle.rs
+++ b/src/cycle.rs
@@ -16,7 +16,7 @@ use std::{panic::AssertUnwindSafe, sync::Arc};
 ///
 /// You can read more about cycle handling in
 /// the [salsa book](https://https://salsa-rs.github.io/salsa/cycles.html).
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Cycle {
     participants: CycleParticipants,
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,6 +1,9 @@
 use std::thread::ThreadId;
 
-use crate::{key::DatabaseKeyIndex, key::DependencyIndex};
+use crate::{
+    key::DatabaseKeyIndex,
+    key::{InputDependencyIndex, OutputDependencyIndex},
+};
 
 /// The `Event` struct identifies various notable things that can
 /// occur during salsa execution. Instances of this struct are given
@@ -64,7 +67,7 @@ pub enum EventKind {
         execute_key: DatabaseKeyIndex,
 
         /// Key for the query that is no longer output
-        output_key: DependencyIndex,
+        output_key: OutputDependencyIndex,
     },
 
     /// Tracked structs or memoized data were discarded (freed).
@@ -79,6 +82,6 @@ pub enum EventKind {
         executor_key: DatabaseKeyIndex,
 
         /// Accumulator that was accumulated into
-        accumulator: DependencyIndex,
+        accumulator: InputDependencyIndex,
     },
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -212,9 +212,8 @@ where
         &self,
         db: &dyn Database,
         executor: DatabaseKeyIndex,
-        output_key: Option<crate::Id>,
+        output_key: crate::Id,
     ) {
-        let output_key = output_key.unwrap();
         self.validate_specified_value(db, executor, output_key);
     }
 
@@ -222,7 +221,7 @@ where
         &self,
         _db: &dyn Database,
         _executor: DatabaseKeyIndex,
-        _stale_output_key: Option<crate::Id>,
+        _stale_output_key: crate::Id,
     ) {
         // This function is invoked when a query Q specifies the value for `stale_output_key` in rev 1,
         // but not in rev 2. We don't do anything in this case, we just leave the (now stale) memo.

--- a/src/function/diff_outputs.rs
+++ b/src/function/diff_outputs.rs
@@ -1,6 +1,6 @@
 use super::{memo::Memo, Configuration, IngredientImpl};
 use crate::{
-    hash::FxHashSet, key::DependencyIndex, zalsa_local::QueryRevisions, AsDynDatabase as _,
+    hash::FxHashSet, key::OutputDependencyIndex, zalsa_local::QueryRevisions, AsDynDatabase as _,
     DatabaseKeyIndex, Event, EventKind,
 };
 
@@ -33,7 +33,7 @@ where
             // Remove the outputs that are no longer present in the current revision
             // to prevent that the next revision is seeded with a id mapping that no longer exists.
             revisions.tracked_struct_ids.retain(|&k, &mut value| {
-                !old_outputs.contains(&DependencyIndex::new(k.ingredient_index(), value))
+                !old_outputs.contains(&OutputDependencyIndex::new(k.ingredient_index(), value))
             });
         }
 
@@ -42,7 +42,7 @@ where
         }
     }
 
-    fn report_stale_output(db: &C::DbView, key: DatabaseKeyIndex, output: DependencyIndex) {
+    fn report_stale_output(db: &C::DbView, key: DatabaseKeyIndex, output: OutputDependencyIndex) {
         let db = db.as_dyn_database();
 
         db.salsa_event(&|| Event {

--- a/src/function/diff_outputs.rs
+++ b/src/function/diff_outputs.rs
@@ -32,11 +32,8 @@ where
         if !old_outputs.is_empty() {
             // Remove the outputs that are no longer present in the current revision
             // to prevent that the next revision is seeded with a id mapping that no longer exists.
-            revisions.tracked_struct_ids.retain(|k, value| {
-                !old_outputs.contains(&DependencyIndex {
-                    ingredient_index: k.ingredient_index(),
-                    key_index: Some(*value),
-                })
+            revisions.tracked_struct_ids.retain(|&k, &mut value| {
+                !old_outputs.contains(&DependencyIndex::new(k.ingredient_index(), value))
             });
         }
 

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -1,7 +1,7 @@
 use crate::{
     key::DatabaseKeyIndex,
     zalsa::{Zalsa, ZalsaDatabase},
-    zalsa_local::{ActiveQueryGuard, EdgeKind, QueryOrigin},
+    zalsa_local::{ActiveQueryGuard, EdgeKind, QueryEdge, QueryOrigin},
     AsDynDatabase as _, Id, Revision,
 };
 
@@ -182,8 +182,12 @@ where
                 // valid, then some later input I1 might never have executed at all, so verifying
                 // it is still up to date is meaningless.
                 let last_verified_at = old_memo.verified_at.load();
-                for &(edge_kind, dependency_index) in edges.input_outputs.iter() {
-                    match edge_kind {
+                for &QueryEdge {
+                    kind,
+                    dependency_index,
+                } in edges.input_outputs.iter()
+                {
+                    match kind {
                         EdgeKind::Input => {
                             if dependency_index
                                 .maybe_changed_after(db.as_dyn_database(), last_verified_at)

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -83,7 +83,7 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
         &'db self,
         db: &'db dyn Database,
         executor: DatabaseKeyIndex,
-        output_key: Option<Id>,
+        output_key: crate::Id,
     );
 
     /// Invoked when the value `stale_output` was output by `executor` in a previous
@@ -94,7 +94,7 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
         &self,
         db: &dyn Database,
         executor: DatabaseKeyIndex,
-        stale_output_key: Option<Id>,
+        stale_output_key: Id,
     );
 
     /// Returns the [`IngredientIndex`] of this ingredient.

--- a/src/input.rs
+++ b/src/input.rs
@@ -191,10 +191,7 @@ impl<C: Configuration> IngredientImpl<C> {
         let value = Self::data(zalsa, id);
         let stamp = &value.stamps[field_index];
         zalsa_local.report_tracked_read(
-            DependencyIndex {
-                ingredient_index: field_ingredient_index,
-                key_index: Some(id),
-            },
+            DependencyIndex::new(field_ingredient_index, id),
             stamp.durability,
             stamp.changed_at,
             InputAccumulatedValues::Empty,
@@ -240,7 +237,7 @@ impl<C: Configuration> Ingredient for IngredientImpl<C> {
         &self,
         _db: &dyn Database,
         executor: DatabaseKeyIndex,
-        output_key: Option<Id>,
+        output_key: Id,
     ) {
         unreachable!(
             "mark_validated_output({:?}, {:?}): input cannot be the output of a tracked function",
@@ -252,7 +249,7 @@ impl<C: Configuration> Ingredient for IngredientImpl<C> {
         &self,
         _db: &dyn Database,
         executor: DatabaseKeyIndex,
-        stale_output_key: Option<Id>,
+        stale_output_key: Id,
     ) {
         unreachable!(
             "remove_stale_output({:?}, {:?}): input cannot be the output of a tracked function",

--- a/src/input.rs
+++ b/src/input.rs
@@ -16,7 +16,7 @@ use crate::{
     cycle::CycleRecoveryStrategy,
     id::{AsId, FromId},
     ingredient::{fmt_index, Ingredient},
-    key::{DatabaseKeyIndex, DependencyIndex},
+    key::{DatabaseKeyIndex, InputDependencyIndex},
     plumbing::{Jar, JarAux, Stamp},
     table::{memo::MemoTable, sync::SyncTable, Slot, Table},
     zalsa::{IngredientIndex, Zalsa},
@@ -191,7 +191,7 @@ impl<C: Configuration> IngredientImpl<C> {
         let value = Self::data(zalsa, id);
         let stamp = &value.stamps[field_index];
         zalsa_local.report_tracked_read(
-            DependencyIndex::new(field_ingredient_index, id),
+            InputDependencyIndex::new(field_ingredient_index, id),
             stamp.durability,
             stamp.changed_at,
             InputAccumulatedValues::Empty,

--- a/src/input/input_field.rs
+++ b/src/input/input_field.rs
@@ -69,7 +69,7 @@ where
         &self,
         _db: &dyn Database,
         _executor: DatabaseKeyIndex,
-        _output_key: Option<Id>,
+        _output_key: Id,
     ) {
     }
 
@@ -77,7 +77,7 @@ where
         &self,
         _db: &dyn Database,
         _executor: DatabaseKeyIndex,
-        _stale_output_key: Option<Id>,
+        _stale_output_key: Id,
     ) {
     }
 

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -241,7 +241,7 @@ where
         &self,
         _db: &dyn Database,
         executor: DatabaseKeyIndex,
-        output_key: Option<crate::Id>,
+        output_key: crate::Id,
     ) {
         unreachable!(
             "mark_validated_output({:?}, {:?}): input cannot be the output of a tracked function",
@@ -253,7 +253,7 @@ where
         &self,
         _db: &dyn Database,
         executor: DatabaseKeyIndex,
-        stale_output_key: Option<crate::Id>,
+        stale_output_key: crate::Id,
     ) {
         unreachable!(
             "remove_stale_output({:?}, {:?}): interned ids are not outputs",

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -2,7 +2,7 @@ use crate::accumulator::accumulated_map::InputAccumulatedValues;
 use crate::durability::Durability;
 use crate::id::AsId;
 use crate::ingredient::fmt_index;
-use crate::key::DependencyIndex;
+use crate::key::InputDependencyIndex;
 use crate::plumbing::{Jar, JarAux};
 use crate::table::memo::MemoTable;
 use crate::table::sync::SyncTable;
@@ -136,7 +136,7 @@ where
     ) -> C::Struct<'db> {
         let zalsa_local = db.zalsa_local();
         zalsa_local.report_tracked_read(
-            DependencyIndex::for_table(self.ingredient_index),
+            InputDependencyIndex::for_table(self.ingredient_index),
             Durability::MAX,
             self.reset_at,
             InputAccumulatedValues::Empty,

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,16 +1,68 @@
+use core::fmt;
+
 use crate::{cycle::CycleRecoveryStrategy, zalsa::IngredientIndex, Database, Id};
 
 /// An integer that uniquely identifies a particular query instance within the
-/// database. Used to track dependencies between queries. Fully ordered and
+/// database. Used to track output dependencies between queries. Fully ordered and
 /// equatable but those orderings are arbitrary, and meant to be used only for
 /// inserting into maps and the like.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DependencyIndex {
+pub struct OutputDependencyIndex {
+    ingredient_index: IngredientIndex,
+    key_index: Id,
+}
+
+/// An integer that uniquely identifies a particular query instance within the
+/// database. Used to track input dependencies between queries. Fully ordered and
+/// equatable but those orderings are arbitrary, and meant to be used only for
+/// inserting into maps and the like.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct InputDependencyIndex {
     ingredient_index: IngredientIndex,
     key_index: Option<Id>,
 }
 
-impl DependencyIndex {
+impl OutputDependencyIndex {
+    pub(crate) fn new(ingredient_index: IngredientIndex, key_index: Id) -> Self {
+        Self {
+            ingredient_index,
+            key_index,
+        }
+    }
+
+    pub(crate) fn remove_stale_output(&self, db: &dyn Database, executor: DatabaseKeyIndex) {
+        db.zalsa()
+            .lookup_ingredient(self.ingredient_index)
+            .remove_stale_output(db, executor, self.key_index)
+    }
+
+    pub(crate) fn mark_validated_output(
+        &self,
+        db: &dyn Database,
+        database_key_index: DatabaseKeyIndex,
+    ) {
+        db.zalsa()
+            .lookup_ingredient(self.ingredient_index)
+            .mark_validated_output(db, database_key_index, self.key_index)
+    }
+}
+
+impl fmt::Debug for OutputDependencyIndex {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        crate::attach::with_attached_database(|db| {
+            let ingredient = db.zalsa().lookup_ingredient(self.ingredient_index);
+            ingredient.fmt_index(Some(self.key_index), f)
+        })
+        .unwrap_or_else(|| {
+            f.debug_tuple("OutputDependencyIndex")
+                .field(&self.ingredient_index)
+                .field(&self.key_index)
+                .finish()
+        })
+    }
+}
+
+impl InputDependencyIndex {
     /// Create a database-key-index for an interning or entity table.
     /// The `key_index` here is always `None`, which deliberately corresponds to
     /// no particular id or entry. This is because the data in such tables
@@ -30,22 +82,6 @@ impl DependencyIndex {
         }
     }
 
-    pub(crate) fn remove_stale_output(&self, db: &dyn Database, executor: DatabaseKeyIndex) {
-        db.zalsa()
-            .lookup_ingredient(self.ingredient_index)
-            .remove_stale_output(db, executor, self.key_index.unwrap())
-    }
-
-    pub(crate) fn mark_validated_output(
-        &self,
-        db: &dyn Database,
-        database_key_index: DatabaseKeyIndex,
-    ) {
-        db.zalsa()
-            .lookup_ingredient(self.ingredient_index)
-            .mark_validated_output(db, database_key_index, self.key_index.unwrap())
-    }
-
     pub(crate) fn maybe_changed_after(
         &self,
         db: &dyn Database,
@@ -61,14 +97,14 @@ impl DependencyIndex {
     }
 }
 
-impl std::fmt::Debug for DependencyIndex {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for InputDependencyIndex {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         crate::attach::with_attached_database(|db| {
             let ingredient = db.zalsa().lookup_ingredient(self.ingredient_index);
             ingredient.fmt_index(self.key_index, f)
         })
         .unwrap_or_else(|| {
-            f.debug_tuple("DependencyIndex")
+            f.debug_tuple("InputDependencyIndex")
                 .field(&self.ingredient_index)
                 .field(&self.key_index)
                 .finish()
@@ -103,12 +139,20 @@ impl DatabaseKeyIndex {
 
 impl std::fmt::Debug for DatabaseKeyIndex {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let i: DependencyIndex = (*self).into();
-        std::fmt::Debug::fmt(&i, f)
+        crate::attach::with_attached_database(|db| {
+            let ingredient = db.zalsa().lookup_ingredient(self.ingredient_index);
+            ingredient.fmt_index(Some(self.key_index), f)
+        })
+        .unwrap_or_else(|| {
+            f.debug_tuple("DatabaseKeyIndex")
+                .field(&self.ingredient_index)
+                .field(&self.key_index)
+                .finish()
+        })
     }
 }
 
-impl From<DatabaseKeyIndex> for DependencyIndex {
+impl From<DatabaseKeyIndex> for InputDependencyIndex {
     fn from(value: DatabaseKeyIndex) -> Self {
         Self {
             ingredient_index: value.ingredient_index,
@@ -117,10 +161,19 @@ impl From<DatabaseKeyIndex> for DependencyIndex {
     }
 }
 
-impl TryFrom<DependencyIndex> for DatabaseKeyIndex {
+impl From<DatabaseKeyIndex> for OutputDependencyIndex {
+    fn from(value: DatabaseKeyIndex) -> Self {
+        Self {
+            ingredient_index: value.ingredient_index,
+            key_index: value.key_index,
+        }
+    }
+}
+
+impl TryFrom<InputDependencyIndex> for DatabaseKeyIndex {
     type Error = ();
 
-    fn try_from(value: DependencyIndex) -> Result<Self, Self::Error> {
+    fn try_from(value: InputDependencyIndex) -> Result<Self, Self::Error> {
         let key_index = value.key_index.ok_or(())?;
         Ok(Self {
             ingredient_index: value.ingredient_index,

--- a/src/key.rs
+++ b/src/key.rs
@@ -6,7 +6,7 @@ use crate::{cycle::CycleRecoveryStrategy, zalsa::IngredientIndex, Database, Id};
 /// database. Used to track output dependencies between queries. Fully ordered and
 /// equatable but those orderings are arbitrary, and meant to be used only for
 /// inserting into maps and the like.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct OutputDependencyIndex {
     ingredient_index: IngredientIndex,
     key_index: Id,
@@ -16,7 +16,7 @@ pub struct OutputDependencyIndex {
 /// database. Used to track input dependencies between queries. Fully ordered and
 /// equatable but those orderings are arbitrary, and meant to be used only for
 /// inserting into maps and the like.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct InputDependencyIndex {
     ingredient_index: IngredientIndex,
     key_index: Option<Id>,
@@ -116,7 +116,7 @@ impl fmt::Debug for InputDependencyIndex {
 /// An "active" database key index represents a database key index
 /// that is actively executing. In that case, the `key_index` cannot be
 /// None.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct DatabaseKeyIndex {
     pub(crate) ingredient_index: IngredientIndex,
     pub(crate) key_index: Id,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -274,10 +274,10 @@ impl Runtime {
                 // no matter where it started on the stack. Find the minimum
                 // key and rotate it to the front.
 
-                if let Some((_, index, _)) = v
+                if let Some((_, index)) = v
                     .iter()
                     .enumerate()
-                    .map(|(idx, key)| (key.ingredient_index.debug_name(db), idx, key))
+                    .map(|(idx, key)| (key.ingredient_index.debug_name(db), idx))
                     .min()
                 {
                     v.rotate_left(index);

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -7,7 +7,7 @@ use crate::{
     accumulator::accumulated_map::InputAccumulatedValues,
     cycle::CycleRecoveryStrategy,
     ingredient::{fmt_index, Ingredient, Jar, JarAux},
-    key::{DatabaseKeyIndex, DependencyIndex},
+    key::{DatabaseKeyIndex, InputDependencyIndex},
     plumbing::ZalsaLocal,
     runtime::StampedValue,
     salsa_struct::SalsaStructInDb,
@@ -559,7 +559,7 @@ where
         let field_changed_at = data.revisions[field_index];
 
         zalsa_local.report_tracked_read(
-            DependencyIndex::new(field_ingredient_index, id),
+            InputDependencyIndex::new(field_ingredient_index, id),
             data.durability,
             field_changed_at,
             InputAccumulatedValues::Empty,

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -520,9 +520,7 @@ where
             });
 
             for stale_output in memo.origin().outputs() {
-                zalsa
-                    .lookup_ingredient(stale_output.ingredient_index)
-                    .remove_stale_output(db, executor, stale_output.key_index);
+                stale_output.remove_stale_output(db, executor);
             }
         }
 
@@ -561,10 +559,7 @@ where
         let field_changed_at = data.revisions[field_index];
 
         zalsa_local.report_tracked_read(
-            DependencyIndex {
-                ingredient_index: field_ingredient_index,
-                key_index: Some(id),
-            },
+            DependencyIndex::new(field_ingredient_index, id),
             data.durability,
             field_changed_at,
             InputAccumulatedValues::Empty,
@@ -603,7 +598,7 @@ where
         &'db self,
         _db: &'db dyn Database,
         _executor: DatabaseKeyIndex,
-        _output_key: Option<crate::Id>,
+        _output_key: crate::Id,
     ) {
         // we used to update `update_at` field but now we do it lazilly when data is accessed
         //
@@ -614,13 +609,13 @@ where
         &self,
         db: &dyn Database,
         _executor: DatabaseKeyIndex,
-        stale_output_key: Option<crate::Id>,
+        stale_output_key: crate::Id,
     ) {
         // This method is called when, in prior revisions,
         // `executor` creates a tracked struct `salsa_output_key`,
         // but it did not in the current revision.
         // In that case, we can delete `stale_output_key` and any data associated with it.
-        self.delete_entity(db.as_dyn_database(), stale_output_key.unwrap());
+        self.delete_entity(db.as_dyn_database(), stale_output_key);
     }
 
     fn fmt_index(&self, index: Option<crate::Id>, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/tracked_struct/tracked_field.rs
+++ b/src/tracked_struct/tracked_field.rs
@@ -73,7 +73,7 @@ where
         &self,
         _db: &dyn Database,
         _executor: crate::DatabaseKeyIndex,
-        _output_key: Option<crate::Id>,
+        _output_key: crate::Id,
     ) {
         panic!("tracked field ingredients have no outputs")
     }
@@ -82,7 +82,7 @@ where
         &self,
         _db: &dyn Database,
         _executor: crate::DatabaseKeyIndex,
-        _stale_output_key: Option<crate::Id>,
+        _stale_output_key: crate::Id,
     ) {
         panic!("tracked field ingredients have no outputs")
     }


### PR DESCRIPTION
Output edges can never contain a `None` key index so `mark_validated_output` and `remove_stale_output` unwrap these options. We can easily get around that with a bit more strict typing though.