### PR TITLE
add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,16 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,57 @@
-name: Release
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
 
 on:
   push:
-    tags:
-      - 'v*.*.*'
+    branches:
+      - master
 
 jobs:
-  release:
-    name: Release
+  # Release unpublished packages.
+  release-plz-release:
+    name: Release-plz release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
-      - run: cargo publish
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  # Create a PR with the new versions and changelog, preparing the next release.
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -46,7 +46,14 @@ To learn more about Salsa, try one of the following:
 
 ## Getting in touch
 
-The bulk of the discussion happens in the [issues](https://github.com/salsa-rs/salsa/issues) 
-and [pull requests](https://github.com/salsa-rs/salsa/pulls), 
+The bulk of the discussion happens in the [issues](https://github.com/salsa-rs/salsa/issues)
+and [pull requests](https://github.com/salsa-rs/salsa/pulls),
 but we have a [zulip chat](https://salsa.zulipchat.com/) as well.
 
+## Contributing
+
+To create a release and publish to crates.io, follow the steps:
+
+1. Update the `version` field in Cargo.toml.
+2. Create a Git tag. The tag name must follow the format like "v*.*.*".
+3. Push. GitHub Actions will publish the crate to crates.io automatically.


### PR DESCRIPTION
This PR adds a GitHub Actions workflow for publishing crate to crates.io.

Once merged this PR, remember to :

1. Go to crates.io and generate a token.
2. Open repository settings on GitHub.
3. Select the "Actions" under the "Secrets and variables":
  ![image](https://github.com/user-attachments/assets/c82cc11f-5b9f-41b9-93d4-1b67982ad772)
4. Create a repository secret called `CARGO_REGISTRY_TOKEN` and paste the token into there.

To publish a new version to crates.io, just update the `version` field of Cargo.toml and create a corresponding Git tag.

Hope it helps. I'm looking forward to new versions of Salsa.

Close #489 