### PR TITLE
Track revisions for tracked-fields only

### DIFF
--- a/components/salsa-macro-rules/src/setup_tracked_struct.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_struct.rs
@@ -50,7 +50,7 @@ macro_rules! setup_tracked_struct {
         // Absolute indices of any untracked fields.
         absolute_untracked_indices: [$($absolute_untracked_index:tt),*],
 
-        // A set of "field options" for each field.
+        // A set of "field options" for each tracked field.
         //
         // Each field option is a tuple `(maybe_clone, maybe_backdate)` where:
         //
@@ -59,16 +59,21 @@ macro_rules! setup_tracked_struct {
         //
         // These are used to drive conditional logic for each field via recursive macro invocation
         // (see e.g. @maybe_clone below).
-        field_options: [$($field_option:tt),*],
-
-        // A set of "field options" for each tracked field.
         tracked_options: [$($tracked_option:tt),*],
 
         // A set of "field options" for each untracked field.
+        //
+        // Each field option is a tuple `(maybe_clone, maybe_backdate)` where:
+        //
+        // * `maybe_clone` is either the identifier `clone` or `no_clone`
+        // * `maybe_backdate` is either the identifier `backdate` or `no_backdate`
+        //
+        // These are used to drive conditional logic for each field via recursive macro invocation
+        // (see e.g. @maybe_clone below).
         untracked_options: [$($untracked_option:tt),*],
 
-        // Number of fields.
-        num_fields: $N:literal,
+        // Number of tracked fields.
+        num_tracked_fields: $N:literal,
 
         // If true, generate a debug impl.
         generate_debug_impl: $generate_debug_impl:tt,
@@ -111,7 +116,7 @@ macro_rules! setup_tracked_struct {
                 ];
 
                 const TRACKED_FIELD_INDICES: &'static [usize] = &[
-                    $($absolute_tracked_index,)*
+                    $($relative_tracked_index,)*
                 ];
 
                 type Fields<$db_lt> = ($($field_ty,)*);
@@ -150,7 +155,7 @@ macro_rules! setup_tracked_struct {
                                 $tracked_ty,
                                 (*old_fields).$absolute_tracked_index,
                                 new_fields.$absolute_tracked_index,
-                                revisions[$absolute_tracked_index],
+                                revisions[$relative_tracked_index],
                                 current_revision,
                                 $zalsa,
                             );
@@ -246,7 +251,7 @@ macro_rules! setup_tracked_struct {
                         $Db: ?Sized + $zalsa::Database,
                     {
                         let db = db.as_dyn_database();
-                        let fields = $Configuration::ingredient(db).tracked_field(db, self, $absolute_tracked_index, $relative_tracked_index);
+                        let fields = $Configuration::ingredient(db).tracked_field(db, self, $relative_tracked_index);
                         $crate::maybe_clone!(
                             $tracked_option,
                             $tracked_ty,

--- a/components/salsa-macros/src/salsa_struct.rs
+++ b/components/salsa-macros/src/salsa_struct.rs
@@ -227,6 +227,10 @@ where
         Literal::usize_unsuffixed(self.fields.len())
     }
 
+    pub(crate) fn num_tracked_fields(&self) -> Literal {
+        Literal::usize_unsuffixed(self.tracked_fields_iter().count())
+    }
+
     pub(crate) fn required_fields(&self) -> Vec<TokenStream> {
         self.fields
             .iter()

--- a/components/salsa-macros/src/tracked_struct.rs
+++ b/components/salsa-macros/src/tracked_struct.rs
@@ -101,7 +101,6 @@ impl Macro {
 
         let absolute_untracked_indices = salsa_struct.untracked_field_indices();
 
-        let field_options = salsa_struct.field_options();
         let tracked_options = salsa_struct.tracked_options();
         let untracked_options = salsa_struct.untracked_options();
 
@@ -109,7 +108,7 @@ impl Macro {
         let tracked_tys = salsa_struct.tracked_tys();
         let untracked_tys = salsa_struct.untracked_tys();
 
-        let num_fields = salsa_struct.num_fields();
+        let num_tracked_fields = salsa_struct.num_tracked_fields();
         let generate_debug_impl = salsa_struct.generate_debug_impl();
 
         let zalsa = self.hygiene.ident("zalsa");
@@ -147,11 +146,10 @@ impl Macro {
 
                     absolute_untracked_indices: [#(#absolute_untracked_indices),*],
 
-                    field_options: [#(#field_options),*],
                     tracked_options: [#(#tracked_options),*],
                     untracked_options: [#(#untracked_options),*],
 
-                    num_fields: #num_fields,
+                    num_tracked_fields: #num_tracked_fields,
                     generate_debug_impl: #generate_debug_impl,
                     unused_names: [
                         #zalsa,


### PR DESCRIPTION
Based on https://github.com/salsa-rs/salsa/pull/708

Avoid tracking revisions for untracked fields (all tracked fields are covered by the tracked struct's `created_at` field). This should reduce memory consumption of tracked structs because it avoids tracking unused revisions for untracked field.

Closes https://github.com/salsa-rs/salsa/issues/672
