### PR TITLE
refactor(perf): Remove extra page indirection in `Table`

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -187,12 +187,7 @@ impl<C: Configuration> IngredientImpl<C> {
         &'db self,
         db: &'db dyn crate::Database,
     ) -> impl Iterator<Item = &'db Value<C>> {
-        db.zalsa()
-            .table()
-            .pages
-            .iter()
-            .filter_map(|(_, page)| page.cast_type::<crate::table::Page<Value<C>>>())
-            .flat_map(|page| page.slots())
+        db.zalsa().table().slots_of::<Value<C>>()
     }
 
     /// Peek at the field values without recording any read dependency.
@@ -318,14 +313,17 @@ impl<C> Slot for Value<C>
 where
     C: Configuration,
 {
+    #[inline]
     unsafe fn memos(&self, _current_revision: Revision) -> &crate::table::memo::MemoTable {
         &self.memos
     }
 
+    #[inline]
     fn memos_mut(&mut self) -> &mut crate::table::memo::MemoTable {
         &mut self.memos
     }
 
+    #[inline]
     unsafe fn syncs(&self, _current_revision: Revision) -> &SyncTable {
         &self.syncs
     }

--- a/src/input/singleton.rs
+++ b/src/input/singleton.rs
@@ -34,7 +34,8 @@ impl SingletonChoice for Singleton {
     fn index(&self) -> Option<Id> {
         match self.index.load(Ordering::Acquire) {
             0 => None,
-            id => Some(Id::from_u32(id - 1)),
+            // SAFETY: Our u32 is derived from an ID and thus safe to convert back.
+            id => Some(unsafe { Id::from_u32(id - 1) }),
         }
     }
 }

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -364,12 +364,7 @@ where
         &'db self,
         db: &'db dyn crate::Database,
     ) -> impl Iterator<Item = &'db Value<C>> {
-        db.zalsa()
-            .table()
-            .pages
-            .iter()
-            .filter_map(|(_, page)| page.cast_type::<crate::table::Page<Value<C>>>())
-            .flat_map(|page| page.slots())
+        db.zalsa().table().slots_of::<Value<C>>()
     }
 }
 
