### PR TITLE
Replace all uses of `AtomicCell` with appropriate atomic primitives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.76"
 [dependencies]
 arc-swap = "1"
 compact_str = { version = "0.8", optional = true }
-crossbeam = "0.8"
+crossbeam-queue = "0.3.11"
 dashmap = { version = "6", features = ["raw-api"] }
 hashlink = "0.9"
 hashbrown = "0.14.3"
@@ -41,6 +41,7 @@ ordered-float = "4.2.1"
 rustversion = "1.0"
 test-log = { version = "0.2.11", features = ["trace"] }
 trybuild = "1.0"
+crossbeam-channel = "0.5.14"
 
 [[bench]]
 name = "compare"

--- a/examples/lazy-input/main.rs
+++ b/examples/lazy-input/main.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use crossbeam::channel::{unbounded, Sender};
+use crossbeam_channel::{unbounded, Sender};
 use dashmap::{mapref::entry::Entry, DashMap};
 use eyre::{eyre, Context, Report, Result};
 use notify_debouncer_mini::{

--- a/src/accumulator/accumulated_map.rs
+++ b/src/accumulator/accumulated_map.rs
@@ -58,7 +58,7 @@ impl Clone for AccumulatedMap {
 ///
 /// Knowning whether any input has accumulated values makes aggregating the accumulated values
 /// cheaper because we can skip over entire subtrees.
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub enum InputAccumulatedValues {
     /// The query nor any of its inputs have any accumulated values.
     #[default]
@@ -119,5 +119,22 @@ impl AtomicInputAccumulatedValues {
         } else {
             InputAccumulatedValues::Empty
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn atomic_input_accumulated_values() {
+        let val = AtomicInputAccumulatedValues::new(InputAccumulatedValues::Empty);
+        assert_eq!(val.load(), InputAccumulatedValues::Empty);
+        val.store(InputAccumulatedValues::Any);
+        assert_eq!(val.load(), InputAccumulatedValues::Any);
+        let val = AtomicInputAccumulatedValues::new(InputAccumulatedValues::Any);
+        assert_eq!(val.load(), InputAccumulatedValues::Any);
+        val.store(InputAccumulatedValues::Empty);
+        assert_eq!(val.load(), InputAccumulatedValues::Empty);
     }
 }

--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -1,8 +1,7 @@
 use std::ops::Not;
 
-use crossbeam::atomic::AtomicCell;
-
 use super::zalsa_local::{QueryEdges, QueryOrigin, QueryRevisions};
+use crate::accumulator::accumulated_map::AtomicInputAccumulatedValues;
 use crate::key::OutputDependencyIndex;
 use crate::tracked_struct::{DisambiguatorMap, IdentityHash, IdentityMap};
 use crate::zalsa_local::QueryEdge;
@@ -131,7 +130,7 @@ impl ActiveQuery {
             origin,
             durability: self.durability,
             tracked_struct_ids: self.tracked_struct_ids,
-            accumulated_inputs: AtomicCell::new(self.accumulated_inputs),
+            accumulated_inputs: AtomicInputAccumulatedValues::new(self.accumulated_inputs),
             accumulated,
         }
     }

--- a/src/function/delete.rs
+++ b/src/function/delete.rs
@@ -1,4 +1,4 @@
-use crossbeam::queue::SegQueue;
+use crossbeam_queue::SegQueue;
 
 use super::{memo::ArcMemo, Configuration};
 

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -3,9 +3,8 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use crossbeam::atomic::AtomicCell;
-
 use crate::accumulator::accumulated_map::InputAccumulatedValues;
+use crate::revision::AtomicRevision;
 use crate::zalsa_local::QueryOrigin;
 use crate::{
     key::DatabaseKeyIndex, zalsa::Zalsa, zalsa_local::QueryRevisions, Event, EventKind, Id,
@@ -95,7 +94,7 @@ impl<C: Configuration> IngredientImpl<C> {
                                 origin: origin.clone(),
                                 tracked_struct_ids: tracked_struct_ids.clone(),
                                 accumulated: accumulated.clone(),
-                                accumulated_inputs: AtomicCell::new(accumulated_inputs.load()),
+                                accumulated_inputs: accumulated_inputs.clone(),
                             },
                         ))
                     }
