### PR TITLE
Out of date comment in overview

### DIFF
--- a/book/src/overview.md
+++ b/book/src/overview.md
@@ -163,8 +163,7 @@ struct Ast<'db> {
 }
 ```
 
-Just as with an input, new values are created by invoking `Ast::new`.
-Unlike with an input, the `new` for a tracked struct only requires a `&`-reference to the database:
+Just as with an input, new values are created by invoking `Ast::new`, and the `new` for a tracked struct only requires a `&`-reference to the database:
 
 ```rust
 #[salsa::tracked]

--- a/book/src/overview.md
+++ b/book/src/overview.md
@@ -163,7 +163,7 @@ struct Ast<'db> {
 }
 ```
 
-Just as with an input, new values are created by invoking `Ast::new`, and the `new` for a tracked struct only requires a `&`-reference to the database:
+Just as with an input, new values are created by invoking `Ast::new`. The `new` function on a tracked struct only requires a `&`-reference to the database:
 
 ```rust
 #[salsa::tracked]


### PR DESCRIPTION
*Like* an input, the new for a tracked struct only requires a &-reference to the database: