### PR TITLE
Prevent fragmention of table due to frequent `ZalsaLocal` reconstruction

### DIFF
--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -4,6 +4,7 @@ use std::{
     any::Any,
     fmt::{self, Debug},
     marker::PhantomData,
+    panic::UnwindSafe,
 };
 
 use accumulated::Accumulated;
@@ -23,7 +24,7 @@ pub(crate) mod accumulated_map;
 
 /// Trait implemented on the struct that user annotated with `#[salsa::accumulator]`.
 /// The `Self` type is therefore the types to be accumulated.
-pub trait Accumulator: Clone + Debug + Send + Sync + Any + Sized {
+pub trait Accumulator: Clone + Debug + Send + Sync + Any + Sized + UnwindSafe {
     const DEBUG_NAME: &'static str;
 
     /// Accumulate an instance of this in the database for later retrieval.

--- a/src/table.rs
+++ b/src/table.rs
@@ -9,6 +9,7 @@ use std::{
 
 use memo::MemoTable;
 use parking_lot::Mutex;
+use rustc_hash::FxHashMap;
 use sync::SyncTable;
 
 use crate::{zalsa::transmute_data_ptr, Id, IngredientIndex, Revision};
@@ -24,6 +25,8 @@ const MAX_PAGES: usize = 1 << (32 - PAGE_LEN_BITS);
 
 pub struct Table {
     pub(crate) pages: boxcar::Vec<Box<dyn TablePage>>,
+    /// Map from ingredient to non-full pages that are up for grabs
+    non_full_pages: Mutex<FxHashMap<IngredientIndex, Vec<PageIndex>>>,
 }
 
 pub(crate) trait TablePage: Any + Send + Sync {
@@ -118,6 +121,7 @@ impl Default for Table {
     fn default() -> Self {
         Self {
             pages: boxcar::Vec::new(),
+            non_full_pages: Default::default(),
         }
     }
 }
@@ -195,6 +199,26 @@ impl Table {
     pub(crate) unsafe fn syncs(&self, id: Id, current_revision: Revision) -> &SyncTable {
         let (page, slot) = split_id(id);
         self.pages[page.0].syncs(slot, current_revision)
+    }
+
+    pub(crate) fn fetch_or_push_page<T: Slot>(&self, ingredient: IngredientIndex) -> PageIndex {
+        if let Some(page) = self
+            .non_full_pages
+            .lock()
+            .get_mut(&ingredient)
+            .and_then(Vec::pop)
+        {
+            return page;
+        }
+        self.push_page::<T>(ingredient)
+    }
+
+    pub(crate) fn record_unfilled_page(&self, ingredient: IngredientIndex, page: PageIndex) {
+        self.non_full_pages
+            .lock()
+            .entry(ingredient)
+            .or_default()
+            .push(page);
     }
 }
 


### PR DESCRIPTION
Currently when creating a new `ZalsaLocal` struct, using it and dropping it (which is going to be a common scenario for rust-analyzer where we effectively create one per LSP request) we will allocate pages when required for allocating a new salsa struct and then drop them, only having partially filled the pages. The way salsa struct allocation currently works means that such pages will be "leaked" as far as allocating into them is concerned and so they won't ever be filled.

This PR implements a free list approach for the table that records unfilled pages currently not "owned" by `ZalsaLocal` instances, so that new `ZalsaLocal` instances can try fetching from that first before considering allocating a new page and putting their unfilled pages back when they drop.