@@ -117,7 +116,7 @@ pub(super) struct Memo<V> {
 
     /// Last revision when this memo was verified; this begins
     /// as the current revision.
-    pub(super) verified_at: AtomicCell<Revision>,
+    pub(super) verified_at: AtomicRevision,
 
     /// Revision information
     pub(super) revisions: QueryRevisions,
@@ -132,7 +131,7 @@ impl<V> Memo<V> {
     pub(super) fn new(value: Option<V>, revision_now: Revision, revisions: QueryRevisions) -> Self {
         Memo {
             value,
-            verified_at: AtomicCell::new(revision_now),
+            verified_at: AtomicRevision::from(revision_now),
             revisions,
         }
     }

--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -1,7 +1,6 @@
-use crossbeam::atomic::AtomicCell;
-
 use crate::{
     accumulator::accumulated_map::InputAccumulatedValues,
+    revision::AtomicRevision,
     tracked_struct::TrackedStructInDb,
     zalsa::ZalsaDatabase,
     zalsa_local::{QueryOrigin, QueryRevisions},
@@ -81,7 +80,7 @@ where
 
         let memo = Memo {
             value: Some(value),
-            verified_at: AtomicCell::new(revision),
+            verified_at: AtomicRevision::from(revision),
             revisions,
         };
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -106,7 +106,7 @@ impl<C: Configuration> IngredientImpl<C> {
     pub fn new_input(&self, db: &dyn Database, fields: C::Fields, stamps: C::Stamps) -> C::Struct {
         let (zalsa, zalsa_local) = db.zalsas();
 
-        let id = self.singleton.with_lock(|| {
+        let id = self.singleton.with_scope(|| {
             zalsa_local.allocate(zalsa.table(), self.ingredient_index, |_| Value::<C> {
                 fields,
                 stamps,

--- a/src/revision.rs
+++ b/src/revision.rs
@@ -75,7 +75,7 @@ impl AtomicRevision {
     }
 
     pub(crate) fn store(&self, r: Revision) {
-        self.data.store(r.as_usize(), Ordering::SeqCst);
+        self.data.store(r.as_usize(), Ordering::Release);
     }
 }
 

--- a/src/revision.rs
+++ b/src/revision.rs
@@ -126,3 +126,26 @@ impl OptionalAtomicRevision {
             .map_err(Revision::from_opt)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pptional_atomic_revision() {
+        let val = OptionalAtomicRevision::new(Some(Revision::start()));
+        assert_eq!(val.load(), Some(Revision::start()));
+        assert_eq!(val.swap(None), Some(Revision::start()));
+        assert_eq!(val.load(), None);
+        assert_eq!(val.swap(Some(Revision::start())), None);
+        assert_eq!(val.load(), Some(Revision::start()));
+        assert_eq!(
+            val.compare_exchange(Some(Revision::start()), None),
+            Ok(Some(Revision::start()))
+        );
+        assert_eq!(
+            val.compare_exchange(Some(Revision::start()), None),
+            Err(None)
+        );
+    }
+}

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -1,6 +1,6 @@
 use std::{any::TypeId, fmt, hash::Hash, marker::PhantomData, ops::DerefMut};
 
-use crossbeam::queue::SegQueue;
+use crossbeam_queue::SegQueue;
 use tracked_field::FieldIngredientImpl;
 
 use crate::{

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -1,8 +1,9 @@
-use crossbeam::atomic::AtomicCell;
 use rustc_hash::FxHashMap;
 use tracing::debug;
 
-use crate::accumulator::accumulated_map::{AccumulatedMap, InputAccumulatedValues};
+use crate::accumulator::accumulated_map::{
+    AccumulatedMap, AtomicInputAccumulatedValues, InputAccumulatedValues,
+};
 use crate::active_query::ActiveQuery;
 use crate::durability::Durability;
 use crate::key::{DatabaseKeyIndex, InputDependencyIndex, OutputDependencyIndex};
@@ -341,7 +342,7 @@ pub(crate) struct QueryRevisions {
     pub(super) accumulated: Option<Box<AccumulatedMap>>,
     /// [`InputAccumulatedValues::Empty`] if any input read during the query's execution
     /// has any direct or indirect accumulated values.
-    pub(super) accumulated_inputs: AtomicCell<InputAccumulatedValues>,
+    pub(super) accumulated_inputs: AtomicInputAccumulatedValues,
 }
 
 impl QueryRevisions {

--- a/tests/parallel/parallel_cancellation.rs
+++ b/tests/parallel/parallel_cancellation.rs
@@ -51,7 +51,7 @@ fn execute() {
         move || a1(&db, input)
     });
 
-    db.signal_on_did_cancel.store(2);
+    db.signal_on_did_cancel(2);
     input.set_field(&mut db).to(2);
 
     // Assert thread A *should* was cancelled

--- a/tests/parallel/parallel_cycle_all_recover.rs
+++ b/tests/parallel/parallel_cycle_all_recover.rs
@@ -90,7 +90,7 @@ fn execute() {
 
     let thread_a = std::thread::spawn({
         let db = db.clone();
-        db.knobs().signal_on_will_block.store(3);
+        db.knobs().signal_on_will_block(3);
         move || a1(&db, input)
     });
 

--- a/tests/parallel/parallel_cycle_mid_recover.rs
+++ b/tests/parallel/parallel_cycle_mid_recover.rs
@@ -90,7 +90,7 @@ fn execute() {
 
     let thread_b = std::thread::spawn({
         let db = db.clone();
-        db.knobs().signal_on_will_block.store(3);
+        db.knobs().signal_on_will_block(3);
         move || b1(&db, input)
     });
 

--- a/tests/parallel/parallel_cycle_none_recover.rs
+++ b/tests/parallel/parallel_cycle_none_recover.rs
@@ -42,7 +42,7 @@ fn execute() {
 
     let thread_a = std::thread::spawn({
         let db = db.clone();
-        db.knobs().signal_on_will_block.store(3);
+        db.knobs().signal_on_will_block(3);
         move || a(&db, input)
     });
 

--- a/tests/parallel/parallel_cycle_one_recover.rs
+++ b/tests/parallel/parallel_cycle_one_recover.rs
@@ -74,7 +74,7 @@ fn execute() {
 
     let thread_a = std::thread::spawn({
         let db = db.clone();
-        db.knobs().signal_on_will_block.store(3);
+        db.knobs().signal_on_will_block(3);
         move || a1(&db, input)
     });
 

--- a/tests/parallel/parallel_map.rs
+++ b/tests/parallel/parallel_map.rs
@@ -83,7 +83,7 @@ fn execute_cancellation() {
 
     let counts = (2..=20).collect::<Vec<u32>>();
 
-    db.signal_on_did_cancel.store(2);
+    db.signal_on_did_cancel(2);
     input.set_field(&mut db).to(counts);
 
     // Assert thread A *should* was cancelled


### PR DESCRIPTION
I believe Ibrahim talked about this and it seemed reasonable to me to do. This just carries over the orderings that atomic cell uses for now (with one exception). We also drop the crossbeam dependency now, replacing it with `crossbeam-queue` and `crossbeam-channel`.