### PR TITLE
LRU eviction at revision bump

### DIFF
--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -13,6 +13,7 @@ use crate::{
     cycle::CycleRecoveryStrategy,
     ingredient::{fmt_index, Ingredient, Jar, MaybeChangedAfter},
     plumbing::JarAux,
+    table::Table,
     zalsa::IngredientIndex,
     zalsa_local::QueryOrigin,
     Database, DatabaseKeyIndex, Id, Revision,
@@ -137,7 +138,7 @@ impl<A: Accumulator> Ingredient for IngredientImpl<A> {
         false
     }
 
-    fn reset_for_new_revision(&mut self) {
+    fn reset_for_new_revision(&mut self, _: &mut Table) {
         panic!("unexpected reset on accumulator")
     }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -7,6 +7,7 @@ use crate::{
     key::DatabaseKeyIndex,
     plumbing::JarAux,
     salsa_struct::SalsaStructInDb,
+    table::Table,
     zalsa::{IngredientIndex, MemoIngredientIndex, Zalsa},
     zalsa_local::QueryOrigin,
     Cycle, Database, Id, Revision,
@@ -231,7 +232,9 @@ where
         true
     }
 
-    fn reset_for_new_revision(&mut self) {
+    fn reset_for_new_revision(&mut self, table: &mut Table) {
+        self.lru
+            .for_each_evicted(|evict| self.evict_value_from_memo_for(table.memos_mut(evict)));
         std::mem::take(&mut self.deleted_entries);
     }
 

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -9,7 +9,7 @@ where
     C: Configuration,
 {
     pub fn fetch<'db>(&'db self, db: &'db C::DbView, id: Id) -> &'db C::Output<'db> {
-        let (zalsa, zalsa_local) = db.zalsas();
+        let zalsa_local = db.zalsa_local();
         zalsa_local.unwind_if_revision_cancelled(db.as_dyn_database());
 
         let memo = self.refresh_memo(db, id);
@@ -19,9 +19,7 @@ where
             changed_at,
         } = memo.revisions.stamped_value(memo.value.as_ref().unwrap());
 
-        if let Some(evicted) = self.lru.record_use(id) {
-            self.evict_value_from_memo_for(zalsa, evicted);
-        }
+        self.lru.record_use(id);
 
         zalsa_local.report_tracked_read(
             self.database_key_index(id).into(),

--- a/src/function/lru.rs
+++ b/src/function/lru.rs
@@ -11,31 +11,35 @@ pub(super) struct Lru {
 }
 
 impl Lru {
-    pub(super) fn record_use(&self, index: Id) -> Option<Id> {
+    pub(super) fn record_use(&self, index: Id) {
         // Relaxed should be fine, we don't need to synchronize on this.
         let capacity = self.capacity.load(Ordering::Relaxed);
-
         if capacity == 0 {
             // LRU is disabled
-            return None;
+            return;
         }
 
         let mut set = self.set.lock();
         set.insert(index);
-        if set.len() > capacity {
-            return set.pop_front();
-        }
-
-        None
     }
 
     pub(super) fn set_capacity(&self, capacity: usize) {
         // Relaxed should be fine, we don't need to synchronize on this.
         self.capacity.store(capacity, Ordering::Relaxed);
+    }
 
-        if capacity == 0 {
-            let mut set = self.set.lock();
-            *set = FxLinkedHashSet::default();
+    pub(super) fn for_each_evicted(&self, mut cb: impl FnMut(Id)) {
+        let mut set = self.set.lock();
+        // Relaxed should be fine, we don't need to synchronize on this.
+        let cap = self.capacity.load(Ordering::Relaxed);
+        if set.len() <= cap || cap == 0 {
+            return;
+        }
+        while let Some(id) = set.pop_front() {
+            cb(id);
+            if set.len() <= cap {
+                break;
+            }
         }
     }
 }

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use crate::accumulator::accumulated_map::InputAccumulatedValues;
 use crate::revision::AtomicRevision;
+use crate::table::memo::MemoTable;
 use crate::zalsa_local::QueryOrigin;
 use crate::{
     key::DatabaseKeyIndex, zalsa::Zalsa, zalsa_local::QueryRevisions, Event, EventKind, Id,
@@ -60,47 +61,46 @@ impl<C: Configuration> IngredientImpl<C> {
     /// Evicts the existing memo for the given key, replacing it
     /// with an equivalent memo that has no value. If the memo is untracked, BaseInput,
     /// or has values assigned as output of another query, this has no effect.
-    pub(super) fn evict_value_from_memo_for<'db>(&'db self, zalsa: &'db Zalsa, id: Id) {
-        let old = zalsa.memo_table_for(id).map_memo::<Memo<C::Output<'_>>>(
-            self.memo_ingredient_index,
-            |memo| {
-                match memo.revisions.origin {
-                    QueryOrigin::Assigned(_)
-                    | QueryOrigin::DerivedUntracked(_)
-                    | QueryOrigin::BaseInput => {
-                        // Careful: Cannot evict memos whose values were
-                        // assigned as output of another query
-                        // or those with untracked inputs
-                        // as their values cannot be reconstructed.
-                        memo
-                    }
-                    QueryOrigin::Derived(_) => {
-                        // QueryRevisions: !Clone to discourage cloning, we need it here though
-                        let &QueryRevisions {
+    pub(super) fn evict_value_from_memo_for(&self, table: &mut MemoTable) {
+        let old = table.map_memo::<Memo<C::Output<'_>>>(self.memo_ingredient_index, |memo| {
+            match &memo.revisions.origin {
+                QueryOrigin::Assigned(_)
+                | QueryOrigin::DerivedUntracked(_)
+                | QueryOrigin::BaseInput => {
+                    // Careful: Cannot evict memos whose values were
+                    // assigned as output of another query
+                    // or those with untracked inputs
+                    // as their values cannot be reconstructed.
+                    memo
+                }
+                QueryOrigin::Derived(_) => {
+                    // Note that we cannot use `Arc::get_mut` here as the use of `ArcSwap` makes it
+                    // impossible to get unique access to the interior Arc
+                    // QueryRevisions: !Clone to discourage cloning, we need it here though
+                    let &QueryRevisions {
+                        changed_at,
+                        durability,
+                        ref origin,
+                        ref tracked_struct_ids,
+                        ref accumulated,
+                        ref accumulated_inputs,
+                    } = &memo.revisions;
+                    // Re-assemble the memo but with the value set to `None`
+                    Arc::new(Memo::new(
+                        None,
+                        memo.verified_at.load(),
+                        QueryRevisions {
                             changed_at,
                             durability,
-                            ref origin,
-                            ref tracked_struct_ids,
-                            ref accumulated,
-                            ref accumulated_inputs,
-                        } = &memo.revisions;
-                        // Re-assemble the memo but with the value set to `None`
-                        Arc::new(Memo::new(
-                            None,
-                            memo.verified_at.load(),
-                            QueryRevisions {
-                                changed_at,
-                                durability,
-                                origin: origin.clone(),
-                                tracked_struct_ids: tracked_struct_ids.clone(),
-                                accumulated: accumulated.clone(),
-                                accumulated_inputs: accumulated_inputs.clone(),
-                            },
-                        ))
-                    }
+                            origin: origin.clone(),
+                            tracked_struct_ids: tracked_struct_ids.clone(),
+                            accumulated: accumulated.clone(),
+                            accumulated_inputs: accumulated_inputs.clone(),
+                        },
+                    ))
                 }
-            },
-        );
+            }
+        });
         if let Some(old) = old {
             // In case there is a reference to the old memo out there, we have to store it
             // in the deleted entries. This will get cleared when a new revision starts.

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -6,6 +6,7 @@ use std::{
 use crate::{
     accumulator::accumulated_map::{AccumulatedMap, InputAccumulatedValues},
     cycle::CycleRecoveryStrategy,
+    table::Table,
     zalsa::{IngredientIndex, MemoIngredientIndex},
     zalsa_local::QueryOrigin,
     Database, DatabaseKeyIndex, Id,
@@ -122,7 +123,7 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
     ///
     /// **Important:** to actually receive resets, the ingredient must set
     /// [`IngredientRequiresReset::RESET_ON_NEW_REVISION`] to true.
-    fn reset_for_new_revision(&mut self);
+    fn reset_for_new_revision(&mut self, table: &mut Table);
 
     fn fmt_index(&self, index: Option<crate::Id>, fmt: &mut fmt::Formatter<'_>) -> fmt::Result;
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -260,7 +260,7 @@ impl<C: Configuration> Ingredient for IngredientImpl<C> {
         false
     }
 
-    fn reset_for_new_revision(&mut self) {
+    fn reset_for_new_revision(&mut self, _: &mut Table) {
         panic!("unexpected call to `reset_for_new_revision`")
     }
 
@@ -326,6 +326,10 @@ where
 {
     unsafe fn memos(&self, _current_revision: Revision) -> &crate::table::memo::MemoTable {
         &self.memos
+    }
+
+    fn memos_mut(&mut self) -> &mut crate::table::memo::MemoTable {
+        &mut self.memos
     }
 
     unsafe fn syncs(&self, _current_revision: Revision) -> &SyncTable {

--- a/src/input/input_field.rs
+++ b/src/input/input_field.rs
@@ -1,6 +1,7 @@
 use crate::cycle::CycleRecoveryStrategy;
 use crate::ingredient::{fmt_index, Ingredient, MaybeChangedAfter};
 use crate::input::Configuration;
+use crate::table::Table;
 use crate::zalsa::IngredientIndex;
 use crate::zalsa_local::QueryOrigin;
 use crate::{Database, DatabaseKeyIndex, Id, Revision};
@@ -85,7 +86,7 @@ where
         false
     }
 
-    fn reset_for_new_revision(&mut self) {
+    fn reset_for_new_revision(&mut self, _: &mut Table) {
         panic!("unexpected call: input fields don't register for resets");
     }
 

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -7,7 +7,7 @@ use crate::key::InputDependencyIndex;
 use crate::plumbing::{Jar, JarAux};
 use crate::table::memo::MemoTable;
 use crate::table::sync::SyncTable;
-use crate::table::Slot;
+use crate::table::{Slot, Table};
 use crate::zalsa::IngredientIndex;
 use crate::zalsa_local::QueryOrigin;
 use crate::{Database, DatabaseKeyIndex, Id};
@@ -327,7 +327,7 @@ where
         false
     }
 
-    fn reset_for_new_revision(&mut self) {
+    fn reset_for_new_revision(&mut self, _: &mut Table) {
         // Interned ingredients do not, normally, get deleted except when they are "reset" en masse.
         // There ARE methods (e.g., `clear_deleted_entries` and `remove`) for deleting individual
         // items, but those are only used for tracked struct ingredients.
@@ -360,6 +360,10 @@ where
 {
     unsafe fn memos(&self, _current_revision: Revision) -> &MemoTable {
         &self.memos
+    }
+
+    fn memos_mut(&mut self) -> &mut MemoTable {
+        &mut self.memos
     }
 
     unsafe fn syncs(&self, _current_revision: Revision) -> &crate::table::sync::SyncTable {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -138,6 +138,10 @@ impl Runtime {
         &self.table
     }
 
+    pub(crate) fn table_mut(&mut self) -> &mut Table {
+        &mut self.table
+    }
+
     /// Increments the "current revision" counter and clears
     /// the cancellation flag.
     ///

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -166,13 +166,11 @@ impl MemoTable {
     /// Calls `f` on the memo at `memo_ingredient_index` and replaces the memo with the result of `f`.
     /// If the memo is not present, `f` is not called.
     pub(crate) fn map_memo<M: Memo>(
-        &self,
+        &mut self,
         memo_ingredient_index: MemoIngredientIndex,
         f: impl FnOnce(Arc<M>) -> Arc<M>,
     ) -> Option<Arc<M>> {
-        // If the memo slot is already occupied, it must already have the
-        // right type info etc, and we only need the read-lock.
-        let memos = self.memos.read();
+        let memos = self.memos.get_mut();
         let Some(MemoEntry {
             data:
                 Some(MemoEntryData {
@@ -189,6 +187,10 @@ impl MemoTable {
             TypeId::of::<M>(),
             "inconsistent type-id for `{memo_ingredient_index:?}`"
         );
+        // arc-swap does not expose accessing the interior mutably at all unfortunately
+        // https://github.com/vorner/arc-swap/issues/131
+        // so we are required to allocate a nwe arc within `f` instead of being able
+        // to swap out the interior
         // SAFETY: type_id check asserted above
         let memo = f(unsafe { Self::from_dummy(arc_swap.load_full()) });
         Some(unsafe { Self::from_dummy::<M>(arc_swap.swap(Self::to_dummy(memo))) })

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -1,6 +1,7 @@
 use std::{
     any::{Any, TypeId},
     fmt::Debug,
+    mem::ManuallyDrop,
     sync::Arc,
 };
 
@@ -79,11 +80,15 @@ impl MemoTable {
         }
     }
 
-    pub(crate) fn insert<M: Memo>(
+    /// # Safety
+    ///
+    /// The caller needs to make sure to not drop the returned value until no more references into
+    /// the database exist as there may be outstanding borrows into the `Arc` contents.
+    pub(crate) unsafe fn insert<M: Memo>(
         &self,
         memo_ingredient_index: MemoIngredientIndex,
         memo: Arc<M>,
-    ) -> Option<Arc<M>> {
+    ) -> Option<ManuallyDrop<Arc<M>>> {
         // If the memo slot is already occupied, it must already have the
         // right type info etc, and we only need the read-lock.
         if let Some(MemoEntry {
@@ -101,18 +106,23 @@ impl MemoTable {
                 "inconsistent type-id for `{memo_ingredient_index:?}`"
             );
             let old_memo = arc_swap.swap(Self::to_dummy(memo));
-            return unsafe { Some(Self::from_dummy(old_memo)) };
+            return Some(ManuallyDrop::new(unsafe { Self::from_dummy(old_memo) }));
         }
 
         // Otherwise we need the write lock.
-        self.insert_cold(memo_ingredient_index, memo)
+        // SAFETY: The caller is responsible for dropping
+        unsafe { self.insert_cold(memo_ingredient_index, memo) }
     }
 
-    fn insert_cold<M: Memo>(
+    /// # Safety
+    ///
+    /// The caller needs to make sure to not drop the returned value until no more references into
+    /// the database exist as there may be outstanding borrows into the `Arc` contents.
+    unsafe fn insert_cold<M: Memo>(
         &self,
         memo_ingredient_index: MemoIngredientIndex,
         memo: Arc<M>,
-    ) -> Option<Arc<M>> {
+    ) -> Option<ManuallyDrop<Arc<M>>> {
         let mut memos = self.memos.write();
         let memo_ingredient_index = memo_ingredient_index.as_usize();
         if memos.len() < memo_ingredient_index + 1 {
@@ -126,13 +136,15 @@ impl MemoTable {
                 arc_swap: ArcSwap::new(Self::to_dummy(memo)),
             }),
         );
-        old_entry.map(
-            |MemoEntryData {
-                 type_id: _,
-                 to_dyn_fn: _,
-                 arc_swap,
-             }| unsafe { Self::from_dummy(arc_swap.into_inner()) },
-        )
+        old_entry
+            .map(
+                |MemoEntryData {
+                     type_id: _,
+                     to_dyn_fn: _,
+                     arc_swap,
+                 }| unsafe { Self::from_dummy(arc_swap.into_inner()) },
+            )
+            .map(ManuallyDrop::new)
     }
 
     pub(crate) fn get<M: Memo>(
@@ -165,11 +177,16 @@ impl MemoTable {
 
     /// Calls `f` on the memo at `memo_ingredient_index` and replaces the memo with the result of `f`.
     /// If the memo is not present, `f` is not called.
-    pub(crate) fn map_memo<M: Memo>(
+    ///
+    /// # Safety
+    ///
+    /// The caller needs to make sure to not drop the returned value until no more references into
+    /// the database exist as there may be outstanding borrows into the `Arc` contents.
+    pub(crate) unsafe fn map_memo<M: Memo>(
         &mut self,
         memo_ingredient_index: MemoIngredientIndex,
         f: impl FnOnce(Arc<M>) -> Arc<M>,
-    ) -> Option<Arc<M>> {
+    ) -> Option<ManuallyDrop<Arc<M>>> {
         let memos = self.memos.get_mut();
         let Some(MemoEntry {
             data:
@@ -189,14 +206,22 @@ impl MemoTable {
         );
         // arc-swap does not expose accessing the interior mutably at all unfortunately
         // https://github.com/vorner/arc-swap/issues/131
-        // so we are required to allocate a nwe arc within `f` instead of being able
+        // so we are required to allocate a new arc within `f` instead of being able
         // to swap out the interior
         // SAFETY: type_id check asserted above
         let memo = f(unsafe { Self::from_dummy(arc_swap.load_full()) });
-        Some(unsafe { Self::from_dummy::<M>(arc_swap.swap(Self::to_dummy(memo))) })
+        Some(ManuallyDrop::new(unsafe {
+            Self::from_dummy::<M>(arc_swap.swap(Self::to_dummy(memo)))
+        }))
     }
 
-    pub(crate) fn into_memos(self) -> impl Iterator<Item = (MemoIngredientIndex, Arc<dyn Memo>)> {
+    /// # Safety
+    ///
+    /// The caller needs to make sure to not drop the returned value until no more references into
+    /// the database exist as there may be outstanding borrows into the `Arc` contents.
+    pub(crate) unsafe fn into_memos(
+        self,
+    ) -> impl Iterator<Item = (MemoIngredientIndex, ManuallyDrop<Arc<dyn Memo>>)> {
         self.memos
             .into_inner()
             .into_iter()
@@ -213,7 +238,7 @@ impl MemoTable {
                 )| {
                     (
                         MemoIngredientIndex::from_usize(index),
-                        to_dyn_fn(arc_swap.into_inner()),
+                        ManuallyDrop::new(to_dyn_fn(arc_swap.into_inner())),
                     )
                 },
             )

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -759,7 +759,9 @@ where
         false
     }
 
-    fn reset_for_new_revision(&mut self) {}
+    fn reset_for_new_revision(&mut self, _: &mut Table) {
+        panic!("tracked struct ingredients do not require reset")
+    }
 }
 
 impl<C> std::fmt::Debug for IngredientImpl<C>
@@ -829,6 +831,10 @@ where
         // when deleting a tracked struct.
         self.read_lock(current_revision);
         &self.memos
+    }
+
+    fn memos_mut(&mut self) -> &mut crate::table::memo::MemoTable {
+        &mut self.memos
     }
 
     unsafe fn syncs(&self, current_revision: Revision) -> &crate::table::sync::SyncTable {

--- a/src/tracked_struct/tracked_field.rs
+++ b/src/tracked_struct/tracked_field.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 
 use crate::{
     ingredient::{Ingredient, MaybeChangedAfter},
+    table::Table,
     zalsa::IngredientIndex,
     Database, Id,
 };
@@ -97,7 +98,7 @@ where
         false
     }
 
-    fn reset_for_new_revision(&mut self) {
+    fn reset_for_new_revision(&mut self, _: &mut Table) {
         panic!("tracked field ingredients do not require reset")
     }
 

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -272,7 +272,7 @@ impl Zalsa {
         let new_revision = self.runtime.new_revision();
 
         for index in self.ingredients_requiring_reset.iter() {
-            self.ingredients_vec[index.as_usize()].reset_for_new_revision();
+            self.ingredients_vec[index.as_usize()].reset_for_new_revision(self.runtime.table_mut());
         }
 
         new_revision


### PR DESCRIPTION
This change makes us LRU evict once a new revision starts, instead of at the very moment we reach the limit while computing tracked functions.