### PR TITLE
feature: allow skipping the lifetime on `#[salsa::interned]` structs

### DIFF
--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -15,6 +15,8 @@ macro_rules! setup_interned_struct {
         // is unstable and taking an additional dependency is unnecessary.
         StructData: $StructDataIdent:ident,
 
+        // Name of the struct type with a `'static` argument (unless this type has no db lifetime,
+        // in which case this is the same as `$Struct`)
         StructWithStatic: $StructWithStatic:ty,
 
         // Name of the `'db` lifetime that the user gave

--- a/components/salsa-macros/src/accumulator.rs
+++ b/components/salsa-macros/src/accumulator.rs
@@ -36,6 +36,7 @@ impl AllowedOptions for Accumulator {
     const NO_EQ: bool = false;
     const NO_DEBUG: bool = true;
     const NO_CLONE: bool = true;
+    const NO_LIFETIME: bool = false;
     const SINGLETON: bool = false;
     const DATA: bool = false;
     const DB: bool = false;

--- a/components/salsa-macros/src/accumulator.rs
+++ b/components/salsa-macros/src/accumulator.rs
@@ -43,6 +43,7 @@ impl AllowedOptions for Accumulator {
     const RECOVERY_FN: bool = false;
     const LRU: bool = false;
     const CONSTRUCTOR_NAME: bool = false;
+    const ID: bool = false;
 }
 
 struct StructMacro {

--- a/components/salsa-macros/src/input.rs
+++ b/components/salsa-macros/src/input.rs
@@ -57,6 +57,8 @@ impl crate::options::AllowedOptions for InputStruct {
     const LRU: bool = false;
 
     const CONSTRUCTOR_NAME: bool = true;
+
+    const ID: bool = false;
 }
 
 impl SalsaStructAllowedOptions for InputStruct {

--- a/components/salsa-macros/src/input.rs
+++ b/components/salsa-macros/src/input.rs
@@ -42,6 +42,8 @@ impl crate::options::AllowedOptions for InputStruct {
 
     const NO_DEBUG: bool = true;
 
+    const NO_LIFETIME: bool = false;
+
     const NO_CLONE: bool = false;
 
     const SINGLETON: bool = true;
@@ -63,6 +65,8 @@ impl SalsaStructAllowedOptions for InputStruct {
     const ALLOW_ID: bool = false;
 
     const HAS_LIFETIME: bool = false;
+
+    const ELIDABLE_LIFETIME: bool = false;
 
     const ALLOW_DEFAULT: bool = true;
 }

--- a/components/salsa-macros/src/interned.rs
+++ b/components/salsa-macros/src/interned.rs
@@ -58,6 +58,8 @@ impl crate::options::AllowedOptions for InternedStruct {
     const LRU: bool = false;
 
     const CONSTRUCTOR_NAME: bool = true;
+
+    const ID: bool = true;
 }
 
 impl SalsaStructAllowedOptions for InternedStruct {
@@ -99,6 +101,7 @@ impl Macro {
         let field_indexed_tys = salsa_struct.field_indexed_tys();
         let generate_debug_impl = salsa_struct.generate_debug_impl();
         let has_lifetime = salsa_struct.generate_lifetime();
+        let id = salsa_struct.id();
 
         let (db_lt_arg, cfg, interior_lt) = if has_lifetime {
             (
@@ -133,6 +136,7 @@ impl Macro {
                     StructWithStatic: #cfg,
                     db_lt: #db_lt,
                     db_lt_arg: #db_lt_arg,
+                    id: #id,
                     interior_lt: #interior_lt,
                     new_fn: #new_fn,
                     field_options: [#(#field_options),*],

--- a/components/salsa-macros/src/interned.rs
+++ b/components/salsa-macros/src/interned.rs
@@ -82,6 +82,7 @@ impl Macro {
         let attrs = &self.struct_item.attrs;
         let vis = &self.struct_item.vis;
         let struct_ident = &self.struct_item.ident;
+        let struct_data_ident = format_ident!("{}Data", struct_ident);
         let db_lt = db_lifetime::db_lifetime(&self.struct_item.generics);
         let new_fn = salsa_struct.constructor_name();
         let field_ids = salsa_struct.field_ids();
@@ -107,6 +108,7 @@ impl Macro {
                     attrs: [#(#attrs),*],
                     vis: #vis,
                     Struct: #struct_ident,
+                    StructData: #struct_data_ident,
                     db_lt: #db_lt,
                     new_fn: #new_fn,
                     field_options: [#(#field_options),*],

--- a/components/salsa-macros/src/options.rs
+++ b/components/salsa-macros/src/options.rs
@@ -7,6 +7,7 @@ use syn::{ext::IdentExt, spanned::Spanned};
 /// are required and trailing commas are permitted. The options accepted
 /// for any particular location are configured via the `AllowedOptions`
 /// trait.
+#[derive(Debug)]
 pub(crate) struct Options<A: AllowedOptions> {
     /// The `return_ref` option is used to signal that field/return type is "by ref"
     ///
@@ -71,6 +72,12 @@ pub(crate) struct Options<A: AllowedOptions> {
     /// If this is `Some`, the value is the `<ident>`.
     pub constructor_name: Option<syn::Ident>,
 
+    /// The `id = <path>` option is used to set a custom ID for interrned structs.
+    ///
+    /// The ID must implement `salsa::plumbing::AsId` and `salsa::plumbing::FromId`.
+    /// If this is `Some`, the value is the `<ident>`.
+    pub id: Option<syn::Path>,
+
     /// Remember the `A` parameter, which plays no role after parsing.
     phantom: PhantomData<A>,
 }
@@ -91,6 +98,7 @@ impl<A: AllowedOptions> Default for Options<A> {
             phantom: Default::default(),
             lru: Default::default(),
             singleton: Default::default(),
+            id: Default::default(),
         }
     }
 }
@@ -109,6 +117,7 @@ pub(crate) trait AllowedOptions {
     const RECOVERY_FN: bool;
     const LRU: bool;
     const CONSTRUCTOR_NAME: bool;
+    const ID: bool;
 }
 
 type Equals = syn::Token![=];
@@ -286,6 +295,17 @@ impl<A: AllowedOptions> syn::parse::Parse for Options<A> {
                     return Err(syn::Error::new(
                         ident.span(),
                         "`constructor` option not allowed here",
+                    ));
+                }
+            } else if ident == "id" {
+                if A::ID {
+                    let _eq = Equals::parse(input)?;
+                    let path = syn::Path::parse(input)?;
+                    options.id = Some(path);
+                } else {
+                    return Err(syn::Error::new(
+                        ident.span(),
+                        "`id` option not allowed here",
                     ));
                 }
             } else {

--- a/components/salsa-macros/src/options.rs
+++ b/components/salsa-macros/src/options.rs
@@ -24,6 +24,11 @@ pub(crate) struct Options<A: AllowedOptions> {
     /// If this is `Some`, the value is the `no_debug` identifier.
     pub no_debug: Option<syn::Ident>,
 
+    /// Signal we should not include the `'db` lifetime.
+    ///
+    /// If this is `Some`, the value is the `no_lifetime` identifier.
+    pub no_lifetime: Option<syn::Ident>,
+
     /// Signal we should not generate a `Clone` impl.
     ///
     /// If this is `Some`, the value is the `no_clone` identifier.
@@ -77,6 +82,7 @@ impl<A: AllowedOptions> Default for Options<A> {
             specify: Default::default(),
             no_eq: Default::default(),
             no_debug: Default::default(),
+            no_lifetime: Default::default(),
             no_clone: Default::default(),
             db_path: Default::default(),
             recovery_fn: Default::default(),
@@ -95,6 +101,7 @@ pub(crate) trait AllowedOptions {
     const SPECIFY: bool;
     const NO_EQ: bool;
     const NO_DEBUG: bool;
+    const NO_LIFETIME: bool;
     const NO_CLONE: bool;
     const SINGLETON: bool;
     const DATA: bool;
@@ -150,6 +157,20 @@ impl<A: AllowedOptions> syn::parse::Parse for Options<A> {
                     return Err(syn::Error::new(
                         ident.span(),
                         "`no_debug` option not allowed here",
+                    ));
+                }
+            } else if ident == "no_lifetime" {
+                if A::NO_LIFETIME {
+                    if let Some(old) = std::mem::replace(&mut options.no_lifetime, Some(ident)) {
+                        return Err(syn::Error::new(
+                            old.span(),
+                            "option `no_lifetime` provided twice",
+                        ));
+                    }
+                } else {
+                    return Err(syn::Error::new(
+                        ident.span(),
+                        "`no_lifetime` option not allowed here",
                     ));
                 }
             } else if ident == "no_clone" {

--- a/components/salsa-macros/src/salsa_struct.rs
+++ b/components/salsa-macros/src/salsa_struct.rs
@@ -121,6 +121,14 @@ where
         }
     }
 
+    /// Returns the `id` in `Options` if it is `Some`, else `salsa::Id`.
+    pub(crate) fn id(&self) -> syn::Path {
+        match &self.args.id {
+            Some(id) => id.clone(),
+            None => parse_quote!(salsa::Id),
+        }
+    }
+
     /// Disallow `#[id]` attributes on the fields of this struct.
     ///
     /// If an `#[id]` field is found, return an error.

--- a/components/salsa-macros/src/tracked_fn.rs
+++ b/components/salsa-macros/src/tracked_fn.rs
@@ -46,6 +46,8 @@ impl crate::options::AllowedOptions for TrackedFn {
     const LRU: bool = true;
 
     const CONSTRUCTOR_NAME: bool = false;
+
+    const ID: bool = false;
 }
 
 struct Macro {

--- a/components/salsa-macros/src/tracked_fn.rs
+++ b/components/salsa-macros/src/tracked_fn.rs
@@ -31,6 +31,8 @@ impl crate::options::AllowedOptions for TrackedFn {
 
     const NO_DEBUG: bool = false;
 
+    const NO_LIFETIME: bool = false;
+
     const NO_CLONE: bool = false;
 
     const SINGLETON: bool = false;
@@ -160,6 +162,7 @@ impl Macro {
 
         Ok(ValidFn { db_ident, db_path })
     }
+
     fn cycle_recovery(&self) -> (TokenStream, TokenStream) {
         if let Some(recovery_fn) = &self.args.recovery_fn {
             (quote!((#recovery_fn)), quote!(Fallback))

--- a/components/salsa-macros/src/tracked_struct.rs
+++ b/components/salsa-macros/src/tracked_struct.rs
@@ -37,6 +37,8 @@ impl crate::options::AllowedOptions for TrackedStruct {
 
     const NO_DEBUG: bool = true;
 
+    const NO_LIFETIME: bool = false;
+
     const NO_CLONE: bool = false;
 
     const SINGLETON: bool = true;
@@ -58,6 +60,8 @@ impl SalsaStructAllowedOptions for TrackedStruct {
     const ALLOW_ID: bool = true;
 
     const HAS_LIFETIME: bool = true;
+
+    const ELIDABLE_LIFETIME: bool = false;
 
     const ALLOW_DEFAULT: bool = false;
 }

--- a/components/salsa-macros/src/tracked_struct.rs
+++ b/components/salsa-macros/src/tracked_struct.rs
@@ -52,6 +52,8 @@ impl crate::options::AllowedOptions for TrackedStruct {
     const LRU: bool = false;
 
     const CONSTRUCTOR_NAME: bool = true;
+
+    const ID: bool = false;
 }
 
 impl SalsaStructAllowedOptions for TrackedStruct {

--- a/src/id.rs
+++ b/src/id.rs
@@ -29,8 +29,9 @@ impl Id {
     /// In general, you should not need to create salsa ids yourself,
     /// but it can be useful if you are using the type as a general
     /// purpose "identifier" internally.
+    #[doc(hidden)]
     #[track_caller]
-    pub(crate) const fn from_u32(x: u32) -> Self {
+    pub const fn from_u32(x: u32) -> Self {
         Id {
             value: match NonZeroU32::new(x + 1) {
                 Some(v) => v,

--- a/tests/interned-structs.rs
+++ b/tests/interned-structs.rs
@@ -36,6 +36,11 @@ struct InternedPathBuf<'db> {
     data1: PathBuf,
 }
 
+#[salsa::interned(no_lifetime)]
+struct InternedStringNoLifetime {
+    data: String,
+}
+
 #[salsa::tracked]
 fn intern_stuff(db: &dyn salsa::Database) -> String {
     let s1 = InternedString::new(db, "Hello, ".to_string());
@@ -129,4 +134,16 @@ fn interning_path_buf() {
     assert_eq!(s1, s2);
     assert_eq!(s1, s3);
     assert_ne!(s1, s4);
+}
+
+#[test]
+fn interning_without_lifetimes() {
+    let db = salsa::DatabaseImpl::new();
+
+    let s1 = InternedStringNoLifetime::new(&db, "Hello, ".to_string());
+    let s2 = InternedStringNoLifetime::new(&db, "World, ".to_string());
+    let s1_2 = InternedStringNoLifetime::new(&db, "Hello, ");
+    let s2_2 = InternedStringNoLifetime::new(&db, "World, ");
+    assert_eq!(s1, s1_2);
+    assert_eq!(s2, s2_2);
 }

--- a/tests/interned-structs.rs
+++ b/tests/interned-structs.rs
@@ -89,6 +89,18 @@ fn interning_boxed() {
 }
 
 #[test]
+fn interned_structs_have_public_ingredients() {
+    use salsa::plumbing::AsId;
+
+    let db = salsa::DatabaseImpl::new();
+    let s = InternedString::new(&db, String::from("Hello, world!"));
+    let underlying_id = s.0;
+
+    let data = InternedString::ingredient(&db).data(&db, underlying_id.as_id());
+    assert_eq!(data, &(String::from("Hello, world!"),));
+}
+
+#[test]
 fn interning_vec() {
     let db = salsa::DatabaseImpl::new();
     let s1 = InternedVec::new(&db, ["Hello, ".to_string(), "World".to_string()].as_slice());


### PR DESCRIPTION
This PR adds support for three features:

1. Writing `#[salsa::interned(no_lifetime)]` allows skipping the `'db` lifetime.
2. `#[salsa::interned]` structs now have public ingredients, which allows accessing the underlying, interned data through the `salsa::Id` alone.
3. Adds support for custom Salsa IDs. While rust-analyzer doesn't need this, their presence makes migration easier. I'd like to jettison this feature before the 1.0 release.
 
In my view, the use of the above features should be discouraged, but they are necessary for rust-analyzer to migrate to the new version of Salsa.
 
This PR supersedes https://github.com/salsa-rs/salsa/pull/632. 