### PR TITLE
Update boxcar

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ description = "A generic framework for on-demand, incrementalized computation (e
 salsa-macro-rules = { version = "0.19.0", path = "components/salsa-macro-rules" }
 salsa-macros = { version = "0.19.0", path = "components/salsa-macros", optional = true }
 
-boxcar = "0.2.9"
+boxcar = "0.2.11"
 crossbeam-queue = "0.3.11"
 dashmap = { version = "6", features = ["raw-api"] }
 hashbrown = "0.15"


### PR DESCRIPTION
It looks like the reason for the regression in https://github.com/salsa-rs/salsa/pull/688 might have been simpler than I thought and come down to some poor codegen when allocating new boxcar buckets (see https://github.com/ibraheemdev/boxcar/pull/28). Hoping CodSpeed also picks up these changes.