### PR TITLE
Fix incorrect query caching for recycled tracked structs

### DIFF
--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -740,7 +740,7 @@ where
         input: Id,
         revision: Revision,
     ) -> MaybeChangedAfter {
-        let (zalsa, _) = db.zalsas();
+        let zalsa = db.zalsa();
         let data = Self::data(zalsa.table(), input);
 
         MaybeChangedAfter::from(data.created_at > revision)

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -264,11 +264,13 @@ where
     /// create this struct with different values.
     durability: Durability,
 
-    /// The revisiono in which the tracked struct was first-created.
-    /// This is different from `updated_at` which gets bumped on every read.
+    /// The revision in which the tracked struct was first created.
     ///
-    /// Tracking `created_at` is important to detect tracked struct ids
-    /// that are being reused after they've been freed in a previous revision.
+    /// Unlike `updated_at`, which gets bumped on every read,
+    /// `created_at` is updated whenever an untracked field is updated.
+    /// This is necessary to detect reused tracked struct ids _after_
+    /// they've been freed in a prior revision or tracked structs that have been updated
+    /// in-place because of a bad `Hash` implementation.
     created_at: Revision,
 
     /// The revision when this tracked struct was last updated.
@@ -472,11 +474,11 @@ where
 
         // The protocol is:
         //
-        // * When we begin updating, we store `None` in the `created_at` field
-        // * When completed, we store `Some(current_revision)` in `created_at`
+        // * When we begin updating, we store `None` in the `updated_at` field
+        // * When completed, we store `Some(current_revision)` in `updated_at`
         //
         // No matter what mischief users get up to, it should be impossible for us to
-        // observe `None` in `created_at`. The `id` should only be associated with one
+        // observe `None` in `updated_at`. The `id` should only be associated with one
         // query and that query can only be running in one thread at a time.
         //
         // We *can* observe `Some(current_revision)` however, which means that this

--- a/tests/tracked_struct_with_interned_query.rs
+++ b/tests/tracked_struct_with_interned_query.rs
@@ -1,0 +1,54 @@
+mod common;
+
+use salsa::Setter;
+
+#[salsa::input]
+struct MyInput {
+    value: usize,
+}
+
+#[salsa::tracked]
+struct Tracked<'db> {
+    value: String,
+}
+
+#[salsa::tracked]
+fn query_tracked(db: &dyn salsa::Database, input: MyInput) -> Tracked<'_> {
+    Tracked::new(db, format!("{value}", value = input.value(db)))
+}
+
+#[salsa::tracked]
+fn join<'db>(db: &'db dyn salsa::Database, tracked: Tracked<'db>, with: String) -> String {
+    format!("{}{}", tracked.value(db), with)
+}
+
+#[test]
+fn execute() {
+    let mut db = salsa::DatabaseImpl::default();
+    let input = MyInput::new(&db, 1);
+
+    let tracked = query_tracked(&db, input);
+    let joined = join(&db, tracked, "world".to_string());
+
+    assert_eq!(joined, "1world");
+
+    // Create a new revision: This puts the tracked struct created in revision 0
+    // into the free list.
+    input.set_value(&mut db).to(2);
+
+    let tracked = query_tracked(&db, input);
+    let joined = join(&db, tracked, "world".to_string());
+
+    assert_eq!(joined, "2world");
+
+    // Create a new revision: The tracked struct created in revision 0 is now
+    // reused, including its id. The argument to `join` will hash and compare
+    // equal to the argument used in revision 0 but the return value should be
+    // 3world and not 1world.
+    input.set_value(&mut db).to(3);
+
+    let tracked = query_tracked(&db, input);
+    let joined = join(&db, tracked, "world".to_string());
+
+    assert_eq!(joined, "3world");
+}


### PR DESCRIPTION
This PR fixes a bug specific to tracked structs that are recycled and the query doesn't read any tracked fields. 

Salsa maintains a free-list with tracked structs that were created in a previous revision but are now no longer used. The storage and IDs of those tracked structs can be reused in the next revision. This helps reduce overall memory usage and allows the recycling of IDs. 

However, the reuse of ids combined with coarse-grained dependencies as implemented today can lead to incorrect cache-reuse if a tracked struct ID gets reused and a query takes multiple arguments -- which requires interning. The problem is that the interned argument struct compares equal because the tracked struct has equal ids, making salsa believe that reusing the cached data is fine (when it isn't). 

This PR fixes this by:

* Adding a new `created_at` field to tracked structs that stores the revision when the tracked struct was first created. This field gets updated to the current revision when a tracked struct is recycled
* Add a `maybe_changed_after` implementation to `TrackedStruct` that returns `true` if the tracked struct was created after the query was last run. This suggests that this is no longer the same tracked struct
* Add a read dependency to the tracked struct (not the field) when accessing any untracked field. This guarantees that the query depends on the tracked struct and calls its `maybe_changed_after` when validating if the query has changed.

The new field is similar to the interned struct's `reset_at` field. It's also the same as we have for tracked fields on tracked structs where each field caries its own revision.

I added a new test and verified that it failed on master before implementing this fix.


**Note**:

Why not use `updated_at`?: `updated_at` gets bumped in every revision any field of the tracked struct was read. This is different from what we need here where it's mainly to identify when the id was reused. 