### PR TITLE
feature: expose database contents as inherent method on Ingredients

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -184,6 +184,20 @@ impl<C: Configuration> IngredientImpl<C> {
         &value.fields
     }
 
+    #[cfg(feature = "salsa_unstable")]
+    /// Returns all data corresponding to the input struct.
+    pub fn entries<'db>(
+        &'db self,
+        db: &'db dyn crate::Database,
+    ) -> impl Iterator<Item = &'db Value<C>> {
+        db.zalsa()
+            .table()
+            .pages
+            .iter()
+            .filter_map(|page| page.cast_type::<crate::table::Page<Value<C>>>())
+            .flat_map(|page| page.slots())
+    }
+
     /// Peek at the field values without recording any read dependency.
     /// Used for debug printouts.
     pub fn leak_fields<'db>(&'db self, db: &'db dyn Database, id: C::Struct) -> &'db C::Fields {

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -253,6 +253,20 @@ where
         self.data(db, C::deref_struct(s))
     }
 
+    #[cfg(feature = "salsa_unstable")]
+    /// Returns all data corresponding to the interned struct.
+    pub fn entries<'db>(
+        &'db self,
+        db: &'db dyn crate::Database,
+    ) -> impl Iterator<Item = &'db Value<C>> {
+        db.zalsa()
+            .table()
+            .pages
+            .iter()
+            .filter_map(|page| page.cast_type::<crate::table::Page<Value<C>>>())
+            .flat_map(|page| page.slots())
+    }
+
     pub fn reset(&mut self, revision: Revision) {
         assert!(revision > self.reset_at);
         self.reset_at = revision;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -3,7 +3,6 @@ use std::{marker::PhantomData, panic::RefUnwindSafe, sync::Arc};
 use parking_lot::{Condvar, Mutex};
 
 use crate::{
-    plumbing::{input, interned, tracked_struct},
     zalsa::{Zalsa, ZalsaDatabase},
     zalsa_local::{self, ZalsaLocal},
     Database, Event, EventKind,
@@ -61,52 +60,6 @@ impl<Db: Database> Default for Storage<Db> {
 }
 
 impl<Db: Database> Storage<Db> {
-    pub fn debug_input_entries<T>(&self) -> impl Iterator<Item = &input::Value<T>>
-    where
-        T: input::Configuration,
-    {
-        let zalsa = self.zalsa_impl();
-        zalsa
-            .table()
-            .pages
-            .iter()
-            .filter_map(|page| page.cast_type::<crate::table::Page<input::Value<T>>>())
-            .flat_map(|page| page.slots())
-    }
-
-    pub fn debug_interned_entries<T>(&self) -> impl Iterator<Item = &interned::Value<T>>
-    where
-        T: interned::Configuration,
-    {
-        let zalsa = self.zalsa_impl();
-        zalsa
-            .table()
-            .pages
-            .iter()
-            .filter_map(|page| page.cast_type::<crate::table::Page<interned::Value<T>>>())
-            .flat_map(|page| page.slots())
-    }
-
-    pub fn debug_tracked_entries<T>(&self) -> impl Iterator<Item = &tracked_struct::Value<T>>
-    where
-        T: tracked_struct::Configuration,
-    {
-        let zalsa = self.zalsa_impl();
-        zalsa
-            .table()
-            .pages
-            .iter()
-            .filter_map(|page| page.cast_type::<crate::table::Page<tracked_struct::Value<T>>>())
-            .flat_map(|pages| pages.slots())
-    }
-
-    /// Access the `Arc<Zalsa>`. This should always be
-    /// possible as `zalsa_impl` only becomes
-    /// `None` once we are in the `Drop` impl.
-    fn zalsa_impl(&self) -> &Arc<Zalsa> {
-        &self.zalsa_impl
-    }
-
     // ANCHOR: cancel_other_workers
     /// Sets cancellation flag and blocks until all other workers with access
     /// to this storage have completed.

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -688,6 +688,20 @@ where
 
         unsafe { self.to_self_ref(&data.fields) }
     }
+
+    #[cfg(feature = "salsa_unstable")]
+    /// Returns all data corresponding to the tracked struct.
+    pub fn entries<'db>(
+        &'db self,
+        db: &'db dyn crate::Database,
+    ) -> impl Iterator<Item = &'db Value<C>> {
+        db.zalsa()
+            .table()
+            .pages
+            .iter()
+            .filter_map(|page| page.cast_type::<crate::table::Page<Value<C>>>())
+            .flat_map(|page| page.slots())
+    }
 }
 
 impl<C> Ingredient for IngredientImpl<C>

--- a/tests/debug_db_contents.rs
+++ b/tests/debug_db_contents.rs
@@ -26,9 +26,8 @@ fn execute() {
     let _ = InternedStruct::new(&db, "Salsa2".to_string());
 
     // test interned structs
-    let interned = db
-        .storage()
-        .debug_interned_entries::<InternedStruct>()
+    let interned = InternedStruct::ingredient(&db)
+        .entries(&db)
         .collect::<Vec<_>>();
 
     assert_eq!(interned.len(), 2);
@@ -37,9 +36,9 @@ fn execute() {
 
     // test input structs
     let input = InputStruct::new(&db, 22);
-    let inputs = db
-        .storage()
-        .debug_input_entries::<InputStruct>()
+
+    let inputs = InputStruct::ingredient(&db)
+        .entries(&db)
         .collect::<Vec<_>>();
 
     assert_eq!(inputs.len(), 1);
@@ -48,9 +47,8 @@ fn execute() {
     // test tracked structs
     let computed = tracked_fn(&db, input).field(&db);
     assert_eq!(computed, 44);
-    let tracked = db
-        .storage()
-        .debug_tracked_entries::<TrackedStruct>()
+    let tracked = TrackedStruct::ingredient(&db)
+        .entries(&db)
         .collect::<Vec<_>>();
 
     assert_eq!(tracked.len(), 1);


### PR DESCRIPTION
This PR redesigns the functionality introduced in #640 so that the dump-all-database contents methods are on the Salsa struct ingredient instead of the database's `Storage`. I think this is an improvement for two reasons:
1. This design is closer to the original [`DebugQueryTable`](https://docs.rs/salsa/0.16.1/salsa/debug/trait.DebugQueryTable.html) trait.
2. At least within rust-analyzer, it's not feasible to get access to the underlying storage from methods that only have a `&dyn SomeDatabase`. However, it _is_ feasible to access the ingredient

## Example

Here's an example for interned structs (input and tracked structs have an identical API): 

```rust
#[salsa::interned]
struct InternedStruct<'db> {
    name: String,
}

let _ = InternedStruct::new(&db, "Hello, world!".to_string());

let interned = InternedStruct::ingredient(&db)
    .entries(&db)
    .collect::<Vec<_>>();
```

Note that the `entries` method is defined on the `{interned, input, tracked}::IngredientImpl`. The more optimal API would be to define `entries` on the Salsa struct itself, alongside `ingredient`. However, this is substantially more annoying to feature-flag through macros.

## Notes

While I don't have a good idea how to access a tracked function's memos, I also don't really know how much it makes sense to do so outside of some migrations.