### PR TITLE
Coarse-grained tracked structs

### DIFF
--- a/components/salsa-macro-rules/src/setup_tracked_struct.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_struct.rs
@@ -107,6 +107,10 @@ macro_rules! setup_tracked_struct {
                     $(stringify!($field_id),)*
                 ];
 
+                const TRACKED_FIELD_DEBUG_NAMES: &'static [&'static str] = &[
+                    $(stringify!($tracked_id),)*
+                ];
+
                 type Fields<$db_lt> = ($($field_ty,)*);
 
                 type Revisions = $zalsa::Array<$Revision, $N>;

--- a/components/salsa-macro-rules/src/setup_tracked_struct.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_struct.rs
@@ -2,49 +2,49 @@
 #[macro_export]
 macro_rules! setup_tracked_struct {
     (
-        // Attributes on the function
+        // Attributes on the function.
         attrs: [$(#[$attr:meta]),*],
 
-        // Visibility of the struct
+        // Visibility of the struct.
         vis: $vis:vis,
 
-        // Name of the struct
+        // Name of the struct.
         Struct: $Struct:ident,
 
-        // Name of the `'db` lifetime that the user gave
+        // Name of the `'db` lifetime that the user gave.
         db_lt: $db_lt:lifetime,
 
-        // Name user gave for `new`
+        // Name user gave for `new`.
         new_fn: $new_fn:ident,
 
-        // Field names
+        // Field names.
         field_ids: [$($field_id:ident),*],
 
-        // Tracked field names
+        // Tracked field names.
         tracked_ids: [$($tracked_id:ident),*],
 
-        // Tracked field names
+        // Visibility and names of tracked fields.
         tracked_getters: [$($tracked_getter_vis:vis $tracked_getter_id:ident),*],
 
-        // Untracked field names
+        // Visibility and names of untracked fields.
         untracked_getters: [$($untracked_getter_vis:vis $untracked_getter_id:ident),*],
 
-        // Field types, may reference `db_lt`
+        // Field types, may reference `db_lt`.
         field_tys: [$($field_ty:ty),*],
 
-        // Tracked field types
+        // Tracked field types.
         tracked_tys: [$($tracked_ty:ty),*],
 
-        // Untracked field types
+        // Untracked field types.
         untracked_tys: [$($untracked_ty:ty),*],
 
         // Indices for each field from 0..N -- must be unsuffixed (e.g., `0`, `1`).
         field_indices: [$($field_index:tt),*],
 
-        // Indices of tracked fields.
+        // Absolute indices of any tracked fields, relative to all other fields of this struct.
         tracked_indices: [$($tracked_index:tt),*],
 
-        // Indices of untracked fields.
+        // Absolute indices of any untracked fields.
         untracked_indices: [$($untracked_index:tt),*],
 
         // A set of "field options" for each field.
@@ -64,7 +64,7 @@ macro_rules! setup_tracked_struct {
         // A set of "field options" for each untracked field.
         untracked_options: [$($untracked_option:tt),*],
 
-        // Number of fields
+        // Number of fields.
         num_fields: $N:literal,
 
         // If true, generate a debug impl.
@@ -105,10 +105,6 @@ macro_rules! setup_tracked_struct {
 
                 const FIELD_DEBUG_NAMES: &'static [&'static str] = &[
                     $(stringify!($field_id),)*
-                ];
-
-                const TRACKED_FIELD_DEBUG_NAMES: &'static [&'static str] = &[
-                    $(stringify!($tracked_id),)*
                 ];
 
                 type Fields<$db_lt> = ($($field_ty,)*);

--- a/components/salsa-macros/src/input.rs
+++ b/components/salsa-macros/src/input.rs
@@ -64,7 +64,7 @@ impl crate::options::AllowedOptions for InputStruct {
 impl SalsaStructAllowedOptions for InputStruct {
     const KIND: &'static str = "input";
 
-    const ALLOW_ID: bool = false;
+    const ALLOW_TRACKED: bool = false;
 
     const HAS_LIFETIME: bool = false;
 

--- a/components/salsa-macros/src/interned.rs
+++ b/components/salsa-macros/src/interned.rs
@@ -65,7 +65,7 @@ impl crate::options::AllowedOptions for InternedStruct {
 impl SalsaStructAllowedOptions for InternedStruct {
     const KIND: &'static str = "interned";
 
-    const ALLOW_ID: bool = false;
+    const ALLOW_TRACKED: bool = false;
 
     const HAS_LIFETIME: bool = true;
 

--- a/components/salsa-macros/src/salsa_struct.rs
+++ b/components/salsa-macros/src/salsa_struct.rs
@@ -211,13 +211,13 @@ where
             .collect()
     }
 
-    pub(crate) fn tracked_indices(&self) -> Vec<Literal> {
+    pub(crate) fn tracked_field_indices(&self) -> Vec<Literal> {
         self.tracked_fields_iter()
             .map(|(index, _)| Literal::usize_unsuffixed(index))
             .collect()
     }
 
-    pub(crate) fn untracked_indices(&self) -> Vec<Literal> {
+    pub(crate) fn untracked_field_indices(&self) -> Vec<Literal> {
         self.untracked_fields_iter()
             .map(|(index, _)| Literal::usize_unsuffixed(index))
             .collect()

--- a/components/salsa-macros/src/salsa_struct.rs
+++ b/components/salsa-macros/src/salsa_struct.rs
@@ -41,8 +41,8 @@ pub(crate) trait SalsaStructAllowedOptions: AllowedOptions {
     /// The kind of struct (e.g., interned, input, tracked).
     const KIND: &'static str;
 
-    /// Are `#[id]` fields allowed?
-    const ALLOW_ID: bool;
+    /// Are `#[tracked]` fields allowed?
+    const ALLOW_TRACKED: bool;
 
     /// Does this kind of struct have a `'db` lifetime?
     const HAS_LIFETIME: bool;
@@ -57,7 +57,7 @@ pub(crate) trait SalsaStructAllowedOptions: AllowedOptions {
 pub(crate) struct SalsaField<'s> {
     field: &'s syn::Field,
 
-    pub(crate) has_id_attr: bool,
+    pub(crate) has_tracked_attr: bool,
     pub(crate) has_default_attr: bool,
     pub(crate) has_ref_attr: bool,
     pub(crate) has_no_eq_attr: bool,
@@ -69,7 +69,7 @@ const BANNED_FIELD_NAMES: &[&str] = &["from", "new"];
 
 #[allow(clippy::type_complexity)]
 pub(crate) const FIELD_OPTION_ATTRIBUTES: &[(&str, fn(&syn::Attribute, &mut SalsaField))] = &[
-    ("id", |_, ef| ef.has_id_attr = true),
+    ("tracked", |_, ef| ef.has_tracked_attr = true),
     ("default", |_, ef| ef.has_default_attr = true),
     ("return_ref", |_, ef| ef.has_ref_attr = true),
     ("no_eq", |_, ef| ef.has_no_eq_attr = true),
@@ -105,7 +105,7 @@ where
             fields,
         };
 
-        this.maybe_disallow_id_fields()?;
+        this.maybe_disallow_tracked_fields()?;
         this.maybe_disallow_default_fields()?;
 
         this.check_generics()?;
@@ -129,24 +129,24 @@ where
         }
     }
 
-    /// Disallow `#[id]` attributes on the fields of this struct.
+    /// Disallow `#[tracked]` attributes on the fields of this struct.
     ///
-    /// If an `#[id]` field is found, return an error.
+    /// If an `#[tracked]` field is found, return an error.
     ///
     /// # Parameters
     ///
     /// * `kind`, the attribute name (e.g., `input` or `interned`)
-    fn maybe_disallow_id_fields(&self) -> syn::Result<()> {
-        if A::ALLOW_ID {
+    fn maybe_disallow_tracked_fields(&self) -> syn::Result<()> {
+        if A::ALLOW_TRACKED {
             return Ok(());
         }
 
-        // Check if any field has the `#[id]` attribute.
+        // Check if any field has the `#[tracked]` attribute.
         for ef in &self.fields {
-            if ef.has_id_attr {
+            if ef.has_tracked_attr {
                 return Err(syn::Error::new_spanned(
                     ef.field,
-                    format!("`#[id]` cannot be used with `#[salsa::{}]`", A::KIND),
+                    format!("`#[tracked]` cannot be used with `#[salsa::{}]`", A::KIND),
                 ));
             }
         }
@@ -199,23 +199,32 @@ where
             .collect()
     }
 
+    pub(crate) fn tracked_ids(&self) -> Vec<&syn::Ident> {
+        self.tracked_fields_iter()
+            .map(|(_, f)| f.field.ident.as_ref().unwrap())
+            .collect()
+    }
+
     pub(crate) fn field_indices(&self) -> Vec<Literal> {
         (0..self.fields.len())
             .map(Literal::usize_unsuffixed)
             .collect()
     }
 
-    pub(crate) fn num_fields(&self) -> Literal {
-        Literal::usize_unsuffixed(self.fields.len())
+    pub(crate) fn tracked_indices(&self) -> Vec<Literal> {
+        self.tracked_fields_iter()
+            .map(|(index, _)| Literal::usize_unsuffixed(index))
+            .collect()
     }
 
-    pub(crate) fn id_field_indices(&self) -> Vec<Literal> {
-        self.fields
-            .iter()
-            .zip(0..)
-            .filter_map(|(f, index)| if f.has_id_attr { Some(index) } else { None })
-            .map(Literal::usize_unsuffixed)
+    pub(crate) fn untracked_indices(&self) -> Vec<Literal> {
+        self.untracked_fields_iter()
+            .map(|(index, _)| Literal::usize_unsuffixed(index))
             .collect()
+    }
+
+    pub(crate) fn num_fields(&self) -> Literal {
+        Literal::usize_unsuffixed(self.fields.len())
     }
 
     pub(crate) fn required_fields(&self) -> Vec<TokenStream> {
@@ -237,8 +246,32 @@ where
         self.fields.iter().map(|f| &f.field.vis).collect()
     }
 
+    pub(crate) fn tracked_vis(&self) -> Vec<&syn::Visibility> {
+        self.tracked_fields_iter()
+            .map(|(_, f)| &f.field.vis)
+            .collect()
+    }
+
+    pub(crate) fn untracked_vis(&self) -> Vec<&syn::Visibility> {
+        self.untracked_fields_iter()
+            .map(|(_, f)| &f.field.vis)
+            .collect()
+    }
+
     pub(crate) fn field_getter_ids(&self) -> Vec<&syn::Ident> {
         self.fields.iter().map(|f| &f.get_name).collect()
+    }
+
+    pub(crate) fn tracked_getter_ids(&self) -> Vec<&syn::Ident> {
+        self.tracked_fields_iter()
+            .map(|(_, f)| &f.get_name)
+            .collect()
+    }
+
+    pub(crate) fn untracked_getter_ids(&self) -> Vec<&syn::Ident> {
+        self.untracked_fields_iter()
+            .map(|(_, f)| &f.get_name)
+            .collect()
     }
 
     pub(crate) fn field_setter_ids(&self) -> Vec<&syn::Ident> {
@@ -256,6 +289,18 @@ where
         self.fields.iter().map(|f| &f.field.ty).collect()
     }
 
+    pub(crate) fn tracked_tys(&self) -> Vec<&syn::Type> {
+        self.tracked_fields_iter()
+            .map(|(_, f)| &f.field.ty)
+            .collect()
+    }
+
+    pub(crate) fn untracked_tys(&self) -> Vec<&syn::Type> {
+        self.untracked_fields_iter()
+            .map(|(_, f)| &f.field.ty)
+            .collect()
+    }
+
     pub(crate) fn field_indexed_tys(&self) -> Vec<syn::Ident> {
         self.fields
             .iter()
@@ -265,29 +310,18 @@ where
     }
 
     pub(crate) fn field_options(&self) -> Vec<TokenStream> {
-        self.fields
-            .iter()
-            .map(|f| {
-                let clone_ident = if f.has_ref_attr {
-                    syn::Ident::new("no_clone", Span::call_site())
-                } else {
-                    syn::Ident::new("clone", Span::call_site())
-                };
+        self.fields.iter().map(SalsaField::options).collect()
+    }
 
-                let backdate_ident = if f.has_no_eq_attr {
-                    syn::Ident::new("no_backdate", Span::call_site())
-                } else {
-                    syn::Ident::new("backdate", Span::call_site())
-                };
+    pub(crate) fn tracked_options(&self) -> Vec<TokenStream> {
+        self.tracked_fields_iter()
+            .map(|(_, f)| f.options())
+            .collect()
+    }
 
-                let default_ident = if f.has_default_attr {
-                    syn::Ident::new("default", Span::call_site())
-                } else {
-                    syn::Ident::new("required", Span::call_site())
-                };
-
-                quote!((#clone_ident, #backdate_ident, #default_ident))
-            })
+    pub(crate) fn untracked_options(&self) -> Vec<TokenStream> {
+        self.untracked_fields_iter()
+            .map(|(_, f)| f.options())
             .collect()
     }
 
@@ -297,6 +331,20 @@ where
 
     pub fn generate_lifetime(&self) -> bool {
         self.args.no_lifetime.is_none()
+    }
+
+    fn tracked_fields_iter(&self) -> impl Iterator<Item = (usize, &SalsaField<'s>)> {
+        self.fields
+            .iter()
+            .enumerate()
+            .filter(|(_, f)| f.has_tracked_attr)
+    }
+
+    fn untracked_fields_iter(&self) -> impl Iterator<Item = (usize, &SalsaField<'s>)> {
+        self.fields
+            .iter()
+            .enumerate()
+            .filter(|(_, f)| !f.has_tracked_attr)
     }
 }
 
@@ -318,7 +366,7 @@ impl<'s> SalsaField<'s> {
         let set_name = Ident::new(&format!("set_{}", field_name_str), field_name.span());
         let mut result = SalsaField {
             field,
-            has_id_attr: false,
+            has_tracked_attr: false,
             has_ref_attr: false,
             has_default_attr: false,
             has_no_eq_attr: false,
@@ -336,5 +384,27 @@ impl<'s> SalsaField<'s> {
         }
 
         Ok(result)
+    }
+
+    fn options(&self) -> TokenStream {
+        let clone_ident = if self.has_ref_attr {
+            syn::Ident::new("no_clone", Span::call_site())
+        } else {
+            syn::Ident::new("clone", Span::call_site())
+        };
+
+        let backdate_ident = if self.has_no_eq_attr {
+            syn::Ident::new("no_backdate", Span::call_site())
+        } else {
+            syn::Ident::new("backdate", Span::call_site())
+        };
+
+        let default_ident = if self.has_default_attr {
+            syn::Ident::new("default", Span::call_site())
+        } else {
+            syn::Ident::new("required", Span::call_site())
+        };
+
+        quote!((#clone_ident, #backdate_ident, #default_ident))
     }
 }

--- a/components/salsa-macros/src/tracked_struct.rs
+++ b/components/salsa-macros/src/tracked_struct.rs
@@ -84,22 +84,29 @@ impl Macro {
         let struct_ident = &self.struct_item.ident;
         let db_lt = db_lifetime::db_lifetime(&self.struct_item.generics);
         let new_fn = salsa_struct.constructor_name();
+
         let field_ids = salsa_struct.field_ids();
         let tracked_ids = salsa_struct.tracked_ids();
+
         let tracked_vis = salsa_struct.tracked_vis();
         let untracked_vis = salsa_struct.untracked_vis();
+
         let tracked_getter_ids = salsa_struct.tracked_getter_ids();
         let untracked_getter_ids = salsa_struct.untracked_getter_ids();
+
         let field_indices = salsa_struct.field_indices();
         let tracked_indices = salsa_struct.tracked_indices();
         let untracked_indices = salsa_struct.untracked_indices();
-        let num_fields = salsa_struct.num_fields();
+
         let field_options = salsa_struct.field_options();
         let tracked_options = salsa_struct.tracked_options();
         let untracked_options = salsa_struct.untracked_options();
+
         let field_tys = salsa_struct.field_tys();
         let tracked_tys = salsa_struct.tracked_tys();
         let untracked_tys = salsa_struct.untracked_tys();
+
+        let num_fields = salsa_struct.num_fields();
         let generate_debug_impl = salsa_struct.generate_debug_impl();
 
         let zalsa = self.hygiene.ident("zalsa");

--- a/components/salsa-macros/src/tracked_struct.rs
+++ b/components/salsa-macros/src/tracked_struct.rs
@@ -59,7 +59,7 @@ impl crate::options::AllowedOptions for TrackedStruct {
 impl SalsaStructAllowedOptions for TrackedStruct {
     const KIND: &'static str = "tracked";
 
-    const ALLOW_ID: bool = true;
+    const ALLOW_TRACKED: bool = true;
 
     const HAS_LIFETIME: bool = true;
 
@@ -85,13 +85,21 @@ impl Macro {
         let db_lt = db_lifetime::db_lifetime(&self.struct_item.generics);
         let new_fn = salsa_struct.constructor_name();
         let field_ids = salsa_struct.field_ids();
-        let field_vis = salsa_struct.field_vis();
-        let field_getter_ids = salsa_struct.field_getter_ids();
+        let tracked_ids = salsa_struct.tracked_ids();
+        let tracked_vis = salsa_struct.tracked_vis();
+        let untracked_vis = salsa_struct.untracked_vis();
+        let tracked_getter_ids = salsa_struct.tracked_getter_ids();
+        let untracked_getter_ids = salsa_struct.untracked_getter_ids();
         let field_indices = salsa_struct.field_indices();
-        let id_field_indices = salsa_struct.id_field_indices();
+        let tracked_indices = salsa_struct.tracked_indices();
+        let untracked_indices = salsa_struct.untracked_indices();
         let num_fields = salsa_struct.num_fields();
         let field_options = salsa_struct.field_options();
+        let tracked_options = salsa_struct.tracked_options();
+        let untracked_options = salsa_struct.untracked_options();
         let field_tys = salsa_struct.field_tys();
+        let tracked_tys = salsa_struct.tracked_tys();
+        let untracked_tys = salsa_struct.untracked_tys();
         let generate_debug_impl = salsa_struct.generate_debug_impl();
 
         let zalsa = self.hygiene.ident("zalsa");
@@ -112,11 +120,18 @@ impl Macro {
                     db_lt: #db_lt,
                     new_fn: #new_fn,
                     field_ids: [#(#field_ids),*],
-                    field_getters: [#(#field_vis #field_getter_ids),*],
+                    tracked_ids: [#(#tracked_ids),*],
+                    tracked_getters: [#(#tracked_vis #tracked_getter_ids),*],
+                    untracked_getters: [#(#untracked_vis #untracked_getter_ids),*],
                     field_tys: [#(#field_tys),*],
+                    tracked_tys: [#(#tracked_tys),*],
+                    untracked_tys: [#(#untracked_tys),*],
                     field_indices: [#(#field_indices),*],
-                    id_field_indices: [#(#id_field_indices),*],
+                    tracked_indices: [#(#tracked_indices),*],
+                    untracked_indices: [#(#untracked_indices),*],
                     field_options: [#(#field_options),*],
+                    tracked_options: [#(#tracked_options),*],
+                    untracked_options: [#(#untracked_options),*],
                     num_fields: #num_fields,
                     generate_debug_impl: #generate_debug_impl,
                     unused_names: [

--- a/components/salsa-macros/src/tracked_struct.rs
+++ b/components/salsa-macros/src/tracked_struct.rs
@@ -95,8 +95,11 @@ impl Macro {
         let untracked_getter_ids = salsa_struct.untracked_getter_ids();
 
         let field_indices = salsa_struct.field_indices();
-        let tracked_indices = salsa_struct.tracked_indices();
-        let untracked_indices = salsa_struct.untracked_indices();
+
+        let absolute_tracked_indices = salsa_struct.tracked_field_indices();
+        let relative_tracked_indices = (0..absolute_tracked_indices.len()).collect::<Vec<_>>();
+
+        let absolute_untracked_indices = salsa_struct.untracked_field_indices();
 
         let field_options = salsa_struct.field_options();
         let tracked_options = salsa_struct.tracked_options();
@@ -126,19 +129,28 @@ impl Macro {
                     Struct: #struct_ident,
                     db_lt: #db_lt,
                     new_fn: #new_fn,
+
                     field_ids: [#(#field_ids),*],
                     tracked_ids: [#(#tracked_ids),*],
+
                     tracked_getters: [#(#tracked_vis #tracked_getter_ids),*],
                     untracked_getters: [#(#untracked_vis #untracked_getter_ids),*],
+
                     field_tys: [#(#field_tys),*],
                     tracked_tys: [#(#tracked_tys),*],
                     untracked_tys: [#(#untracked_tys),*],
+
                     field_indices: [#(#field_indices),*],
-                    tracked_indices: [#(#tracked_indices),*],
-                    untracked_indices: [#(#untracked_indices),*],
+
+                    absolute_tracked_indices: [#(#absolute_tracked_indices),*],
+                    relative_tracked_indices: [#(#relative_tracked_indices),*],
+
+                    absolute_untracked_indices: [#(#absolute_untracked_indices),*],
+
                     field_options: [#(#field_options),*],
                     tracked_options: [#(#tracked_options),*],
                     untracked_options: [#(#untracked_options),*],
+
                     num_fields: #num_fields,
                     generate_debug_impl: #generate_debug_impl,
                     unused_names: [

--- a/examples/calc/ir.rs
+++ b/examples/calc/ir.rs
@@ -79,7 +79,6 @@ pub enum Op {
 pub struct Function<'db> {
     pub name: FunctionId<'db>,
 
-    #[tracked]
     name_span: Span<'db>,
 
     #[tracked]

--- a/examples/calc/ir.rs
+++ b/examples/calc/ir.rs
@@ -28,6 +28,7 @@ pub struct FunctionId<'db> {
 // ANCHOR: program
 #[salsa::tracked]
 pub struct Program<'db> {
+    #[tracked]
     #[return_ref]
     pub statements: Vec<Statement<'db>>,
 }
@@ -76,14 +77,16 @@ pub enum Op {
 // ANCHOR: functions
 #[salsa::tracked]
 pub struct Function<'db> {
-    #[id]
     pub name: FunctionId<'db>,
 
+    #[tracked]
     name_span: Span<'db>,
 
+    #[tracked]
     #[return_ref]
     pub args: Vec<VariableId<'db>>,
 
+    #[tracked]
     #[return_ref]
     pub body: Expression<'db>,
 }
@@ -91,7 +94,9 @@ pub struct Function<'db> {
 
 #[salsa::tracked]
 pub struct Span<'db> {
+    #[tracked]
     pub start: usize,
+    #[tracked]
     pub end: usize,
 }
 

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -26,7 +26,6 @@ pub mod tracked_field;
 pub trait Configuration: Sized + 'static {
     const DEBUG_NAME: &'static str;
     const FIELD_DEBUG_NAMES: &'static [&'static str];
-    const TRACKED_FIELD_DEBUG_NAMES: &'static [&'static str];
 
     /// A (possibly empty) tuple of the fields for this struct.
     type Fields<'db>: Send + Sync;
@@ -109,7 +108,9 @@ impl<C: Configuration> Jar for JarImpl<C> {
         let struct_ingredient = <IngredientImpl<C>>::new(struct_index);
 
         std::iter::once(Box::new(struct_ingredient) as _)
-            .chain((0..C::TRACKED_FIELD_DEBUG_NAMES.len()).map(|field_index| {
+            // Note that we create ingredients for untracked fields as well, in order to
+            // keep field indices relative to the entire struct.
+            .chain((0..C::FIELD_DEBUG_NAMES.len()).map(|field_index| {
                 Box::new(<FieldIngredientImpl<C>>::new(struct_index, field_index)) as _
             }))
             .collect()

--- a/src/tracked_struct/tracked_field.rs
+++ b/src/tracked_struct/tracked_field.rs
@@ -23,7 +23,10 @@ where
 {
     /// Index of this ingredient in the database (used to construct database-ids, etc).
     ingredient_index: IngredientIndex,
+
+    /// The absolute index of this field on the tracked struct.
     field_index: usize,
+
     phantom: PhantomData<fn() -> Value<C>>,
 }
 
@@ -31,10 +34,10 @@ impl<C> FieldIngredientImpl<C>
 where
     C: Configuration,
 {
-    pub(super) fn new(struct_index: IngredientIndex, field_index: usize) -> Self {
+    pub(super) fn new(field_index: usize, ingredient_index: IngredientIndex) -> Self {
         Self {
-            ingredient_index: struct_index.successor(field_index),
             field_index,
+            ingredient_index,
             phantom: PhantomData,
         }
     }

--- a/tests/compile-fail/input_struct_incompatibles.rs
+++ b/tests/compile-fail/input_struct_incompatibles.rs
@@ -17,8 +17,8 @@ struct InputWithRecover(u32);
 struct InputWithLru(u32);
 
 #[salsa::input]
-struct InputWithIdField {
-    #[id]
+struct InputWithTrackedField {
+    #[tracked]
     field: u32,
 }
 

--- a/tests/compile-fail/input_struct_incompatibles.stderr
+++ b/tests/compile-fail/input_struct_incompatibles.stderr
@@ -34,15 +34,22 @@ error: `lru` option not allowed here
 16 | #[salsa::input(lru =12)]
    |                ^^^
 
-error: `#[id]` cannot be used with `#[salsa::input]`
+error: `#[tracked]` cannot be used with `#[salsa::input]`
   --> tests/compile-fail/input_struct_incompatibles.rs:21:5
    |
-21 | /     #[id]
+21 | /     #[tracked]
 22 | |     field: u32,
    | |______________^
 
-error: cannot find attribute `id` in this scope
+error: cannot find attribute `tracked` in this scope
   --> tests/compile-fail/input_struct_incompatibles.rs:21:7
    |
-21 |     #[id]
-   |       ^^
+21 |     #[tracked]
+   |       ^^^^^^^
+   |
+help: consider importing one of these attribute macros
+   |
+1  + use salsa::tracked;
+   |
+1  + use salsa_macros::tracked;
+   |

--- a/tests/compile-fail/interned_struct_incompatibles.rs
+++ b/tests/compile-fail/interned_struct_incompatibles.rs
@@ -29,8 +29,8 @@ struct InternedWithLru {
 }
 
 #[salsa::interned]
-struct InternedWithIdField {
-    #[id]
+struct InternedWithTrackedField {
+    #[tracked]
     field: u32,
 }
 

--- a/tests/compile-fail/interned_struct_incompatibles.stderr
+++ b/tests/compile-fail/interned_struct_incompatibles.stderr
@@ -34,15 +34,22 @@ error: `lru` option not allowed here
 26 | #[salsa::interned(lru = 12)]
    |                   ^^^
 
-error: `#[id]` cannot be used with `#[salsa::interned]`
+error: `#[tracked]` cannot be used with `#[salsa::interned]`
   --> tests/compile-fail/interned_struct_incompatibles.rs:33:5
    |
-33 | /     #[id]
+33 | /     #[tracked]
 34 | |     field: u32,
    | |______________^
 
-error: cannot find attribute `id` in this scope
+error: cannot find attribute `tracked` in this scope
   --> tests/compile-fail/interned_struct_incompatibles.rs:33:7
    |
-33 |     #[id]
-   |       ^^
+33 |     #[tracked]
+   |       ^^^^^^^
+   |
+help: consider importing one of these attribute macros
+   |
+1  + use salsa::tracked;
+   |
+1  + use salsa_macros::tracked;
+   |

--- a/tests/deletion-drops.rs
+++ b/tests/deletion-drops.rs
@@ -14,9 +14,9 @@ struct MyInput {
 
 #[salsa::tracked]
 struct MyTracked<'db> {
-    #[id]
     identifier: u32,
 
+    #[tracked]
     #[return_ref]
     field: Bomb,
 }

--- a/tests/expect_reuse_field_x_of_a_tracked_struct_changes_but_fn_depends_on_field_y.rs
+++ b/tests/expect_reuse_field_x_of_a_tracked_struct_changes_but_fn_depends_on_field_y.rs
@@ -28,7 +28,9 @@ fn final_result_depends_on_y(db: &dyn LogDatabase, input: MyInput) -> u32 {
 
 #[salsa::tracked]
 struct MyTracked<'db> {
+    #[tracked]
     x: u32,
+    #[tracked]
     y: u32,
 }
 

--- a/tests/expect_reuse_field_x_of_an_input_changes_but_fn_depends_on_field_y.rs
+++ b/tests/expect_reuse_field_x_of_an_input_changes_but_fn_depends_on_field_y.rs
@@ -26,6 +26,7 @@ fn result_depends_on_y(db: &dyn LogDatabase, input: MyInput) -> u32 {
     db.push_log(format!("result_depends_on_y({:?})", input));
     input.y(db) - 1
 }
+
 #[test]
 fn execute() {
     // result_depends_on_x = x + 1

--- a/tests/preverify-struct-with-leaked-data-2.rs
+++ b/tests/preverify-struct-with-leaked-data-2.rs
@@ -21,6 +21,7 @@ struct MyInput {
 
 #[salsa::tracked]
 struct MyTracked<'db> {
+    #[tracked]
     counter: usize,
 }
 

--- a/tests/preverify-struct-with-leaked-data.rs
+++ b/tests/preverify-struct-with-leaked-data.rs
@@ -21,6 +21,7 @@ struct MyInput {
 
 #[salsa::tracked]
 struct MyTracked<'db> {
+    #[tracked]
     counter: usize,
 }
 

--- a/tests/tracked-struct-id-field-bad-eq.rs
+++ b/tests/tracked-struct-id-field-bad-eq.rs
@@ -28,7 +28,6 @@ impl From<bool> for BadEq {
 
 #[salsa::tracked]
 struct MyTracked<'db> {
-    #[id]
     field: BadEq,
 }
 

--- a/tests/tracked-struct-id-field-bad-hash.rs
+++ b/tests/tracked-struct-id-field-bad-hash.rs
@@ -1,9 +1,9 @@
-//! Test for a tracked struct where the id field has a
+//! Test for a tracked struct where an untracked field has a
 //! very poorly chosen hash impl (always returns 0).
-//! This demonstrates that the `#[id]` fields on a struct
+//! This demonstrates that the `untracked fields on a struct
 //! can change values and yet the struct can have the same
 //! id (because struct ids are based on the *hash* of the
-//! `#[id]` fields).
+//! untracked fields).
 
 use salsa::{Database as Db, Setter};
 use test_log::test;
@@ -32,7 +32,6 @@ impl std::hash::Hash for BadHash {
 
 #[salsa::tracked]
 struct MyTracked<'db> {
-    #[id]
     field: BadHash,
 }
 

--- a/tests/tracked-struct-value-field-bad-eq.rs
+++ b/tests/tracked-struct-value-field-bad-eq.rs
@@ -33,6 +33,7 @@ impl From<bool> for BadEq {
 
 #[salsa::tracked]
 struct MyTracked<'db> {
+    #[tracked]
     field: BadEq,
 }
 

--- a/tests/tracked-struct-value-field-not-eq.rs
+++ b/tests/tracked-struct-value-field-not-eq.rs
@@ -23,6 +23,7 @@ impl From<bool> for NotEq {
 
 #[salsa::tracked]
 struct MyTracked<'db> {
+    #[tracked]
     #[no_eq]
     field: NotEq,
 }

--- a/tests/tracked_struct_durability.rs
+++ b/tests/tracked_struct_durability.rs
@@ -32,21 +32,25 @@ struct File {
 
 #[salsa::tracked]
 struct Definition<'db> {
+    #[tracked]
     file: File,
 }
 
 #[salsa::tracked]
 struct Index<'db> {
+    #[tracked]
     definitions: Definitions<'db>,
 }
 
 #[salsa::tracked]
 struct Definitions<'db> {
+    #[tracked]
     definition: Definition<'db>,
 }
 
 #[salsa::tracked]
 struct Inference<'db> {
+    #[tracked]
     definition: Definition<'db>,
 }
 

--- a/tests/tracked_struct_mixed_tracked_fields.rs
+++ b/tests/tracked_struct_mixed_tracked_fields.rs
@@ -1,0 +1,68 @@
+mod common;
+
+use salsa::{Database, Setter};
+
+// A tracked struct with mixed tracked and untracked fields to ensure
+// the correct field indices are used when tracking dependencies.
+#[salsa::tracked]
+struct Tracked<'db> {
+    untracked_1: usize,
+
+    #[tracked]
+    tracked_1: usize,
+
+    untracked_2: usize,
+
+    untracked_3: usize,
+
+    #[tracked]
+    tracked_2: usize,
+
+    untracked_4: usize,
+}
+
+#[salsa::input]
+struct MyInput {
+    field1: usize,
+    field2: usize,
+}
+
+#[salsa::tracked]
+fn intermediate(db: &dyn salsa::Database, input: MyInput) -> Tracked<'_> {
+    Tracked::new(db, 0, input.field1(db), 0, 0, input.field2(db), 0)
+}
+
+#[salsa::tracked]
+fn accumulate(db: &dyn salsa::Database, input: MyInput) -> (usize, usize) {
+    let tracked = intermediate(db, input);
+    let one = read_tracked_1(db, tracked);
+    let two = read_tracked_2(db, tracked);
+
+    (one, two)
+}
+
+#[salsa::tracked]
+fn read_tracked_1<'db>(db: &'db dyn Database, tracked: Tracked<'db>) -> usize {
+    tracked.tracked_1(db)
+}
+
+#[salsa::tracked]
+fn read_tracked_2<'db>(db: &'db dyn Database, tracked: Tracked<'db>) -> usize {
+    tracked.tracked_2(db)
+}
+
+#[test]
+fn execute() {
+    let mut db = salsa::DatabaseImpl::default();
+    let input = MyInput::new(&db, 1, 1);
+
+    assert_eq!(accumulate(&db, input), (1, 1));
+
+    // Should only re-execute `read_tracked_1`.
+    input.set_field1(&mut db).to(2);
+    assert_eq!(accumulate(&db, input), (2, 1));
+
+    // Should only re-execute `read_tracked_2`.
+    input.set_field2(&mut db).to(2);
+    assert_eq!(accumulate(&db, input), (2, 2));
+}

--- a/tests/tracked_with_intern.rs
+++ b/tests/tracked_with_intern.rs
@@ -10,6 +10,7 @@ struct MyInput {
 
 #[salsa::tracked]
 struct MyTracked<'db> {
+    #[tracked]
     field: MyInterned<'db>,
 }
 

--- a/tests/tracked_with_struct_db.rs
+++ b/tests/tracked_with_struct_db.rs
@@ -11,7 +11,9 @@ struct MyInput {
 
 #[salsa::tracked]
 struct MyTracked<'db> {
+    #[tracked]
     data: MyInput,
+    #[tracked]
     next: MyList<'db>,
 }
 


### PR DESCRIPTION
This PR makes tracked structs coarse-grained by default. To declare a field independently tracked, you now use the `#[tracked]` attribute. This is the opposite of the previous behavior, where `#[id]` effectively declared a field untracked. The `#[id]` attribute now has no effect. Importantly, reads of untracked fields do not require a read dependency to be declared.

There is some duplicated code in the macros as we need to generate separate accessors for tracked vs. untracked fields and I would like these to be static (as opposed to branching at runtime).

I believe the guide documentation also needs to be updated.

Resolves https://github.com/salsa-rs/salsa/issues/598.