### PR TITLE
Require `Update` trait for tracked function return values

### DIFF
--- a/components/salsa-macro-rules/src/setup_input_struct.rs
+++ b/components/salsa-macro-rules/src/setup_input_struct.rs
@@ -115,6 +115,17 @@ macro_rules! setup_input_struct {
                 }
             }
 
+            unsafe impl $zalsa::Update for $Struct {
+                unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
+                    if unsafe { *old_pointer } != new_value {
+                        unsafe { *old_pointer = new_value };
+                        true
+                    } else {
+                        false
+                    }
+                }
+            }
+
             $zalsa::macro_if! { $generate_debug_impl =>
                 impl std::fmt::Debug for $Struct {
                     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/src/function.rs
+++ b/src/function.rs
@@ -9,7 +9,7 @@ use crate::{
     salsa_struct::SalsaStructInDb,
     zalsa::{IngredientIndex, MemoIngredientIndex, Zalsa},
     zalsa_local::QueryOrigin,
-    Cycle, Database, Id, Revision,
+    Cycle, Database, Id, Revision, Update,
 };
 
 use self::delete::DeletedEntries;
@@ -43,7 +43,7 @@ pub trait Configuration: Any {
     type Input<'db>: Send + Sync;
 
     /// The value computed by the function.
-    type Output<'db>: fmt::Debug + Send + Sync;
+    type Output<'db>: fmt::Debug + Send + Sync + Update;
 
     /// Determines whether this function can recover from being a participant in a cycle
     /// (and, if so, how).

--- a/src/update.rs
+++ b/src/update.rs
@@ -296,6 +296,10 @@ where
     unsafe fn maybe_update(old_pointer: *mut Self, new_arc: Self) -> bool {
         let old_arc: &mut Arc<T> = unsafe { &mut *old_pointer };
 
+        if Arc::ptr_eq(old_arc, &new_arc) {
+            return false;
+        }
+
         if let Some(inner) = Arc::get_mut(old_arc) {
             match Arc::try_unwrap(new_arc) {
                 Ok(new_inner) => T::maybe_update(inner, new_inner),

--- a/tests/compile-fail/tracked_fn_return_ref.rs
+++ b/tests/compile-fail/tracked_fn_return_ref.rs
@@ -1,0 +1,30 @@
+use salsa::Database as Db;
+use salsa::Update;
+
+#[salsa::input]
+struct MyInput {
+    #[return_ref]
+    text: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ContainsRef<'db> {
+    text: &'db str,
+}
+
+#[salsa::tracked]
+fn tracked_fn_return_ref<'db>(db: &'db dyn Db, input: MyInput) -> &'db str {
+    input.text(db)
+}
+
+#[salsa::tracked]
+fn tracked_fn_return_struct_containing_ref<'db>(
+    db: &'db dyn Db,
+    input: MyInput,
+) -> ContainsRef<'db> {
+    ContainsRef {
+        text: input.text(db),
+    }
+}
+
+fn main() {}

--- a/tests/compile-fail/tracked_fn_return_ref.stderr
+++ b/tests/compile-fail/tracked_fn_return_ref.stderr
@@ -1,0 +1,42 @@
+warning: unused import: `salsa::Update`
+ --> tests/compile-fail/tracked_fn_return_ref.rs:2:5
+  |
+2 | use salsa::Update;
+  |     ^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default
+
+error[E0277]: the trait bound `&'db str: Update` is not satisfied
+  --> tests/compile-fail/tracked_fn_return_ref.rs:16:67
+   |
+16 | fn tracked_fn_return_ref<'db>(db: &'db dyn Db, input: MyInput) -> &'db str {
+   |                                                                   ^^^^^^^^ the trait `Update` is not implemented for `&'db str`
+   |
+   = help: the trait `Update` is implemented for `String`
+note: required by a bound in `salsa::plumbing::function::Configuration::Output`
+  --> src/function.rs
+   |
+   |     type Output<'db>: fmt::Debug + Send + Sync + Update;
+   |                                                  ^^^^^^ required by this bound in `Configuration::Output`
+
+error[E0277]: the trait bound `ContainsRef<'db>: Update` is not satisfied
+  --> tests/compile-fail/tracked_fn_return_ref.rs:24:6
+   |
+24 | ) -> ContainsRef<'db> {
+   |      ^^^^^^^^^^^^^^^^ the trait `Update` is not implemented for `ContainsRef<'db>`
+   |
+   = help: the following other types implement trait `Update`:
+             ()
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
+           and $N others
+note: required by a bound in `salsa::plumbing::function::Configuration::Output`
+  --> src/function.rs
+   |
+   |     type Output<'db>: fmt::Debug + Send + Sync + Update;
+   |                                                  ^^^^^^ required by this bound in `Configuration::Output`

--- a/tests/cycles.rs
+++ b/tests/cycles.rs
@@ -49,13 +49,14 @@ use salsa::Durability;
 // | Cross  | Fallback | N/A      | Tracked   | both     | parallel/parallel_cycle_mid_recover.rs |
 // | Cross  | Fallback | N/A      | Tracked   | both     | parallel/parallel_cycle_all_recover.rs |
 
-#[derive(PartialEq, Eq, Hash, Clone, Debug)]
+#[derive(PartialEq, Eq, Hash, Clone, Debug, Update)]
 struct Error {
     cycle: Vec<String>,
 }
 
 use salsa::Database as Db;
 use salsa::Setter;
+use salsa::Update;
 
 #[salsa::input]
 struct MyInput {}

--- a/tests/lru.rs
+++ b/tests/lru.rs
@@ -8,10 +8,10 @@ use std::sync::{
 
 mod common;
 use common::LogDatabase;
-use salsa::Database as _;
+use salsa::{Database as _, Update};
 use test_log::test;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Update)]
 struct HotPotato(u32);
 
 thread_local! {

--- a/tests/warnings/needless_lifetimes.rs
+++ b/tests/warnings/needless_lifetimes.rs
@@ -1,7 +1,9 @@
+use salsa::Update;
+
 #[salsa::db]
 pub trait Db: salsa::Database {}
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq, Hash, Update)]
 pub struct Item {}
 
 #[salsa::tracked]


### PR DESCRIPTION
Fixes https://github.com/salsa-rs/salsa/issues/610 by requiring the `Output` of tracked functions to implement `Update`

Let's see how annoying this will be...
