### PR TITLE
`#[inline(never)]` queries in benchmarks

### DIFF
--- a/benches/accumulator.rs
+++ b/benches/accumulator.rs
@@ -20,6 +20,7 @@ struct Expression<'db> {
 }
 
 #[salsa::tracked]
+#[inline(never)]
 fn root<'db>(db: &'db dyn salsa::Database, input: Input) -> Vec<usize> {
     (0..input.expressions(db))
         .map(|i| infer_expression(db, Expression::new(db, i)))
@@ -27,6 +28,7 @@ fn root<'db>(db: &'db dyn salsa::Database, input: Input) -> Vec<usize> {
 }
 
 #[salsa::tracked]
+#[inline(never)]
 fn infer_expression<'db>(db: &'db dyn salsa::Database, expression: Expression<'db>) -> usize {
     let number = expression.number(db);
 

--- a/benches/compare.rs
+++ b/benches/compare.rs
@@ -15,6 +15,7 @@ pub struct Input {
 }
 
 #[salsa::tracked]
+#[inline(never)]
 pub fn length(db: &dyn salsa::Database, input: Input) -> usize {
     input.text(db).len()
 }
@@ -32,11 +33,13 @@ enum SupertypeInput<'db> {
 }
 
 #[salsa::tracked]
+#[inline(never)]
 pub fn interned_length<'db>(db: &'db dyn salsa::Database, input: InternedInput<'db>) -> usize {
     input.text(db).len()
 }
 
 #[salsa::tracked]
+#[inline(never)]
 pub fn either_length<'db>(db: &'db dyn salsa::Database, input: SupertypeInput<'db>) -> usize {
     match input {
         SupertypeInput::InternedInput(input) => interned_length(db, input),

--- a/benches/incremental.rs
+++ b/benches/incremental.rs
@@ -16,11 +16,13 @@ struct Tracked<'db> {
 }
 
 #[salsa::tracked(return_ref)]
+#[inline(never)]
 fn index<'db>(db: &'db dyn salsa::Database, input: Input) -> Vec<Tracked<'db>> {
     (0..input.field(db)).map(|i| Tracked::new(db, i)).collect()
 }
 
 #[salsa::tracked]
+#[inline(never)]
 fn root(db: &dyn salsa::Database, input: Input) -> usize {
     let index = index(db, input);
     index.len()


### PR DESCRIPTION
The compiler seems to throw a coin when deciding about whether to inline these or not making the codspeed profiles annoying to read