### PR TITLE
Enforce `unsafe_op_in_unsafe_fn`

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -163,7 +163,7 @@ where
         &'this self,
         memo: &memo::Memo<C::Output<'this>>,
     ) -> &'this memo::Memo<C::Output<'this>> {
-        std::mem::transmute(memo)
+        unsafe { std::mem::transmute(memo) }
     }
 
     fn insert_memo<'db>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_op_in_unsafe_fn)]
+
 mod accumulator;
 mod active_query;
 mod array;

--- a/src/table.rs
+++ b/src/table.rs
@@ -172,7 +172,7 @@ impl Table {
     /// of the owner of database owning this table.
     pub(crate) unsafe fn memos(&self, id: Id, current_revision: Revision) -> &MemoTable {
         let (page, slot) = split_id(id);
-        self.pages[page.0].memos(slot, current_revision)
+        unsafe { self.pages[page.0].memos(slot, current_revision) }
     }
 
     /// Get the memo table associated with `id`
@@ -194,7 +194,7 @@ impl Table {
     /// of the owner of database owning this table.
     pub(crate) unsafe fn syncs(&self, id: Id, current_revision: Revision) -> &SyncTable {
         let (page, slot) = split_id(id);
-        self.pages[page.0].syncs(slot, current_revision)
+        unsafe { self.pages[page.0].syncs(slot, current_revision) }
     }
 }
 
@@ -297,7 +297,7 @@ impl<T: Slot> TablePage for Page<T> {
     }
 
     unsafe fn memos(&self, slot: SlotIndex, current_revision: Revision) -> &MemoTable {
-        self.get(slot).memos(current_revision)
+        unsafe { self.get(slot).memos(current_revision) }
     }
 
     fn memos_mut(&mut self, slot: SlotIndex) -> &mut MemoTable {
@@ -305,7 +305,7 @@ impl<T: Slot> TablePage for Page<T> {
     }
 
     unsafe fn syncs(&self, slot: SlotIndex, current_revision: Revision) -> &SyncTable {
-        self.get(slot).syncs(current_revision)
+        unsafe { self.get(slot).syncs(current_revision) }
     }
 }
 

--- a/src/views.rs
+++ b/src/views.rs
@@ -169,7 +169,7 @@ where
     /// The underlying type of `caster` must be `ViewCaster::<Db, DbView>`.
     unsafe fn erased_cast(caster: *mut (), db: &dyn Database) -> &DbView {
         let caster = unsafe { &*caster.cast::<ViewCaster<Db, DbView>>() };
-        caster.cast(db)
+        unsafe { caster.cast(db) }
     }
 
     /// The destructor for `Box<ViewCaster<Db, DbView>>`.


### PR DESCRIPTION
We'll need to do this for the 2024 edition upgrade. The motivation for this change thouhgh is so I can quickly check whether the merge queue works now (and so I'll self approve this)