### PR TITLE
feature: expose `Database::unwind_if_revision_cancelled`

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -54,6 +54,24 @@ pub trait Database: Send + AsDynDatabase + Any + ZalsaDatabase {
         )
     }
 
+    /// Starts unwinding the stack if the current revision is cancelled.
+    ///
+    /// This method can be called by query implementations that perform
+    /// potentially expensive computations, in order to speed up propagation of
+    /// cancellation.
+    ///
+    /// Cancellation will automatically be triggered by salsa on any query
+    /// invocation.
+    ///
+    /// This method should not be overridden by `Database` implementors. A
+    /// `salsa_event` is emitted when this method is called, so that should be
+    /// used instead.
+    fn unwind_if_revision_cancelled(&self) {
+        let db = self.as_dyn_database();
+        let zalsa_local = db.zalsa_local();
+        zalsa_local.unwind_if_revision_cancelled(db);
+    }
+
     /// Execute `op` with the database in thread-local storage for debug print-outs.
     fn attach<R>(&self, op: impl FnOnce(&Self) -> R) -> R
     where


### PR DESCRIPTION
This method is used all over rust-analyzer, most prominently in rust-analyzer's `parallel_prime_caches` method. We use this method in order to check for cancellation in an ad-hoc, map/reduce-shaped threadpool inside of `parallel_prime_caches`, and (re)introducing this method solves a hang there.