### PR TITLE
Use *fallback* trick for tracked-fn `Update` constraint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ rust-version = "1.76"
 
 [dependencies]
 arc-swap = "1"
+compact_str = { version = "0.8", optional = true }
 crossbeam = "0.8"
 dashmap = { version = "6", features = ["raw-api"] }
 hashlink = "0.9"

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -55,6 +55,8 @@ macro_rules! setup_tracked_fn {
         // True if we `return_ref` flag was given to the function
         return_ref: $return_ref:tt,
 
+        maybe_update_fn: {$($maybe_update_fn:tt)*},
+
         // Annoyingly macro-rules hygiene does not extend to items defined in the macro.
         // We have the procedural macro generate names for those items that are
         // not used elsewhere in the user's code.
@@ -150,14 +152,8 @@ macro_rules! setup_tracked_fn {
             ///
             /// # Safety
             /// The same safety rules as for `Update` apply.
-            unsafe fn _implements_update<'db>(old_pointer: *mut $output_ty, new_value: $output_ty) -> bool {
-                unsafe {
-                    use $zalsa::UpdateFallback;
-                    $zalsa::UpdateDispatch::<$output_ty>::maybe_update(
-                        old_pointer, new_value
-                    )
-                }
-            }
+            $($maybe_update_fn)*
+
 
             impl $zalsa::function::Configuration for $Configuration {
                 const DEBUG_NAME: &'static str = stringify!($fn_name);

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -145,6 +145,20 @@ macro_rules! setup_tracked_fn {
                 }
             }
 
+            /// This method isn't used anywhere. It only exitst to enforce the `Self::Output: Update` constraint
+            /// for types that aren't `'static`.
+            ///
+            /// # Safety
+            /// The same safety rules as for `Update` apply.
+            unsafe fn _implements_update<'db>(old_pointer: *mut $output_ty, new_value: $output_ty) -> bool {
+                unsafe {
+                    use $zalsa::UpdateFallback;
+                    $zalsa::UpdateDispatch::<$output_ty>::maybe_update(
+                        old_pointer, new_value
+                    )
+                }
+            }
+
             impl $zalsa::function::Configuration for $Configuration {
                 const DEBUG_NAME: &'static str = stringify!($fn_name);
 

--- a/components/salsa-macros/src/tracked_fn.rs
+++ b/components/salsa-macros/src/tracked_fn.rs
@@ -117,6 +117,18 @@ impl Macro {
 
         let return_ref: bool = self.args.return_ref.is_some();
 
+        let maybe_update_fn = quote_spanned! {output_ty.span()=> {
+            #[allow(clippy::all, unsafe_code)]
+            unsafe fn _maybe_update_fn<'db>(old_pointer: *mut #output_ty, new_value: #output_ty) -> bool {
+                unsafe {
+                    use #zalsa::UpdateFallback;
+                    #zalsa::UpdateDispatch::<#output_ty>::maybe_update(
+                        old_pointer, new_value
+                    )
+                }
+            }
+        }};
+
         Ok(crate::debug::dump_tokens(
             fn_name,
             quote![salsa::plumbing::setup_tracked_fn! {
@@ -137,6 +149,7 @@ impl Macro {
                 needs_interner: #needs_interner,
                 lru: #lru,
                 return_ref: #return_ref,
+                maybe_update_fn: { #maybe_update_fn },
                 unused_names: [
                     #zalsa,
                     #Configuration,

--- a/examples/calc/ir.rs
+++ b/examples/calc/ir.rs
@@ -65,7 +65,7 @@ pub enum ExpressionData<'db> {
     Call(FunctionId<'db>, Vec<Expression<'db>>),
 }
 
-#[derive(Eq, PartialEq, Copy, Clone, Hash, Debug, salsa::Update)]
+#[derive(Eq, PartialEq, Copy, Clone, Hash, Debug)]
 pub enum Op {
     Add,
     Subtract,

--- a/src/function.rs
+++ b/src/function.rs
@@ -9,7 +9,7 @@ use crate::{
     salsa_struct::SalsaStructInDb,
     zalsa::{IngredientIndex, MemoIngredientIndex, Zalsa},
     zalsa_local::QueryOrigin,
-    Cycle, Database, Id, Revision, Update,
+    Cycle, Database, Id, Revision,
 };
 
 use self::delete::DeletedEntries;
@@ -43,7 +43,7 @@ pub trait Configuration: Any {
     type Input<'db>: Send + Sync;
 
     /// The value computed by the function.
-    type Output<'db>: fmt::Debug + Send + Sync + Update;
+    type Output<'db>: fmt::Debug + Send + Sync;
 
     /// Determines whether this function can recover from being a participant in a cycle
     /// (and, if so, how).

--- a/tests/compile-fail/tracked_fn_return_ref.rs
+++ b/tests/compile-fail/tracked_fn_return_ref.rs
@@ -1,5 +1,4 @@
 use salsa::Database as Db;
-use salsa::Update;
 
 #[salsa::input]
 struct MyInput {

--- a/tests/compile-fail/tracked_fn_return_ref.stderr
+++ b/tests/compile-fail/tracked_fn_return_ref.stderr
@@ -6,37 +6,24 @@ warning: unused import: `salsa::Update`
   |
   = note: `#[warn(unused_imports)]` on by default
 
-error[E0277]: the trait bound `&'db str: Update` is not satisfied
-  --> tests/compile-fail/tracked_fn_return_ref.rs:16:67
+error: lifetime may not live long enough
+  --> tests/compile-fail/tracked_fn_return_ref.rs:15:1
    |
-16 | fn tracked_fn_return_ref<'db>(db: &'db dyn Db, input: MyInput) -> &'db str {
-   |                                                                   ^^^^^^^^ the trait `Update` is not implemented for `&'db str`
+15 | #[salsa::tracked]
+   | ^^^^^^^^^^^^^^^^^
+   | |
+   | lifetime `'db` defined here
+   | requires that `'db` must outlive `'static`
    |
-   = help: the trait `Update` is implemented for `String`
-note: required by a bound in `salsa::plumbing::function::Configuration::Output`
-  --> src/function.rs
-   |
-   |     type Output<'db>: fmt::Debug + Send + Sync + Update;
-   |                                                  ^^^^^^ required by this bound in `Configuration::Output`
+   = note: this error originates in the macro `salsa::plumbing::setup_tracked_fn` which comes from the expansion of the attribute macro `salsa::tracked` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `ContainsRef<'db>: Update` is not satisfied
-  --> tests/compile-fail/tracked_fn_return_ref.rs:24:6
+error: lifetime may not live long enough
+  --> tests/compile-fail/tracked_fn_return_ref.rs:20:1
    |
-24 | ) -> ContainsRef<'db> {
-   |      ^^^^^^^^^^^^^^^^ the trait `Update` is not implemented for `ContainsRef<'db>`
+20 | #[salsa::tracked]
+   | ^^^^^^^^^^^^^^^^^
+   | |
+   | lifetime `'db` defined here
+   | requires that `'db` must outlive `'static`
    |
-   = help: the following other types implement trait `Update`:
-             ()
-             (A, B)
-             (A, B, C)
-             (A, B, C, D)
-             (A, B, C, D, E)
-             (A, B, C, D, E, F)
-             (A, B, C, D, E, F, G)
-             (A, B, C, D, E, F, G, H)
-           and $N others
-note: required by a bound in `salsa::plumbing::function::Configuration::Output`
-  --> src/function.rs
-   |
-   |     type Output<'db>: fmt::Debug + Send + Sync + Update;
-   |                                                  ^^^^^^ required by this bound in `Configuration::Output`
+   = note: this error originates in the macro `salsa::plumbing::setup_tracked_fn` which comes from the expansion of the attribute macro `salsa::tracked` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-fail/tracked_fn_return_ref.stderr
+++ b/tests/compile-fail/tracked_fn_return_ref.stderr
@@ -1,29 +1,20 @@
-warning: unused import: `salsa::Update`
- --> tests/compile-fail/tracked_fn_return_ref.rs:2:5
-  |
-2 | use salsa::Update;
-  |     ^^^^^^^^^^^^^
-  |
-  = note: `#[warn(unused_imports)]` on by default
+error: lifetime may not live long enough
+  --> tests/compile-fail/tracked_fn_return_ref.rs:14:1
+   |
+14 | #[salsa::tracked]
+   | ^^^^^^^^^^^^^^^^^ requires that `'db` must outlive `'static`
+15 | fn tracked_fn_return_ref<'db>(db: &'db dyn Db, input: MyInput) -> &'db str {
+   |                                                                   - lifetime `'db` defined here
+   |
+   = note: this error originates in the attribute macro `salsa::tracked` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: lifetime may not live long enough
-  --> tests/compile-fail/tracked_fn_return_ref.rs:15:1
+  --> tests/compile-fail/tracked_fn_return_ref.rs:19:1
    |
-15 | #[salsa::tracked]
-   | ^^^^^^^^^^^^^^^^^
-   | |
-   | lifetime `'db` defined here
-   | requires that `'db` must outlive `'static`
+19 | #[salsa::tracked]
+   | ^^^^^^^^^^^^^^^^^ requires that `'db` must outlive `'static`
+...
+23 | ) -> ContainsRef<'db> {
+   |      ----------- lifetime `'db` defined here
    |
-   = note: this error originates in the macro `salsa::plumbing::setup_tracked_fn` which comes from the expansion of the attribute macro `salsa::tracked` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: lifetime may not live long enough
-  --> tests/compile-fail/tracked_fn_return_ref.rs:20:1
-   |
-20 | #[salsa::tracked]
-   | ^^^^^^^^^^^^^^^^^
-   | |
-   | lifetime `'db` defined here
-   | requires that `'db` must outlive `'static`
-   |
-   = note: this error originates in the macro `salsa::plumbing::setup_tracked_fn` which comes from the expansion of the attribute macro `salsa::tracked` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the attribute macro `salsa::tracked` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/lru.rs
+++ b/tests/lru.rs
@@ -8,10 +8,10 @@ use std::sync::{
 
 mod common;
 use common::LogDatabase;
-use salsa::{Database as _, Update};
+use salsa::Database as _;
 use test_log::test;
 
-#[derive(Debug, PartialEq, Eq, Update)]
+#[derive(Debug, PartialEq, Eq)]
 struct HotPotato(u32);
 
 thread_local! {

--- a/tests/tracked_struct.rs
+++ b/tests/tracked_struct.rs
@@ -1,0 +1,56 @@
+mod common;
+
+use salsa::{Database, Setter};
+
+#[salsa::tracked]
+struct Tracked<'db> {
+    untracked_1: usize,
+
+    untracked_2: usize,
+}
+
+#[salsa::input]
+struct MyInput {
+    field1: usize,
+    field2: usize,
+}
+
+#[salsa::tracked]
+fn intermediate(db: &dyn salsa::Database, input: MyInput) -> Tracked<'_> {
+    Tracked::new(db, input.field1(db), input.field2(db))
+}
+
+#[salsa::tracked]
+fn accumulate(db: &dyn salsa::Database, input: MyInput) -> (usize, usize) {
+    let tracked = intermediate(db, input);
+    let one = read_tracked_1(db, tracked);
+    let two = read_tracked_2(db, tracked);
+
+    (one, two)
+}
+
+#[salsa::tracked]
+fn read_tracked_1<'db>(db: &'db dyn Database, tracked: Tracked<'db>) -> usize {
+    tracked.untracked_1(db)
+}
+
+#[salsa::tracked]
+fn read_tracked_2<'db>(db: &'db dyn Database, tracked: Tracked<'db>) -> usize {
+    tracked.untracked_2(db)
+}
+
+#[test]
+fn execute() {
+    let mut db = salsa::DatabaseImpl::default();
+    let input = MyInput::new(&db, 1, 1);
+
+    assert_eq!(accumulate(&db, input), (1, 1));
+
+    // Should only re-execute `read_tracked_1`.
+    input.set_field1(&mut db).to(2);
+    assert_eq!(accumulate(&db, input), (2, 1));
+
+    // Should only re-execute `read_tracked_2`.
+    input.set_field2(&mut db).to(2);
+    assert_eq!(accumulate(&db, input), (2, 2));
+}

--- a/tests/warnings/needless_lifetimes.rs
+++ b/tests/warnings/needless_lifetimes.rs
@@ -1,9 +1,7 @@
-use salsa::Update;
-
 #[salsa::db]
 pub trait Db: salsa::Database {}
 
-#[derive(Debug, PartialEq, Eq, Hash, Update)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub struct Item {}
 
 #[salsa::tracked]


### PR DESCRIPTION
Use the Fallback trick similar to what the `derive(Update)` does to constrain the tracked-fn's return type to `Update`. 

This removes the need to implement `Update` for types with a `'static` lifetime.


I also added a few `Update` implementations that are needed for Ruff. The not good news is, Ruff now panics with some assertions and I haven't figured out the root cause yet. 

Edit: Okay, the panics go away if I back out of the coarse-grained dependency changes... So something goes wrong there, uff.
