### PR TITLE
fix: fix missing version in Cargo manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ tracing = "0.1"
 parking_lot = "0.12"
 rustc-hash = "2"
 salsa-macro-rules = { version = "0.1.0", path = "components/salsa-macro-rules" }
-salsa-macros = { path = "components/salsa-macros" }
+salsa-macros = { version = "0.18.0", path = "components/salsa-macros" }
 smallvec = "1"
 rayon = "1.10.0"
 


### PR DESCRIPTION
https://github.com/salsa-rs/salsa/actions/runs/13416786546/job/37479444250 is failed due to lack of `version` of `salsa-macros` in Cargo manifest. This PR fixes it.