@@ -475,14 +470,17 @@ impl<C> Slot for Value<C>
 where
     C: Configuration,
 {
+    #[inline]
     unsafe fn memos(&self, _current_revision: Revision) -> &MemoTable {
         &self.memos
     }
 
+    #[inline]
     fn memos_mut(&mut self) -> &mut MemoTable {
         &mut self.memos
     }
 
+    #[inline]
     unsafe fn syncs(&self, _current_revision: Revision) -> &crate::table::sync::SyncTable {
         &self.syncs
     }

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,9 +1,11 @@
 use std::{
+    alloc::Layout,
     any::{Any, TypeId},
     cell::UnsafeCell,
-    mem::MaybeUninit,
-    panic::RefUnwindSafe,
-    ptr, slice,
+    marker::PhantomData,
+    mem::{self, MaybeUninit},
+    ptr::{self, NonNull},
+    slice,
     sync::atomic::{AtomicUsize, Ordering},
 };
 
@@ -12,7 +14,7 @@ use parking_lot::Mutex;
 use rustc_hash::FxHashMap;
 use sync::SyncTable;
 
-use crate::{zalsa::transmute_data_ptr, Id, IngredientIndex, Revision};
+use crate::{Id, IngredientIndex, Revision};
 
 pub(crate) mod memo;
 pub(crate) mod sync;
@@ -23,54 +25,13 @@ const PAGE_LEN_MASK: usize = PAGE_LEN - 1;
 const PAGE_LEN: usize = 1 << PAGE_LEN_BITS;
 const MAX_PAGES: usize = 1 << (32 - PAGE_LEN_BITS);
 
+/// A typed [`Page`] view.
+pub(crate) struct PageView<'p, T: Slot>(&'p Page, PhantomData<&'p T>);
+
 pub struct Table {
-    pub(crate) pages: boxcar::Vec<Box<dyn TablePage>>,
+    pages: boxcar::Vec<Page>,
     /// Map from ingredient to non-full pages that are up for grabs
     non_full_pages: Mutex<FxHashMap<IngredientIndex, Vec<PageIndex>>>,
-}
-
-pub(crate) trait TablePage: Any + Send + Sync {
-    fn hidden_type_name(&self) -> &'static str;
-
-    fn ingredient_index(&self) -> IngredientIndex;
-
-    /// Access the memos attached to `slot`.
-    ///
-    /// # Safety condition
-    ///
-    /// The `current_revision` MUST be the current revision of the database owning this table page.
-    unsafe fn memos(&self, slot: SlotIndex, current_revision: Revision) -> &MemoTable;
-
-    /// Access the memos attached to `slot`.
-    fn memos_mut(&mut self, slot: SlotIndex) -> &mut MemoTable;
-
-    /// Access the syncs attached to `slot`.
-    ///
-    /// # Safety condition
-    ///
-    /// The `current_revision` MUST be the current revision of the database owning this table page.
-    unsafe fn syncs(&self, slot: SlotIndex, current_revision: Revision) -> &SyncTable;
-}
-
-pub(crate) struct Page<T: Slot> {
-    /// The ingredient for elements on this page.
-    ingredient: IngredientIndex,
-
-    /// Number of elements of `data` that are initialized.
-    allocated: AtomicUsize,
-
-    /// The "allocation lock" is held when we allocate a new entry.
-    ///
-    /// It ensures that we can load the index, initialize it, and then update the length atomically
-    /// with respect to other allocations.
-    ///
-    /// We could avoid it if we wanted, we'd just have to be a bit fancier in our reasoning
-    /// (for example, the bounds check in `Page::get` no longer suffices to truly guarantee
-    /// that the data is initialized).
-    allocation_lock: Mutex<()>,
-
-    /// The potentially uninitialized data of this page. As we initialize new entries, we increment `allocated`.
-    data: Box<[UnsafeCell<MaybeUninit<T>>; PAGE_LEN]>,
 }
 
 pub(crate) trait Slot: Any + Send + Sync {
@@ -92,28 +53,112 @@ pub(crate) trait Slot: Any + Send + Sync {
     unsafe fn syncs(&self, current_revision: Revision) -> &SyncTable;
 }
 
-unsafe impl<T: Slot> Send for Page<T> {}
+/// [Slot::memos]
+type SlotMemosFnRaw = unsafe fn(*const (), current_revision: Revision) -> *const MemoTable;
+/// [Slot::memos]
+type SlotMemosFn<T> = unsafe fn(&T, current_revision: Revision) -> &MemoTable;
+/// [Slot::memos_mut]
+type SlotMemosMutFnRaw = unsafe fn(*mut ()) -> *mut MemoTable;
+/// [Slot::memos_mut]
+type SlotMemosMutFn<T> = unsafe fn(&mut T) -> &mut MemoTable;
+/// [Slot::syncs]
+type SlotSyncsFnRaw = unsafe fn(*const (), current_revision: Revision) -> *const SyncTable;
+/// [Slot::syncs]
+type SlotSyncsFn<T> = unsafe fn(&T, current_revision: Revision) -> &SyncTable;
 
-unsafe impl<T: Slot> Sync for Page<T> {}
+struct SlotVTable {
+    layout: Layout,
+    /// [`Slot`] methods
+    memos: SlotMemosFnRaw,
+    memos_mut: SlotMemosMutFnRaw,
+    syncs: SlotSyncsFnRaw,
+    /// A drop impl to call when the own page drops
+    /// SAFETY: The caller is required to supply a correct data pointer to a `Box<PageDataEntry<T>>` and initialized length
+    drop_impl: unsafe fn(data: *mut (), initialized: usize),
+}
 
-impl<T: Slot> RefUnwindSafe for Page<T> {}
+impl SlotVTable {
+    const fn of<T: Slot>() -> &'static Self {
+        const {
+            &Self {
+                // SAFETY: The caller is required to supply a correct data pointer and initialized length
+                drop_impl: |data, initialized| unsafe {
+                    let data = Box::from_raw(data.cast::<PageData<T>>());
+                    for i in 0..initialized {
+                        ptr::drop_in_place(data[i].get().cast::<T>());
+                    }
+                },
+                layout: Layout::new::<T>(),
+                // SAFETY: The signatures are compatible
+                memos: unsafe { mem::transmute::<SlotMemosFn<T>, SlotMemosFnRaw>(T::memos) },
+                // SAFETY: The signatures are compatible
+                memos_mut: unsafe {
+                    mem::transmute::<SlotMemosMutFn<T>, SlotMemosMutFnRaw>(T::memos_mut)
+                },
+                // SAFETY: The signatures are compatible
+                syncs: unsafe { mem::transmute::<SlotSyncsFn<T>, SlotSyncsFnRaw>(T::syncs) },
+            }
+        }
+    }
+}
+
+type PageDataEntry<T> = UnsafeCell<MaybeUninit<T>>;
+type PageData<T> = [PageDataEntry<T>; PAGE_LEN];
+
+struct Page {
+    /// The ingredient for elements on this page.
+    ingredient: IngredientIndex,
+
+    /// Number of elements of `data` that are initialized.
+    allocated: AtomicUsize,
+
+    /// The "allocation lock" is held when we allocate a new entry.
+    ///
+    /// It ensures that we can load the index, initialize it, and then update the length atomically
+    /// with respect to other allocations.
+    ///
+    /// We could avoid it if we wanted, we'd just have to be a bit fancier in our reasoning
+    /// (for example, the bounds check in `Page::get` no longer suffices to truly guarantee
+    /// that the data is initialized).
+    allocation_lock: Mutex<()>,
+
+    /// The potentially uninitialized data of this page. As we initialize new entries, we increment `allocated`.
+    /// This is a box allocated `PageData<SlotType>`
+    data: NonNull<()>,
+
+    /// A vtable for the slot type stored in this page.
+    slot_vtable: &'static SlotVTable,
+    /// The type id of what is stored as entries in data.
+    // FIXME: Move this into SlotVTable once const stable
+    slot_type_id: TypeId,
+    /// The type name of what is stored as entries in data.
+    // FIXME: Move this into SlotVTable once const stable
+    slot_type_name: &'static str,
+}
+
+// SAFETY: `Page` is `Send` as we make sure to only ever store `Slot` types in it which
+// requires `Send`.`
+unsafe impl Send for Page {}
+// SAFETY: `Page` is `Sync` as we make sure to only ever store `Slot` types in it which
+// requires `Sync`.`
+unsafe impl Sync for Page {}
 
 #[derive(Copy, Clone, Debug)]
 pub struct PageIndex(usize);
 
 impl PageIndex {
     fn new(idx: usize) -> Self {
-        assert!(idx < MAX_PAGES);
+        debug_assert!(idx < MAX_PAGES);
         Self(idx)
     }
 }
 
 #[derive(Copy, Clone, Debug)]
-pub struct SlotIndex(usize);
+struct SlotIndex(usize);
 
 impl SlotIndex {
     fn new(idx: usize) -> Self {
-        assert!(idx < PAGE_LEN);
+        debug_assert!(idx < PAGE_LEN);
         Self(idx)
     }
 }
@@ -132,7 +177,7 @@ impl Table {
     #[inline]
     pub fn ingredient_index(&self, id: Id) -> IngredientIndex {
         let (page_idx, _) = split_id(id);
-        self.pages[page_idx.0].ingredient_index()
+        self.pages[page_idx.0].ingredient
     }
 
     /// Get a reference to the data for `id`, which must have been allocated from this table with type `T`.
@@ -143,7 +188,7 @@ impl Table {
     pub(crate) fn get<T: Slot>(&self, id: Id) -> &T {
         let (page, slot) = split_id(id);
         let page_ref = self.page::<T>(page);
-        page_ref.get(slot)
+        &page_ref.data()[slot.0]
     }
 
     /// Get a raw pointer to the data for `id`, which must have been allocated from this table.
@@ -158,7 +203,7 @@ impl Table {
     pub(crate) fn get_raw<T: Slot>(&self, id: Id) -> *mut T {
         let (page, slot) = split_id(id);
         let page_ref = self.page::<T>(page);
-        page_ref.get_raw(slot)
+        page_ref.page_data()[slot.0].get().cast::<T>()
     }
 
     /// Gets a reference to the page which has slots of type `T`
@@ -166,14 +211,13 @@ impl Table {
     /// # Panics
     ///
     /// If `page` is out of bounds or the type `T` is incorrect.
-    pub(crate) fn page<T: Slot>(&self, page: PageIndex) -> &Page<T> {
-        self.pages[page.0].assert_type::<Page<T>>()
+    pub(crate) fn page<T: Slot>(&self, page: PageIndex) -> PageView<T> {
+        self.pages[page.0].assert_type::<T>()
     }
 
     /// Allocate a new page for the given ingredient and with slots of type `T`
     pub(crate) fn push_page<T: Slot>(&self, ingredient: IngredientIndex) -> PageIndex {
-        let page = Box::new(<Page<T>>::new(ingredient));
-        PageIndex::new(self.pages.push(page))
+        PageIndex::new(self.pages.push(Page::new::<T>(ingredient)))
     }
 
     /// Get the memo table associated with `id`
@@ -184,7 +228,9 @@ impl Table {
     /// of the owner of database owning this table.
     pub(crate) unsafe fn memos(&self, id: Id, current_revision: Revision) -> &MemoTable {
         let (page, slot) = split_id(id);
-        unsafe { self.pages[page.0].memos(slot, current_revision) }
+        let page = &self.pages[page.0];
+        // SAFETY: We supply a proper slot pointer and the caller is required to pass the `current_revision`.
+        unsafe { &*(page.slot_vtable.memos)(page.get(slot), current_revision) }
     }
 
     /// Get the memo table associated with `id`
@@ -195,7 +241,8 @@ impl Table {
             .pages
             .get_mut(page_index)
             .unwrap_or_else(|| panic!("index `{page_index}` is uninitialized"));
-        page.memos_mut(slot)
+        // SAFETY: We supply a proper slot pointer and the caller is required to pass the `current_revision`.
+        unsafe { &mut *(page.slot_vtable.memos_mut)(page.get(slot)) }
     }
 
     /// Get the sync table associated with `id`
@@ -206,7 +253,16 @@ impl Table {
     /// of the owner of database owning this table.
     pub(crate) unsafe fn syncs(&self, id: Id, current_revision: Revision) -> &SyncTable {
         let (page, slot) = split_id(id);
-        unsafe { self.pages[page.0].syncs(slot, current_revision) }
+        let page = &self.pages[page.0];
+        // SAFETY: We supply a proper slot pointer and the caller is required to pass the `current_revision`.
+        unsafe { &*(page.slot_vtable.syncs)(page.get(slot), current_revision) }
+    }
+
+    pub(crate) fn slots_of<T: Slot>(&self) -> impl Iterator<Item = &T> + '_ {
+        self.pages
+            .iter()
+            .filter_map(|(_, page)| page.cast_type::<T>())
+            .flat_map(|view| view.data())
     }
 
     pub(crate) fn fetch_or_push_page<T: Slot>(&self, ingredient: IngredientIndex) -> PageIndex {
@@ -230,161 +286,112 @@ impl Table {
     }
 }
 
-impl<T: Slot> Page<T> {
-    #[allow(clippy::uninit_vec)]
-    fn new(ingredient: IngredientIndex) -> Self {
-        Self {
-            ingredient,
-            allocated: Default::default(),
-            allocation_lock: Default::default(),
-            data: Box::new([const { UnsafeCell::new(MaybeUninit::uninit()) }; PAGE_LEN]),
-        }
+impl<'p, T: Slot> PageView<'p, T> {
+    fn page_data(&self) -> &[PageDataEntry<T>] {
+        let len = self.0.allocated.load(Ordering::Acquire);
+        // SAFETY: `len` is the initialized length of the page
+        unsafe { slice::from_raw_parts(self.0.data.cast::<PageDataEntry<T>>().as_ptr(), len) }
     }
 
-    fn check_bounds(&self, slot: SlotIndex) {
-        let len = self.allocated.load(Ordering::Acquire);
-        assert!(
-            slot.0 < len,
-            "out of bounds access `{slot:?}` (maximum slot `{len}`)"
-        );
-    }
-
-    /// Returns a reference to the given slot.
-    ///
-    /// # Panics
-    ///
-    /// If slot is out of bounds
-    pub(crate) fn get(&self, slot: SlotIndex) -> &T {
-        self.check_bounds(slot);
-        unsafe { (*self.data[slot.0].get()).assume_init_ref() }
-    }
-
-    /// Returns a reference to the given slot.
-    ///
-    /// # Panics
-    ///
-    /// If slot is out of bounds
-    pub(crate) fn get_mut(&mut self, slot: SlotIndex) -> &mut T {
-        self.check_bounds(slot);
-        unsafe { (*self.data[slot.0].get()).assume_init_mut() }
-    }
-
-    pub(crate) fn slots(&self) -> impl Iterator<Item = &T> {
-        let len = self.allocated.load(std::sync::atomic::Ordering::Acquire);
-        let mut idx = 0;
-
-        std::iter::from_fn(move || {
-            let ret = if idx < len {
-                let value = self.get(crate::table::SlotIndex::new(idx));
-                Some(value)
-            } else {
-                None
-            };
-            idx += 1;
-            ret
-        })
-    }
-
-    /// Returns a raw pointer to the given slot.
-    ///
-    /// # Panics
-    ///
-    /// If slot is out of bounds
-    ///
-    /// # Safety
-    ///
-    /// Safe to call, but reads/writes through this pointer must be coordinated
-    /// properly with calls to [`get`](`Self::get`) and [`get_mut`](`Self::get_mut`).
-    pub(crate) fn get_raw(&self, slot: SlotIndex) -> *mut T {
-        self.check_bounds(slot);
-        self.data[slot.0].get().cast()
+    fn data(&self) -> &'p [T] {
+        let len = self.0.allocated.load(Ordering::Acquire);
+        // SAFETY: `len` is the initialized length of the page
+        unsafe { slice::from_raw_parts(self.0.data.cast::<T>().as_ptr(), len) }
     }
 
     pub(crate) fn allocate<V>(&self, page: PageIndex, value: V) -> Result<Id, V>
     where
         V: FnOnce(Id) -> T,
     {
-        let guard = self.allocation_lock.lock();
-        let index = self.allocated.load(Ordering::Acquire);
-        if index == PAGE_LEN {
+        let _guard = self.0.allocation_lock.lock();
+        let index = self.0.allocated.load(Ordering::Acquire);
+        if index >= PAGE_LEN {
             return Err(value);
         }
 
         // Initialize entry `index`
         let id = make_id(page, SlotIndex::new(index));
-        let data = &self.data[index];
-        unsafe { (*data.get()).write(value(id)) };
+        let data = self.0.data.cast::<PageDataEntry<T>>();
+        // SAFETY: We acquired the allocation lock, so we have unique access to the UnsafeCell
+        // interior.
+        // `index` is also guaranteed to be in bounds as per the check above.
+        unsafe { (*(*data.as_ptr().add(index)).get()).write(value(id)) };
 
-        // Update the length (this must be done after initialization!)
-        self.allocated.store(index + 1, Ordering::Release);
-        drop(guard);
+        // Update the length (this must be done after initialization as otherwise an uninitialized
+        // read could occur!)
+        self.0.allocated.store(index + 1, Ordering::Release);
 
         Ok(id)
     }
 }
 
-impl<T: Slot> TablePage for Page<T> {
-    fn hidden_type_name(&self) -> &'static str {
-        std::any::type_name::<Self>()
-    }
-
-    fn ingredient_index(&self) -> IngredientIndex {
-        self.ingredient
-    }
-
-    unsafe fn memos(&self, slot: SlotIndex, current_revision: Revision) -> &MemoTable {
-        unsafe { self.get(slot).memos(current_revision) }
-    }
-
-    fn memos_mut(&mut self, slot: SlotIndex) -> &mut MemoTable {
-        self.get_mut(slot).memos_mut()
-    }
-
-    unsafe fn syncs(&self, slot: SlotIndex, current_revision: Revision) -> &SyncTable {
-        unsafe { self.get(slot).syncs(current_revision) }
-    }
-}
-
-impl<T: Slot> Drop for Page<T> {
-    fn drop(&mut self) {
-        // Execute destructors for all initialized elements
-        let len = self.allocated.load(Ordering::Acquire);
-        // SAFETY: self.data is initialized for T's up to len
-        unsafe {
-            // FIXME: Should be ptr::from_raw_parts_mut but that is unstable
-            let to_drop = slice::from_raw_parts_mut(self.data.as_mut_ptr().cast::<T>(), len);
-            ptr::drop_in_place(to_drop)
+impl Page {
+    fn new<T: Slot>(ingredient: IngredientIndex) -> Self {
+        let data: Box<PageData<T>> =
+            Box::new([const { UnsafeCell::new(MaybeUninit::uninit()) }; PAGE_LEN]);
+        Self {
+            slot_vtable: SlotVTable::of::<T>(),
+            slot_type_id: TypeId::of::<T>(),
+            slot_type_name: std::any::type_name::<T>(),
+            ingredient,
+            allocated: Default::default(),
+            allocation_lock: Default::default(),
+            data: NonNull::from(Box::leak(data)).cast::<()>(),
         }
     }
-}
 
-impl dyn TablePage {
-    fn assert_type<T: Any>(&self) -> &T {
-        assert_eq!(
-            Any::type_id(self),
-            TypeId::of::<T>(),
-            "page has hidden type `{:?}` but `{:?}` was expected",
-            self.hidden_type_name(),
-            std::any::type_name::<T>(),
+    /// Retrieves the pointer for the given slot.
+    ///
+    /// # Panics
+    ///
+    /// If slot is out of bounds
+    fn get(&self, slot: SlotIndex) -> *mut () {
+        let len = self.allocated.load(Ordering::Acquire);
+        assert!(
+            slot.0 < len,
+            "out of bounds access `{slot:?}` (maximum slot `{len}`)"
         );
-
-        // SAFETY: Assertion above
-        unsafe { transmute_data_ptr::<dyn TablePage, T>(self) }
+        // SAFETY: We have checked that the resulting pointer will be within bounds.
+        unsafe {
+            self.data
+                .as_ptr()
+                .byte_add(slot.0 * self.slot_vtable.layout.size())
+        }
     }
 
-    pub(crate) fn cast_type<T: Any>(&self) -> Option<&T> {
-        if Any::type_id(self) == TypeId::of::<T>() {
-            unsafe { Some(transmute_data_ptr::<dyn TablePage, T>(self)) }
+    fn assert_type<T: Slot>(&self) -> PageView<T> {
+        assert_eq!(
+            self.slot_type_id,
+            TypeId::of::<T>(),
+            "page has slot type `{:?}` but `{:?}` was expected",
+            self.slot_type_name,
+            std::any::type_name::<T>(),
+        );
+        PageView(self, PhantomData)
+    }
+
+    fn cast_type<T: Slot>(&self) -> Option<PageView<T>> {
+        if self.slot_type_id == TypeId::of::<T>() {
+            Some(PageView(self, PhantomData))
         } else {
             None
         }
     }
 }
 
+impl Drop for Page {
+    fn drop(&mut self) {
+        let &mut len = self.allocated.get_mut();
+        // SAFETY: We supply the data pointer and the initialized length
+        unsafe { (self.slot_vtable.drop_impl)(self.data.as_ptr(), len) };
+    }
+}
+
 fn make_id(page: PageIndex, slot: SlotIndex) -> Id {
     let page = page.0 as u32;
     let slot = slot.0 as u32;
-    Id::from_u32((page << PAGE_LEN_BITS) | slot)
+    // SAFETY: `page` and `slot` are derived from proper indices.
+    unsafe { Id::from_u32((page << PAGE_LEN_BITS) | slot) }
 }
 
 fn split_id(id: Id) -> (PageIndex, SlotIndex) {

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -721,12 +721,7 @@ where
         &'db self,
         db: &'db dyn crate::Database,
     ) -> impl Iterator<Item = &'db Value<C>> {
-        db.zalsa()
-            .table()
-            .pages
-            .iter()
-            .filter_map(|(_, page)| page.cast_type::<crate::table::Page<Value<C>>>())
-            .flat_map(|page| page.slots())
+        db.zalsa().table().slots_of::<Value<C>>()
     }
 }
 
@@ -857,6 +852,7 @@ impl<C> Slot for Value<C>
 where
     C: Configuration,
 {
+    #[inline]
     unsafe fn memos(&self, current_revision: Revision) -> &crate::table::memo::MemoTable {
         // Acquiring the read lock here with the current revision
         // ensures that there is no danger of a race
@@ -865,10 +861,12 @@ where
         &self.memos
     }
 
+    #[inline]
     fn memos_mut(&mut self) -> &mut crate::table::memo::MemoTable {
         &mut self.memos
     }
 
+    #[inline]
     unsafe fn syncs(&self, current_revision: Revision) -> &crate::table::sync::SyncTable {
         // Acquiring the read lock here with the current revision
         // ensures that there is no danger of a race
@@ -956,22 +954,25 @@ mod tests {
             hash: 1,
             disambiguator: Disambiguator(1),
         };
-        assert_eq!(d.insert(i1, Id::from_u32(0)), None);
-        assert_eq!(d.insert(i2, Id::from_u32(1)), None);
-        assert_eq!(d.insert(i3, Id::from_u32(2)), None);
-        assert_eq!(d.insert(i4, Id::from_u32(3)), None);
-        assert_eq!(d.insert(i5, Id::from_u32(4)), None);
-        assert_eq!(d.insert(i6, Id::from_u32(5)), None);
-        assert_eq!(d.insert(i7, Id::from_u32(6)), None);
-        assert_eq!(d.insert(i8, Id::from_u32(7)), None);
+        // SAFETY: We don't use the IDs within salsa internals so this is fine
+        unsafe {
+            assert_eq!(d.insert(i1, Id::from_u32(0)), None);
+            assert_eq!(d.insert(i2, Id::from_u32(1)), None);
+            assert_eq!(d.insert(i3, Id::from_u32(2)), None);
+            assert_eq!(d.insert(i4, Id::from_u32(3)), None);
+            assert_eq!(d.insert(i5, Id::from_u32(4)), None);
+            assert_eq!(d.insert(i6, Id::from_u32(5)), None);
+            assert_eq!(d.insert(i7, Id::from_u32(6)), None);
+            assert_eq!(d.insert(i8, Id::from_u32(7)), None);
 
-        assert_eq!(d.get(&i1), Some(Id::from_u32(0)));
-        assert_eq!(d.get(&i2), Some(Id::from_u32(1)));
-        assert_eq!(d.get(&i3), Some(Id::from_u32(2)));
-        assert_eq!(d.get(&i4), Some(Id::from_u32(3)));
-        assert_eq!(d.get(&i5), Some(Id::from_u32(4)));
-        assert_eq!(d.get(&i6), Some(Id::from_u32(5)));
-        assert_eq!(d.get(&i7), Some(Id::from_u32(6)));
-        assert_eq!(d.get(&i8), Some(Id::from_u32(7)));
+            assert_eq!(d.get(&i1), Some(Id::from_u32(0)));
+            assert_eq!(d.get(&i2), Some(Id::from_u32(1)));
+            assert_eq!(d.get(&i3), Some(Id::from_u32(2)));
+            assert_eq!(d.get(&i4), Some(Id::from_u32(3)));
+            assert_eq!(d.get(&i5), Some(Id::from_u32(4)));
+            assert_eq!(d.get(&i6), Some(Id::from_u32(5)));
+            assert_eq!(d.get(&i7), Some(Id::from_u32(6)));
+            assert_eq!(d.get(&i8), Some(Id::from_u32(7)));
+        };
     }
 }

--- a/tests/tracked_with_struct_db.rs
+++ b/tests/tracked_with_struct_db.rs
@@ -1,7 +1,7 @@
 //! Test that a setting a field on a `#[salsa::input]`
 //! overwrites and returns the old value.
 
-use salsa::{Database, DatabaseImpl};
+use salsa::{Database, DatabaseImpl, Update};
 use test_log::test;
 
 #[salsa::input(debug)]
@@ -17,7 +17,7 @@ struct MyTracked<'db> {
     next: MyList<'db>,
 }
 
-#[derive(PartialEq, Eq, Clone, Debug, salsa::Update)]
+#[derive(PartialEq, Eq, Clone, Debug, Update)]
 enum MyList<'db> {
     None,
     Next(MyTracked<'db>),


### PR DESCRIPTION

  By manually erasing the concrete slot types and dealing with the vtable ourselves