### PR TITLE
Remove dev dependency `derive-new`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ salsa_unstable = []
 
 [dev-dependencies]
 annotate-snippets = "0.11.5"
-derive-new = "0.6.0"
 codspeed-criterion-compat = { version = "2.6.0", default-features = false }
 expect-test = "1.5.0"
 eyre = "0.6.8"

--- a/examples/calc/ir.rs
+++ b/examples/calc/ir.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::needless_borrow)]
 
-use derive_new::new;
 use ordered_float::OrderedFloat;
 
 // ANCHOR: input
@@ -35,11 +34,17 @@ pub struct Program<'db> {
 // ANCHOR_END: program
 
 // ANCHOR: statements_and_expressions
-#[derive(Eq, PartialEq, Debug, Hash, new, salsa::Update)]
+#[derive(Eq, PartialEq, Debug, Hash, salsa::Update)]
 pub struct Statement<'db> {
     pub span: Span<'db>,
 
     pub data: StatementData<'db>,
+}
+
+impl<'db> Statement<'db> {
+    pub fn new(span: Span<'db>, data: StatementData<'db>) -> Self {
+        Statement { span, data }
+    }
 }
 
 #[derive(Eq, PartialEq, Debug, Hash, salsa::Update)]
@@ -50,11 +55,17 @@ pub enum StatementData<'db> {
     Print(Expression<'db>),
 }
 
-#[derive(Eq, PartialEq, Debug, Hash, new, salsa::Update)]
+#[derive(Eq, PartialEq, Debug, Hash, salsa::Update)]
 pub struct Expression<'db> {
     pub span: Span<'db>,
 
     pub data: ExpressionData<'db>,
+}
+
+impl<'db> Expression<'db> {
+    pub fn new(span: Span<'db>, data: ExpressionData<'db>) -> Self {
+        Expression { span, data }
+    }
 }
 
 #[derive(Eq, PartialEq, Debug, Hash, salsa::Update)]
@@ -102,7 +113,6 @@ pub struct Span<'db> {
 // ANCHOR: diagnostic
 #[salsa::accumulator]
 #[allow(dead_code)] // Debug impl uses them
-#[derive(new)]
 pub struct Diagnostic {
     pub start: usize,
     pub end: usize,
@@ -111,6 +121,14 @@ pub struct Diagnostic {
 // ANCHOR_END: diagnostic
 
 impl Diagnostic {
+    pub fn new(start: usize, end: usize, message: String) -> Self {
+        Diagnostic {
+            start,
+            end,
+            message,
+        }
+    }
+
     #[cfg(test)]
     pub fn render(&self, db: &dyn crate::Db, src: SourceProgram) -> String {
         use annotate_snippets::*;

--- a/examples/calc/type_check.rs
+++ b/examples/calc/type_check.rs
@@ -1,7 +1,6 @@
 use crate::ir::{
     Diagnostic, Expression, Function, FunctionId, Program, Span, StatementData, VariableId,
 };
-use derive_new::new;
 #[cfg(test)]
 use expect_test::expect;
 use salsa::Accumulator;
@@ -44,11 +43,24 @@ pub fn find_function<'db>(
         .next()
 }
 
-#[derive(new)]
 struct CheckExpression<'input, 'db> {
     db: &'db dyn crate::Db,
     program: Program<'db>,
     names_in_scope: &'input [VariableId<'db>],
+}
+
+impl<'input, 'db> CheckExpression<'input, 'db> {
+    pub fn new(
+        db: &'db dyn crate::Db,
+        program: Program<'db>,
+        names_in_scope: &'input [VariableId<'db>],
+    ) -> Self {
+        CheckExpression {
+            db,
+            program,
+            names_in_scope,
+        }
+    }
 }
 
 impl<'db> CheckExpression<'_, 'db> {


### PR DESCRIPTION
This was only used for 4 structs in the `calc` example and the expanded code isn't that large.