### PR TITLE
Move `unwind_if_revision_cancelled` from `ZalsaLocal` to `Zalsa`

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -79,8 +79,7 @@ pub trait Database: Send + AsDynDatabase + Any + ZalsaDatabase {
     /// `salsa_event` is emitted when this method is called, so that should be
     /// used instead.
     fn unwind_if_revision_cancelled(&self) {
-        let db = self.as_dyn_database();
-        self.zalsa_local().unwind_if_revision_cancelled(db);
+        self.zalsa().unwind_if_revision_cancelled(self);
     }
 
     /// Execute `op` with the database in thread-local storage for debug print-outs.

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -11,8 +11,8 @@ where
     C: Configuration,
 {
     pub fn fetch<'db>(&'db self, db: &'db C::DbView, id: Id) -> &'db C::Output<'db> {
-        let zalsa_local = db.zalsa_local();
-        zalsa_local.unwind_if_revision_cancelled(db.as_dyn_database());
+        let (zalsa, zalsa_local) = db.zalsas();
+        zalsa.unwind_if_revision_cancelled(db);
 
         let memo = self.refresh_memo(db, id);
         let StampedValue {

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -20,8 +20,8 @@ where
         id: Id,
         revision: Revision,
     ) -> MaybeChangedAfter {
-        let (zalsa, zalsa_local) = db.zalsas();
-        zalsa_local.unwind_if_revision_cancelled(db.as_dyn_database());
+        let zalsa = db.zalsa();
+        zalsa.unwind_if_revision_cancelled(db);
 
         loop {
             let database_key_index = self.database_key_index(id);
@@ -40,7 +40,7 @@ where
                 }
                 drop(memo_guard); // release the arc-swap guard before cold path
                 if let Some(mcs) =
-                    self.maybe_changed_after_cold(zalsa, zalsa_local, db, id, revision)
+                    self.maybe_changed_after_cold(zalsa, db.zalsa_local(), db, id, revision)
                 {
                     return mcs;
                 } else {

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -16,9 +16,6 @@ use crate::zalsa::IngredientIndex;
 use crate::Accumulator;
 use crate::Cancelled;
 use crate::Cycle;
-use crate::Database;
-use crate::Event;
-use crate::EventKind;
 use crate::Id;
 use crate::Revision;
 use std::cell::RefCell;
@@ -285,26 +282,6 @@ impl ZalsaLocal {
                 "overwrote a previous id for `{identity:?}`"
             );
         })
-    }
-
-    /// Starts unwinding the stack if the current revision is cancelled.
-    ///
-    /// This method can be called by query implementations that perform
-    /// potentially expensive computations, in order to speed up propagation of
-    /// cancellation.
-    ///
-    /// Cancellation will automatically be triggered by salsa on any query
-    /// invocation.
-    ///
-    /// This method should not be overridden by `Database` implementors. A
-    /// `salsa_event` is emitted when this method is called, so that should be
-    /// used instead.
-    pub(crate) fn unwind_if_revision_cancelled(&self, db: &dyn Database) {
-        db.salsa_event(&|| Event::new(EventKind::WillCheckCancellation));
-        let zalsa = db.zalsa();
-        if zalsa.runtime().load_cancellation_flag() {
-            self.unwind_cancelled(zalsa.current_revision());
-        }
     }
 
     #[cold]


### PR DESCRIPTION
This allows reducing some dynamic dispatching calls