### PR TITLE
Add unsafety test for consumers of salsa macros

### DIFF
--- a/tests/downstream_unsafe.rs
+++ b/tests/downstream_unsafe.rs
@@ -1,0 +1,89 @@
+#![forbid(unsafe_code)]
+// Below code directly duplicated from hello_world
+
+//! Test that a `tracked` fn on a `salsa::input`
+//! compiles and executes successfully.
+
+mod common;
+use common::LogDatabase;
+
+use expect_test::expect;
+use salsa::Setter;
+use test_log::test;
+
+#[salsa::input]
+struct MyInput {
+    field: u32,
+}
+
+#[salsa::tracked]
+fn final_result(db: &dyn LogDatabase, input: MyInput) -> u32 {
+    db.push_log(format!("final_result({:?})", input));
+    intermediate_result(db, input).field(db) * 2
+}
+
+#[salsa::tracked]
+struct MyTracked<'db> {
+    field: u32,
+}
+
+#[salsa::tracked]
+fn intermediate_result(db: &dyn LogDatabase, input: MyInput) -> MyTracked<'_> {
+    db.push_log(format!("intermediate_result({:?})", input));
+    MyTracked::new(db, input.field(db) / 2)
+}
+
+#[test]
+fn execute() {
+    let mut db = common::LoggerDatabase::default();
+
+    let input = MyInput::new(&db, 22);
+    assert_eq!(final_result(&db, input), 22);
+    db.assert_logs(expect![[r#"
+        [
+            "final_result(MyInput { [salsa id]: Id(0), field: 22 })",
+            "intermediate_result(MyInput { [salsa id]: Id(0), field: 22 })",
+        ]"#]]);
+
+    // Intermediate result is the same, so final result does
+    // not need to be recomputed:
+    input.set_field(&mut db).to(23);
+    assert_eq!(final_result(&db, input), 22);
+    db.assert_logs(expect![[r#"
+        [
+            "intermediate_result(MyInput { [salsa id]: Id(0), field: 23 })",
+        ]"#]]);
+
+    input.set_field(&mut db).to(24);
+    assert_eq!(final_result(&db, input), 24);
+    db.assert_logs(expect![[r#"
+        [
+            "intermediate_result(MyInput { [salsa id]: Id(0), field: 24 })",
+            "final_result(MyInput { [salsa id]: Id(0), field: 24 })",
+        ]"#]]);
+}
+
+/// Create and mutate a distinct input. No re-execution required.
+#[test]
+fn red_herring() {
+    let mut db = common::LoggerDatabase::default();
+
+    let input = MyInput::new(&db, 22);
+    assert_eq!(final_result(&db, input), 22);
+    db.assert_logs(expect![[r#"
+        [
+            "final_result(MyInput { [salsa id]: Id(0), field: 22 })",
+            "intermediate_result(MyInput { [salsa id]: Id(0), field: 22 })",
+        ]"#]]);
+
+    // Create a distinct input and mutate it.
+    // This will trigger a new revision in the database
+    // but shouldn't actually invalidate our existing ones.
+    let input2 = MyInput::new(&db, 44);
+    input2.set_field(&mut db).to(66);
+
+    // Re-run the query on the original input. Nothing re-executes!
+    assert_eq!(final_result(&db, input), 22);
+    db.assert_logs(expect![[r#"
+        []"#]]);
+}


### PR DESCRIPTION
After I updated a personal project to a Salsa commit that included #680, I started receiving compiler errors due to my project-local use of `#![forbid(unsafe_code)]` together with the `salsa::tracked` derive macro. I wanted to see if this was expected due to chosen trade-offs, or if it's a quality of the earlier versions of Salsa that might be preserved.

**The test included in this PR fails as of current master and on the first commit of #680, but passes on that commit's parent**. I mostly created this PR to be a place for discussion without polluting the comments of a merged PR, but I don't personally have (or need) a vote on what the project chooses to do with this information. I just thought it might save a tiny bit of legwork and contextualize the change that surprised me - I did not expect my own local crate to newly contain `unsafe` via the derive macros.

If it's desired to permanently incorporate this test to help catch future regressions, I'm happy to make any changes to this to line up with desired content, commit message style, etc. but I'm not personally capable of designing or implementing a no-unsafe version of the intent in #680.

If preferred, I'm happy to close this and migrate the concern to an issue instead.

`cargo test --no-run --test downstream_unsafe`:
```
   Compiling salsa v0.18.0 (/Users/shane/src/not_me/lsp/salsa)
error[E0453]: allow(unsafe_code) incompatible with previous forbid
  --> tests/downstream_unsafe.rs:20:58
   |
1  | #![forbid(unsafe_code)]
   |           ----------- `forbid` level set here
...
20 | fn final_result(db: &dyn LogDatabase, input: MyInput) -> u32 {
   |                                                          ^^^ overruled by previous forbid
                                                                                                                                                         
error: declaration of an `unsafe` function
  --> tests/downstream_unsafe.rs:20:58
   |
20 | fn final_result(db: &dyn LogDatabase, input: MyInput) -> u32 {
   |                                                          ^^^
   |
note: the lint level is defined here
  --> tests/downstream_unsafe.rs:1:11
   |
1  | #![forbid(unsafe_code)]
   |           ^^^^^^^^^^^
                                                                                                                                                         
error: usage of an `unsafe` block
  --> tests/downstream_unsafe.rs:20:58
   |
20 | fn final_result(db: &dyn LogDatabase, input: MyInput) -> u32 {
   |                                                          ^^^
                                                                                                                                                         
error[E0453]: allow(unsafe_code) incompatible with previous forbid
  --> tests/downstream_unsafe.rs:31:65
   |
1  | #![forbid(unsafe_code)]
   |           ----------- `forbid` level set here
...
31 | fn intermediate_result(db: &dyn LogDatabase, input: MyInput) -> MyTracked<'_> {
   |                                                                 ^^^^^^^^^ overruled by previous forbid
                                                                                                                                                         
error: declaration of an `unsafe` function
  --> tests/downstream_unsafe.rs:31:65
   |
31 | fn intermediate_result(db: &dyn LogDatabase, input: MyInput) -> MyTracked<'_> {
   |                                                                 ^^^^^^^^^
                                                                                                                                                         
error: usage of an `unsafe` block
  --> tests/downstream_unsafe.rs:31:65
   |
31 | fn intermediate_result(db: &dyn LogDatabase, input: MyInput) -> MyTracked<'_> {
   |                                                                 ^^^^^^^^^
                                                                                                                                                         
For more information about this error, try `rustc --explain E0453`.
error: could not compile `salsa` (test "downstream_unsafe") due to 6 previous errors
```