### PR TITLE
Add scratch space for `diff_outputs`

### DIFF
--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -79,7 +79,14 @@ where
         // old value.
         if let Some(old_memo) = &opt_old_memo {
             self.backdate_if_appropriate(old_memo, &mut revisions, &value);
-            self.diff_outputs(zalsa, db, database_key_index, old_memo, &mut revisions);
+            self.diff_outputs(
+                zalsa,
+                db.zalsa_local(),
+                db,
+                database_key_index,
+                old_memo,
+                &mut revisions,
+            );
         }
 
         tracing::debug!("{database_key_index:?}: read_upgrade: result.revisions = {revisions:#?}");

--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -76,7 +76,14 @@ where
         let memo_ingredient_index = self.memo_ingredient_index(zalsa, key);
         if let Some(old_memo) = self.get_memo_from_table_for(zalsa, key, memo_ingredient_index) {
             self.backdate_if_appropriate(&old_memo, &mut revisions, &value);
-            self.diff_outputs(zalsa, db, database_key_index, &old_memo, &mut revisions);
+            self.diff_outputs(
+                zalsa,
+                zalsa_local,
+                db,
+                database_key_index,
+                &old_memo,
+                &mut revisions,
+            );
         }
 
         let memo = Memo {

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -6,6 +6,7 @@ use crate::accumulator::accumulated_map::{
 };
 use crate::active_query::ActiveQuery;
 use crate::durability::Durability;
+use crate::hash::FxHashSet;
 use crate::key::{DatabaseKeyIndex, InputDependencyIndex, OutputDependencyIndex};
 use crate::runtime::StampedValue;
 use crate::table::PageIndex;
@@ -36,13 +37,15 @@ pub struct ZalsaLocal {
     /// Stores the most recent page for a given ingredient.
     /// This is thread-local to avoid contention.
     most_recent_pages: RefCell<FxHashMap<IngredientIndex, PageIndex>>,
+    pub(crate) diff_outputs_scratch: RefCell<FxHashSet<OutputDependencyIndex>>,
 }
 
 impl ZalsaLocal {
     pub(crate) fn new() -> Self {
         ZalsaLocal {
-            query_stack: RefCell::new(vec![]),
-            most_recent_pages: RefCell::new(FxHashMap::default()),
+            query_stack: RefCell::default(),
+            most_recent_pages: RefCell::default(),
+            diff_outputs_scratch: RefCell::default(),
         }
     }
 


### PR DESCRIPTION
Likely wont have an affect on the benches as we do not keep zalsa local state for them