### PR TITLE
Emit compiler errors for unknown field attributes

### DIFF
--- a/components/salsa-macros/src/salsa_struct.rs
+++ b/components/salsa-macros/src/salsa_struct.rs
@@ -380,10 +380,19 @@ impl<'s> SalsaField<'s> {
 
         // Scan the attributes and look for the salsa attributes:
         for attr in &field.attrs {
+            let mut found = false;
             for (fa, func) in FIELD_OPTION_ATTRIBUTES {
                 if attr.path().is_ident(fa) {
                     func(attr, &mut result);
+                    found = true;
                 }
+            }
+
+            if !found {
+                return Err(syn::Error::new_spanned(
+                    attr,
+                    "unrecognized field attribute",
+                ));
             }
         }
 


### PR DESCRIPTION
Emit an error if an unknown field attribute is used on a `salsa::tracked` struct. For example, when changing the attribute in `ParsedFile` inside the `examples/lazy-input/main.rs` example from `return_ref` to `returns_ref`, the compiler emits:

    error: unrecognized field attribute
       --> examples/lazy-input/main.rs:164:5
        |
    164 |     #[returns_ref]
        |     ^^^^^^^^^^^^^^

I'm opening this as a draft for two reasons:

* It's unclear to me if this is actually desired behavior. Could non-salsa attributes be mixed with salsa attributes?
* The error message above seems fine, but there are actually a lot more downstream compiler errors if that change is made to the example. Maybe there is a way to get rid of those downstream errors?

closes #728 