### PR TITLE
Implement `HashEqLike<&T>` for `T`

### DIFF
--- a/src/interned.rs
+++ b/src/interned.rs
@@ -376,11 +376,13 @@ pub trait HashEqLike<O> {
 pub trait Lookup<O> {
     fn into_owned(self) -> O;
 }
+
 impl<T> Lookup<T> for T {
     fn into_owned(self) -> T {
         self
     }
 }
+
 impl<T> HashEqLike<T> for T
 where
     T: Hash + Eq,
@@ -404,6 +406,19 @@ where
 
     fn eq(&self, data: &T) -> bool {
         **self == *data
+    }
+}
+
+impl<T> HashEqLike<&T> for T
+where
+    T: Hash + Eq,
+{
+    fn hash<H: Hasher>(&self, h: &mut H) {
+        Hash::hash(self, &mut *h);
+    }
+
+    fn eq(&self, data: &&T) -> bool {
+        *self == **data
     }
 }
 

--- a/tests/interned-structs.rs
+++ b/tests/interned-structs.rs
@@ -42,6 +42,14 @@ struct InternedStringNoLifetime {
     data: String,
 }
 
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
+struct Foo;
+
+#[salsa::interned]
+struct InternedFoo<'db> {
+    data: Foo,
+}
+
 #[derive(Clone, Copy, Hash, Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct SalsaIdWrapper(salsa::Id);
 
@@ -196,4 +204,13 @@ fn interning_with_custom_ids_and_no_lifetime() {
     let s2_2 = InternedStringWithCustomIdAndNoLiftime::new(&db, "World, ");
     assert_eq!(s1, s1_2);
     assert_eq!(s2, s2_2);
+}
+
+#[test]
+fn interning_reference() {
+    let db = salsa::DatabaseImpl::new();
+
+    let s1 = InternedFoo::new(&db, Foo);
+    let s2 = InternedFoo::new(&db, &Foo);
+    assert_eq!(s1, s2);
 }


### PR DESCRIPTION
It looks like the fix in https://github.com/salsa-rs/salsa/pull/671 was the wrong way around, I should have confirmed that it fixed the regression.