### PR TITLE
perf: Store view downcaster in function ingredients directly

### DIFF
--- a/components/salsa-macros/src/db.rs
+++ b/components/salsa-macros/src/db.rs
@@ -89,10 +89,12 @@ impl DbMacro {
                 use salsa::plumbing as #zalsa;
 
                 unsafe impl #zalsa::HasStorage for #db {
+                    #[inline(always)]
                     fn storage(&self) -> &#zalsa::Storage<Self> {
                         &self.#storage
                     }
 
+                    #[inline(always)]
                     fn storage_mut(&mut self) -> &mut #zalsa::Storage<Self> {
                         &mut self.#storage
                     }
@@ -138,6 +140,7 @@ impl DbMacro {
         });
         input.items.push(parse_quote! {
             #[doc(hidden)]
+            #[inline(always)]
             unsafe fn downcast(db: &dyn salsa::plumbing::Database) -> &dyn #TraitPath where Self: Sized {
                 debug_assert_eq!(db.type_id(), ::core::any::TypeId::of::<Self>());
                 // SAFETY: Same as the safety of the `downcast` method.

--- a/components/salsa-macros/src/db.rs
+++ b/components/salsa-macros/src/db.rs
@@ -102,16 +102,26 @@ impl DbMacro {
     }
 
     fn add_salsa_view_method(&self, input: &mut syn::ItemTrait) -> syn::Result<()> {
+        let trait_name = &input.ident;
         input.items.push(parse_quote! {
             #[doc(hidden)]
-            fn zalsa_db(&self);
+            fn zalsa_register_downcaster(&self);
+        });
+
+        let comment = format!(" Downcast a [`dyn Database`] to a [`dyn {trait_name}`]");
+        input.items.push(parse_quote! {
+            #[doc = #comment]
+            ///
+            /// # Safety
+            ///
+            /// The input database must be of type `Self`.
+            #[doc(hidden)]
+            unsafe fn downcast(db: &dyn salsa::plumbing::Database) -> &dyn #trait_name where Self: Sized;
         });
         Ok(())
     }
 
     fn add_salsa_view_method_impl(&self, input: &mut syn::ItemImpl) -> syn::Result<()> {
-        let zalsa = self.hygiene.ident("zalsa");
-
         let Some((_, TraitPath, _)) = &input.trait_ else {
             return Err(syn::Error::new_spanned(
                 &input.self_ty,
@@ -121,9 +131,17 @@ impl DbMacro {
 
         input.items.push(parse_quote! {
             #[doc(hidden)]
-            fn zalsa_db(&self) {
-                use salsa::plumbing as #zalsa;
-                #zalsa::views(self).add::<Self, dyn #TraitPath>(|t| t);
+            #[inline(always)]
+            fn zalsa_register_downcaster(&self)  {
+                salsa::plumbing::views(self).add(<Self as #TraitPath>::downcast);
+            }
+        });
+        input.items.push(parse_quote! {
+            #[doc(hidden)]
+            unsafe fn downcast(db: &dyn salsa::plumbing::Database) -> &dyn #TraitPath where Self: Sized {
+                debug_assert_eq!(db.type_id(), ::core::any::TypeId::of::<Self>());
+                // SAFETY: Same as the safety of the `downcast` method.
+                unsafe { &*salsa::plumbing::transmute_data_ptr::<dyn salsa::plumbing::Database, Self>(db) }
             }
         });
         Ok(())

--- a/components/salsa-macros/src/lib.rs
+++ b/components/salsa-macros/src/lib.rs
@@ -2,8 +2,6 @@
 
 #![recursion_limit = "256"]
 
-extern crate proc_macro;
-extern crate proc_macro2;
 #[macro_use]
 extern crate quote;
 

--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -100,7 +100,7 @@ impl<A: Accumulator> Ingredient for IngredientImpl<A> {
         self.index
     }
 
-    fn maybe_changed_after(
+    unsafe fn maybe_changed_after(
         &self,
         _db: &dyn Database,
         _input: Id,

--- a/src/database.rs
+++ b/src/database.rs
@@ -121,6 +121,9 @@ impl dyn Database {
     /// If the view has not been added to the database (see [`crate::views::Views`]).
     #[track_caller]
     pub fn as_view<DbView: ?Sized + Database>(&self) -> &DbView {
-        self.zalsa().views().try_view_as(self).unwrap()
+        let views = self.zalsa().views();
+        views.assert_database(self);
+        // SAFETY: We've asserted that the database is correct.
+        unsafe { views.downcaster_for()(self) }
     }
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -122,8 +122,6 @@ impl dyn Database {
     #[track_caller]
     pub fn as_view<DbView: ?Sized + Database>(&self) -> &DbView {
         let views = self.zalsa().views();
-        views.assert_database(self);
-        // SAFETY: We've asserted that the database is correct.
-        unsafe { views.downcaster_for()(self) }
+        views.downcaster_for().downcast(self)
     }
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -230,9 +230,8 @@ where
         input: Id,
         revision: Revision,
     ) -> MaybeChangedAfter {
-        db.zalsa().views().assert_database(db);
-        // SAFETY: We've asserted that the database is correct.
-        let db = unsafe { (self.view_caster)(db) };
+        // SAFETY: The `db` belongs to the ingredient as per caller invariant
+        let db = unsafe { self.view_caster.downcast_unchecked(db) };
         self.maybe_changed_after(db, input, revision)
     }
 
@@ -292,9 +291,7 @@ where
         db: &'db dyn Database,
         key_index: Id,
     ) -> (Option<&'db AccumulatedMap>, InputAccumulatedValues) {
-        db.zalsa().views().assert_database(db);
-        // SAFETY: We've asserted that the database is correct.
-        let db = unsafe { (self.view_caster)(db) };
+        let db = self.view_caster.downcast(db);
         self.accumulated_map(db, key_index)
     }
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -224,7 +224,7 @@ where
         self.index
     }
 
-    fn maybe_changed_after(
+    unsafe fn maybe_changed_after(
         &self,
         db: &dyn Database,
         input: Id,

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -51,7 +51,11 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
     fn debug_name(&self) -> &'static str;
 
     /// Has the value for `input` in this ingredient changed after `revision`?
-    fn maybe_changed_after<'db>(
+    ///
+    /// # Safety
+    ///
+    /// The passed in database needs to be the same one that the ingredient was created with.
+    unsafe fn maybe_changed_after<'db>(
         &'db self,
         db: &'db dyn Database,
         input: Id,

--- a/src/input.rs
+++ b/src/input.rs
@@ -215,7 +215,7 @@ impl<C: Configuration> Ingredient for IngredientImpl<C> {
         self.ingredient_index
     }
 
-    fn maybe_changed_after(
+    unsafe fn maybe_changed_after(
         &self,
         _db: &dyn Database,
         _input: Id,

--- a/src/input/input_field.rs
+++ b/src/input/input_field.rs
@@ -49,7 +49,7 @@ where
         CycleRecoveryStrategy::Panic
     }
 
-    fn maybe_changed_after(
+    unsafe fn maybe_changed_after(
         &self,
         db: &dyn Database,
         input: Id,

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -282,7 +282,7 @@ where
         self.ingredient_index
     }
 
-    fn maybe_changed_after(
+    unsafe fn maybe_changed_after(
         &self,
         _db: &dyn Database,
         _input: Id,

--- a/src/key.rs
+++ b/src/key.rs
@@ -100,10 +100,12 @@ impl InputDependencyIndex {
         last_verified_at: crate::Revision,
     ) -> MaybeChangedAfter {
         match self.key_index {
-            Some(key_index) => db
-                .zalsa()
-                .lookup_ingredient(self.ingredient_index)
-                .maybe_changed_after(db, key_index, last_verified_at),
+            // SAFETY: The `db` belongs to the ingredient
+            Some(key_index) => unsafe {
+                db.zalsa()
+                    .lookup_ingredient(self.ingredient_index)
+                    .maybe_changed_after(db, key_index, last_verified_at)
+            },
             // Data in tables themselves remain valid until the table as a whole is reset.
             None => MaybeChangedAfter::No(InputAccumulatedValues::Empty),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #![forbid(unsafe_op_in_unsafe_fn)]
 
+extern crate self as salsa;
+
 mod accumulator;
 mod active_query;
 mod array;
@@ -107,6 +109,7 @@ pub mod plumbing {
     pub use crate::update::helper::Dispatch as UpdateDispatch;
     pub use crate::update::helper::Fallback as UpdateFallback;
     pub use crate::update::Update;
+    pub use crate::zalsa::transmute_data_ptr;
     pub use crate::zalsa::views;
     pub use crate::zalsa::IngredientCache;
     pub use crate::zalsa::IngredientIndex;

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -735,7 +735,7 @@ where
         self.ingredient_index
     }
 
-    fn maybe_changed_after(
+    unsafe fn maybe_changed_after(
         &self,
         db: &dyn Database,
         input: Id,

--- a/src/tracked_struct/tracked_field.rs
+++ b/src/tracked_struct/tracked_field.rs
@@ -55,7 +55,7 @@ where
         crate::cycle::CycleRecoveryStrategy::Panic
     }
 
-    fn maybe_changed_after<'db>(
+    unsafe fn maybe_changed_after<'db>(
         &'db self,
         db: &'db dyn Database,
         input: Id,

--- a/src/views.rs
+++ b/src/views.rs
@@ -1,29 +1,16 @@
-use crate::{zalsa::transmute_data_ptr, Database};
-use std::{
-    any::{Any, TypeId},
-    sync::Arc,
-};
+use std::any::{Any, TypeId};
+
+use crate::Database;
 
 /// A `Views` struct is associated with some specific database type
 /// (a `DatabaseImpl<U>` for some existential `U`). It contains functions
-/// to downcast from that type to `dyn DbView` for various traits `DbView`.
+/// to downcast from `dyn Database` to `dyn DbView` for various traits `DbView` via this specific
+/// database type.
 /// None of these types are known at compilation time, they are all checked
 /// dynamically through `TypeId` magic.
-///
-/// You can think of the struct as looking like:
-///
-/// ```rust,ignore
-/// struct Views<ghost Db> {
-///     source_type_id: TypeId,                       // `TypeId` for `Db`
-///     view_casters: Arc<ConcurrentVec<exists<DbView> {
-///         ViewCaster<Db, DbView>
-///     }>>,
-/// }
-/// ```
-#[derive(Clone)]
 pub struct Views {
     source_type_id: TypeId,
-    view_casters: Arc<boxcar::Vec<DynViewCaster>>,
+    view_casters: boxcar::Vec<DynViewCaster>,
 }
 
 /// A DynViewCaster contains a manual trait object that can cast from the
@@ -44,49 +31,42 @@ pub struct Views {
 /// The manual trait object and vtable allows for type erasure without
 /// transmuting between fat pointers, whose layout is undefined.
 struct DynViewCaster {
-    /// The id of the target type `DbView` that we can cast to.
+    /// The id of the target type `dyn DbView` that we can cast to.
     target_type_id: TypeId,
 
-    /// The name of the target type `DbView` that we can cast to.
+    /// The name of the target type `dyn DbView` that we can cast to.
     type_name: &'static str,
 
-    /// A pointer to a `ViewCaster<Db, DbView>`.
-    view_caster: *mut (),
-
     /// Type-erased `ViewCaster::<Db, DbView>::vtable_cast`.
-    cast: *const (),
-
-    /// Type-erased `ViewCaster::<Db, DbView>::drop`.
-    drop: unsafe fn(*mut ()),
+    cast: ErasedDatabaseDownCaster,
 }
 
-impl Drop for DynViewCaster {
-    fn drop(&mut self) {
-        // SAFETY: We own `self.caster` and are in the destructor.
-        unsafe { (self.drop)(self.view_caster) };
-    }
-}
-
-// SAFETY: These traits can be implemented normally as the raw pointers
-// in `DynViewCaster` are only used for type-erasure.
-unsafe impl Send for DynViewCaster {}
-unsafe impl Sync for DynViewCaster {}
+type ErasedDatabaseDownCaster = unsafe fn(&dyn Database) -> *const ();
+pub type DatabaseDownCaster<DbView> = unsafe fn(&dyn Database) -> &DbView;
 
 impl Views {
     pub(crate) fn new<Db: Database>() -> Self {
         let source_type_id = TypeId::of::<Db>();
+        let view_casters = boxcar::Vec::new();
+        // special case the no-op transformation, that way we skip out on reconstructing the wide pointer
+        view_casters.push(DynViewCaster {
+            target_type_id: TypeId::of::<dyn Database>(),
+            type_name: std::any::type_name::<dyn Database>(),
+            cast: unsafe {
+                std::mem::transmute::<DatabaseDownCaster<dyn Database>, ErasedDatabaseDownCaster>(
+                    |db| db,
+                )
+            },
+        });
         Self {
             source_type_id,
-            view_casters: Arc::new(boxcar::Vec::new()),
+            view_casters,
         }
     }
 
-    /// Add a new upcast from `Db` to `T`, given the upcasting function `func`.
-    pub fn add<Db: Database, DbView: ?Sized + Any>(&self, func: fn(&Db) -> &DbView) {
-        assert_eq!(self.source_type_id, TypeId::of::<Db>(), "dyn-upcasts");
-
+    /// Add a new downcaster from `dyn Database` to `dyn DbView`.
+    pub fn add<DbView: ?Sized + Any>(&self, func: DatabaseDownCaster<DbView>) {
         let target_type_id = TypeId::of::<DbView>();
-
         if self
             .view_casters
             .iter()
@@ -94,91 +74,44 @@ impl Views {
         {
             return;
         }
-
-        let view_caster = Box::into_raw(Box::new(ViewCaster(func)));
-
         self.view_casters.push(DynViewCaster {
             target_type_id,
             type_name: std::any::type_name::<DbView>(),
-            view_caster: view_caster.cast(),
-            cast: ViewCaster::<Db, DbView>::erased_cast as _,
-            drop: ViewCaster::<Db, DbView>::erased_drop,
+            cast: unsafe {
+                std::mem::transmute::<DatabaseDownCaster<DbView>, ErasedDatabaseDownCaster>(func)
+            },
         });
     }
 
-    /// Convert one handle to a salsa database (including a `dyn Database`!) to another.
+    /// Retrieve an downcaster function from `dyn Database` to `dyn DbView`.
     ///
     /// # Panics
     ///
     /// If the underlying type of `db` is not the same as the database type this upcasts was created for.
-    pub fn try_view_as<'db, DbView: ?Sized + Any>(
-        &self,
-        db: &'db dyn Database,
-    ) -> Option<&'db DbView> {
-        let db_type_id = <dyn Database as Any>::type_id(db);
-        assert_eq!(self.source_type_id, db_type_id, "database type mismatch");
-
+    pub fn downcaster_for<DbView: ?Sized + Any>(&self) -> DatabaseDownCaster<DbView> {
         let view_type_id = TypeId::of::<DbView>();
         for (_idx, view) in self.view_casters.iter() {
             if view.target_type_id == view_type_id {
-                // SAFETY: We verified that this is the view caster for the
-                // `DbView` type by checking type IDs above.
-                let view = unsafe {
-                    let caster: unsafe fn(*const (), &dyn Database) -> &DbView =
-                        std::mem::transmute(view.cast);
-                    caster(view.view_caster, db)
+                return unsafe {
+                    std::mem::transmute::<ErasedDatabaseDownCaster, DatabaseDownCaster<DbView>>(
+                        view.cast,
+                    )
                 };
-
-                return Some(view);
             }
         }
 
-        None
-    }
-}
-
-/// A generic downcaster for specific `Db` and `DbView` types.
-struct ViewCaster<Db, DbView: ?Sized>(fn(&Db) -> &DbView);
-
-impl<Db, DbView> ViewCaster<Db, DbView>
-where
-    Db: Database,
-    DbView: ?Sized + Any,
-{
-    /// Obtain a reference of type `DbView` from a database.
-    ///
-    /// # Safety
-    ///
-    /// The input database must be of type `Db`.
-    unsafe fn cast<'db>(&self, db: &'db dyn Database) -> &'db DbView {
-        // This tests the safety requirement:
-        debug_assert_eq!(db.type_id(), TypeId::of::<Db>());
-
-        // SAFETY:
-        //
-        // Caller guarantees that the input is of type `Db`
-        // (we test it in the debug-assertion above).
-        let db = unsafe { transmute_data_ptr::<dyn Database, Db>(db) };
-        (self.0)(db)
+        panic!(
+            "No downcaster registered for type `{}` in `Views`",
+            std::any::type_name::<DbView>(),
+        );
     }
 
-    /// A type-erased version of `ViewCaster::<Db, DbView>::cast`.
-    ///
-    /// # Safety
-    ///
-    /// The underlying type of `caster` must be `ViewCaster::<Db, DbView>`.
-    unsafe fn erased_cast(caster: *mut (), db: &dyn Database) -> &DbView {
-        let caster = unsafe { &*caster.cast::<ViewCaster<Db, DbView>>() };
-        unsafe { caster.cast(db) }
-    }
-
-    /// The destructor for `Box<ViewCaster<Db, DbView>>`.
-    ///
-    /// # Safety
-    ///
-    /// All the safety requirements of `Box::<ViewCaster<Db, DbView>>::from_raw` apply.
-    unsafe fn erased_drop(caster: *mut ()) {
-        let _: Box<ViewCaster<Db, DbView>> = unsafe { Box::from_raw(caster.cast()) };
+    pub fn assert_database(&self, db: &dyn Database) {
+        assert_eq!(
+            self.source_type_id,
+            db.type_id(),
+            "Database type does not match the expected type for this `Views` instance"
+        );
     }
 }
 

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -179,10 +179,6 @@ impl Zalsa {
         }
     }
 
-    pub(crate) fn views(&self) -> &Views {
-        &self.views_of
-    }
-
     pub(crate) fn nonce(&self) -> Nonce<StorageNonce> {
         self.nonce
     }
@@ -265,6 +261,11 @@ impl Zalsa {
 
 /// Semver unstable APIs used by the macro expansions
 impl Zalsa {
+    /// **NOT SEMVER STABLE**
+    pub fn views(&self) -> &Views {
+        &self.views_of
+    }
+
     /// **NOT SEMVER STABLE**
     #[inline]
     pub fn lookup_page_type_id(&self, id: Id) -> TypeId {
@@ -471,10 +472,10 @@ where
 
 /// Given a wide pointer `T`, extracts the data pointer (typed as `U`).
 ///
-/// # Safety requirement
+/// # Safety
 ///
 /// `U` must be correct type for the data pointer.
-pub(crate) unsafe fn transmute_data_ptr<T: ?Sized, U>(t: &T) -> &U {
+pub unsafe fn transmute_data_ptr<T: ?Sized, U>(t: &T) -> &U {
     let t: *const T = t;
     let u: *const U = t as *const U;
     unsafe { &*u }
@@ -482,7 +483,7 @@ pub(crate) unsafe fn transmute_data_ptr<T: ?Sized, U>(t: &T) -> &U {
 
 /// Given a wide pointer `T`, extracts the data pointer (typed as `U`).
 ///
-/// # Safety requirement
+/// # Safety
 ///
 /// `U` must be correct type for the data pointer.
 pub(crate) unsafe fn transmute_data_mut_ptr<T: ?Sized, U>(t: &mut T) -> &mut U {


### PR DESCRIPTION
Allows us to skip iterating over all registered view casters whenever we need to cast