### PR TITLE
Emit better diagnostic for invalid tracked function return types

### DIFF
--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -55,7 +55,7 @@ macro_rules! setup_tracked_fn {
         // True if we `return_ref` flag was given to the function
         return_ref: $return_ref:tt,
 
-        maybe_update_fn: {$($maybe_update_fn:tt)*},
+        assert_return_type_is_update: {$($assert_return_type_is_update:tt)*},
 
         // Annoyingly macro-rules hygiene does not extend to items defined in the macro.
         // We have the procedural macro generate names for those items that are
@@ -147,14 +147,6 @@ macro_rules! setup_tracked_fn {
                 }
             }
 
-            /// This method isn't used anywhere. It only exitst to enforce the `Self::Output: Update` constraint
-            /// for types that aren't `'static`.
-            ///
-            /// # Safety
-            /// The same safety rules as for `Update` apply.
-            $($maybe_update_fn)*
-
-
             impl $zalsa::function::Configuration for $Configuration {
                 const DEBUG_NAME: &'static str = stringify!($fn_name);
 
@@ -182,6 +174,8 @@ macro_rules! setup_tracked_fn {
                 }
 
                 fn execute<$db_lt>($db: &$db_lt Self::DbView, ($($input_id),*): ($($input_ty),*)) -> Self::Output<$db_lt> {
+                    $($assert_return_type_is_update)*
+
                     $($inner_fn)*
 
                     $inner($db, $($input_id),*)

--- a/tests/compile-fail/tracked_fn_return_ref.rs
+++ b/tests/compile-fail/tracked_fn_return_ref.rs
@@ -26,4 +26,24 @@ fn tracked_fn_return_struct_containing_ref<'db>(
     }
 }
 
+#[salsa::tracked]
+fn tracked_fn_return_struct_containing_ref_elided_implicit<'db>(
+    db: &'db dyn Db,
+    input: MyInput,
+) -> ContainsRef {
+    ContainsRef {
+        text: input.text(db),
+    }
+}
+
+#[salsa::tracked]
+fn tracked_fn_return_struct_containing_ref_elided_explicit<'db>(
+    db: &'db dyn Db,
+    input: MyInput,
+) -> ContainsRef<'_> {
+    ContainsRef {
+        text: input.text(db),
+    }
+}
+
 fn main() {}

--- a/tests/compile-fail/tracked_fn_return_ref.stderr
+++ b/tests/compile-fail/tracked_fn_return_ref.stderr
@@ -1,20 +1,14 @@
 error: lifetime may not live long enough
-  --> tests/compile-fail/tracked_fn_return_ref.rs:14:1
+  --> tests/compile-fail/tracked_fn_return_ref.rs:15:67
    |
-14 | #[salsa::tracked]
-   | ^^^^^^^^^^^^^^^^^ requires that `'db` must outlive `'static`
 15 | fn tracked_fn_return_ref<'db>(db: &'db dyn Db, input: MyInput) -> &'db str {
-   |                                                                   - lifetime `'db` defined here
-   |
-   = note: this error originates in the attribute macro `salsa::tracked` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |                          --- lifetime `'db` defined here          ^ requires that `'db` must outlive `'static`
 
 error: lifetime may not live long enough
-  --> tests/compile-fail/tracked_fn_return_ref.rs:19:1
+  --> tests/compile-fail/tracked_fn_return_ref.rs:23:6
    |
-19 | #[salsa::tracked]
-   | ^^^^^^^^^^^^^^^^^ requires that `'db` must outlive `'static`
+20 | fn tracked_fn_return_struct_containing_ref<'db>(
+   |                                            --- lifetime `'db` defined here
 ...
 23 | ) -> ContainsRef<'db> {
-   |      ----------- lifetime `'db` defined here
-   |
-   = note: this error originates in the attribute macro `salsa::tracked` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |      ^^^^^^^^^^^ requires that `'db` must outlive `'static`

--- a/tests/compile-fail/tracked_fn_return_ref.stderr
+++ b/tests/compile-fail/tracked_fn_return_ref.stderr
@@ -1,3 +1,34 @@
+error[E0106]: missing lifetime specifier
+  --> tests/compile-fail/tracked_fn_return_ref.rs:33:6
+   |
+33 | ) -> ContainsRef {
+   |      ^^^^^^^^^^^ expected named lifetime parameter
+   |
+help: consider using the `'db` lifetime
+   |
+33 | ) -> ContainsRef<'db> {
+   |                 +++++
+
+warning: elided lifetime has a name
+  --> tests/compile-fail/tracked_fn_return_ref.rs:33:6
+   |
+30 | fn tracked_fn_return_struct_containing_ref_elided_implicit<'db>(
+   |                                                            --- lifetime `'db` declared here
+...
+33 | ) -> ContainsRef {
+   |      ^^^^^^^^^^^ this elided lifetime gets resolved as `'db`
+   |
+   = note: `#[warn(elided_named_lifetimes)]` on by default
+
+warning: elided lifetime has a name
+  --> tests/compile-fail/tracked_fn_return_ref.rs:43:18
+   |
+40 | fn tracked_fn_return_struct_containing_ref_elided_explicit<'db>(
+   |                                                            --- lifetime `'db` declared here
+...
+43 | ) -> ContainsRef<'_> {
+   |                  ^^ this elided lifetime gets resolved as `'db`
+
 error: lifetime may not live long enough
   --> tests/compile-fail/tracked_fn_return_ref.rs:15:67
    |
@@ -11,4 +42,13 @@ error: lifetime may not live long enough
    |                                            --- lifetime `'db` defined here
 ...
 23 | ) -> ContainsRef<'db> {
+   |      ^^^^^^^^^^^ requires that `'db` must outlive `'static`
+
+error: lifetime may not live long enough
+  --> tests/compile-fail/tracked_fn_return_ref.rs:43:6
+   |
+40 | fn tracked_fn_return_struct_containing_ref_elided_explicit<'db>(
+   |                                                            --- lifetime `'db` defined here
+...
+43 | ) -> ContainsRef<'_> {
    |      ^^^^^^^^^^^ requires that `'db` must outlive `'static`


### PR DESCRIPTION
I also slimmed down the generated code for this given it shouldn't be called in the first place, so it being a no-op doesn't matter