### PR TITLE
chore: fix completions in `#[salsa::tracked]` functions

### DIFF
--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -32,7 +32,7 @@ macro_rules! setup_tracked_fn {
         output_ty: $output_ty:ty,
 
         // Function body, may reference identifiers defined in `$input_pats` and the generics from `$generics`
-        inner_fn: $inner_fn:item,
+        inner_fn: {$($inner_fn:tt)*},
 
         // Path to the cycle recovery function to use.
         cycle_recovery_fn: ($($cycle_recovery_fn:tt)*),
@@ -172,7 +172,7 @@ macro_rules! setup_tracked_fn {
                 }
 
                 fn execute<$db_lt>($db: &$db_lt Self::DbView, ($($input_id),*): ($($input_ty),*)) -> Self::Output<$db_lt> {
-                    $inner_fn
+                    $($inner_fn)*
 
                     $inner($db, $($input_id),*)
                 }

--- a/components/salsa-macros/src/tracked_fn.rs
+++ b/components/salsa-macros/src/tracked_fn.rs
@@ -125,7 +125,7 @@ impl Macro {
                 input_ids: [#(#input_ids),*],
                 input_tys: [#(#input_tys),*],
                 output_ty: #output_ty,
-                inner_fn: #inner_fn,
+                inner_fn: { #inner_fn },
                 cycle_recovery_fn: #cycle_recovery_fn,
                 cycle_recovery_strategy: #cycle_recovery_strategy,
                 is_specifiable: #is_specifiable,


### PR DESCRIPTION
This change allows rust-analyzer (and, I assume RustRover) to provide accurate completions inside of a `#[salsa::tracked]` function. Previously, I'd comment out the `#[salsa::tracked]` annotation when writing a tracked function, but this PR removes the need for that workaround.

As @Veykril put it, the _core_ issue is that rust-analyzer's `mbe` crate is not very error-resilient: we no longer pick the correct match arm of the `macro_rules` macro because the input doesn't match—`mbe` _should_ pick the closest match instead of giving up, but until `mbe` supports that, this PR ~~papers over a rust-analyzer weakness~~ 🌟  it makes the macro more IDE friendly 🌟 !

(Credit goes to Lukas for the tip, explanation, and joke!)