### PR TITLE
refactor: Per ingredient sync table

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -164,7 +164,7 @@ where
             lru: lru::Lru::new(lru),
             deleted_entries: Default::default(),
             view_caster,
-            sync_table: Default::default(),
+            sync_table: SyncTable::new(index),
         }
     }
 
@@ -273,10 +273,7 @@ where
     /// Attempts to claim `key_index`, returning `false` if a cycle occurs.
     fn wait_for(&self, db: &dyn Database, key_index: Id) -> bool {
         let zalsa = db.zalsa();
-        match self
-            .sync_table
-            .try_claim(db, zalsa, self.database_key_index(key_index))
-        {
+        match self.sync_table.try_claim(db, zalsa, key_index) {
             ClaimResult::Retry | ClaimResult::Claimed(_) => true,
             ClaimResult::Cycle => false,
         }

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -102,7 +102,7 @@ where
     ) -> Option<VerifyResult> {
         let database_key_index = self.database_key_index(key_index);
 
-        let _claim_guard = match self.sync_table.try_claim(db, zalsa, database_key_index) {
+        let _claim_guard = match self.sync_table.try_claim(db, zalsa, key_index) {
             ClaimResult::Retry => return None,
             ClaimResult::Cycle => match C::CYCLE_STRATEGY {
                 CycleRecoveryStrategy::Panic => db.zalsa_local().with_query_stack(|stack| {

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -3,9 +3,9 @@ use std::sync::atomic::Ordering;
 use crate::accumulator::accumulated_map::InputAccumulatedValues;
 use crate::cycle::{CycleHeadKind, CycleHeads, CycleRecoveryStrategy};
 use crate::function::memo::Memo;
+use crate::function::sync::ClaimResult;
 use crate::function::{Configuration, IngredientImpl};
 use crate::key::DatabaseKeyIndex;
-use crate::table::sync::ClaimResult;
 use crate::zalsa::{MemoIngredientIndex, Zalsa, ZalsaDatabase};
 use crate::zalsa_local::{QueryEdge, QueryOrigin};
 use crate::{AsDynDatabase as _, Id, Revision};
@@ -102,12 +102,7 @@ where
     ) -> Option<VerifyResult> {
         let database_key_index = self.database_key_index(key_index);
 
-        let _claim_guard = match zalsa.sync_table_for(key_index).claim(
-            db,
-            zalsa,
-            database_key_index,
-            memo_ingredient_index,
-        ) {
+        let _claim_guard = match self.sync_table.try_claim(db, zalsa, database_key_index) {
             ClaimResult::Retry => return None,
             ClaimResult::Cycle => match C::CYCLE_STRATEGY {
                 CycleRecoveryStrategy::Panic => db.zalsa_local().with_query_stack(|stack| {

--- a/src/function/sync.rs
+++ b/src/function/sync.rs
@@ -1,18 +1,26 @@
 use std::thread::ThreadId;
 
 use parking_lot::Mutex;
+use rustc_hash::FxHashMap;
 
-use crate::key::DatabaseKeyIndex;
-use crate::runtime::{BlockResult, WaitResult};
-use crate::table::util;
-use crate::zalsa::{MemoIngredientIndex, Zalsa};
-use crate::Database;
+use crate::{
+    key::DatabaseKeyIndex,
+    runtime::{BlockResult, WaitResult},
+    zalsa::Zalsa,
+    Database, Id,
+};
 
 /// Tracks the keys that are currently being processed; used to coordinate between
 /// worker threads.
 #[derive(Default)]
 pub(crate) struct SyncTable {
-    syncs: Mutex<Vec<Option<SyncState>>>,
+    syncs: Mutex<FxHashMap<Id, SyncState>>,
+}
+
+pub(crate) enum ClaimResult<'a> {
+    Retry,
+    Cycle,
+    Claimed(ClaimGuard<'a>),
 }
 
 struct SyncState {
@@ -23,44 +31,20 @@ struct SyncState {
     anyone_waiting: bool,
 }
 
-pub(crate) enum ClaimResult<'a> {
-    Retry,
-    Cycle,
-    Claimed(ClaimGuard<'a>),
-}
-
 impl SyncTable {
-    #[inline]
-    pub(crate) fn claim<'me>(
+    pub(crate) fn try_claim<'me>(
         &'me self,
         db: &'me (impl ?Sized + Database),
         zalsa: &'me Zalsa,
         database_key_index: DatabaseKeyIndex,
-        memo_ingredient_index: MemoIngredientIndex,
     ) -> ClaimResult<'me> {
-        let mut syncs = self.syncs.lock();
-        let thread_id = std::thread::current().id();
-
-        util::ensure_vec_len(&mut syncs, memo_ingredient_index.as_usize() + 1);
-
-        match &mut syncs[memo_ingredient_index.as_usize()] {
-            None => {
-                syncs[memo_ingredient_index.as_usize()] = Some(SyncState {
-                    id: thread_id,
-                    anyone_waiting: false,
-                });
-                ClaimResult::Claimed(ClaimGuard {
-                    database_key_index,
-                    memo_ingredient_index,
-                    zalsa,
-                    sync_table: self,
-                    _padding: false,
-                })
-            }
-            Some(SyncState {
-                id: other_id,
-                anyone_waiting,
-            }) => {
+        let mut write = self.syncs.lock();
+        match write.entry(database_key_index.key_index()) {
+            std::collections::hash_map::Entry::Occupied(occupied_entry) => {
+                let &mut SyncState {
+                    id,
+                    ref mut anyone_waiting,
+                } = occupied_entry.into_mut();
                 // NB: `Ordering::Relaxed` is sufficient here,
                 // as there are no loads that are "gated" on this
                 // value. Everything that is written is also protected
@@ -68,13 +52,22 @@ impl SyncTable {
                 // boolean is to decide *whether* to acquire the lock,
                 // not to gate future atomic reads.
                 *anyone_waiting = true;
-                match zalsa
-                    .runtime()
-                    .block_on(db, database_key_index, *other_id, syncs)
-                {
+                match zalsa.runtime().block_on(db, database_key_index, id, write) {
                     BlockResult::Completed => ClaimResult::Retry,
                     BlockResult::Cycle => ClaimResult::Cycle,
                 }
+            }
+            std::collections::hash_map::Entry::Vacant(vacant_entry) => {
+                vacant_entry.insert(SyncState {
+                    id: std::thread::current().id(),
+                    anyone_waiting: false,
+                });
+                ClaimResult::Claimed(ClaimGuard {
+                    database_key_index,
+                    zalsa,
+                    sync_table: self,
+                    _padding: false,
+                })
             }
         }
     }
@@ -85,7 +78,6 @@ impl SyncTable {
 #[must_use]
 pub(crate) struct ClaimGuard<'me> {
     database_key_index: DatabaseKeyIndex,
-    memo_ingredient_index: MemoIngredientIndex,
     zalsa: &'me Zalsa,
     sync_table: &'me SyncTable,
     // Reduce the size of ClaimResult by making more niches available in ClaimGuard; this fits into
@@ -98,7 +90,7 @@ impl ClaimGuard<'_> {
         let mut syncs = self.sync_table.syncs.lock();
 
         let SyncState { anyone_waiting, .. } =
-            syncs[self.memo_ingredient_index.as_usize()].take().unwrap();
+            syncs.remove(&self.database_key_index.key_index()).unwrap();
 
         if anyone_waiting {
             self.zalsa.runtime().unblock_queries_blocked_on(

--- a/src/input.rs
+++ b/src/input.rs
@@ -16,7 +16,6 @@ use crate::input::singleton::{Singleton, SingletonChoice};
 use crate::key::DatabaseKeyIndex;
 use crate::plumbing::{Jar, Stamp};
 use crate::table::memo::{MemoTable, MemoTableTypes};
-use crate::table::sync::SyncTable;
 use crate::table::{Slot, Table};
 use crate::zalsa::{IngredientIndex, Zalsa};
 use crate::{Database, Durability, Id, Revision, Runtime};
@@ -107,7 +106,6 @@ impl<C: Configuration> IngredientImpl<C> {
                 fields,
                 stamps,
                 memos: Default::default(),
-                syncs: Default::default(),
             })
         });
 
@@ -252,9 +250,6 @@ where
 
     /// Memos
     memos: MemoTable,
-
-    /// Syncs
-    syncs: SyncTable,
 }
 
 impl<C> Value<C>
@@ -287,10 +282,5 @@ where
     #[inline(always)]
     fn memos_mut(&mut self) -> &mut crate::table::memo::MemoTable {
         &mut self.memos
-    }
-
-    #[inline(always)]
-    unsafe fn syncs(&self, _current_revision: Revision) -> &SyncTable {
-        &self.syncs
     }
 }

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -18,7 +18,6 @@ use crate::ingredient::{fmt_index, Ingredient};
 use crate::plumbing::{IngredientIndices, Jar};
 use crate::revision::AtomicRevision;
 use crate::table::memo::{MemoTable, MemoTableTypes};
-use crate::table::sync::SyncTable;
 use crate::table::Slot;
 use crate::zalsa::{IngredientIndex, Zalsa};
 use crate::{Database, DatabaseKeyIndex, Event, EventKind, Id, Revision};
@@ -78,7 +77,6 @@ where
 {
     fields: C::Fields<'static>,
     memos: MemoTable,
-    syncs: SyncTable,
 
     /// The revision the value was first interned in.
     first_interned_at: Revision,
@@ -311,7 +309,6 @@ where
                 let id = zalsa_local.allocate(zalsa, self.ingredient_index, |id| Value::<C> {
                     fields: unsafe { self.to_internal_data(assemble(id, key)) },
                     memos: Default::default(),
-                    syncs: Default::default(),
                     durability: AtomicU8::new(durability.as_u8()),
                     // Record the revision we are interning in.
                     first_interned_at: current_revision,
@@ -462,11 +459,6 @@ where
     #[inline(always)]
     fn memos_mut(&mut self) -> &mut MemoTable {
         &mut self.memos
-    }
-
-    #[inline(always)]
-    unsafe fn syncs(&self, _current_revision: Revision) -> &crate::table::sync::SyncTable {
-        &self.syncs
     }
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -171,7 +171,7 @@ impl Runtime {
         other_id: ThreadId,
         query_mutex_guard: QueryMutexGuard,
     ) -> BlockResult {
-        let mut dg = self.dependency_graph.lock();
+        let dg = self.dependency_graph.lock();
         let thread_id = std::thread::current().id();
 
         if dg.depends_on(other_id, thread_id) {

--- a/src/runtime/dependency_graph.rs
+++ b/src/runtime/dependency_graph.rs
@@ -31,7 +31,7 @@ impl DependencyGraph {
     /// True if `from_id` depends on `to_id`.
     ///
     /// (i.e., there is a path from `from_id` to `to_id` in the graph.)
-    pub(super) fn depends_on(&mut self, from_id: ThreadId, to_id: ThreadId) -> bool {
+    pub(super) fn depends_on(&self, from_id: ThreadId, to_id: ThreadId) -> bool {
         let mut p = from_id;
         while let Some(q) = self.edges.get(&p).map(|edge| edge.blocked_on_id) {
             if q == to_id {

--- a/src/table/util.rs
+++ b/src/table/util.rs
@@ -1,5 +1,0 @@
-pub(super) fn ensure_vec_len<T: Default>(v: &mut Vec<T>, len: usize) {
-    if v.len() < len {
-        v.resize_with(len, T::default);
-    }
-}

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -18,7 +18,6 @@ use crate::revision::OptionalAtomicRevision;
 use crate::runtime::StampedValue;
 use crate::salsa_struct::SalsaStructInDb;
 use crate::table::memo::{MemoTable, MemoTableTypes};
-use crate::table::sync::SyncTable;
 use crate::table::{Slot, Table};
 use crate::zalsa::{IngredientIndex, Zalsa};
 use crate::{Database, Durability, Event, EventKind, Id, Revision};
@@ -318,9 +317,6 @@ where
 
     /// Memo table storing the results of query functions etc.
     memos: MemoTable,
-
-    /// Sync table storing the results of query functions etc.
-    syncs: SyncTable,
 }
 // ANCHOR_END: ValueStruct
 
@@ -452,7 +448,6 @@ where
             fields: unsafe { self.to_static(fields) },
             revisions: C::new_revisions(current_deps.changed_at),
             memos: Default::default(),
-            syncs: Default::default(),
         };
 
         if let Some(id) = self.free_list.pop() {
@@ -880,15 +875,6 @@ where
     #[inline(always)]
     fn memos_mut(&mut self) -> &mut crate::table::memo::MemoTable {
         &mut self.memos
-    }
-
-    #[inline(always)]
-    unsafe fn syncs(&self, current_revision: Revision) -> &crate::table::sync::SyncTable {
-        // Acquiring the read lock here with the current revision
-        // ensures that there is no danger of a race
-        // when deleting a tracked struct.
-        self.read_lock(current_revision);
-        &self.syncs
     }
 }
 

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -14,7 +14,6 @@ use crate::ingredient::{Ingredient, Jar};
 use crate::nonce::{Nonce, NonceGenerator};
 use crate::runtime::Runtime;
 use crate::table::memo::MemoTableWithTypes;
-use crate::table::sync::SyncTable;
 use crate::table::Table;
 use crate::views::Views;
 use crate::zalsa_local::ZalsaLocal;
@@ -197,12 +196,6 @@ impl Zalsa {
         unsafe { table.memos(id, self.current_revision()) }
     }
 
-    /// Returns the [`SyncTable`][] for the salsa struct with the given id
-    pub(crate) fn sync_table_for(&self, id: Id) -> &SyncTable {
-        // SAFETY: We are supplying the correct current revision
-        unsafe { self.table().syncs(id, self.current_revision()) }
-    }
-
     #[inline]
     pub(crate) fn lookup_ingredient(&self, index: IngredientIndex) -> &dyn Ingredient {
         let index = index.as_usize();
@@ -250,7 +243,7 @@ impl Zalsa {
             memo_ingredients.resize_with(idx + 1, Vec::new);
             memo_ingredients.get_mut(idx).unwrap()
         };
-        let mi = MemoIngredientIndex(u32::try_from(memo_ingredients.len()).unwrap());
+        let mi = MemoIngredientIndex::from_usize(memo_ingredients.len());
         memo_ingredients.push(ingredient_index);
 
         mi


### PR DESCRIPTION
I believe given that the lock is held fairly shortly we ought to be fine with this coarser grained locking. A lock per ingredient to claim a sync which means we only content for the lock when two queries try to access something from the same ingredient. This reduces memory usage by a good chunk.