### PR TITLE
feature: add `#[salsa::supertype]`

### DIFF
--- a/components/salsa-macro-rules/src/setup_accumulator_impl.rs
+++ b/components/salsa-macro-rules/src/setup_accumulator_impl.rs
@@ -24,7 +24,8 @@ macro_rules! setup_accumulator_impl {
 
             fn $ingredient(db: &dyn $zalsa::Database) -> &$zalsa_struct::IngredientImpl<$Struct> {
                 $CACHE.get_or_create(db, || {
-                    db.zalsa().add_or_lookup_jar_by_type(&<$zalsa_struct::JarImpl<$Struct>>::default())
+                    db.zalsa()
+                        .add_or_lookup_jar_by_type::<$zalsa_struct::JarImpl<$Struct>>()
                 })
             }
 

--- a/components/salsa-macro-rules/src/setup_input_struct.rs
+++ b/components/salsa-macro-rules/src/setup_input_struct.rs
@@ -89,13 +89,13 @@ macro_rules! setup_input_struct {
                     static CACHE: $zalsa::IngredientCache<$zalsa_struct::IngredientImpl<$Configuration>> =
                         $zalsa::IngredientCache::new();
                     CACHE.get_or_create(db, || {
-                        db.zalsa().add_or_lookup_jar_by_type(&<$zalsa_struct::JarImpl<$Configuration>>::default())
+                        db.zalsa().add_or_lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>()
                     })
                 }
 
                 pub fn ingredient_mut(db: &mut dyn $zalsa::Database) -> (&mut $zalsa_struct::IngredientImpl<Self>, &mut $zalsa::Runtime) {
                     let zalsa_mut = db.zalsa_mut();
-                    let index = zalsa_mut.add_or_lookup_jar_by_type(&<$zalsa_struct::JarImpl<$Configuration>>::default());
+                    let index = zalsa_mut.add_or_lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>();
                     let current_revision = zalsa_mut.current_revision();
                     let (ingredient, runtime) = zalsa_mut.lookup_ingredient_mut(index);
                     let ingredient = ingredient.assert_type_mut::<$zalsa_struct::IngredientImpl<Self>>();
@@ -135,8 +135,17 @@ macro_rules! setup_input_struct {
             }
 
             impl $zalsa::SalsaStructInDb for $Struct {
-                fn lookup_ingredient_index(aux: &dyn $zalsa::JarAux) -> core::option::Option<$zalsa::IngredientIndex> {
-                    aux.lookup_jar_by_type(&<$zalsa_struct::JarImpl<$Configuration>>::default())
+                fn lookup_or_create_ingredient_index(aux: &$zalsa::Zalsa) -> $zalsa::IngredientIndices {
+                    aux.add_or_lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>().into()
+                }
+
+                #[inline]
+                fn cast(id: $zalsa::Id, type_id: $zalsa::TypeId) -> $zalsa::Option<Self> {
+                    if type_id == $zalsa::TypeId::of::<$Struct>() {
+                        $zalsa::Some($Struct(id))
+                    } else {
+                        $zalsa::None
+                    }
                 }
             }
 
@@ -198,7 +207,7 @@ macro_rules! setup_input_struct {
                         // FIXME(rust-lang/rust#65991): The `db` argument *should* have the type `dyn Database`
                         $Db: ?Sized + salsa::Database,
                     {
-                        $Configuration::ingredient(db.as_dyn_database()).get_singleton_input()
+                        $Configuration::ingredient(db.as_dyn_database()).get_singleton_input(db)
                     }
 
                     #[track_caller]

--- a/components/salsa-macro-rules/src/setup_input_struct.rs
+++ b/components/salsa-macro-rules/src/setup_input_struct.rs
@@ -135,6 +135,8 @@ macro_rules! setup_input_struct {
             }
 
             impl $zalsa::SalsaStructInDb for $Struct {
+                type MemoIngredientMap = $zalsa::MemoIngredientSingletonIndex;
+
                 fn lookup_or_create_ingredient_index(aux: &$zalsa::Zalsa) -> $zalsa::IngredientIndices {
                     aux.add_or_lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>().into()
                 }

--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -171,6 +171,8 @@ macro_rules! setup_interned_struct {
             }
 
             impl< $($db_lt_arg)? > $zalsa::SalsaStructInDb for $Struct< $($db_lt_arg)? > {
+                type MemoIngredientMap = $zalsa::MemoIngredientSingletonIndex;
+
                 fn lookup_or_create_ingredient_index(aux: &$zalsa::Zalsa) -> $zalsa::IngredientIndices {
                     aux.add_or_lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>().into()
                 }

--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -141,7 +141,7 @@ macro_rules! setup_interned_struct {
                     static CACHE: $zalsa::IngredientCache<$zalsa_struct::IngredientImpl<$Configuration>> =
                         $zalsa::IngredientCache::new();
                     CACHE.get_or_create(db.as_dyn_database(), || {
-                        db.zalsa().add_or_lookup_jar_by_type(&<$zalsa_struct::JarImpl<$Configuration>>::default())
+                        db.zalsa().add_or_lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>()
                     })
                 }
             }
@@ -171,8 +171,17 @@ macro_rules! setup_interned_struct {
             }
 
             impl< $($db_lt_arg)? > $zalsa::SalsaStructInDb for $Struct< $($db_lt_arg)? > {
-                fn lookup_ingredient_index(aux: &dyn $zalsa::JarAux) -> core::option::Option<$zalsa::IngredientIndex> {
-                    aux.lookup_jar_by_type(&<$zalsa_struct::JarImpl<$Configuration>>::default())
+                fn lookup_or_create_ingredient_index(aux: &$zalsa::Zalsa) -> $zalsa::IngredientIndices {
+                    aux.add_or_lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>().into()
+                }
+
+                #[inline]
+                fn cast(id: $zalsa::Id, type_id: $zalsa::TypeId) -> $zalsa::Option<Self> {
+                    if type_id == $zalsa::TypeId::of::<$Struct>() {
+                        $zalsa::Some(<$Struct as $zalsa::FromId>::from_id(id))
+                    } else {
+                        $zalsa::None
+                    }
                 }
             }
 

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -101,8 +101,17 @@ macro_rules! setup_tracked_fn {
                         $zalsa::IngredientCache::new();
 
                     impl $zalsa::SalsaStructInDb for $InternedData<'_> {
-                        fn lookup_ingredient_index(_aux: &dyn $zalsa::JarAux) -> core::option::Option<$zalsa::IngredientIndex> {
-                            None
+                        fn lookup_or_create_ingredient_index(aux: &$zalsa::Zalsa) -> $zalsa::IngredientIndices {
+                            $zalsa::IngredientIndices::uninitialized()
+                        }
+
+                        #[inline]
+                        fn cast(id: $zalsa::Id, type_id: ::core::any::TypeId) -> Option<Self> {
+                            if type_id == ::core::any::TypeId::of::<$InternedData>() {
+                                Some($InternedData(id, ::core::marker::PhantomData))
+                            } else {
+                                None
+                            }
                         }
                     }
 
@@ -132,7 +141,7 @@ macro_rules! setup_tracked_fn {
                 fn fn_ingredient(db: &dyn $Db) -> &$zalsa::function::IngredientImpl<$Configuration> {
                     $FN_CACHE.get_or_create(db.as_dyn_database(), || {
                         <dyn $Db as $Db>::zalsa_db(db);
-                        db.zalsa().add_or_lookup_jar_by_type(&$Configuration)
+                        db.zalsa().add_or_lookup_jar_by_type::<$Configuration>()
                     })
                 }
 
@@ -141,7 +150,7 @@ macro_rules! setup_tracked_fn {
                         db: &dyn $Db,
                     ) -> &$zalsa::interned::IngredientImpl<$Configuration> {
                         $INTERN_CACHE.get_or_create(db.as_dyn_database(), || {
-                            db.zalsa().add_or_lookup_jar_by_type(&$Configuration).successor(0)
+                            db.zalsa().add_or_lookup_jar_by_type::<$Configuration>().successor(0)
                         })
                     }
                 }
@@ -194,33 +203,43 @@ macro_rules! setup_tracked_fn {
                         if $needs_interner {
                             $Configuration::intern_ingredient(db).data(db.as_dyn_database(), key).clone()
                         } else {
-                            $zalsa::FromId::from_id(key)
+                            $zalsa::FromIdWithDb::from_id(key, db)
                         }
                     }
                 }
             }
 
             impl $zalsa::Jar for $Configuration {
+                fn create_dependencies(zalsa: &$zalsa::Zalsa) -> $zalsa::IngredientIndices
+                where
+                    Self: Sized
+                {
+                    $zalsa::macro_if! {
+                        if $needs_interner {
+                            $zalsa::IngredientIndices::uninitialized()
+                        } else {
+                            <$InternedData as $zalsa::SalsaStructInDb>::lookup_or_create_ingredient_index(zalsa)
+                        }
+                    }
+                }
+
                 fn create_ingredients(
-                    &self,
-                    aux: &dyn $zalsa::JarAux,
+                    zalsa: &$zalsa::Zalsa,
                     first_index: $zalsa::IngredientIndex,
+                    struct_index: $zalsa::IngredientIndices,
                 ) -> Vec<Box<dyn $zalsa::Ingredient>> {
                     let struct_index = $zalsa::macro_if! {
                         if $needs_interner {
-                            first_index.successor(0)
+                            first_index.successor(0).into()
                         } else {
-                            <$InternedData as $zalsa::SalsaStructInDb>::lookup_ingredient_index(aux)
-                                .expect(
-                                    "Salsa struct is passed as an argument of a tracked function, but its ingredient hasn't been added!"
-                                )
+                            struct_index
                         }
                     };
 
                     let fn_ingredient = <$zalsa::function::IngredientImpl<$Configuration>>::new(
                         struct_index,
                         first_index,
-                        aux,
+                        zalsa,
                     );
                     fn_ingredient.set_capacity($lru);
                     $zalsa::macro_if! {
@@ -239,8 +258,8 @@ macro_rules! setup_tracked_fn {
                     }
                 }
 
-                fn salsa_struct_type_id(&self) -> Option<core::any::TypeId> {
-                    None
+                fn id_struct_type_id() -> $zalsa::TypeId {
+                    $zalsa::TypeId::of::<$InternedData<'static>>()
                 }
             }
 

--- a/components/salsa-macro-rules/src/setup_tracked_struct.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_struct.rs
@@ -165,7 +165,7 @@ macro_rules! setup_tracked_struct {
                         $zalsa::IngredientCache::new();
 
                     CACHE.get_or_create(db, || {
-                        db.zalsa().add_or_lookup_jar_by_type(&<$zalsa_struct::JarImpl::<$Configuration>>::default())
+                        db.zalsa().add_or_lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>()
                     })
                 }
             }
@@ -183,8 +183,17 @@ macro_rules! setup_tracked_struct {
             }
 
             impl $zalsa::SalsaStructInDb for $Struct<'_> {
-                fn lookup_ingredient_index(aux: &dyn $zalsa::JarAux) -> core::option::Option<$zalsa::IngredientIndex> {
-                    aux.lookup_jar_by_type(&<$zalsa_struct::JarImpl<$Configuration>>::default())
+                fn lookup_or_create_ingredient_index(aux: &$zalsa::Zalsa) -> $zalsa::IngredientIndices {
+                    aux.add_or_lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>().into()
+                }
+
+                #[inline]
+                fn cast(id: $zalsa::Id, type_id: $zalsa::TypeId) -> $zalsa::Option<Self> {
+                    if type_id == $zalsa::TypeId::of::<$Struct>() {
+                        $zalsa::Some(<$Struct as $zalsa::FromId>::from_id(id))
+                    } else {
+                        $zalsa::None
+                    }
                 }
             }
 

--- a/components/salsa-macro-rules/src/setup_tracked_struct.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_struct.rs
@@ -183,6 +183,8 @@ macro_rules! setup_tracked_struct {
             }
 
             impl $zalsa::SalsaStructInDb for $Struct<'_> {
+                type MemoIngredientMap = $zalsa::MemoIngredientSingletonIndex;
+
                 fn lookup_or_create_ingredient_index(aux: &$zalsa::Zalsa) -> $zalsa::IngredientIndices {
                     aux.add_or_lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>().into()
                 }

--- a/components/salsa-macros/src/lib.rs
+++ b/components/salsa-macros/src/lib.rs
@@ -67,7 +67,7 @@ pub fn interned(args: TokenStream, input: TokenStream) -> TokenStream {
     interned::interned(args, input)
 }
 
-#[proc_macro_derive(supertype)]
+#[proc_macro_derive(Supertype)]
 pub fn supertype(input: TokenStream) -> TokenStream {
     supertype::supertype(input)
 }

--- a/components/salsa-macros/src/lib.rs
+++ b/components/salsa-macros/src/lib.rs
@@ -44,6 +44,7 @@ mod input;
 mod interned;
 mod options;
 mod salsa_struct;
+mod supertype;
 mod tracked;
 mod tracked_fn;
 mod tracked_impl;
@@ -64,6 +65,11 @@ pub fn db(args: TokenStream, input: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn interned(args: TokenStream, input: TokenStream) -> TokenStream {
     interned::interned(args, input)
+}
+
+#[proc_macro_derive(supertype)]
+pub fn supertype(input: TokenStream) -> TokenStream {
+    supertype::supertype(input)
 }
 
 #[proc_macro_attribute]

--- a/components/salsa-macros/src/supertype.rs
+++ b/components/salsa-macros/src/supertype.rs
@@ -97,35 +97,35 @@ fn enum_impl(enum_item: syn::ItemEnum) -> syn::Result<TokenStream> {
         }
     };
 
-    let std_traits = quote! {
-        impl #impl_generics ::core::marker::Copy for #enum_name #type_generics
-        #where_clause {}
+    // let std_traits = quote! {
+    //     impl #impl_generics ::core::marker::Copy for #enum_name #type_generics
+    //     #where_clause {}
 
-        impl #impl_generics ::core::clone::Clone for #enum_name #type_generics
-        #where_clause {
-            #[inline]
-            fn clone(&self) -> Self { *self }
-        }
+    //     impl #impl_generics ::core::clone::Clone for #enum_name #type_generics
+    //     #where_clause {
+    //         #[inline]
+    //         fn clone(&self) -> Self { *self }
+    //     }
 
-        impl #impl_generics ::core::cmp::Eq for #enum_name #type_generics
-        #where_clause {}
+    //     impl #impl_generics ::core::cmp::Eq for #enum_name #type_generics
+    //     #where_clause {}
 
-        impl #impl_generics ::core::cmp::PartialEq for #enum_name #type_generics
-        #where_clause {
-            #[inline]
-            fn eq(&self, __other: &Self) -> bool {
-                zalsa::AsId::as_id(self) == zalsa::AsId::as_id(__other)
-            }
-        }
+    //     impl #impl_generics ::core::cmp::PartialEq for #enum_name #type_generics
+    //     #where_clause {
+    //         #[inline]
+    //         fn eq(&self, __other: &Self) -> bool {
+    //             zalsa::AsId::as_id(self) == zalsa::AsId::as_id(__other)
+    //         }
+    //     }
 
-        impl #impl_generics ::core::hash::Hash for #enum_name #type_generics
-        #where_clause {
-            #[inline]
-            fn hash<__H: ::core::hash::Hasher>(&self, __state: &mut __H) {
-                ::core::hash::Hash::hash(&zalsa::AsId::as_id(self), __state);
-            }
-        }
-    };
+    //     impl #impl_generics ::core::hash::Hash for #enum_name #type_generics
+    //     #where_clause {
+    //         #[inline]
+    //         fn hash<__H: ::core::hash::Hasher>(&self, __state: &mut __H) {
+    //             ::core::hash::Hash::hash(&zalsa::AsId::as_id(self), __state);
+    //         }
+    //     }
+    // };
 
     let all_impls = quote! {
         const _: () = {
@@ -134,8 +134,6 @@ fn enum_impl(enum_item: syn::ItemEnum) -> syn::Result<TokenStream> {
             #as_id
             #from_id
             #salsa_struct_in_db
-
-            #std_traits
         };
     };
     Ok(all_impls)

--- a/components/salsa-macros/src/supertype.rs
+++ b/components/salsa-macros/src/supertype.rs
@@ -1,11 +1,10 @@
 use crate::token_stream_with_error;
 use proc_macro2::TokenStream;
 
-/// For an entity struct `Foo` with fields `f1: T1, ..., fN: TN`, we generate...
+/// The implementation of the `supertype` macro.
 ///
-/// * the "id struct" `struct Foo(salsa::Id)`
-/// * the entity ingredient, which maps the id fields to the `Id`
-/// * for each value field, a function ingredient
+/// For an entity enum `Foo` with variants `Variant1, ..., VariantN`, we generate
+/// mappings between the variants and their corresponding supertypes.
 pub(crate) fn supertype(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let enum_item = parse_macro_input!(input as syn::ItemEnum);
     match enum_impl(enum_item) {
@@ -70,15 +69,11 @@ fn enum_impl(enum_item: syn::ItemEnum) -> syn::Result<TokenStream> {
     let salsa_struct_in_db = quote! {
         impl #impl_generics zalsa::SalsaStructInDb for #enum_name #type_generics
         #where_clause {
+            type MemoIngredientMap = zalsa::MemoIngredientIndices;
+
             #[inline]
             fn lookup_or_create_ingredient_index(__zalsa: &zalsa::Zalsa) -> zalsa::IngredientIndices {
-                let mut __result = zalsa::IngredientIndices::uninitialized();
-                #(
-                    __result.merge(
-                        &<#variant_types as zalsa::SalsaStructInDb>::lookup_or_create_ingredient_index(__zalsa)
-                    );
-                )*
-                __result
+                zalsa::IngredientIndices::merge([ #( <#variant_types as zalsa::SalsaStructInDb>::lookup_or_create_ingredient_index(__zalsa) ),* ])
             }
 
             #[inline]
@@ -96,36 +91,6 @@ fn enum_impl(enum_item: syn::ItemEnum) -> syn::Result<TokenStream> {
             }
         }
     };
-
-    // let std_traits = quote! {
-    //     impl #impl_generics ::core::marker::Copy for #enum_name #type_generics
-    //     #where_clause {}
-
-    //     impl #impl_generics ::core::clone::Clone for #enum_name #type_generics
-    //     #where_clause {
-    //         #[inline]
-    //         fn clone(&self) -> Self { *self }
-    //     }
-
-    //     impl #impl_generics ::core::cmp::Eq for #enum_name #type_generics
-    //     #where_clause {}
-
-    //     impl #impl_generics ::core::cmp::PartialEq for #enum_name #type_generics
-    //     #where_clause {
-    //         #[inline]
-    //         fn eq(&self, __other: &Self) -> bool {
-    //             zalsa::AsId::as_id(self) == zalsa::AsId::as_id(__other)
-    //         }
-    //     }
-
-    //     impl #impl_generics ::core::hash::Hash for #enum_name #type_generics
-    //     #where_clause {
-    //         #[inline]
-    //         fn hash<__H: ::core::hash::Hasher>(&self, __state: &mut __H) {
-    //             ::core::hash::Hash::hash(&zalsa::AsId::as_id(self), __state);
-    //         }
-    //     }
-    // };
 
     let all_impls = quote! {
         const _: () = {

--- a/components/salsa-macros/src/supertype.rs
+++ b/components/salsa-macros/src/supertype.rs
@@ -1,0 +1,142 @@
+use crate::token_stream_with_error;
+use proc_macro2::TokenStream;
+
+/// For an entity struct `Foo` with fields `f1: T1, ..., fN: TN`, we generate...
+///
+/// * the "id struct" `struct Foo(salsa::Id)`
+/// * the entity ingredient, which maps the id fields to the `Id`
+/// * for each value field, a function ingredient
+pub(crate) fn supertype(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let enum_item = parse_macro_input!(input as syn::ItemEnum);
+    match enum_impl(enum_item) {
+        Ok(v) => v.into(),
+        Err(e) => token_stream_with_error(input, e),
+    }
+}
+
+fn enum_impl(enum_item: syn::ItemEnum) -> syn::Result<TokenStream> {
+    let enum_name = enum_item.ident.clone();
+    let mut variant_names = Vec::new();
+    let mut variant_types = Vec::new();
+    if enum_item.variants.is_empty() {
+        return Err(syn::Error::new(
+            enum_item.enum_token.span,
+            "empty enums are not permitted",
+        ));
+    }
+    for variant in &enum_item.variants {
+        let valid = match &variant.fields {
+            syn::Fields::Unnamed(fields) => {
+                variant_names.push(variant.ident.clone());
+                variant_types.push(fields.unnamed[0].ty.clone());
+                fields.unnamed.len() == 1
+            }
+            syn::Fields::Unit | syn::Fields::Named(_) => false,
+        };
+        if !valid {
+            return Err(syn::Error::new(
+                variant.ident.span(),
+                "the only form allowed is `Variant(SalsaStruct)`",
+            ));
+        }
+    }
+
+    let (impl_generics, type_generics, where_clause) = enum_item.generics.split_for_impl();
+
+    let as_id = quote! {
+        impl #impl_generics zalsa::AsId for #enum_name #type_generics
+        #where_clause {
+            #[inline]
+            fn as_id(&self) -> zalsa::Id {
+                match self {
+                    #( Self::#variant_names(__v) => zalsa::AsId::as_id(__v), )*
+                }
+            }
+        }
+    };
+
+    let from_id = quote! {
+        impl #impl_generics zalsa::FromIdWithDb for #enum_name #type_generics
+        #where_clause {
+            #[inline]
+            fn from_id(__id: zalsa::Id, __db: &(impl ?Sized + zalsa::Database)) -> Self {
+                let __zalsa = __db.zalsa();
+                let __type_id = __zalsa.lookup_page_type_id(__id);
+                <Self as zalsa::SalsaStructInDb>::cast(__id, __type_id).expect("invalid enum variant")
+            }
+        }
+    };
+
+    let salsa_struct_in_db = quote! {
+        impl #impl_generics zalsa::SalsaStructInDb for #enum_name #type_generics
+        #where_clause {
+            #[inline]
+            fn lookup_or_create_ingredient_index(__zalsa: &zalsa::Zalsa) -> zalsa::IngredientIndices {
+                let mut __result = zalsa::IngredientIndices::uninitialized();
+                #(
+                    __result.merge(
+                        &<#variant_types as zalsa::SalsaStructInDb>::lookup_or_create_ingredient_index(__zalsa)
+                    );
+                )*
+                __result
+            }
+
+            #[inline]
+            fn cast(id: zalsa::Id, type_id: ::core::any::TypeId) -> Option<Self> {
+                #(
+                    // Subtle: the ingredient can be missing, but in this case the id cannot come
+                    // from it - because it wasn't initialized yet.
+                    if let Some(result) = <#variant_types as zalsa::SalsaStructInDb>::cast(id, type_id) {
+                        Some(Self::#variant_names(result))
+                    } else
+                )*
+                {
+                    None
+                }
+            }
+        }
+    };
+
+    let std_traits = quote! {
+        impl #impl_generics ::core::marker::Copy for #enum_name #type_generics
+        #where_clause {}
+
+        impl #impl_generics ::core::clone::Clone for #enum_name #type_generics
+        #where_clause {
+            #[inline]
+            fn clone(&self) -> Self { *self }
+        }
+
+        impl #impl_generics ::core::cmp::Eq for #enum_name #type_generics
+        #where_clause {}
+
+        impl #impl_generics ::core::cmp::PartialEq for #enum_name #type_generics
+        #where_clause {
+            #[inline]
+            fn eq(&self, __other: &Self) -> bool {
+                zalsa::AsId::as_id(self) == zalsa::AsId::as_id(__other)
+            }
+        }
+
+        impl #impl_generics ::core::hash::Hash for #enum_name #type_generics
+        #where_clause {
+            #[inline]
+            fn hash<__H: ::core::hash::Hasher>(&self, __state: &mut __H) {
+                ::core::hash::Hash::hash(&zalsa::AsId::as_id(self), __state);
+            }
+        }
+    };
+
+    let all_impls = quote! {
+        const _: () = {
+            use salsa::plumbing as zalsa;
+
+            #as_id
+            #from_id
+            #salsa_struct_in_db
+
+            #std_traits
+        };
+    };
+    Ok(all_impls)
+}

--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -1,7 +1,7 @@
 //! Basic test of accumulator functionality.
 
 use std::{
-    any::Any,
+    any::{Any, TypeId},
     fmt::{self, Debug},
     marker::PhantomData,
 };
@@ -12,9 +12,9 @@ use accumulated::AnyAccumulated;
 use crate::{
     cycle::CycleRecoveryStrategy,
     ingredient::{fmt_index, Ingredient, Jar, MaybeChangedAfter},
-    plumbing::JarAux,
+    plumbing::IngredientIndices,
     table::Table,
-    zalsa::IngredientIndex,
+    zalsa::{IngredientIndex, Zalsa},
     zalsa_local::QueryOrigin,
     Database, DatabaseKeyIndex, Id, Revision,
 };
@@ -47,15 +47,15 @@ impl<A: Accumulator> Default for JarImpl<A> {
 
 impl<A: Accumulator> Jar for JarImpl<A> {
     fn create_ingredients(
-        &self,
-        _aux: &dyn JarAux,
+        _zalsa: &Zalsa,
         first_index: IngredientIndex,
+        _dependencies: IngredientIndices,
     ) -> Vec<Box<dyn Ingredient>> {
         vec![Box::new(<IngredientImpl<A>>::new(first_index))]
     }
 
-    fn salsa_struct_type_id(&self) -> Option<std::any::TypeId> {
-        None
+    fn id_struct_type_id() -> TypeId {
+        TypeId::of::<A>()
     }
 }
 
@@ -70,9 +70,8 @@ impl<A: Accumulator> IngredientImpl<A> {
     where
         Db: ?Sized + Database,
     {
-        let jar: JarImpl<A> = Default::default();
         let zalsa = db.zalsa();
-        let index = zalsa.add_or_lookup_jar_by_type(&jar);
+        let index = zalsa.add_or_lookup_jar_by_type::<JarImpl<A>>();
         let ingredient = zalsa.lookup_ingredient(index).assert_type::<Self>();
         Some(ingredient)
     }

--- a/src/function.rs
+++ b/src/function.rs
@@ -5,7 +5,7 @@ use crate::{
     cycle::CycleRecoveryStrategy,
     ingredient::{fmt_index, MaybeChangedAfter},
     key::DatabaseKeyIndex,
-    plumbing::JarAux,
+    memo_ingredient_indices::{IngredientIndices, MemoIngredientIndices},
     salsa_struct::SalsaStructInDb,
     table::Table,
     zalsa::{IngredientIndex, MemoIngredientIndex, Zalsa},
@@ -96,7 +96,7 @@ pub struct IngredientImpl<C: Configuration> {
     index: IngredientIndex,
 
     /// The index for the memo/sync tables
-    memo_ingredient_index: MemoIngredientIndex,
+    memo_ingredient_indices: MemoIngredientIndices,
 
     /// Used to find memos to throw out when we have too many memoized values.
     lru: lru::Lru,
@@ -127,10 +127,12 @@ impl<C> IngredientImpl<C>
 where
     C: Configuration,
 {
-    pub fn new(struct_index: IngredientIndex, index: IngredientIndex, aux: &dyn JarAux) -> Self {
+    pub fn new(struct_indices: IngredientIndices, index: IngredientIndex, zalsa: &Zalsa) -> Self {
+        let memo_ingredient_indices = struct_indices
+            .memo_indices(|struct_index| zalsa.next_memo_ingredient_index(struct_index, index));
         Self {
             index,
-            memo_ingredient_index: aux.next_memo_ingredient_index(struct_index, index),
+            memo_ingredient_indices,
             lru: Default::default(),
             deleted_entries: Default::default(),
         }
@@ -166,6 +168,7 @@ where
         zalsa: &'db Zalsa,
         id: Id,
         memo: memo::Memo<C::Output<'db>>,
+        memo_ingredient_index: MemoIngredientIndex,
     ) -> &'db memo::Memo<C::Output<'db>> {
         let memo = Arc::new(memo);
         // Unsafety conditions: memo must be in the map (it's not yet, but it will be by the time this
@@ -173,13 +176,32 @@ where
         let db_memo = unsafe { self.extend_memo_lifetime(&memo) };
         // Safety: We delay the drop of `old_value` until a new revision starts which ensures no
         // references will exist for the memo contents.
-        if let Some(old_value) = unsafe { self.insert_memo_into_table_for(zalsa, id, memo) } {
+        if let Some(old_value) =
+            unsafe { self.insert_memo_into_table_for(zalsa, id, memo, memo_ingredient_index) }
+        {
             // In case there is a reference to the old memo out there, we have to store it
             // in the deleted entries. This will get cleared when a new revision starts.
             self.deleted_entries
                 .push(ManuallyDrop::into_inner(old_value));
         }
         db_memo
+    }
+
+    // FIXME: deduplicate `memo_ingredient_index` and `memo_ingredient_index_for_id`.
+    // this is only duplciated because `reset_for_new_revision` in `function.rs` doesn't have easy access
+    // to zalsa (nor should it, really).
+    #[inline]
+    fn memo_ingredient_index_for_ingredient(
+        &self,
+        ingredient_index: IngredientIndex,
+    ) -> MemoIngredientIndex {
+        self.memo_ingredient_indices.find(ingredient_index)
+    }
+
+    #[inline]
+    fn memo_ingredient_index(&self, zalsa: &Zalsa, id: Id) -> MemoIngredientIndex {
+        self.memo_ingredient_indices
+            .find(zalsa.ingredient_index(id))
     }
 }
 
@@ -234,8 +256,10 @@ where
     }
 
     fn reset_for_new_revision(&mut self, table: &mut Table) {
-        self.lru
-            .for_each_evicted(|evict| self.evict_value_from_memo_for(table.memos_mut(evict)));
+        self.lru.for_each_evicted(|evict| {
+            let ingredient_index = table.ingredient_index(evict);
+            self.evict_value_from_memo_for(table.memos_mut(evict), ingredient_index);
+        });
         std::mem::take(&mut self.deleted_entries);
     }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -96,8 +96,9 @@ pub struct IngredientImpl<C: Configuration> {
 
     /// The index for the memo/sync tables
     ///
-    /// This may be a `MemoIngredientSingletonIndex` or a `MemoIngredientIndex`, depending on
-    /// whether the tracked function's struct is a plain salsa struct or an enum `#[derive(Supertype)]`.
+    /// This may be a [`crate::memo_ingredient_indices::MemoIngredientSingletonIndex`] or a
+    /// [`crate::memo_ingredient_indices::MemoIngredientIndices`], depending on whether the
+    /// tracked function's struct is a plain salsa struct or an enum `#[derive(Supertype)]`.
     memo_ingredient_indices: <C::SalsaStruct<'static> as SalsaStructInDb>::MemoIngredientMap,
 
     /// Used to find memos to throw out when we have too many memoized values.

--- a/src/function.rs
+++ b/src/function.rs
@@ -5,7 +5,6 @@ use crate::{
     cycle::CycleRecoveryStrategy,
     ingredient::{fmt_index, MaybeChangedAfter},
     key::DatabaseKeyIndex,
-    memo_ingredient_indices::{IngredientIndices, MemoIngredientIndices},
     salsa_struct::SalsaStructInDb,
     table::Table,
     zalsa::{IngredientIndex, MemoIngredientIndex, Zalsa},
@@ -96,7 +95,10 @@ pub struct IngredientImpl<C: Configuration> {
     index: IngredientIndex,
 
     /// The index for the memo/sync tables
-    memo_ingredient_indices: MemoIngredientIndices,
+    ///
+    /// This may be a `MemoIngredientSingletonIndex` or a `MemoIngredientIndex`, depending on
+    /// whether the tracked function's struct is a plain salsa struct or an enum `#[derive(Supertype)]`.
+    memo_ingredient_indices: <C::SalsaStruct<'static> as SalsaStructInDb>::MemoIngredientMap,
 
     /// Used to find memos to throw out when we have too many memoized values.
     lru: lru::Lru,
@@ -127,9 +129,10 @@ impl<C> IngredientImpl<C>
 where
     C: Configuration,
 {
-    pub fn new(struct_indices: IngredientIndices, index: IngredientIndex, zalsa: &Zalsa) -> Self {
-        let memo_ingredient_indices = struct_indices
-            .memo_indices(|struct_index| zalsa.next_memo_ingredient_index(struct_index, index));
+    pub fn new(
+        index: IngredientIndex,
+        memo_ingredient_indices: <C::SalsaStruct<'static> as SalsaStructInDb>::MemoIngredientMap,
+    ) -> Self {
         Self {
             index,
             memo_ingredient_indices,
@@ -195,13 +198,12 @@ where
         &self,
         ingredient_index: IngredientIndex,
     ) -> MemoIngredientIndex {
-        self.memo_ingredient_indices.find(ingredient_index)
+        self.memo_ingredient_indices[ingredient_index]
     }
 
     #[inline]
     fn memo_ingredient_index(&self, zalsa: &Zalsa, id: Id) -> MemoIngredientIndex {
-        self.memo_ingredient_indices
-            .find(zalsa.ingredient_index(id))
+        self.memo_ingredient_indices[zalsa.ingredient_index(id)]
     }
 }
 

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -84,6 +84,12 @@ where
 
         tracing::debug!("{database_key_index:?}: read_upgrade: result.revisions = {revisions:#?}");
 
-        self.insert_memo(zalsa, id, Memo::new(Some(value), revision_now, revisions))
+        let memo_ingredient_index = self.memo_ingredient_index(zalsa, id);
+        self.insert_memo(
+            zalsa,
+            id,
+            Memo::new(Some(value), revision_now, revisions),
+            memo_ingredient_index,
+        )
     }
 }

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -1,4 +1,5 @@
 use super::{memo::Memo, Configuration, IngredientImpl};
+use crate::zalsa::MemoIngredientIndex;
 use crate::{
     accumulator::accumulated_map::InputAccumulatedValues, runtime::StampedValue,
     zalsa::ZalsaDatabase, AsDynDatabase as _, Id,
@@ -40,17 +41,26 @@ where
         db: &'db C::DbView,
         id: Id,
     ) -> &'db Memo<C::Output<'db>> {
+        let memo_ingredient_index = self.memo_ingredient_index(db.zalsa(), id);
         loop {
-            if let Some(memo) = self.fetch_hot(db, id).or_else(|| self.fetch_cold(db, id)) {
+            if let Some(memo) = self
+                .fetch_hot(db, id, memo_ingredient_index)
+                .or_else(|| self.fetch_cold(db, id, memo_ingredient_index))
+            {
                 return memo;
             }
         }
     }
 
     #[inline]
-    fn fetch_hot<'db>(&'db self, db: &'db C::DbView, id: Id) -> Option<&'db Memo<C::Output<'db>>> {
+    fn fetch_hot<'db>(
+        &'db self,
+        db: &'db C::DbView,
+        id: Id,
+        memo_ingredient_index: MemoIngredientIndex,
+    ) -> Option<&'db Memo<C::Output<'db>>> {
         let zalsa = db.zalsa();
-        let memo_guard = self.get_memo_from_table_for(zalsa, id);
+        let memo_guard = self.get_memo_from_table_for(zalsa, id, memo_ingredient_index);
         if let Some(memo) = &memo_guard {
             if memo.value.is_some()
                 && self.shallow_verify_memo(db, zalsa, self.database_key_index(id), memo)
@@ -63,7 +73,12 @@ where
         None
     }
 
-    fn fetch_cold<'db>(&'db self, db: &'db C::DbView, id: Id) -> Option<&'db Memo<C::Output<'db>>> {
+    fn fetch_cold<'db>(
+        &'db self,
+        db: &'db C::DbView,
+        id: Id,
+        memo_ingredient_index: MemoIngredientIndex,
+    ) -> Option<&'db Memo<C::Output<'db>>> {
         let (zalsa, zalsa_local) = db.zalsas();
         let database_key_index = self.database_key_index(id);
 
@@ -72,7 +87,7 @@ where
             db.as_dyn_database(),
             zalsa_local,
             database_key_index,
-            self.memo_ingredient_index,
+            memo_ingredient_index,
         )?;
 
         // Push the query on the stack.
@@ -80,7 +95,7 @@ where
 
         // Now that we've claimed the item, check again to see if there's a "hot" value.
         let zalsa = db.zalsa();
-        let opt_old_memo = self.get_memo_from_table_for(zalsa, id);
+        let opt_old_memo = self.get_memo_from_table_for(zalsa, id, memo_ingredient_index);
         if let Some(old_memo) = &opt_old_memo {
             if old_memo.value.is_some() && self.deep_verify_memo(db, old_memo, &active_query) {
                 // Unsafety invariant: memo is present in memo_map and we have verified that it is

--- a/src/function/inputs.rs
+++ b/src/function/inputs.rs
@@ -7,7 +7,8 @@ where
     C: Configuration,
 {
     pub(super) fn origin(&self, zalsa: &Zalsa, key: Id) -> Option<QueryOrigin> {
-        self.get_memo_from_table_for(zalsa, key)
+        let memo_ingredient_index = self.memo_ingredient_index(zalsa, key);
+        self.get_memo_from_table_for(zalsa, key, memo_ingredient_index)
             .map(|m| m.revisions.origin.clone())
     }
 }

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -2,7 +2,7 @@ use crate::{
     accumulator::accumulated_map::InputAccumulatedValues,
     ingredient::MaybeChangedAfter,
     key::DatabaseKeyIndex,
-    zalsa::{Zalsa, ZalsaDatabase},
+    zalsa::{MemoIngredientIndex, Zalsa, ZalsaDatabase},
     zalsa_local::{ActiveQueryGuard, QueryEdge, QueryOrigin},
     AsDynDatabase as _, Id, Revision,
 };
@@ -20,6 +20,7 @@ where
         revision: Revision,
     ) -> MaybeChangedAfter {
         let (zalsa, zalsa_local) = db.zalsas();
+        let memo_ingredient_index = self.memo_ingredient_index(zalsa, id);
         zalsa_local.unwind_if_revision_cancelled(db.as_dyn_database());
 
         loop {
@@ -28,7 +29,7 @@ where
             tracing::debug!("{database_key_index:?}: maybe_changed_after(revision = {revision:?})");
 
             // Check if we have a verified version: this is the hot path.
-            let memo_guard = self.get_memo_from_table_for(zalsa, id);
+            let memo_guard = self.get_memo_from_table_for(zalsa, id, memo_ingredient_index);
             if let Some(memo) = &memo_guard {
                 if self.shallow_verify_memo(db, zalsa, database_key_index, memo) {
                     return if memo.revisions.changed_at > revision {
@@ -38,7 +39,9 @@ where
                     };
                 }
                 drop(memo_guard); // release the arc-swap guard before cold path
-                if let Some(mcs) = self.maybe_changed_after_cold(db, id, revision) {
+                if let Some(mcs) =
+                    self.maybe_changed_after_cold(db, id, revision, memo_ingredient_index)
+                {
                     return mcs;
                 } else {
                     // We failed to claim, have to retry.
@@ -55,6 +58,7 @@ where
         db: &'db C::DbView,
         key_index: Id,
         revision: Revision,
+        memo_ingredient_index: MemoIngredientIndex,
     ) -> Option<MaybeChangedAfter> {
         let (zalsa, zalsa_local) = db.zalsas();
         let database_key_index = self.database_key_index(key_index);
@@ -63,12 +67,13 @@ where
             db.as_dyn_database(),
             zalsa_local,
             database_key_index,
-            self.memo_ingredient_index,
+            memo_ingredient_index,
         )?;
         let active_query = zalsa_local.push_query(database_key_index);
 
         // Load the current memo, if any.
-        let Some(old_memo) = self.get_memo_from_table_for(zalsa, key_index) else {
+        let Some(old_memo) = self.get_memo_from_table_for(zalsa, key_index, memo_ingredient_index)
+        else {
             return Some(MaybeChangedAfter::Yes);
         };
 

--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -73,7 +73,8 @@ where
             accumulated_inputs: Default::default(),
         };
 
-        if let Some(old_memo) = self.get_memo_from_table_for(zalsa, key) {
+        let memo_ingredient_index = self.memo_ingredient_index(zalsa, key);
+        if let Some(old_memo) = self.get_memo_from_table_for(zalsa, key, memo_ingredient_index) {
             self.backdate_if_appropriate(&old_memo, &mut revisions, &value);
             self.diff_outputs(db, database_key_index, &old_memo, &mut revisions);
         }
@@ -89,7 +90,7 @@ where
             memo.tracing_debug(),
             key
         );
-        self.insert_memo(zalsa, key, memo);
+        self.insert_memo(zalsa, key, memo, memo_ingredient_index);
 
         // Record that the current query *specified* a value for this cell.
         let database_key_index = self.database_key_index(key);
@@ -107,8 +108,9 @@ where
         key: Id,
     ) {
         let zalsa = db.zalsa();
+        let memo_ingredient_index = self.memo_ingredient_index(zalsa, key);
 
-        let memo = match self.get_memo_from_table_for(zalsa, key) {
+        let memo = match self.get_memo_from_table_for(zalsa, key, memo_ingredient_index) {
             Some(m) => m,
             None => return,
         };

--- a/src/id.rs
+++ b/src/id.rs
@@ -2,6 +2,8 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::num::NonZeroU32;
 
+use crate::Database;
+
 /// The `Id` of a salsa struct in the database [`Table`](`crate::table::Table`).
 ///
 /// The higher-order bits of an `Id` identify a [`Page`](`crate::table::Page`)
@@ -70,5 +72,18 @@ impl AsId for Id {
 impl FromId for Id {
     fn from_id(id: Id) -> Self {
         id
+    }
+}
+
+/// Enums cannot use [`FromId`] because they need access to the DB to tell the `TypeId` of the variant,
+/// so they use this trait instead, that has a blanket implementation for `FromId`.
+pub trait FromIdWithDb: AsId + Copy + Eq + Hash + Debug {
+    fn from_id(id: Id, db: &(impl ?Sized + Database)) -> Self;
+}
+
+impl<T: FromId> FromIdWithDb for T {
+    #[inline]
+    fn from_id(id: Id, _db: &(impl ?Sized + Database)) -> Self {
+        FromId::from_id(id)
     }
 }

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -27,7 +27,7 @@ pub trait Jar: Any {
     where
         Self: Sized,
     {
-        IngredientIndices::uninitialized()
+        IngredientIndices::empty()
     }
 
     /// Create the ingredients given the index of the first one.

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -6,8 +6,9 @@ use std::{
 use crate::{
     accumulator::accumulated_map::{AccumulatedMap, InputAccumulatedValues},
     cycle::CycleRecoveryStrategy,
+    plumbing::IngredientIndices,
     table::Table,
-    zalsa::{IngredientIndex, MemoIngredientIndex},
+    zalsa::{IngredientIndex, Zalsa},
     zalsa_local::QueryOrigin,
     Database, DatabaseKeyIndex, Id,
 };
@@ -17,40 +18,33 @@ use super::Revision;
 /// A "jar" is a group of ingredients that are added atomically.
 /// Each type implementing jar can be added to the database at most once.
 pub trait Jar: Any {
+    /// This creates the ingredient dependencies of this jar. We need to split this from `create_ingredients()`
+    /// because while `create_ingredients()` is called, a lock on the ingredient map is held (to guarantee
+    /// atomicity), so other ingredients could not be created.
+    ///
+    /// Only tracked fns use this.
+    fn create_dependencies(_zalsa: &Zalsa) -> IngredientIndices
+    where
+        Self: Sized,
+    {
+        IngredientIndices::uninitialized()
+    }
+
     /// Create the ingredients given the index of the first one.
     /// All subsequent ingredients will be assigned contiguous indices.
     fn create_ingredients(
-        &self,
-        aux: &dyn JarAux,
+        zalsa: &Zalsa,
         first_index: IngredientIndex,
-    ) -> Vec<Box<dyn Ingredient>>;
+        dependencies: IngredientIndices,
+    ) -> Vec<Box<dyn Ingredient>>
+    where
+        Self: Sized;
 
-    /// If this jar's first ingredient is a salsa struct, return its `TypeId`
-    fn salsa_struct_type_id(&self) -> Option<TypeId>;
-}
-
-/// Methods on the Salsa database available to jars while they are creating their ingredients.
-pub trait JarAux {
-    /// Return index of first ingredient from `jar` (based on the dynamic type of `jar`).
-    /// Returns `None` if the jar has not yet been added.
-    /// Used by tracked functions to lookup the ingredient index for the salsa struct they take as argument.
-    fn lookup_jar_by_type(&self, jar: &dyn Jar) -> Option<IngredientIndex>;
-
-    /// Returns the memo ingredient index that should be used to attach data from the given tracked function
-    /// to the given salsa struct (which the fn accepts as argument).
-    ///
-    /// The memo ingredient indices for a given function must be distinct from the memo indices
-    /// of all other functions that take the same salsa struct.
-    ///
-    /// # Parameters
-    ///
-    /// * `struct_ingredient_index`, the index of the salsa struct the memo will be attached to
-    /// * `ingredient_index`, the index of the tracked function whose data is stored in the memo
-    fn next_memo_ingredient_index(
-        &self,
-        struct_ingredient_index: IngredientIndex,
-        ingredient_index: IngredientIndex,
-    ) -> MemoIngredientIndex;
+    /// This returns the [`TypeId`] of the ID struct, that is, the struct that wraps `salsa::Id`
+    /// and carry the name of the jar.
+    fn id_struct_type_id() -> TypeId
+    where
+        Self: Sized;
 }
 
 pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -4,11 +4,11 @@ use crate::accumulator::accumulated_map::InputAccumulatedValues;
 use crate::durability::Durability;
 use crate::ingredient::{fmt_index, MaybeChangedAfter};
 use crate::key::InputDependencyIndex;
-use crate::plumbing::{Jar, JarAux};
+use crate::plumbing::{IngredientIndices, Jar};
 use crate::table::memo::MemoTable;
 use crate::table::sync::SyncTable;
 use crate::table::{Slot, Table};
-use crate::zalsa::IngredientIndex;
+use crate::zalsa::{IngredientIndex, Zalsa};
 use crate::zalsa_local::QueryOrigin;
 use crate::{Database, DatabaseKeyIndex, Id};
 use std::any::TypeId;
@@ -100,15 +100,15 @@ impl<C: Configuration> Default for JarImpl<C> {
 
 impl<C: Configuration> Jar for JarImpl<C> {
     fn create_ingredients(
-        &self,
-        _aux: &dyn JarAux,
+        _zalsa: &Zalsa,
         first_index: IngredientIndex,
+        _dependencies: IngredientIndices,
     ) -> Vec<Box<dyn Ingredient>> {
         vec![Box::new(IngredientImpl::<C>::new(first_index)) as _]
     }
 
-    fn salsa_struct_type_id(&self) -> Option<std::any::TypeId> {
-        Some(TypeId::of::<<C as Configuration>::Struct<'static>>())
+    fn id_struct_type_id() -> TypeId {
+        TypeId::of::<C::Struct<'static>>()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,8 @@ pub use salsa_macros::accumulator;
 pub use salsa_macros::db;
 pub use salsa_macros::input;
 pub use salsa_macros::interned;
-pub use salsa_macros::supertype;
 pub use salsa_macros::tracked;
+pub use salsa_macros::Supertype;
 pub use salsa_macros::Update;
 
 pub mod prelude {
@@ -87,7 +87,9 @@ pub mod plumbing {
     pub use crate::ingredient::Ingredient;
     pub use crate::ingredient::Jar;
     pub use crate::key::DatabaseKeyIndex;
-    pub use crate::memo_ingredient_indices::IngredientIndices;
+    pub use crate::memo_ingredient_indices::{
+        IngredientIndices, MemoIngredientIndices, MemoIngredientSingletonIndex,
+    };
     pub use crate::revision::Revision;
     pub use crate::runtime::stamp;
     pub use crate::runtime::Runtime;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ mod ingredient;
 mod input;
 mod interned;
 mod key;
+mod memo_ingredient_indices;
 mod nonce;
 mod par_map;
 mod revision;
@@ -51,6 +52,7 @@ pub use salsa_macros::accumulator;
 pub use salsa_macros::db;
 pub use salsa_macros::input;
 pub use salsa_macros::interned;
+pub use salsa_macros::supertype;
 pub use salsa_macros::tracked;
 pub use salsa_macros::Update;
 
@@ -66,6 +68,9 @@ pub mod prelude {
 ///
 /// The contents of this module are NOT subject to semver.
 pub mod plumbing {
+    pub use std::any::TypeId;
+    pub use std::option::Option::{self, None, Some};
+
     pub use crate::accumulator::Accumulator;
     pub use crate::array::Array;
     pub use crate::attach::attach;
@@ -77,11 +82,12 @@ pub mod plumbing {
     pub use crate::function::should_backdate_value;
     pub use crate::id::AsId;
     pub use crate::id::FromId;
+    pub use crate::id::FromIdWithDb;
     pub use crate::id::Id;
     pub use crate::ingredient::Ingredient;
     pub use crate::ingredient::Jar;
-    pub use crate::ingredient::JarAux;
     pub use crate::key::DatabaseKeyIndex;
+    pub use crate::memo_ingredient_indices::IngredientIndices;
     pub use crate::revision::Revision;
     pub use crate::runtime::stamp;
     pub use crate::runtime::Runtime;

--- a/src/memo_ingredient_indices.rs
+++ b/src/memo_ingredient_indices.rs
@@ -1,0 +1,114 @@
+use std::fmt;
+
+use crate::zalsa::MemoIngredientIndex;
+use crate::IngredientIndex;
+
+/// The maximum number of memo ingredient indices we can hold. This affects the
+/// maximum number of variants possible in `#[derive(salsa::Enum)]`. We use a const
+/// so that we don't allocate and to perhaps allow the compiler to vectorize the search.
+pub const MAX_MEMO_INGREDIENT_INDICES: usize = 20;
+
+/// An ingredient has an [ingredient index][IngredientIndex]. However, Salsa also supports
+/// enums of salsa structs, and those don't have a constant ingredient index, because they
+/// are not ingredients by themselves but rather composed of them. However, an enum can be
+/// viewed as a *set* of [`IngredientIndex`], where each instance of the enum can belong
+/// to one, potentially different, index. This is what this type represents: a set of
+/// `IngredientIndex`.
+///
+/// This type is represented as an array, for efficiency, and supports up to 20 indices.
+/// That means that Salsa enums can have at most 20 variants. Alternatively, they can also
+/// contain Salsa enums as variants, but then the total number of variants is counter - because
+/// what matters is the number of unique `IngredientIndex`s.
+#[derive(Clone)]
+pub struct IngredientIndices {
+    indices: [IngredientIndex; MAX_MEMO_INGREDIENT_INDICES],
+    len: u8,
+}
+
+impl From<IngredientIndex> for IngredientIndices {
+    #[inline]
+    fn from(value: IngredientIndex) -> Self {
+        let mut result = Self::uninitialized();
+        result.indices[0] = value;
+        result.len = 1;
+        result
+    }
+}
+
+impl fmt::Debug for IngredientIndices {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list()
+            .entries(&self.indices[..self.len.into()])
+            .finish()
+    }
+}
+
+impl IngredientIndices {
+    #[inline]
+    pub(crate) fn memo_indices(
+        &self,
+        mut memo_index: impl FnMut(IngredientIndex) -> MemoIngredientIndex,
+    ) -> MemoIngredientIndices {
+        let mut memo_ingredient_indices = [(
+            IngredientIndex::from((u32::MAX - 1) as usize),
+            MemoIngredientIndex::from_usize((u32::MAX - 1) as usize),
+        ); MAX_MEMO_INGREDIENT_INDICES];
+        for i in 0..usize::from(self.len) {
+            let memo_ingredient_index = memo_index(self.indices[i]);
+            memo_ingredient_indices[i] = (self.indices[i], memo_ingredient_index);
+        }
+        MemoIngredientIndices {
+            indices: memo_ingredient_indices,
+            len: self.len,
+        }
+    }
+
+    #[inline]
+    pub fn uninitialized() -> Self {
+        Self {
+            indices: [IngredientIndex::from((u32::MAX - 1) as usize); MAX_MEMO_INGREDIENT_INDICES],
+            len: 0,
+        }
+    }
+
+    #[track_caller]
+    #[inline]
+    pub fn merge(&mut self, other: &Self) {
+        if usize::from(self.len) + usize::from(other.len) > MAX_MEMO_INGREDIENT_INDICES {
+            panic!("too many variants in the salsa enum");
+        }
+        self.indices[usize::from(self.len)..][..usize::from(other.len)]
+            .copy_from_slice(&other.indices[..usize::from(other.len)]);
+        self.len += other.len;
+    }
+}
+
+/// This type is to [`MemoIngredientIndex`] what [`IngredientIndices`] is to [`IngredientIndex`]:
+/// since enums can contain different ingredient indices, they can also have different memo indices,
+/// so we need to keep track of them.
+#[derive(Clone)]
+pub struct MemoIngredientIndices {
+    indices: [(IngredientIndex, MemoIngredientIndex); MAX_MEMO_INGREDIENT_INDICES],
+    len: u8,
+}
+
+impl fmt::Debug for MemoIngredientIndices {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list()
+            .entries(&self.indices[..self.len.into()])
+            .finish()
+    }
+}
+
+impl MemoIngredientIndices {
+    #[inline]
+    pub(crate) fn find(&self, ingredient_index: IngredientIndex) -> MemoIngredientIndex {
+        for &(ingredient, memo_ingredient_index) in &self.indices[..(self.len - 1).into()] {
+            if ingredient == ingredient_index {
+                return memo_ingredient_index;
+            }
+        }
+        // It must be the last.
+        self.indices[usize::from(self.len - 1)].1
+    }
+}

--- a/src/memo_ingredient_indices.rs
+++ b/src/memo_ingredient_indices.rs
@@ -1,114 +1,122 @@
-use std::fmt;
+use std::ops;
 
-use crate::zalsa::MemoIngredientIndex;
+use crate::zalsa::{MemoIngredientIndex, Zalsa};
 use crate::IngredientIndex;
 
-/// The maximum number of memo ingredient indices we can hold. This affects the
-/// maximum number of variants possible in `#[derive(salsa::Enum)]`. We use a const
-/// so that we don't allocate and to perhaps allow the compiler to vectorize the search.
-pub const MAX_MEMO_INGREDIENT_INDICES: usize = 20;
-
 /// An ingredient has an [ingredient index][IngredientIndex]. However, Salsa also supports
-/// enums of salsa structs, and those don't have a constant ingredient index, because they
-/// are not ingredients by themselves but rather composed of them. However, an enum can be
-/// viewed as a *set* of [`IngredientIndex`], where each instance of the enum can belong
+/// enums of salsa structs (and other salsa enums), and those don't have a constant ingredient index,
+/// because they are not ingredients by themselves but rather composed of them. However, an enum can
+/// be viewed as a *set* of [`IngredientIndex`], where each instance of the enum can belong
 /// to one, potentially different, index. This is what this type represents: a set of
 /// `IngredientIndex`.
-///
-/// This type is represented as an array, for efficiency, and supports up to 20 indices.
-/// That means that Salsa enums can have at most 20 variants. Alternatively, they can also
-/// contain Salsa enums as variants, but then the total number of variants is counter - because
-/// what matters is the number of unique `IngredientIndex`s.
 #[derive(Clone)]
 pub struct IngredientIndices {
-    indices: [IngredientIndex; MAX_MEMO_INGREDIENT_INDICES],
-    len: u8,
+    indices: Box<[IngredientIndex]>,
 }
 
 impl From<IngredientIndex> for IngredientIndices {
     #[inline]
     fn from(value: IngredientIndex) -> Self {
-        let mut result = Self::uninitialized();
-        result.indices[0] = value;
-        result.len = 1;
-        result
-    }
-}
-
-impl fmt::Debug for IngredientIndices {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_list()
-            .entries(&self.indices[..self.len.into()])
-            .finish()
+        Self {
+            indices: Box::new([value]),
+        }
     }
 }
 
 impl IngredientIndices {
     #[inline]
-    pub(crate) fn memo_indices(
-        &self,
-        mut memo_index: impl FnMut(IngredientIndex) -> MemoIngredientIndex,
-    ) -> MemoIngredientIndices {
-        let mut memo_ingredient_indices = [(
-            IngredientIndex::from((u32::MAX - 1) as usize),
+    pub fn empty() -> Self {
+        Self {
+            indices: Box::default(),
+        }
+    }
+
+    pub fn merge(iter: impl IntoIterator<Item = Self>) -> Self {
+        let mut indices = Vec::new();
+        for index in iter {
+            indices.extend(index.indices);
+        }
+        indices.sort_unstable();
+        indices.dedup();
+        Self {
+            indices: indices.into_boxed_slice(),
+        }
+    }
+}
+
+impl From<(&Zalsa, IngredientIndices, IngredientIndex)> for MemoIngredientIndices {
+    #[inline]
+    fn from(
+        (zalsa, struct_indices, ingredient): (&Zalsa, IngredientIndices, IngredientIndex),
+    ) -> Self {
+        let Some(&last) = struct_indices.indices.last() else {
+            unreachable!("Attempting to construct struct memo mapping for non tracked function?")
+        };
+        let mut indices = Vec::new();
+        indices.resize(
+            last.as_usize() + 1,
             MemoIngredientIndex::from_usize((u32::MAX - 1) as usize),
-        ); MAX_MEMO_INGREDIENT_INDICES];
-        for i in 0..usize::from(self.len) {
-            let memo_ingredient_index = memo_index(self.indices[i]);
-            memo_ingredient_indices[i] = (self.indices[i], memo_ingredient_index);
+        );
+        for &struct_ingredient in &struct_indices.indices {
+            indices[struct_ingredient.as_usize()] =
+                zalsa.next_memo_ingredient_index(struct_ingredient, ingredient);
         }
         MemoIngredientIndices {
-            indices: memo_ingredient_indices,
-            len: self.len,
+            indices: indices.into_boxed_slice(),
         }
-    }
-
-    #[inline]
-    pub fn uninitialized() -> Self {
-        Self {
-            indices: [IngredientIndex::from((u32::MAX - 1) as usize); MAX_MEMO_INGREDIENT_INDICES],
-            len: 0,
-        }
-    }
-
-    #[track_caller]
-    #[inline]
-    pub fn merge(&mut self, other: &Self) {
-        if usize::from(self.len) + usize::from(other.len) > MAX_MEMO_INGREDIENT_INDICES {
-            panic!("too many variants in the salsa enum");
-        }
-        self.indices[usize::from(self.len)..][..usize::from(other.len)]
-            .copy_from_slice(&other.indices[..usize::from(other.len)]);
-        self.len += other.len;
     }
 }
 
 /// This type is to [`MemoIngredientIndex`] what [`IngredientIndices`] is to [`IngredientIndex`]:
 /// since enums can contain different ingredient indices, they can also have different memo indices,
 /// so we need to keep track of them.
-#[derive(Clone)]
+///
+/// This acts a map from [`IngredientIndex`] to [`MemoIngredientIndex`] but implemented
+/// via a slice for fast lookups, trading memory for speed. With these changes, lookups are `O(1)`
+/// instead of `O(n)`.
+///
+/// A database tends to have few ingredients (i), less function ingredients and even less
+/// function ingredients targeting `#[derive(Supertype)]` enums (e).
+/// While this is bounded as `O(i * e)` memory usage, the average case is significantly smaller: a
+/// function ingredient targeting enums only stores a slice whose length corresponds to the largest
+/// ingredient index's _value_. For example, if we have the ingredient indices `[2, 6, 17]`, then we
+/// will allocate a slice whose length is `17 + 1`.
+///
+/// Assuming a heavy example scenario of 1000 ingredients (500 of which are function ingredients, 100
+/// of which are enum targeting functions) this would come out to a maximum possibly memory usage of
+/// 4bytes * 1000 * 100 ~= 0.38MB which is negligible.
 pub struct MemoIngredientIndices {
-    indices: [(IngredientIndex, MemoIngredientIndex); MAX_MEMO_INGREDIENT_INDICES],
-    len: u8,
+    indices: Box<[MemoIngredientIndex]>,
 }
 
-impl fmt::Debug for MemoIngredientIndices {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_list()
-            .entries(&self.indices[..self.len.into()])
-            .finish()
+impl ops::Index<IngredientIndex> for MemoIngredientIndices {
+    type Output = MemoIngredientIndex;
+
+    #[inline]
+    fn index(&self, index: IngredientIndex) -> &Self::Output {
+        &self.indices[index.as_usize()]
     }
 }
 
-impl MemoIngredientIndices {
+#[derive(Debug)]
+pub struct MemoIngredientSingletonIndex(MemoIngredientIndex);
+
+impl ops::Index<IngredientIndex> for MemoIngredientSingletonIndex {
+    type Output = MemoIngredientIndex;
+
     #[inline]
-    pub(crate) fn find(&self, ingredient_index: IngredientIndex) -> MemoIngredientIndex {
-        for &(ingredient, memo_ingredient_index) in &self.indices[..(self.len - 1).into()] {
-            if ingredient == ingredient_index {
-                return memo_ingredient_index;
-            }
-        }
-        // It must be the last.
-        self.indices[usize::from(self.len - 1)].1
+    fn index(&self, _: IngredientIndex) -> &Self::Output {
+        &self.0
+    }
+}
+
+impl From<(&Zalsa, IngredientIndices, IngredientIndex)> for MemoIngredientSingletonIndex {
+    #[inline]
+    fn from((zalsa, indices, ingredient): (&Zalsa, IngredientIndices, IngredientIndex)) -> Self {
+        let &[struct_ingredient] = &*indices.indices else {
+            unreachable!("Attempting to construct struct memo mapping from enum?")
+        };
+
+        Self(zalsa.next_memo_ingredient_index(struct_ingredient, ingredient))
     }
 }

--- a/src/salsa_struct.rs
+++ b/src/salsa_struct.rs
@@ -1,5 +1,52 @@
-use crate::{plumbing::JarAux, IngredientIndex};
+use std::any::TypeId;
 
-pub trait SalsaStructInDb {
-    fn lookup_ingredient_index(aux: &dyn JarAux) -> Option<IngredientIndex>;
+use crate::memo_ingredient_indices::IngredientIndices;
+use crate::zalsa::Zalsa;
+use crate::Id;
+
+pub trait SalsaStructInDb: Sized {
+    /// This method is used to create ingredient indices. Note, it does *not* create the ingredients
+    /// themselves, that is the job of [`Zalsa::add_or_lookup_jar_by_type()`]. This method only creates
+    /// or lookup the indices. Naturally, implementors may call `add_or_lookup_jar_by_type()` to
+    /// create the ingredient, but they do not must, e.g. enums recursively call
+    /// `lookup_or_create_ingredient_index()` for their variants and combine them.
+    fn lookup_or_create_ingredient_index(zalsa: &Zalsa) -> IngredientIndices;
+
+    /// This method is used to support nested Salsa enums, a.k.a.:
+    /// ```ignore
+    /// #[salsa::input]
+    /// struct Input {}
+    ///
+    /// #[salsa::interned]
+    /// struct Interned1 {}
+    ///
+    /// #[salsa::interned]
+    /// struct Interned2 {}
+    ///
+    /// #[derive(Debug, salsa::Enum)]
+    /// enum InnerEnum {
+    ///     Input(Input),
+    ///     Interned1(Interned1),
+    /// }
+    ///
+    /// #[derive(Debug, salsa::Enum)]
+    /// enum OuterEnum {
+    ///     InnerEnum(InnerEnum),
+    ///     Interned2(Interned2),
+    /// }
+    /// ```
+    /// Imagine `OuterEnum` got a [`salsa::Id`][Id] and it wants to know which variant it belongs to.
+    /// It cannot ask each variant "what is your ingredient index?" and compare, because `InnerEnum`
+    /// has multiple possible ingredient indices.
+    ///
+    /// It could ask each variant "is this value yours?" and then invoke [`FromId`][crate::id::FromId]
+    /// with the correct variant, but that will duplicate the work: now `InnerEnum` will have to do
+    /// the same thing for its variants.
+    ///
+    /// Instead, we keep track of the [`TypeId`] of the ID struct, and ask each variant to "cast" it. If
+    /// it succeeds, we return that value; if not, we go to the next variant.
+    ///
+    /// Why `TypeId` and not `IngredientIndex`? Because it's cheaper and easier. The `TypeId` is readily
+    /// available at compile time, while the `IngredientIndex` requires a runtime lookup.
+    fn cast(id: Id, type_id: TypeId) -> Option<Self>;
 }

--- a/src/salsa_struct.rs
+++ b/src/salsa_struct.rs
@@ -5,14 +5,27 @@ use crate::zalsa::Zalsa;
 use crate::Id;
 
 pub trait SalsaStructInDb: Sized {
-    /// This method is used to create ingredient indices. Note, it does *not* create the ingredients
-    /// themselves, that is the job of [`Zalsa::add_or_lookup_jar_by_type()`]. This method only creates
-    /// or lookup the indices. Naturally, implementors may call `add_or_lookup_jar_by_type()` to
-    /// create the ingredient, but they do not must, e.g. enums recursively call
-    /// `lookup_or_create_ingredient_index()` for their variants and combine them.
+    type MemoIngredientMap: std::ops::Index<crate::IngredientIndex, Output = crate::zalsa::MemoIngredientIndex>
+        + Send
+        + Sync;
+
+    /// Lookup or create ingredient indices.
+    ///
+    /// Note that this method does *not* create the ingredients themselves, this is handled by
+    /// [`Zalsa::add_or_lookup_jar_by_type()`]. This method only creates
+    /// or looks up the indices corresponding to the ingredients.
+    ///
+    /// While implementors of this trait may call [`Zalsa::add_or_lookup_jar_by_type()`]
+    /// to create the ingredient, they aren't required to. For example, supertypes recursively
+    /// call [`Zalsa::add_or_lookup_jar_by_type()`] for their variants and combine them.
     fn lookup_or_create_ingredient_index(zalsa: &Zalsa) -> IngredientIndices;
 
-    /// This method is used to support nested Salsa enums, a.k.a.:
+    /// Plumbing to support nested salsa supertypes.
+    ///
+    /// In the example below, there are two supertypes: `InnerEnum` and `OuterEnum`,
+    /// where the former is a supertype of `Input` and `Interned1` and the latter
+    /// is a supertype of `InnerEnum` and `Interned2`.
+    ///
     /// ```ignore
     /// #[salsa::input]
     /// struct Input {}
@@ -35,18 +48,20 @@ pub trait SalsaStructInDb: Sized {
     ///     Interned2(Interned2),
     /// }
     /// ```
+    ///
     /// Imagine `OuterEnum` got a [`salsa::Id`][Id] and it wants to know which variant it belongs to.
-    /// It cannot ask each variant "what is your ingredient index?" and compare, because `InnerEnum`
-    /// has multiple possible ingredient indices.
     ///
-    /// It could ask each variant "is this value yours?" and then invoke [`FromId`][crate::id::FromId]
-    /// with the correct variant, but that will duplicate the work: now `InnerEnum` will have to do
-    /// the same thing for its variants.
+    /// `OuterEnum` cannot ask each variant "what is your ingredient index?" and compare because `InnerEnum`
+    /// has *multiple*, possible ingredient indices. Alternatively, `OuterEnum` could ask eaach variant
+    /// "is this value yours?" and then invoke [`FromId`][crate::id::FromId] with the correct variant,
+    /// but this duplicates work: now, `InnerEnum` will have to repeat this check-and-cast for *its*
+    /// variants.
     ///
-    /// Instead, we keep track of the [`TypeId`] of the ID struct, and ask each variant to "cast" it. If
-    /// it succeeds, we return that value; if not, we go to the next variant.
+    /// Instead, the implementor keeps track of the [`std::any::TypeId`] of the ID struct, and ask each
+    /// variant to "cast" to it. If it succeeds, `cast` returns that value; if not, we
+    /// go to the next variant.
     ///
-    /// Why `TypeId` and not `IngredientIndex`? Because it's cheaper and easier. The `TypeId` is readily
+    /// Why `TypeId` and not `IngredientIndex`? Because it's cheaper and easier: the `TypeId` is readily
     /// available at compile time, while the `IngredientIndex` requires a runtime lookup.
     fn cast(id: Id, type_id: TypeId) -> Option<Self>;
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -29,6 +29,8 @@ pub struct Table {
 pub(crate) trait TablePage: Any + Send + Sync {
     fn hidden_type_name(&self) -> &'static str;
 
+    fn ingredient_index(&self) -> IngredientIndex;
+
     /// Access the memos attached to `slot`.
     ///
     /// # Safety condition
@@ -49,7 +51,6 @@ pub(crate) trait TablePage: Any + Send + Sync {
 
 pub(crate) struct Page<T: Slot> {
     /// The ingredient for elements on this page.
-    #[allow(dead_code)] // pretty sure we'll need this
     ingredient: IngredientIndex,
 
     /// Number of elements of `data` that are initialized.
@@ -123,6 +124,13 @@ impl Default for Table {
 }
 
 impl Table {
+    /// Returns the [`IngredientIndex`] for an [`Id`].
+    #[inline]
+    pub fn ingredient_index(&self, id: Id) -> IngredientIndex {
+        let (page_idx, _) = split_id(id);
+        self.pages[page_idx.0].ingredient_index()
+    }
+
     /// Get a reference to the data for `id`, which must have been allocated from this table with type `T`.
     ///
     /// # Panics
@@ -294,6 +302,10 @@ impl<T: Slot> Page<T> {
 impl<T: Slot> TablePage for Page<T> {
     fn hidden_type_name(&self) -> &'static str {
         std::any::type_name::<Self>()
+    }
+
+    fn ingredient_index(&self) -> IngredientIndex {
+        self.ingredient
     }
 
     unsafe fn memos(&self, slot: SlotIndex, current_revision: Revision) -> &MemoTable {

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -6,7 +6,7 @@ use tracked_field::FieldIngredientImpl;
 use crate::{
     accumulator::accumulated_map::InputAccumulatedValues,
     cycle::CycleRecoveryStrategy,
-    ingredient::{fmt_index, Ingredient, Jar, JarAux, MaybeChangedAfter},
+    ingredient::{fmt_index, Ingredient, Jar, MaybeChangedAfter},
     key::{DatabaseKeyIndex, InputDependencyIndex},
     plumbing::ZalsaLocal,
     revision::OptionalAtomicRevision,
@@ -108,9 +108,9 @@ impl<C: Configuration> Default for JarImpl<C> {
 
 impl<C: Configuration> Jar for JarImpl<C> {
     fn create_ingredients(
-        &self,
-        _aux: &dyn JarAux,
+        _zalsa: &Zalsa,
         struct_index: crate::zalsa::IngredientIndex,
+        _dependencies: crate::memo_ingredient_indices::IngredientIndices,
     ) -> Vec<Box<dyn Ingredient>> {
         let struct_ingredient = <IngredientImpl<C>>::new(struct_index);
 
@@ -128,8 +128,8 @@ impl<C: Configuration> Jar for JarImpl<C> {
             .collect()
     }
 
-    fn salsa_struct_type_id(&self) -> Option<TypeId> {
-        Some(TypeId::of::<<C as Configuration>::Struct<'static>>())
+    fn id_struct_type_id() -> TypeId {
+        TypeId::of::<C::Struct<'static>>()
     }
 }
 

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -1,13 +1,15 @@
 use parking_lot::{Mutex, RwLock};
 use rustc_hash::FxHashMap;
 use std::any::{Any, TypeId};
+use std::collections::hash_map;
 use std::marker::PhantomData;
 use std::ops::Deref;
 use std::panic::RefUnwindSafe;
 use std::thread::ThreadId;
 
 use crate::cycle::CycleRecoveryStrategy;
-use crate::ingredient::{Ingredient, Jar, JarAux};
+use crate::hash::FxDashMap;
+use crate::ingredient::{Ingredient, Jar};
 use crate::nonce::{Nonce, NonceGenerator};
 use crate::runtime::{Runtime, WaitResult};
 use crate::table::memo::MemoTable;
@@ -137,6 +139,9 @@ pub struct Zalsa {
     /// adding new kinds of ingredients.
     jar_map: Mutex<FxHashMap<TypeId, IngredientIndex>>,
 
+    /// A map from the `IngredientIndex` to the `TypeId` of its ID struct.
+    ingredient_to_id_struct_type_id_map: FxDashMap<IngredientIndex, TypeId>,
+
     /// Vector of ingredients.
     ///
     /// Immutable unless the mutex on `ingredients_map` is held.
@@ -163,6 +168,7 @@ impl Zalsa {
             views_of: Views::new::<Db>(),
             nonce: NONCE.nonce(),
             jar_map: Default::default(),
+            ingredient_to_id_struct_type_id_map: Default::default(),
             ingredients_vec: boxcar::Vec::new(),
             ingredients_requiring_reset: boxcar::Vec::new(),
             runtime: Runtime::default(),
@@ -195,46 +201,77 @@ impl Zalsa {
         unsafe { self.table().syncs(id, self.current_revision()) }
     }
 
+    pub(crate) fn next_memo_ingredient_index(
+        &self,
+        struct_ingredient_index: IngredientIndex,
+        ingredient_index: IngredientIndex,
+    ) -> MemoIngredientIndex {
+        let mut memo_ingredients = self.memo_ingredient_indices.write();
+        let idx = struct_ingredient_index.as_usize();
+        let memo_ingredients = if let Some(memo_ingredients) = memo_ingredients.get_mut(idx) {
+            memo_ingredients
+        } else {
+            memo_ingredients.resize_with(idx + 1, Vec::new);
+            memo_ingredients.get_mut(idx).unwrap()
+        };
+        let mi = MemoIngredientIndex(u32::try_from(memo_ingredients.len()).unwrap());
+        memo_ingredients.push(ingredient_index);
+        mi
+    }
+
     /// **NOT SEMVER STABLE**
-    pub fn add_or_lookup_jar_by_type(&self, jar: &dyn Jar) -> IngredientIndex {
-        {
-            let jar_type_id = jar.type_id();
-            let mut jar_map = self.jar_map.lock();
-            let mut should_create = false;
-            // First record the index we will use into the map and then go and create the ingredients.
-            // Those ingredients may invoke methods on the `JarAux` trait that read from this map
-            // to lookup ingredient indices for already created jars.
-            //
-            // Note that we still hold the lock above so only one jar is being created at a time and hence
-            // ingredient indices cannot overlap.
-            let index = *jar_map.entry(jar_type_id).or_insert_with(|| {
-                should_create = true;
-                IngredientIndex::from(self.ingredients_vec.count())
-            });
-            if should_create {
-                let aux = JarAuxImpl(self, &jar_map);
-                let ingredients = jar.create_ingredients(&aux, index);
-                for ingredient in ingredients {
-                    let expected_index = ingredient.ingredient_index();
+    #[inline]
+    pub fn lookup_page_type_id(&self, id: Id) -> TypeId {
+        let ingredient_index = self.ingredient_index(id);
+        *self
+            .ingredient_to_id_struct_type_id_map
+            .get(&ingredient_index)
+            .expect("should have the ingredient index available")
+    }
 
-                    if ingredient.requires_reset_for_new_revision() {
-                        self.ingredients_requiring_reset.push(expected_index);
-                    }
+    /// **NOT SEMVER STABLE**
+    pub fn add_or_lookup_jar_by_type<J: Jar>(&self) -> IngredientIndex {
+        let jar_type_id = TypeId::of::<J>();
+        let mut jar_map = self.jar_map.lock();
+        if let Some(index) = jar_map.get(&jar_type_id) {
+            return *index;
+        };
+        drop(jar_map);
+        let dependencies = J::create_dependencies(self);
 
-                    let actual_index = self.ingredients_vec.push(ingredient);
-                    assert_eq!(
-                        expected_index.as_usize(),
-                        actual_index,
-                        "ingredient `{:?}` was predicted to have index `{:?}` but actually has index `{:?}`",
-                        self.ingredients_vec[actual_index],
-                        expected_index,
-                        actual_index,
-                    );
-                }
+        jar_map = self.jar_map.lock();
+        let index = IngredientIndex::from(self.ingredients_vec.len());
+        match jar_map.entry(jar_type_id) {
+            hash_map::Entry::Occupied(entry) => {
+                // Someone made it earlier than us.
+                return *entry.get();
+            }
+            hash_map::Entry::Vacant(entry) => entry.insert(index),
+        };
+        let ingredients = J::create_ingredients(self, index, dependencies);
+        for ingredient in ingredients {
+            let expected_index = ingredient.ingredient_index();
+
+            if ingredient.requires_reset_for_new_revision() {
+                self.ingredients_requiring_reset.push(expected_index);
             }
 
-            index
+            let actual_index = self.ingredients_vec.push(ingredient);
+            assert_eq!(
+                expected_index.as_usize(),
+                actual_index,
+                "ingredient `{:?}` was predicted to have index `{:?}` but actually has index `{:?}`",
+                self.ingredients_vec[actual_index],
+                expected_index,
+                actual_index,
+            );
         }
+
+        drop(jar_map);
+        self.ingredient_to_id_struct_type_id_map
+            .insert(index, J::id_struct_type_id());
+
+        index
     }
 
     pub(crate) fn lookup_ingredient(&self, index: IngredientIndex) -> &dyn Ingredient {
@@ -330,31 +367,10 @@ impl Zalsa {
         self.memo_ingredient_indices.read()[struct_ingredient_index.as_usize()]
             [memo_ingredient_index.as_usize()]
     }
-}
 
-struct JarAuxImpl<'a>(&'a Zalsa, &'a FxHashMap<TypeId, IngredientIndex>);
-
-impl JarAux for JarAuxImpl<'_> {
-    fn lookup_jar_by_type(&self, jar: &dyn Jar) -> Option<IngredientIndex> {
-        self.1.get(&jar.type_id()).map(ToOwned::to_owned)
-    }
-
-    fn next_memo_ingredient_index(
-        &self,
-        struct_ingredient_index: IngredientIndex,
-        ingredient_index: IngredientIndex,
-    ) -> MemoIngredientIndex {
-        let mut memo_ingredients = self.0.memo_ingredient_indices.write();
-        let idx = struct_ingredient_index.as_usize();
-        let memo_ingredients = if let Some(memo_ingredients) = memo_ingredients.get_mut(idx) {
-            memo_ingredients
-        } else {
-            memo_ingredients.resize_with(idx + 1, Vec::new);
-            &mut memo_ingredients[idx]
-        };
-        let mi = MemoIngredientIndex(u32::try_from(memo_ingredients.len()).unwrap());
-        memo_ingredients.push(ingredient_index);
-        mi
+    #[inline]
+    pub fn ingredient_index(&self, id: Id) -> IngredientIndex {
+        self.table().ingredient_index(id)
     }
 }
 

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -240,7 +240,7 @@ impl Zalsa {
         let dependencies = J::create_dependencies(self);
 
         jar_map = self.jar_map.lock();
-        let index = IngredientIndex::from(self.ingredients_vec.len());
+        let index = IngredientIndex::from(self.ingredients_vec.count());
         match jar_map.entry(jar_type_id) {
             hash_map::Entry::Occupied(entry) => {
                 // Someone made it earlier than us.

--- a/tests/interned-structs_self_ref.rs
+++ b/tests/interned-structs_self_ref.rs
@@ -112,6 +112,8 @@ const _: () = {
         }
     }
     impl zalsa_::SalsaStructInDb for InternedString<'_> {
+        type MemoIngredientMap = zalsa_::MemoIngredientSingletonIndex;
+
         fn lookup_or_create_ingredient_index(aux: &Zalsa) -> salsa::plumbing::IngredientIndices {
             aux.add_or_lookup_jar_by_type::<zalsa_struct_::JarImpl<Configuration_>>()
                 .into()

--- a/tests/tracked_fn_on_interned_enum.rs
+++ b/tests/tracked_fn_on_interned_enum.rs
@@ -16,7 +16,7 @@ struct Age {
     age: u32,
 }
 
-#[derive(Debug, salsa::supertype)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::supertype)]
 enum Enum<'db> {
     Name(Name),
     NameAndAge(NameAndAge<'db>),
@@ -28,7 +28,7 @@ struct Input {
     value: String,
 }
 
-#[derive(Debug, salsa::supertype)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::supertype)]
 enum EnumOfEnum<'db> {
     Enum(Enum<'db>),
     Input(Input),

--- a/tests/tracked_fn_on_interned_enum.rs
+++ b/tests/tracked_fn_on_interned_enum.rs
@@ -1,0 +1,93 @@
+//! Test that a `tracked` fn on a `salsa::interned`
+//! compiles and executes successfully.
+
+#[salsa::interned(no_lifetime)]
+struct Name {
+    name: String,
+}
+
+#[salsa::interned]
+struct NameAndAge<'db> {
+    name_and_age: String,
+}
+
+#[salsa::interned(no_lifetime)]
+struct Age {
+    age: u32,
+}
+
+#[derive(Debug, salsa::supertype)]
+enum Enum<'db> {
+    Name(Name),
+    NameAndAge(NameAndAge<'db>),
+    Age(Age),
+}
+
+#[salsa::input]
+struct Input {
+    value: String,
+}
+
+#[derive(Debug, salsa::supertype)]
+enum EnumOfEnum<'db> {
+    Enum(Enum<'db>),
+    Input(Input),
+}
+
+#[salsa::tracked]
+fn tracked_fn<'db>(db: &'db dyn salsa::Database, enum_: Enum<'db>) -> String {
+    match enum_ {
+        Enum::Name(name) => name.name(db),
+        Enum::NameAndAge(name_and_age) => name_and_age.name_and_age(db),
+        Enum::Age(age) => age.age(db).to_string(),
+    }
+}
+
+#[salsa::tracked]
+fn tracked_fn2<'db>(db: &'db dyn salsa::Database, enum_: EnumOfEnum<'db>) -> String {
+    match enum_ {
+        EnumOfEnum::Enum(enum_) => tracked_fn(db, enum_),
+        EnumOfEnum::Input(input) => input.value(db),
+    }
+}
+
+#[test]
+fn execute() {
+    let db = salsa::DatabaseImpl::new();
+    let name = Name::new(&db, "Salsa".to_string());
+    let name_and_age = NameAndAge::new(&db, "Salsa 3".to_string());
+    let age = Age::new(&db, 123);
+
+    assert_eq!(tracked_fn(&db, Enum::Name(name)), "Salsa");
+    assert_eq!(tracked_fn(&db, Enum::NameAndAge(name_and_age)), "Salsa 3");
+    assert_eq!(tracked_fn(&db, Enum::Age(age)), "123");
+    assert_eq!(tracked_fn(&db, Enum::Name(name)), "Salsa");
+    assert_eq!(tracked_fn(&db, Enum::NameAndAge(name_and_age)), "Salsa 3");
+    assert_eq!(tracked_fn(&db, Enum::Age(age)), "123");
+
+    assert_eq!(
+        tracked_fn2(&db, EnumOfEnum::Enum(Enum::Name(name))),
+        "Salsa"
+    );
+    assert_eq!(
+        tracked_fn2(&db, EnumOfEnum::Enum(Enum::NameAndAge(name_and_age))),
+        "Salsa 3"
+    );
+    assert_eq!(tracked_fn2(&db, EnumOfEnum::Enum(Enum::Age(age))), "123");
+    assert_eq!(
+        tracked_fn2(&db, EnumOfEnum::Enum(Enum::Name(name))),
+        "Salsa"
+    );
+    assert_eq!(
+        tracked_fn2(&db, EnumOfEnum::Enum(Enum::NameAndAge(name_and_age))),
+        "Salsa 3"
+    );
+    assert_eq!(tracked_fn2(&db, EnumOfEnum::Enum(Enum::Age(age))), "123");
+    assert_eq!(
+        tracked_fn2(
+            &db,
+            EnumOfEnum::Input(Input::new(&db, "Hello world!".to_string()))
+        ),
+        "Hello world!"
+    );
+}

--- a/tests/tracked_fn_on_interned_enum.rs
+++ b/tests/tracked_fn_on_interned_enum.rs
@@ -16,7 +16,7 @@ struct Age {
     age: u32,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::supertype)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Supertype)]
 enum Enum<'db> {
     Name(Name),
     NameAndAge(NameAndAge<'db>),
@@ -28,7 +28,7 @@ struct Input {
     value: String,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::supertype)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Supertype)]
 enum EnumOfEnum<'db> {
     Enum(Enum<'db>),
     Input(Input),


### PR DESCRIPTION
This PR implements https://github.com/salsa-rs/salsa/issues/578 and is (currently) stacked atop of https://github.com/salsa-rs/salsa/pull/676. All authorship/credit for this work goes to @ChayimFriedman2 for the implementation, I largely renamed some stuff.

Two notes on this PR:
1. There's no corresponding `macro_rules!` macro for `#[salsa::supertype]`. We can add it, need be.
2. I've commented out some hand-written `PartialEq` implementations because they caused a bunch of test failures in rust-analyzer. Those test failures stemmed from rust-analyzer's native, non-Salsa powered interner, which persists even after we changed databases in tests! For more details, see what [Chayim wrote on Zulip](https://rust-lang.zulipchat.com/#narrow/channel/185405-t-compiler.2Frust-analyzer/topic/Porting.20to.20Salsa.203.2E0/near/494538002). Instead of commenting things out, I'll make these options on the attribute macro.