### PR TITLE
Cancel duplicate test workflow runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,10 @@ on:
       - "tests/compile-fail/**.stderr"
   merge_group:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test


### PR DESCRIPTION
miri takes ages to complete, so if one pushes frequently to their branch we now cancel the previous job with this (as its not useful anymore anyways)