### PR TITLE
No-op LRU impl for non-lru tracked functions

### DIFF
--- a/components/salsa-macros/src/tracked_fn.rs
+++ b/components/salsa-macros/src/tracked_fn.rs
@@ -109,7 +109,11 @@ impl Macro {
             FunctionType::SalsaStruct => false,
         };
 
-        let lru = Literal::usize_unsuffixed(self.args.lru.unwrap_or(0));
+        let (has_lru, lru_capacity) = match self.args.lru {
+            Some(cap) => (true, cap),
+            None => (false, 0),
+        };
+        let lru_capacity = Literal::usize_unsuffixed(lru_capacity);
 
         let return_ref: bool = self.args.return_ref.is_some();
 
@@ -131,7 +135,8 @@ impl Macro {
                 is_specifiable: #is_specifiable,
                 no_eq: #no_eq,
                 needs_interner: #needs_interner,
-                lru: #lru,
+                lru_capacity: #lru_capacity,
+                has_lru: #has_lru,
                 return_ref: #return_ref,
                 unused_names: [
                     #zalsa,

--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -13,6 +13,7 @@ use crate::{
     cycle::CycleRecoveryStrategy,
     ingredient::{fmt_index, Ingredient, Jar, MaybeChangedAfter},
     plumbing::JarAux,
+    table::memo::MemoTable,
     zalsa::IngredientIndex,
     zalsa_local::QueryOrigin,
     Database, DatabaseKeyIndex, Id, Revision,
@@ -137,7 +138,7 @@ impl<A: Accumulator> Ingredient for IngredientImpl<A> {
         false
     }
 
-    fn reset_for_new_revision(&mut self) {
+    fn reset_for_new_revision<'a>(&mut self, _: &'a dyn Fn(crate::Id) -> &'a MemoTable) {
         panic!("unexpected reset on accumulator")
     }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -160,8 +160,8 @@ where
     /// only cleared with `&mut self`.
     unsafe fn extend_memo_lifetime<'this>(
         &'this self,
-        memo: &memo::Memo<C::Output<'this>>,
-    ) -> &'this memo::Memo<C::Output<'this>> {
+        memo: &memo::Memo<C::Lru, C::Output<'this>>,
+    ) -> &'this memo::Memo<C::Lru, C::Output<'this>> {
         std::mem::transmute(memo)
     }
 
@@ -169,8 +169,8 @@ where
         &'db self,
         zalsa: &'db Zalsa,
         id: Id,
-        memo: memo::Memo<C::Output<'db>>,
-    ) -> &'db memo::Memo<C::Output<'db>> {
+        memo: memo::Memo<C::Lru, C::Output<'db>>,
+    ) -> &'db memo::Memo<C::Lru, C::Output<'db>> {
         let memo = Arc::new(memo);
         let db_memo = unsafe {
             // Unsafety conditions: memo must be in the map (it's not yet, but it will be by the time this
@@ -189,6 +189,7 @@ where
 impl<C> Ingredient for IngredientImpl<C>
 where
     C: Configuration,
+    for<'lt> <C::Lru as LruChoice>::LruCtor<<C as Configuration>::Output<'lt>>: Send + Sync,
 {
     fn ingredient_index(&self) -> IngredientIndex {
         self.index

--- a/src/function.rs
+++ b/src/function.rs
@@ -160,8 +160,8 @@ where
     /// only cleared with `&mut self`.
     unsafe fn extend_memo_lifetime<'this>(
         &'this self,
-        memo: &memo::Memo<C::Lru, C::Output<'this>>,
-    ) -> &'this memo::Memo<C::Lru, C::Output<'this>> {
+        memo: &memo::MemoConfigured<'this, C>,
+    ) -> &'this memo::MemoConfigured<'this, C> {
         std::mem::transmute(memo)
     }
 
@@ -169,8 +169,8 @@ where
         &'db self,
         zalsa: &'db Zalsa,
         id: Id,
-        memo: memo::Memo<C::Lru, C::Output<'db>>,
-    ) -> &'db memo::Memo<C::Lru, C::Output<'db>> {
+        memo: memo::MemoConfigured<'db, C>,
+    ) -> &'db memo::MemoConfigured<'db, C> {
         let memo = Arc::new(memo);
         let db_memo = unsafe {
             // Unsafety conditions: memo must be in the map (it's not yet, but it will be by the time this

--- a/src/function/backdate.rs
+++ b/src/function/backdate.rs
@@ -1,6 +1,6 @@
-use crate::zalsa_local::QueryRevisions;
+use crate::{function::memo::MemoConfigured, zalsa_local::QueryRevisions};
 
-use super::{memo::Memo, Configuration, IngredientImpl, LruChoice};
+use super::{Configuration, IngredientImpl, LruChoice};
 
 impl<C> IngredientImpl<C>
 where
@@ -11,7 +11,7 @@ where
     /// on an old memo when a new memo has been produced to check whether there have been changed.
     pub(super) fn backdate_if_appropriate(
         &self,
-        old_memo: &Memo<C::Lru, C::Output<'_>>,
+        old_memo: &MemoConfigured<'_, C>,
         revisions: &mut QueryRevisions,
         value: &C::Output<'_>,
     ) {

--- a/src/function/diff_outputs.rs
+++ b/src/function/diff_outputs.rs
@@ -17,7 +17,7 @@ where
         &self,
         db: &C::DbView,
         key: DatabaseKeyIndex,
-        old_memo: &Memo<C::Output<'_>>,
+        old_memo: &Memo<C::Lru, C::Output<'_>>,
         revisions: &mut QueryRevisions,
     ) {
         // Iterate over the outputs of the `old_memo` and put them into a hashset

--- a/src/function/diff_outputs.rs
+++ b/src/function/diff_outputs.rs
@@ -1,7 +1,7 @@
-use super::{memo::Memo, Configuration, IngredientImpl};
+use super::{Configuration, IngredientImpl};
 use crate::{
-    hash::FxHashSet, key::OutputDependencyIndex, zalsa_local::QueryRevisions, AsDynDatabase as _,
-    DatabaseKeyIndex, Event, EventKind,
+    function::memo::MemoConfigured, hash::FxHashSet, key::OutputDependencyIndex,
+    zalsa_local::QueryRevisions, AsDynDatabase as _, DatabaseKeyIndex, Event, EventKind,
 };
 
 impl<C> IngredientImpl<C>
@@ -17,7 +17,7 @@ where
         &self,
         db: &C::DbView,
         key: DatabaseKeyIndex,
-        old_memo: &Memo<C::Lru, C::Output<'_>>,
+        old_memo: &MemoConfigured<'_, C>,
         revisions: &mut QueryRevisions,
     ) {
         // Iterate over the outputs of the `old_memo` and put them into a hashset

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
 use crate::{
-    zalsa::ZalsaDatabase, zalsa_local::ActiveQueryGuard, Cycle, Database, Event, EventKind,
+    function::memo::MemoConfigured, zalsa::ZalsaDatabase, zalsa_local::ActiveQueryGuard, Cycle,
+    Database, Event, EventKind,
 };
 
 use super::{memo::Memo, Configuration, IngredientImpl, LruChoice};
@@ -23,8 +24,8 @@ where
         &'db self,
         db: &'db C::DbView,
         active_query: ActiveQueryGuard<'_>,
-        opt_old_memo: Option<Arc<Memo<C::Lru, C::Output<'_>>>>,
-    ) -> &'db Memo<C::Lru, C::Output<'db>> {
+        opt_old_memo: Option<Arc<MemoConfigured<'_, C>>>,
+    ) -> &'db MemoConfigured<'db, C> {
         let zalsa = db.zalsa();
         let revision_now = zalsa.current_revision();
         let database_key_index = active_query.database_key_index;

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -1,7 +1,7 @@
 use super::{memo::Memo, Configuration, IngredientImpl};
 use crate::{
-    accumulator::accumulated_map::InputAccumulatedValues, runtime::StampedValue,
-    zalsa::ZalsaDatabase, AsDynDatabase as _, Id,
+    accumulator::accumulated_map::InputAccumulatedValues, function::lru::LruChoice as _,
+    runtime::StampedValue, zalsa::ZalsaDatabase, AsDynDatabase as _, Id,
 };
 
 impl<C> IngredientImpl<C>
@@ -9,7 +9,7 @@ where
     C: Configuration,
 {
     pub fn fetch<'db>(&'db self, db: &'db C::DbView, id: Id) -> &'db C::Output<'db> {
-        let (zalsa, zalsa_local) = db.zalsas();
+        let zalsa_local = db.zalsa_local();
         zalsa_local.unwind_if_revision_cancelled(db.as_dyn_database());
 
         let memo = self.refresh_memo(db, id);
@@ -19,9 +19,7 @@ where
             changed_at,
         } = memo.revisions.stamped_value(memo.value.as_ref().unwrap());
 
-        if let Some(evicted) = self.lru.record_use(id) {
-            self.evict_value_from_memo_for(zalsa, evicted);
-        }
+        self.lru.record_use(id);
 
         zalsa_local.report_tracked_read(
             self.database_key_index(id).into(),

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -1,7 +1,8 @@
-use super::{memo::Memo, Configuration, IngredientImpl};
+use super::{Configuration, IngredientImpl};
 use crate::{
     accumulator::accumulated_map::InputAccumulatedValues, function::lru::LruChoice as _,
-    runtime::StampedValue, zalsa::ZalsaDatabase, AsDynDatabase as _, Id,
+    function::memo::MemoConfigured, runtime::StampedValue, zalsa::ZalsaDatabase,
+    AsDynDatabase as _, Id,
 };
 
 impl<C> IngredientImpl<C>
@@ -41,7 +42,7 @@ where
         &'db self,
         db: &'db C::DbView,
         id: Id,
-    ) -> &'db Memo<C::Lru, C::Output<'db>> {
+    ) -> &'db MemoConfigured<'db, C> {
         loop {
             if let Some(memo) = self.fetch_hot(db, id).or_else(|| self.fetch_cold(db, id)) {
                 return memo;
@@ -54,7 +55,7 @@ where
         &'db self,
         db: &'db C::DbView,
         id: Id,
-    ) -> Option<&'db Memo<C::Lru, C::Output<'db>>> {
+    ) -> Option<&'db MemoConfigured<'db, C>> {
         let zalsa = db.zalsa();
         let memo_guard = self.get_memo_from_table_for(zalsa, id);
         if let Some(memo) = &memo_guard {
@@ -73,7 +74,7 @@ where
         &'db self,
         db: &'db C::DbView,
         id: Id,
-    ) -> Option<&'db Memo<C::Lru, C::Output<'db>>> {
+    ) -> Option<&'db MemoConfigured<'db, C>> {
         let (zalsa, zalsa_local) = db.zalsas();
         let database_key_index = self.database_key_index(id);
 

--- a/src/function/lru.rs
+++ b/src/function/lru.rs
@@ -3,36 +3,61 @@ use crate::{hash::FxLinkedHashSet, Id};
 use crossbeam::atomic::AtomicCell;
 use parking_lot::Mutex;
 
+mod sealed {
+    pub trait Sealed {}
+}
+
+pub trait LruChoice: sealed::Sealed + Default {
+    /// Records the `index` into this LRU, returning the index to evict if any.
+    fn record_use(&self, index: Id);
+    /// Fetches all elements that should be evicted.
+    fn to_be_evicted(&self, cb: impl FnMut(Id));
+    /// Sets the capacity of the LRU.
+    fn set_capacity(&self, capacity: usize);
+}
+
+/// An LRU choice that does not evict anything.
 #[derive(Default)]
-pub(super) struct Lru {
+pub struct NoLru;
+
+impl sealed::Sealed for NoLru {}
+impl LruChoice for NoLru {
+    fn record_use(&self, _: Id) {}
+    fn to_be_evicted(&self, _: impl FnMut(Id)) {}
+    fn set_capacity(&self, _: usize) {}
+}
+
+/// An LRU choice that tracks elements but does not evict on its own.
+///
+/// The user must manually trigger eviction.
+#[derive(Default)]
+pub struct Lru {
     capacity: AtomicCell<usize>,
     set: Mutex<FxLinkedHashSet<Id>>,
 }
 
-impl Lru {
-    pub(super) fn record_use(&self, index: Id) -> Option<Id> {
-        let capacity = self.capacity.load();
-
-        if capacity == 0 {
-            // LRU is disabled
-            return None;
-        }
-
-        let mut set = self.set.lock();
-        set.insert(index);
-        if set.len() > capacity {
-            return set.pop_front();
-        }
-
-        None
+impl sealed::Sealed for Lru {}
+impl LruChoice for Lru {
+    fn record_use(&self, index: Id) {
+        self.set.lock().insert(index);
     }
-
-    pub(super) fn set_capacity(&self, capacity: usize) {
+    fn to_be_evicted(&self, mut cb: impl FnMut(Id)) {
+        let mut set = self.set.lock();
+        let cap = self.capacity.load();
+        if set.len() <= cap || cap == 0 {
+            return;
+        }
+        while let Some(id) = set.pop_front() {
+            cb(id);
+            if set.len() <= cap {
+                break;
+            }
+        }
+    }
+    fn set_capacity(&self, capacity: usize) {
         self.capacity.store(capacity);
-
         if capacity == 0 {
-            let mut set = self.set.lock();
-            *set = FxLinkedHashSet::default();
+            *self.set.lock() = FxLinkedHashSet::default();
         }
     }
 }

--- a/src/function/lru.rs
+++ b/src/function/lru.rs
@@ -8,12 +8,36 @@ mod sealed {
 }
 
 pub trait LruChoice: sealed::Sealed + Default {
+    type LruCtor<T>: Send + Sync
+    where
+        T: Send + Sync;
     /// Records the `index` into this LRU, returning the index to evict if any.
     fn record_use(&self, index: Id);
     /// Fetches all elements that should be evicted.
     fn to_be_evicted(&self, cb: impl FnMut(Id));
     /// Sets the capacity of the LRU.
     fn set_capacity(&self, capacity: usize);
+    fn if_enabled(f: impl FnOnce());
+
+    fn evicted<T>() -> Self::LruCtor<T>
+    where
+        T: Send + Sync;
+
+    fn is_evicted<T>(it: &Self::LruCtor<T>) -> bool
+    where
+        T: Send + Sync;
+
+    fn assert_ref<T>(v: &Self::LruCtor<T>) -> &T
+    where
+        T: Send + Sync;
+
+    fn make_value<T>(v: T) -> Self::LruCtor<T>
+    where
+        T: Send + Sync;
+
+    fn with_value<T>(v: &Self::LruCtor<T>, cb: impl FnOnce(&T))
+    where
+        T: Send + Sync;
 }
 
 /// An LRU choice that does not evict anything.
@@ -22,9 +46,45 @@ pub struct NoLru;
 
 impl sealed::Sealed for NoLru {}
 impl LruChoice for NoLru {
+    type LruCtor<T>
+        = T
+    where
+        T: Send + Sync;
     fn record_use(&self, _: Id) {}
     fn to_be_evicted(&self, _: impl FnMut(Id)) {}
     fn set_capacity(&self, _: usize) {}
+    fn if_enabled(_: impl FnOnce()) {}
+
+    fn evicted<T>() -> Self::LruCtor<T>
+    where
+        T: Send + Sync,
+    {
+        unreachable!("NoLru::evicted should never be called")
+    }
+    fn is_evicted<T>(_: &Self::LruCtor<T>) -> bool
+    where
+        T: Send + Sync,
+    {
+        false
+    }
+    fn assert_ref<T>(v: &Self::LruCtor<T>) -> &T
+    where
+        T: Send + Sync,
+    {
+        v
+    }
+    fn make_value<T>(v: T) -> Self::LruCtor<T>
+    where
+        T: Send + Sync,
+    {
+        v
+    }
+    fn with_value<T>(v: &Self::LruCtor<T>, cb: impl FnOnce(&T))
+    where
+        T: Send + Sync,
+    {
+        cb(v);
+    }
 }
 
 /// An LRU choice that tracks elements but does not evict on its own.
@@ -38,6 +98,10 @@ pub struct Lru {
 
 impl sealed::Sealed for Lru {}
 impl LruChoice for Lru {
+    type LruCtor<T>
+        = Option<T>
+    where
+        T: Send + Sync;
     fn record_use(&self, index: Id) {
         self.set.lock().insert(index);
     }
@@ -58,6 +122,42 @@ impl LruChoice for Lru {
         self.capacity.store(capacity);
         if capacity == 0 {
             *self.set.lock() = FxLinkedHashSet::default();
+        }
+    }
+    fn if_enabled(f: impl FnOnce()) {
+        f();
+    }
+
+    fn evicted<T>() -> Self::LruCtor<T>
+    where
+        T: Send + Sync,
+    {
+        None
+    }
+    fn is_evicted<T>(it: &Self::LruCtor<T>) -> bool
+    where
+        T: Send + Sync,
+    {
+        it.is_none()
+    }
+    fn assert_ref<T>(v: &Self::LruCtor<T>) -> &T
+    where
+        T: Send + Sync,
+    {
+        v.as_ref().unwrap()
+    }
+    fn make_value<T>(v: T) -> Self::LruCtor<T>
+    where
+        T: Send + Sync,
+    {
+        Some(v)
+    }
+    fn with_value<T>(v: &Self::LruCtor<T>, cb: impl FnOnce(&T))
+    where
+        T: Send + Sync,
+    {
+        if let Some(v) = v {
+            cb(v);
         }
     }
 }

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -1,5 +1,6 @@
 use crate::{
     accumulator::accumulated_map::InputAccumulatedValues,
+    function::memo::MemoConfigured,
     ingredient::MaybeChangedAfter,
     key::DatabaseKeyIndex,
     zalsa::{Zalsa, ZalsaDatabase},
@@ -7,7 +8,7 @@ use crate::{
     AsDynDatabase as _, Id, Revision,
 };
 
-use super::{memo::Memo, Configuration, IngredientImpl, LruChoice};
+use super::{Configuration, IngredientImpl, LruChoice};
 
 impl<C> IngredientImpl<C>
 where
@@ -117,7 +118,7 @@ where
         db: &C::DbView,
         zalsa: &Zalsa,
         database_key_index: DatabaseKeyIndex,
-        memo: &Memo<C::Lru, C::Output<'_>>,
+        memo: &MemoConfigured<'_, C>,
     ) -> bool {
         let verified_at = memo.verified_at.load();
         let revision_now = zalsa.current_revision();
@@ -159,7 +160,7 @@ where
     pub(super) fn deep_verify_memo(
         &self,
         db: &C::DbView,
-        old_memo: &Memo<C::Lru, C::Output<'_>>,
+        old_memo: &MemoConfigured<'_, C>,
         active_query: &ActiveQueryGuard<'_>,
     ) -> bool {
         let zalsa = db.zalsa();

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -67,8 +67,8 @@ impl<C: Configuration> IngredientImpl<C> {
     /// or has values assigned as output of another query, this has no effect.
     pub(super) fn evict_value_from_memo_for(&self, table: &MemoTable) {
         C::Lru::if_enabled(|| {
-            table.map_memo::<Memo<C::Lru, C::Output<'_>>>(self.memo_ingredient_index, |memo| {
-                match memo.revisions.origin {
+            table.map_memo::<MemoConfigured<'_, C>>(self.memo_ingredient_index, |memo| {
+                match &memo.revisions.origin {
                     QueryOrigin::Assigned(_)
                     | QueryOrigin::DerivedUntracked(_)
                     | QueryOrigin::BaseInput => {
@@ -107,6 +107,10 @@ impl<C: Configuration> IngredientImpl<C> {
         })
     }
 }
+
+#[allow(type_alias_bounds)]
+pub(super) type MemoConfigured<'db, C: Configuration<Lru: LruChoice>> =
+    Memo<C::Lru, C::Output<'db>>;
 
 pub(super) struct Memo<L: LruChoice, V: Send + Sync> {
     /// The result of the query, if we decide to memoize it.

--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -2,6 +2,7 @@ use crossbeam::atomic::AtomicCell;
 
 use crate::{
     accumulator::accumulated_map::InputAccumulatedValues,
+    function::LruChoice,
     tracked_struct::TrackedStructInDb,
     zalsa::ZalsaDatabase,
     zalsa_local::{QueryOrigin, QueryRevisions},
@@ -80,7 +81,7 @@ where
         }
 
         let memo = Memo {
-            value: Some(value),
+            value: C::Lru::make_value(value),
             verified_at: AtomicCell::new(revision),
             revisions,
         };

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -6,6 +6,7 @@ use std::{
 use crate::{
     accumulator::accumulated_map::{AccumulatedMap, InputAccumulatedValues},
     cycle::CycleRecoveryStrategy,
+    table::memo::MemoTable,
     zalsa::{IngredientIndex, MemoIngredientIndex},
     zalsa_local::QueryOrigin,
     Database, DatabaseKeyIndex, Id,
@@ -122,7 +123,10 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
     ///
     /// **Important:** to actually receive resets, the ingredient must set
     /// [`IngredientRequiresReset::RESET_ON_NEW_REVISION`] to true.
-    fn reset_for_new_revision(&mut self);
+    fn reset_for_new_revision<'a>(
+        &mut self,
+        memo_table_for: &'a dyn Fn(crate::Id) -> &'a MemoTable,
+    );
 
     fn fmt_index(&self, index: Option<crate::Id>, fmt: &mut fmt::Formatter<'_>) -> fmt::Result;
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -246,7 +246,7 @@ impl<C: Configuration> Ingredient for IngredientImpl<C> {
         false
     }
 
-    fn reset_for_new_revision(&mut self) {
+    fn reset_for_new_revision<'a>(&mut self, _: &'a dyn Fn(crate::Id) -> &'a MemoTable) {
         panic!("unexpected call to `reset_for_new_revision`")
     }
 

--- a/src/input/input_field.rs
+++ b/src/input/input_field.rs
@@ -1,6 +1,7 @@
 use crate::cycle::CycleRecoveryStrategy;
 use crate::ingredient::{fmt_index, Ingredient, MaybeChangedAfter};
 use crate::input::Configuration;
+use crate::table::memo::MemoTable;
 use crate::zalsa::IngredientIndex;
 use crate::zalsa_local::QueryOrigin;
 use crate::{Database, DatabaseKeyIndex, Id, Revision};
@@ -85,7 +86,7 @@ where
         false
     }
 
-    fn reset_for_new_revision(&mut self) {
+    fn reset_for_new_revision<'a>(&mut self, _: &'a dyn Fn(crate::Id) -> &'a MemoTable) {
         panic!("unexpected call: input fields don't register for resets");
     }
 

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -299,7 +299,7 @@ where
         false
     }
 
-    fn reset_for_new_revision(&mut self) {
+    fn reset_for_new_revision<'a>(&mut self, _: &'a dyn Fn(crate::Id) -> &'a MemoTable) {
         // Interned ingredients do not, normally, get deleted except when they are "reset" en masse.
         // There ARE methods (e.g., `clear_deleted_entries` and `remove`) for deleting individual
         // items, but those are only used for tracked struct ingredients.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ pub mod plumbing {
     pub use crate::cycle::CycleRecoveryStrategy;
     pub use crate::database::current_revision;
     pub use crate::database::Database;
+    pub use crate::function::lru;
     pub use crate::function::should_backdate_value;
     pub use crate::id::AsId;
     pub use crate::id::FromId;

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -13,7 +13,7 @@ use crate::{zalsa::MemoIngredientIndex, zalsa_local::QueryOrigin};
 /// Every tracked function must take a salsa struct as its first argument
 /// and memo tables are attached to those salsa structs as auxiliary data.
 #[derive(Default)]
-pub(crate) struct MemoTable {
+pub struct MemoTable {
     memos: RwLock<Vec<MemoEntry>>,
 }
 

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -1,6 +1,5 @@
 use std::{
     any::{Any, TypeId},
-    fmt::Debug,
     sync::Arc,
 };
 
@@ -17,7 +16,7 @@ pub struct MemoTable {
     memos: RwLock<Vec<MemoEntry>>,
 }
 
-pub(crate) trait Memo: Any + Send + Sync + Debug {
+pub(crate) trait Memo: Any + Send + Sync {
     /// Returns the `origin` of this memo
     fn origin(&self) -> &QueryOrigin;
 }

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -713,7 +713,7 @@ where
         false
     }
 
-    fn reset_for_new_revision(&mut self) {}
+    fn reset_for_new_revision<'a>(&mut self, _: &'a dyn Fn(crate::Id) -> &'a MemoTable) {}
 }
 
 impl<C> std::fmt::Debug for IngredientImpl<C>

--- a/src/tracked_struct/tracked_field.rs
+++ b/src/tracked_struct/tracked_field.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 
 use crate::{
     ingredient::{Ingredient, MaybeChangedAfter},
+    table::memo::MemoTable,
     zalsa::IngredientIndex,
     Database, Id,
 };
@@ -94,7 +95,7 @@ where
         false
     }
 
-    fn reset_for_new_revision(&mut self) {
+    fn reset_for_new_revision<'a>(&mut self, _: &'a dyn Fn(crate::Id) -> &'a MemoTable) {
         panic!("tracked field ingredients do not require reset")
     }
 

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -177,13 +177,13 @@ impl Zalsa {
 
     /// Returns the [`MemoTable`][] for the salsa struct with the given id
     pub(crate) fn memo_table_for(&self, id: Id) -> &MemoTable {
-        // SAFETY: We are supply the correct current revision
+        // SAFETY: We are supplying the correct current revision
         unsafe { self.table().memos(id, self.current_revision()) }
     }
 
     /// Returns the [`SyncTable`][] for the salsa struct with the given id
     pub(crate) fn sync_table_for(&self, id: Id) -> &SyncTable {
-        // SAFETY: We are supply the correct current revision
+        // SAFETY: We are supplying the correct current revision
         unsafe { self.table().syncs(id, self.current_revision()) }
     }
 
@@ -271,8 +271,12 @@ impl Zalsa {
     pub(crate) fn new_revision(&mut self) -> Revision {
         let new_revision = self.runtime.new_revision();
 
+        let table = self.runtime.table();
         for index in self.ingredients_requiring_reset.iter() {
-            self.ingredients_vec[index.as_usize()].reset_for_new_revision();
+            self.ingredients_vec[index.as_usize()].reset_for_new_revision(&|id| unsafe {
+                // SAFETY: We are supplying the correct current revision
+                table.memos(id, new_revision)
+            });
         }
 
         new_revision

--- a/tests/lru.rs
+++ b/tests/lru.rs
@@ -48,76 +48,48 @@ fn get_hot_potato2(db: &dyn LogDatabase, input: MyInput) -> u32 {
     get_hot_potato(db, input).0
 }
 
-#[salsa::tracked(lru = 32)]
-fn get_volatile(db: &dyn LogDatabase, _input: MyInput) -> usize {
-    static COUNTER: AtomicUsize = AtomicUsize::new(0);
-    db.report_untracked_read();
-    COUNTER.fetch_add(1, Ordering::SeqCst)
-}
-
 fn load_n_potatoes() -> usize {
     N_POTATOES.with(|n| n.load(Ordering::SeqCst))
 }
 
 #[test]
 fn lru_works() {
-    let db = common::LoggerDatabase::default();
+    let mut db = common::LoggerDatabase::default();
     assert_eq!(load_n_potatoes(), 0);
 
     for i in 0..128u32 {
         let input = MyInput::new(&db, i);
         let p = get_hot_potato(&db, input);
-        assert_eq!(p.0, i)
+        assert_eq!(p.0, i);
     }
 
-    // Create a new input to change the revision, and trigger the GC
-    MyInput::new(&db, 0);
+    db.synthetic_write(salsa::Durability::HIGH);
     assert_eq!(load_n_potatoes(), 32);
 }
 
 #[test]
-fn lru_doesnt_break_volatile_queries() {
-    let db = common::LoggerDatabase::default();
-
-    // Create all inputs first, so that there are no revision changes among calls to `get_volatile`
-    let inputs: Vec<MyInput> = (0..128usize).map(|i| MyInput::new(&db, i as u32)).collect();
-
-    // Here, we check that we execute each volatile query at most once, despite
-    // LRU. That does mean that we have more values in DB than the LRU capacity,
-    // but it's much better than inconsistent results from volatile queries!
-    for _ in 0..3 {
-        for (i, input) in inputs.iter().enumerate() {
-            let x = get_volatile(&db, *input);
-            assert_eq!(x, i);
-        }
-    }
-}
-
-#[test]
 fn lru_can_be_changed_at_runtime() {
-    let db = common::LoggerDatabase::default();
+    let mut db = common::LoggerDatabase::default();
     assert_eq!(load_n_potatoes(), 0);
 
     let inputs: Vec<(u32, MyInput)> = (0..128).map(|i| (i, MyInput::new(&db, i))).collect();
 
     for &(i, input) in inputs.iter() {
         let p = get_hot_potato(&db, input);
-        assert_eq!(p.0, i)
+        assert_eq!(p.0, i);
     }
 
-    // Create a new input to change the revision, and trigger the GC
-    MyInput::new(&db, 0);
+    db.synthetic_write(salsa::Durability::HIGH);
     assert_eq!(load_n_potatoes(), 32);
 
     get_hot_potato::set_lru_capacity(&db, 64);
     assert_eq!(load_n_potatoes(), 32);
     for &(i, input) in inputs.iter() {
         let p = get_hot_potato(&db, input);
-        assert_eq!(p.0, i)
+        assert_eq!(p.0, i);
     }
 
-    // Create a new input to change the revision, and trigger the GC
-    MyInput::new(&db, 0);
+    db.synthetic_write(salsa::Durability::HIGH);
     assert_eq!(load_n_potatoes(), 64);
 
     // Special case: setting capacity to zero disables LRU
@@ -125,11 +97,10 @@ fn lru_can_be_changed_at_runtime() {
     assert_eq!(load_n_potatoes(), 64);
     for &(i, input) in inputs.iter() {
         let p = get_hot_potato(&db, input);
-        assert_eq!(p.0, i)
+        assert_eq!(p.0, i);
     }
 
-    // Create a new input to change the revision, and trigger the GC
-    MyInput::new(&db, 0);
+    db.synthetic_write(salsa::Durability::HIGH);
     assert_eq!(load_n_potatoes(), 128);
 
     drop(db);


### PR DESCRIPTION
This change allows us to omit LRU state from function ingredients when they don't actually have LRU support as well as remove the `Option` wrapping for functions that don't do LRU.

This should have a very minor speed and memory improvement in theory as it removes some unnecessary branching and option wrapping.

This was split out of https://github.com/salsa-rs/salsa/pull/660