### PR TITLE
refactor: Option::replace instead of std::mem::replace

### DIFF
--- a/components/salsa-macros/src/options.rs
+++ b/components/salsa-macros/src/options.rs
@@ -131,7 +131,7 @@ impl<A: AllowedOptions> syn::parse::Parse for Options<A> {
             let ident: syn::Ident = syn::Ident::parse_any(input)?;
             if ident == "return_ref" {
                 if A::RETURN_REF {
-                    if let Some(old) = std::mem::replace(&mut options.return_ref, Some(ident)) {
+                    if let Some(old) = options.return_ref.replace(ident) {
                         return Err(syn::Error::new(
                             old.span(),
                             "option `return_ref` provided twice",
@@ -145,7 +145,7 @@ impl<A: AllowedOptions> syn::parse::Parse for Options<A> {
                 }
             } else if ident == "no_eq" {
                 if A::NO_EQ {
-                    if let Some(old) = std::mem::replace(&mut options.no_eq, Some(ident)) {
+                    if let Some(old) = options.no_eq.replace(ident) {
                         return Err(syn::Error::new(old.span(), "option `no_eq` provided twice"));
                     }
                 } else {
@@ -156,7 +156,7 @@ impl<A: AllowedOptions> syn::parse::Parse for Options<A> {
                 }
             } else if ident == "no_debug" {
                 if A::NO_DEBUG {
-                    if let Some(old) = std::mem::replace(&mut options.no_debug, Some(ident)) {
+                    if let Some(old) = options.no_debug.replace(ident) {
                         return Err(syn::Error::new(
                             old.span(),
                             "option `no_debug` provided twice",
@@ -170,7 +170,7 @@ impl<A: AllowedOptions> syn::parse::Parse for Options<A> {
                 }
             } else if ident == "no_lifetime" {
                 if A::NO_LIFETIME {
-                    if let Some(old) = std::mem::replace(&mut options.no_lifetime, Some(ident)) {
+                    if let Some(old) = options.no_lifetime.replace(ident) {
                         return Err(syn::Error::new(
                             old.span(),
                             "option `no_lifetime` provided twice",
@@ -184,7 +184,7 @@ impl<A: AllowedOptions> syn::parse::Parse for Options<A> {
                 }
             } else if ident == "no_clone" {
                 if A::NO_CLONE {
-                    if let Some(old) = std::mem::replace(&mut options.no_clone, Some(ident)) {
+                    if let Some(old) = options.no_clone.replace(ident) {
                         return Err(syn::Error::new(
                             old.span(),
                             "option `no_clone` provided twice",
@@ -198,7 +198,7 @@ impl<A: AllowedOptions> syn::parse::Parse for Options<A> {
                 }
             } else if ident == "singleton" {
                 if A::SINGLETON {
-                    if let Some(old) = std::mem::replace(&mut options.singleton, Some(ident)) {
+                    if let Some(old) = options.singleton.replace(ident) {
                         return Err(syn::Error::new(
                             old.span(),
                             "option `singleton` provided twice",
@@ -212,7 +212,7 @@ impl<A: AllowedOptions> syn::parse::Parse for Options<A> {
                 }
             } else if ident == "specify" {
                 if A::SPECIFY {
-                    if let Some(old) = std::mem::replace(&mut options.specify, Some(ident)) {
+                    if let Some(old) = options.specify.replace(ident) {
                         return Err(syn::Error::new(
                             old.span(),
                             "option `specify` provided twice",
@@ -228,7 +228,7 @@ impl<A: AllowedOptions> syn::parse::Parse for Options<A> {
                 if A::DB {
                     let _eq = Equals::parse(input)?;
                     let path = syn::Path::parse(input)?;
-                    if let Some(old) = std::mem::replace(&mut options.db_path, Some(path)) {
+                    if let Some(old) = options.db_path.replace(path) {
                         return Err(syn::Error::new(old.span(), "option `db` provided twice"));
                     }
                 } else {
@@ -241,7 +241,7 @@ impl<A: AllowedOptions> syn::parse::Parse for Options<A> {
                 if A::RECOVERY_FN {
                     let _eq = Equals::parse(input)?;
                     let path = syn::Path::parse(input)?;
-                    if let Some(old) = std::mem::replace(&mut options.recovery_fn, Some(path)) {
+                    if let Some(old) = options.recovery_fn.replace(path) {
                         return Err(syn::Error::new(
                             old.span(),
                             "option `recovery_fn` provided twice",
@@ -257,7 +257,7 @@ impl<A: AllowedOptions> syn::parse::Parse for Options<A> {
                 if A::DATA {
                     let _eq = Equals::parse(input)?;
                     let ident = syn::Ident::parse(input)?;
-                    if let Some(old) = std::mem::replace(&mut options.data, Some(ident)) {
+                    if let Some(old) = options.data.replace(ident) {
                         return Err(syn::Error::new(old.span(), "option `data` provided twice"));
                     }
                 } else {
@@ -271,7 +271,7 @@ impl<A: AllowedOptions> syn::parse::Parse for Options<A> {
                     let _eq = Equals::parse(input)?;
                     let lit = syn::LitInt::parse(input)?;
                     let value = lit.base10_parse::<usize>()?;
-                    if let Some(old) = std::mem::replace(&mut options.lru, Some(value)) {
+                    if let Some(old) = options.lru.replace(value) {
                         return Err(syn::Error::new(old.span(), "option `lru` provided twice"));
                     }
                 } else {
@@ -284,8 +284,7 @@ impl<A: AllowedOptions> syn::parse::Parse for Options<A> {
                 if A::CONSTRUCTOR_NAME {
                     let _eq = Equals::parse(input)?;
                     let ident = syn::Ident::parse(input)?;
-                    if let Some(old) = std::mem::replace(&mut options.constructor_name, Some(ident))
-                    {
+                    if let Some(old) = options.constructor_name.replace(ident) {
                         return Err(syn::Error::new(
                             old.span(),
                             "option `constructor` provided twice",

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -135,14 +135,11 @@ impl MemoTable {
         if memos.len() < memo_ingredient_index + 1 {
             memos.resize_with(memo_ingredient_index + 1, MemoEntry::default);
         }
-        let old_entry = std::mem::replace(
-            &mut memos[memo_ingredient_index].data,
-            Some(MemoEntryData {
-                type_id: TypeId::of::<M>(),
-                to_dyn_fn: Self::to_dyn_fn::<M>(),
-                atomic_memo: AtomicPtr::new(Self::to_dummy(memo).as_ptr()),
-            }),
-        );
+        let old_entry = memos[memo_ingredient_index].data.replace(MemoEntryData {
+            type_id: TypeId::of::<M>(),
+            to_dyn_fn: Self::to_dyn_fn::<M>(),
+            atomic_memo: AtomicPtr::new(Self::to_dummy(memo).as_ptr()),
+        });
         old_entry.map(
             |MemoEntryData {
                  type_id: _,


### PR DESCRIPTION
This fixes violations of a new nightly clippy rule.