### PR TITLE
Remove some `ZalsaDatabase::zalsa` calls

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -49,9 +49,8 @@ pub trait Database: Send + AsDynDatabase + Any + ZalsaDatabase {
     /// Queries which report untracked reads will be re-executed in the next
     /// revision.
     fn report_untracked_read(&self) {
-        let db = self.as_dyn_database();
-        let zalsa_local = db.zalsa_local();
-        zalsa_local.report_untracked_read(db.zalsa().current_revision())
+        let (zalsa, zalsa_local) = self.zalsas();
+        zalsa_local.report_untracked_read(zalsa.current_revision())
     }
 
     /// Return the "debug name" (i.e., the struct name, etc) for an "ingredient",
@@ -81,8 +80,7 @@ pub trait Database: Send + AsDynDatabase + Any + ZalsaDatabase {
     /// used instead.
     fn unwind_if_revision_cancelled(&self) {
         let db = self.as_dyn_database();
-        let zalsa_local = db.zalsa_local();
-        zalsa_local.unwind_if_revision_cancelled(db);
+        self.zalsa_local().unwind_if_revision_cancelled(db);
     }
 
     /// Execute `op` with the database in thread-local storage for debug print-outs.

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -79,7 +79,7 @@ where
         // old value.
         if let Some(old_memo) = &opt_old_memo {
             self.backdate_if_appropriate(old_memo, &mut revisions, &value);
-            self.diff_outputs(db, database_key_index, old_memo, &mut revisions);
+            self.diff_outputs(zalsa, db, database_key_index, old_memo, &mut revisions);
         }
 
         tracing::debug!("{database_key_index:?}: read_upgrade: result.revisions = {revisions:#?}");

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -186,11 +186,12 @@ impl<V> Memo<V> {
 
     pub(super) fn mark_outputs_as_verified(
         &self,
+        zalsa: &Zalsa,
         db: &dyn crate::Database,
         database_key_index: DatabaseKeyIndex,
     ) {
         for output in self.revisions.origin.outputs() {
-            output.mark_validated_output(db, database_key_index);
+            output.mark_validated_output(zalsa, db, database_key_index);
         }
     }
 

--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -75,7 +75,7 @@ where
 
         if let Some(old_memo) = self.get_memo_from_table_for(zalsa, key) {
             self.backdate_if_appropriate(&old_memo, &mut revisions, &value);
-            self.diff_outputs(db, database_key_index, &old_memo, &mut revisions);
+            self.diff_outputs(zalsa, db, database_key_index, &old_memo, &mut revisions);
         }
 
         let memo = Memo {

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,8 +1,11 @@
 use core::fmt;
 
 use crate::{
-    accumulator::accumulated_map::InputAccumulatedValues, cycle::CycleRecoveryStrategy,
-    ingredient::MaybeChangedAfter, zalsa::IngredientIndex, Database, Id,
+    accumulator::accumulated_map::InputAccumulatedValues,
+    cycle::CycleRecoveryStrategy,
+    ingredient::MaybeChangedAfter,
+    zalsa::{IngredientIndex, Zalsa},
+    Database, Id,
 };
 
 /// An integer that uniquely identifies a particular query instance within the
@@ -33,18 +36,24 @@ impl OutputDependencyIndex {
         }
     }
 
-    pub(crate) fn remove_stale_output(&self, db: &dyn Database, executor: DatabaseKeyIndex) {
-        db.zalsa()
+    pub(crate) fn remove_stale_output(
+        &self,
+        zalsa: &Zalsa,
+        db: &dyn Database,
+        executor: DatabaseKeyIndex,
+    ) {
+        zalsa
             .lookup_ingredient(self.ingredient_index)
             .remove_stale_output(db, executor, self.key_index)
     }
 
     pub(crate) fn mark_validated_output(
         &self,
+        zalsa: &Zalsa,
         db: &dyn Database,
         database_key_index: DatabaseKeyIndex,
     ) {
-        db.zalsa()
+        zalsa
             .lookup_ingredient(self.ingredient_index)
             .mark_validated_output(db, database_key_index, self.key_index)
     }

--- a/src/table/sync.rs
+++ b/src/table/sync.rs
@@ -34,12 +34,12 @@ impl SyncTable {
     pub(crate) fn claim<'me>(
         &'me self,
         db: &'me dyn Database,
+        zalsa: &'me Zalsa,
         zalsa_local: &ZalsaLocal,
         database_key_index: DatabaseKeyIndex,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> Option<ClaimGuard<'me>> {
         let mut syncs = self.syncs.write();
-        let zalsa = db.zalsa();
         let thread_id = std::thread::current().id();
 
         util::ensure_vec_len(&mut syncs, memo_ingredient_index.as_usize() + 1);

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -608,7 +608,7 @@ where
             db.salsa_event(&|| Event::new(EventKind::DidDiscard { key: executor }));
 
             for stale_output in memo.origin().outputs() {
-                stale_output.remove_stale_output(db, executor);
+                stale_output.remove_stale_output(zalsa, db, executor);
             }
         }
 


### PR DESCRIPTION
Instead pass around `&Zalsa` to callers more to reduce dynamic dispatch, in most of these cases the functions are only called once so the compiler should have enough knowledge to make the extra argument passing virtually free