### PR TITLE
Don't clone strings in benchmarks

### DIFF
--- a/benches/compare.rs
+++ b/benches/compare.rs
@@ -8,6 +8,7 @@ use salsa::Setter;
 
 #[salsa::input]
 pub struct Input {
+    #[return_ref]
     pub text: String,
 }
 
@@ -18,6 +19,7 @@ pub fn length(db: &dyn salsa::Database, input: Input) -> usize {
 
 #[salsa::interned]
 pub struct InternedInput<'db> {
+    #[return_ref]
     pub text: String,
 }
 


### PR DESCRIPTION
This results in frequent allocator calling which generally hurts reliability of the benchmarks. Saw `malloc` popup as a 10% regression in https://github.com/salsa-rs/salsa/pull/717 