### PR TITLE
Experiment with single-writer `boxcar::Vec`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ dashmap = { version = "6", features = ["raw-api"] }
 hashlink = "0.9"
 hashbrown = "0.14.3"
 indexmap = "2"
-append-only-vec = "0.1.5"
+boxcar = "0.2.9"
 tracing = "0.1"
 parking_lot = "0.12"
 rustc-hash = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ dashmap = { version = "6", features = ["raw-api"] }
 hashlink = "0.9"
 hashbrown = "0.14.3"
 indexmap = "2"
-boxcar = "0.2.9"
+boxcar = { git = "https://github.com/ibraheemdev/boxcar", rev = "4d51fcadc841f16caafa9decc933fffd135fd6fa" }
 tracing = "0.1"
 parking_lot = "0.12"
 rustc-hash = "2"

--- a/src/input.rs
+++ b/src/input.rs
@@ -194,7 +194,7 @@ impl<C: Configuration> IngredientImpl<C> {
             .table()
             .pages
             .iter()
-            .filter_map(|page| page.cast_type::<crate::table::Page<Value<C>>>())
+            .filter_map(|(_, page)| page.cast_type::<crate::table::Page<Value<C>>>())
             .flat_map(|page| page.slots())
     }
 

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -263,7 +263,7 @@ where
             .table()
             .pages
             .iter()
-            .filter_map(|page| page.cast_type::<crate::table::Page<Value<C>>>())
+            .filter_map(|(_, page)| page.cast_type::<crate::table::Page<Value<C>>>())
             .flat_map(|page| page.slots())
     }
 

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -691,7 +691,7 @@ where
             .table()
             .pages
             .iter()
-            .filter_map(|page| page.cast_type::<crate::table::Page<Value<C>>>())
+            .filter_map(|(_, page)| page.cast_type::<crate::table::Page<Value<C>>>())
             .flat_map(|page| page.slots())
     }
 }

--- a/src/views.rs
+++ b/src/views.rs
@@ -1,5 +1,4 @@
 use crate::{zalsa::transmute_data_ptr, Database};
-use append_only_vec::AppendOnlyVec;
 use std::{
     any::{Any, TypeId},
     sync::Arc,
@@ -24,7 +23,7 @@ use std::{
 #[derive(Clone)]
 pub struct Views {
     source_type_id: TypeId,
-    view_casters: Arc<AppendOnlyVec<DynViewCaster>>,
+    view_casters: Arc<boxcar::Vec<DynViewCaster>>,
 }
 
 /// A DynViewCaster contains a manual trait object that can cast from the
@@ -78,7 +77,7 @@ impl Views {
         let source_type_id = TypeId::of::<Db>();
         Self {
             source_type_id,
-            view_casters: Arc::new(AppendOnlyVec::new()),
+            view_casters: Arc::new(boxcar::Vec::new()),
         }
     }
 
@@ -91,7 +90,7 @@ impl Views {
         if self
             .view_casters
             .iter()
-            .any(|u| u.target_type_id == target_type_id)
+            .any(|(_, u)| u.target_type_id == target_type_id)
         {
             return;
         }
@@ -120,7 +119,7 @@ impl Views {
         assert_eq!(self.source_type_id, db_type_id, "database type mismatch");
 
         let view_type_id = TypeId::of::<DbView>();
-        for view in self.view_casters.iter() {
+        for (_idx, view) in self.view_casters.iter() {
             if view.target_type_id == view_type_id {
                 // SAFETY: We verified that this is the view caster for the
                 // `DbView` type by checking type IDs above.

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -210,10 +210,17 @@ impl Zalsa {
                     let expected_index = ingredient.ingredient_index();
 
                     if ingredient.requires_reset_for_new_revision() {
-                        self.ingredients_requiring_reset.push(expected_index);
+                        // Safety: We hold the lock.
+                        unsafe {
+                            self.ingredients_requiring_reset
+                                .push_single_writer(expected_index);
+                        }
                     }
 
-                    let actual_index = self.ingredients_vec.push(ingredient);
+                    // Safety: We hold the lock.
+                    let actual_index =
+                        unsafe { self.ingredients_vec.push_single_writer(ingredient) };
+
                     assert_eq!(
                         expected_index.as_usize(),
                         actual_index,


### PR DESCRIPTION
Testing to see if we can avoid the performance hit in https://github.com/salsa-rs/salsa/pull/688 by using a single-writer optimized `push` method (which I added to boxcar in a branch). It looks like we can only do this for the `ingredient_vec` in `Zalsa`, not the page table or viewcaster vector.