### PR TITLE
Don't `as_view` cast unless needed

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -197,7 +197,6 @@ where
         input: Id,
         revision: Revision,
     ) -> MaybeChangedAfter {
-        let db = db.as_view::<C::DbView>();
         self.maybe_changed_after(db, input, revision)
     }
 

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -53,7 +53,12 @@ where
         let memo_guard = self.get_memo_from_table_for(zalsa, id);
         if let Some(memo) = &memo_guard {
             if memo.value.is_some()
-                && self.shallow_verify_memo(db, zalsa, self.database_key_index(id), memo)
+                && self.shallow_verify_memo(
+                    db.as_dyn_database(),
+                    zalsa,
+                    self.database_key_index(id),
+                    memo,
+                )
             {
                 // Unsafety invariant: memo is present in memo_map and we have verified that it is
                 // still valid for the current revision.
@@ -82,7 +87,9 @@ where
         let zalsa = db.zalsa();
         let opt_old_memo = self.get_memo_from_table_for(zalsa, id);
         if let Some(old_memo) = &opt_old_memo {
-            if old_memo.value.is_some() && self.deep_verify_memo(db, old_memo, &active_query) {
+            if old_memo.value.is_some()
+                && self.deep_verify_memo(db.as_dyn_database(), old_memo, &active_query)
+            {
                 // Unsafety invariant: memo is present in memo_map and we have verified that it is
                 // still valid for the current revision.
                 return unsafe { Some(self.extend_memo_lifetime(old_memo)) };


### PR DESCRIPTION
`maybe_changed_after` only needs a casted view if shallow verification fails. This does mean we might cast multiple times if we fail to claim the sync table. Therefore this change optimizes for the hot path, but pessimizes for the cold path.