### PR TITLE
internal: switch to `boxcar` from `append-only-vec`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ dashmap = { version = "6", features = ["raw-api"] }
 hashlink = "0.9"
 hashbrown = "0.14.3"
 indexmap = "2"
-append-only-vec = "0.1.5"
+boxcar = "0.2.9"
 tracing = "0.1"
 parking_lot = "0.12"
 rustc-hash = "2"

--- a/src/input.rs
+++ b/src/input.rs
@@ -194,7 +194,7 @@ impl<C: Configuration> IngredientImpl<C> {
             .table()
             .pages
             .iter()
-            .filter_map(|page| page.cast_type::<crate::table::Page<Value<C>>>())
+            .filter_map(|(_, page)| page.cast_type::<crate::table::Page<Value<C>>>())
             .flat_map(|page| page.slots())
     }
 

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -263,7 +263,7 @@ where
             .table()
             .pages
             .iter()
-            .filter_map(|page| page.cast_type::<crate::table::Page<Value<C>>>())
+            .filter_map(|(_, page)| page.cast_type::<crate::table::Page<Value<C>>>())
             .flat_map(|page| page.slots())
     }
 

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -691,7 +691,7 @@ where
             .table()
             .pages
             .iter()
-            .filter_map(|page| page.cast_type::<crate::table::Page<Value<C>>>())
+            .filter_map(|(_, page)| page.cast_type::<crate::table::Page<Value<C>>>())
             .flat_map(|page| page.slots())
     }
 }

--- a/src/views.rs
+++ b/src/views.rs
@@ -1,5 +1,4 @@
 use crate::{zalsa::transmute_data_ptr, Database};
-use append_only_vec::AppendOnlyVec;
 use std::{
     any::{Any, TypeId},
     sync::Arc,
@@ -24,7 +23,7 @@ use std::{
 #[derive(Clone)]
 pub struct Views {
     source_type_id: TypeId,
-    view_casters: Arc<AppendOnlyVec<DynViewCaster>>,
+    view_casters: Arc<boxcar::Vec<DynViewCaster>>,
 }
 
 /// A DynViewCaster contains a manual trait object that can cast from the
@@ -78,7 +77,7 @@ impl Views {
         let source_type_id = TypeId::of::<Db>();
         Self {
             source_type_id,
-            view_casters: Arc::new(AppendOnlyVec::new()),
+            view_casters: Arc::new(boxcar::Vec::new()),
         }
     }
 
@@ -91,7 +90,7 @@ impl Views {
         if self
             .view_casters
             .iter()
-            .any(|u| u.target_type_id == target_type_id)
+            .any(|(_, u)| u.target_type_id == target_type_id)
         {
             return;
         }
@@ -120,7 +119,7 @@ impl Views {
         assert_eq!(self.source_type_id, db_type_id, "database type mismatch");
 
         let view_type_id = TypeId::of::<DbView>();
-        for view in self.view_casters.iter() {
+        for (_idx, view) in self.view_casters.iter() {
             if view.target_type_id == view_type_id {
                 // SAFETY: We verified that this is the view caster for the
                 // `DbView` type by checking type IDs above.

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -1,8 +1,8 @@
-use append_only_vec::AppendOnlyVec;
 use parking_lot::{Mutex, RwLock};
 use rustc_hash::FxHashMap;
 use std::any::{Any, TypeId};
 use std::marker::PhantomData;
+use std::ops::Deref;
 use std::panic::RefUnwindSafe;
 use std::thread::ThreadId;
 
@@ -140,10 +140,10 @@ pub struct Zalsa {
     /// Vector of ingredients.
     ///
     /// Immutable unless the mutex on `ingredients_map` is held.
-    ingredients_vec: AppendOnlyVec<Box<dyn Ingredient>>,
+    ingredients_vec: boxcar::Vec<Box<dyn Ingredient>>,
 
     /// Indices of ingredients that require reset when a new revision starts.
-    ingredients_requiring_reset: AppendOnlyVec<IngredientIndex>,
+    ingredients_requiring_reset: boxcar::Vec<IngredientIndex>,
 
     /// The runtime for this particular salsa database handle.
     /// Each handle gets its own runtime, but the runtimes have shared state between them.
@@ -163,8 +163,8 @@ impl Zalsa {
             views_of: Views::new::<Db>(),
             nonce: NONCE.nonce(),
             jar_map: Default::default(),
-            ingredients_vec: AppendOnlyVec::new(),
-            ingredients_requiring_reset: AppendOnlyVec::new(),
+            ingredients_vec: boxcar::Vec::new(),
+            ingredients_requiring_reset: boxcar::Vec::new(),
             runtime: Runtime::default(),
             memo_ingredient_indices: Default::default(),
         }
@@ -209,7 +209,7 @@ impl Zalsa {
             // ingredient indices cannot overlap.
             let index = *jar_map.entry(jar_type_id).or_insert_with(|| {
                 should_create = true;
-                IngredientIndex::from(self.ingredients_vec.len())
+                IngredientIndex::from(self.ingredients_vec.count())
             });
             if should_create {
                 let aux = JarAuxImpl(self, &jar_map);
@@ -238,7 +238,12 @@ impl Zalsa {
     }
 
     pub(crate) fn lookup_ingredient(&self, index: IngredientIndex) -> &dyn Ingredient {
-        &*self.ingredients_vec[index.as_usize()]
+        let index = index.as_usize();
+        let ingredient = self
+            .ingredients_vec
+            .get(index)
+            .unwrap_or_else(|| panic!("index `{index}` is uninitialized"));
+        ingredient.deref()
     }
 
     /// **NOT SEMVER STABLE**
@@ -246,10 +251,12 @@ impl Zalsa {
         &mut self,
         index: IngredientIndex,
     ) -> (&mut dyn Ingredient, &mut Runtime) {
-        (
-            &mut *self.ingredients_vec[index.as_usize()],
-            &mut self.runtime,
-        )
+        let index = index.as_usize();
+        let ingredient = self
+            .ingredients_vec
+            .get_mut(index)
+            .unwrap_or_else(|| panic!("index `{index}` is uninitialized"));
+        (ingredient.as_mut(), &mut self.runtime)
     }
 
     /// **NOT SEMVER STABLE**
@@ -279,8 +286,14 @@ impl Zalsa {
     pub(crate) fn new_revision(&mut self) -> Revision {
         let new_revision = self.runtime.new_revision();
 
-        for index in self.ingredients_requiring_reset.iter() {
-            self.ingredients_vec[index.as_usize()].reset_for_new_revision(self.runtime.table_mut());
+        for (_, index) in self.ingredients_requiring_reset.iter() {
+            let index = index.as_usize();
+            let ingredient = self
+                .ingredients_vec
+                .get_mut(index)
+                .unwrap_or_else(|| panic!("index `{index}` is uninitialized"));
+
+            ingredient.reset_for_new_revision(self.runtime.table_mut());
         }
 
         new_revision


### PR DESCRIPTION
Boxcar now uses [Loom](https://github.com/ibraheemdev/boxcar/pull/25), and I personally trust Loom/Shuttle-tested libraries more than those that aren't despite their apparent simplicity.

(cc: @ibraheemdev)