### PR TITLE
update MSRV to 1.80 and test it in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
     strategy:
       matrix:
         rust:
+          - 1.80.0
           - stable
           - beta
         experimental:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/salsa-rs/salsa"
 description = "A generic framework for on-demand, incrementalized computation (experimental)"
-rust-version = "1.76"
+rust-version = "1.80"
 
 [dependencies]
 arc-swap = "1"

--- a/tests/compile_fail.rs
+++ b/tests/compile_fail.rs
@@ -1,4 +1,4 @@
-#[rustversion::stable]
+#[rustversion::all(stable, since(1.84))]
 #[test]
 fn compile_fail() {
     let t = trybuild::TestCases::new();


### PR DESCRIPTION
We specified an MSRV of 1.76 in `Cargo.toml`, but this was a lie, because it wasn't tested anywhere.

This updates our MSRV to 1.80, the oldest Rust that current main branch actually compiles on, and adds a CI run on 1.80 so that it's tested.

This requires also updating the `rustversion` macro on the `compile_fail` test so that it runs only on stable Rust later than 1.84; that test snapshots compiler output and fails on any Rust version earlier than 1.84.

(Over in #603 I asked about upping our MSRV to 1.83, but the first step is to actually have an MSRV that isn't a lie.)