### PR TITLE
Replace `arc-swap` with manual `AtomicPtr`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ description = "A generic framework for on-demand, incrementalized computation (e
 rust-version = "1.76"
 
 [dependencies]
-arc-swap = "1"
 compact_str = { version = "0.8", optional = true }
 crossbeam-queue = "0.3.11"
 dashmap = { version = "6", features = ["raw-api"] }

--- a/src/function/delete.rs
+++ b/src/function/delete.rs
@@ -1,13 +1,19 @@
+use std::ptr::NonNull;
+
 use crossbeam_queue::SegQueue;
 
-use super::{memo::ArcMemo, Configuration};
+use super::memo::Memo;
+use super::Configuration;
 
 /// Stores the list of memos that have been deleted so they can be freed
 /// once the next revision starts. See the comment on the field
 /// `deleted_entries` of [`FunctionIngredient`][] for more details.
 pub(super) struct DeletedEntries<C: Configuration> {
-    seg_queue: SegQueue<ArcMemo<'static, C>>,
+    seg_queue: SegQueue<SharedBox<Memo<C::Output<'static>>>>,
 }
+
+unsafe impl<C: Configuration> Send for DeletedEntries<C> {}
+unsafe impl<C: Configuration> Sync for DeletedEntries<C> {}
 
 impl<C: Configuration> Default for DeletedEntries<C> {
     fn default() -> Self {
@@ -18,8 +24,29 @@ impl<C: Configuration> Default for DeletedEntries<C> {
 }
 
 impl<C: Configuration> DeletedEntries<C> {
-    pub(super) fn push(&self, memo: ArcMemo<'_, C>) {
-        let memo = unsafe { std::mem::transmute::<ArcMemo<'_, C>, ArcMemo<'static, C>>(memo) };
-        self.seg_queue.push(memo);
+    /// # Safety
+    ///
+    /// The memo must be valid and safe to free when the `DeletedEntries` list is dropped.
+    pub(super) unsafe fn push(&self, memo: NonNull<Memo<C::Output<'_>>>) {
+        let memo = unsafe {
+            std::mem::transmute::<NonNull<Memo<C::Output<'_>>>, NonNull<Memo<C::Output<'static>>>>(
+                memo,
+            )
+        };
+
+        self.seg_queue.push(SharedBox(memo));
+    }
+}
+
+/// A wrapper around `NonNull` that frees the allocation when it is dropped.
+///
+/// `crossbeam::SegQueue` does not expose mutable accessors so we have to create
+/// a wrapper to run code during `Drop`.
+struct SharedBox<T>(NonNull<T>);
+
+impl<T> Drop for SharedBox<T> {
+    fn drop(&mut self) {
+        // SAFETY: Guaranteed by the caller of `DeletedEntries::push`.
+        unsafe { drop(Box::from_raw(self.0.as_ptr())) };
     }
 }

--- a/src/function/delete.rs
+++ b/src/function/delete.rs
@@ -12,8 +12,8 @@ pub(super) struct DeletedEntries<C: Configuration> {
     seg_queue: SegQueue<SharedBox<Memo<C::Output<'static>>>>,
 }
 
-unsafe impl<C: Configuration> Send for DeletedEntries<C> {}
-unsafe impl<C: Configuration> Sync for DeletedEntries<C> {}
+unsafe impl<T: Send> Send for SharedBox<T> {}
+unsafe impl<T: Sync> Sync for SharedBox<T> {}
 
 impl<C: Configuration> Default for DeletedEntries<C> {
     fn default() -> Self {

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::{
     zalsa::ZalsaDatabase, zalsa_local::ActiveQueryGuard, Cycle, Database, Event, EventKind,
 };
@@ -23,7 +21,7 @@ where
         &'db self,
         db: &'db C::DbView,
         active_query: ActiveQueryGuard<'_>,
-        opt_old_memo: Option<Arc<Memo<C::Output<'_>>>>,
+        opt_old_memo: Option<&Memo<C::Output<'_>>>,
     ) -> &'db Memo<C::Output<'db>> {
         let zalsa = db.zalsa();
         let revision_now = zalsa.current_revision();

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -37,7 +37,6 @@ where
                         MaybeChangedAfter::No(memo.revisions.accumulated_inputs.load())
                     };
                 }
-                drop(memo_guard); // release the arc-swap guard before cold path
                 if let Some(mcs) = self.maybe_changed_after_cold(db, id, revision) {
                     return mcs;
                 } else {
@@ -79,7 +78,7 @@ where
         );
 
         // Check if the inputs are still valid. We can just compare `changed_at`.
-        if self.deep_verify_memo(db, &old_memo, &active_query) {
+        if self.deep_verify_memo(db, old_memo, &active_query) {
             return Some(if old_memo.revisions.changed_at > revision {
                 MaybeChangedAfter::Yes
             } else {

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -26,7 +26,7 @@ impl<C: Configuration> IngredientImpl<C> {
         memo.cast()
     }
 
-    /// Convert from an internal memo (which uses `'static``) to one tied to self
+    /// Convert from an internal memo (which uses `'static`) to one tied to self
     /// so it can be publicly released.
     unsafe fn to_self<'db>(
         &'db self,
@@ -35,7 +35,7 @@ impl<C: Configuration> IngredientImpl<C> {
         memo.cast()
     }
 
-    /// Convert from an internal memo (which uses `'static``) to one tied to self
+    /// Convert from an internal memo (which uses `'static`) to one tied to self
     /// so it can be publicly released.
     unsafe fn to_self_ref<'db>(
         &'db self,

--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -74,8 +74,8 @@ where
         };
 
         if let Some(old_memo) = self.get_memo_from_table_for(zalsa, key) {
-            self.backdate_if_appropriate(&old_memo, &mut revisions, &value);
-            self.diff_outputs(db, database_key_index, &old_memo, &mut revisions);
+            self.backdate_if_appropriate(old_memo, &mut revisions, &value);
+            self.diff_outputs(db, database_key_index, old_memo, &mut revisions);
         }
 
         let memo = Memo {

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -1,4 +1,4 @@
-use std::{any::TypeId, fmt, hash::Hash, marker::PhantomData, mem::ManuallyDrop, ops::DerefMut};
+use std::{any::TypeId, fmt, hash::Hash, marker::PhantomData, ops::DerefMut};
 
 use crossbeam_queue::SegQueue;
 use tracked_field::FieldIngredientImpl;
@@ -593,10 +593,10 @@ where
         // Take the memo table. This is safe because we have modified `data_ref.updated_at` to `None`
         // and the code that references the memo-table has a read-lock.
         let memo_table = unsafe { (*data).take_memo_table() };
+
         // SAFETY: We have verified that no more references to these memos exist and so we are good
         // to drop them.
         for (memo_ingredient_index, memo) in unsafe { memo_table.into_memos() } {
-            let memo = ManuallyDrop::into_inner(memo);
             let ingredient_index =
                 zalsa.ingredient_index_for_memo(self.ingredient_index, memo_ingredient_index);
 


### PR DESCRIPTION
It seems that we don't actually need arc-swap for the memo table, because our `deleted_entries` queue takes care of deferring reclamation until there are no live borrows of a given memo. arc-swap does a lot of extra bookkeeping; replacing it with a manual `AtomicPtr` object speeds up red-knot's incremental performance by about 15%. This should also make it easier to test with loom/shuttle.

You'll notice that none of the safety requirements of the `MemoTable` functions actually change with this PR, so I believe it is sound. The one catch is that we have to avoid returning `ManuallyDrop<Box<T>>` and instead work with `NonNull` until the allocation is actually freed and we can assert uniqueness, as `Box` is a noalias type (at least under the current rules).

I also played around with using `boxcar::Vec` instead of the current lock, but the lock is actually relatively uncontended and fine-grained and it was hard to balance cold and incremental performance with a lock-free implementation.