### PR TITLE
bug [salsa-macros]: Improve debug name of tracked methods

### DIFF
--- a/components/salsa-macros/src/tracked_impl.rs
+++ b/components/salsa-macros/src/tracked_impl.rs
@@ -87,7 +87,7 @@ impl Macro {
         };
 
         let InnerTrait = self.hygiene.ident("InnerTrait");
-        let inner_fn_name = self.hygiene.ident("inner_fn_name");
+        let inner_fn_name = self.hygiene.ident(&fn_item.sig.ident.to_string());
 
         let MethodArguments {
             self_token,

--- a/tests/tracked_method.rs
+++ b/tests/tracked_method.rs
@@ -2,6 +2,11 @@
 //! compiles and executes successfully.
 #![allow(warnings)]
 
+use common::LogDatabase as _;
+use expect_test::expect;
+
+mod common;
+
 trait TrackedTrait {
     fn tracked_trait_fn(self, db: &dyn salsa::Database) -> u32;
 }
@@ -39,4 +44,16 @@ fn execute() {
     // assert_eq!(object.tracked_fn(&db), 44);
     // assert_eq!(*object.tracked_fn_ref(&db), 66);
     assert_eq!(object.tracked_trait_fn(&db), 88);
+}
+
+#[test]
+fn debug_name() {
+    let mut db = common::ExecuteValidateLoggerDatabase::default();
+    let object = MyInput::new(&mut db, 22);
+
+    assert_eq!(object.tracked_trait_fn(&db), 88);
+    db.assert_logs(expect![[r#"
+        [
+            "salsa_event(WillExecute { database_key: tracked_trait_fn_(Id(0)) })",
+        ]"#]]);
 }


### PR DESCRIPTION
The debug name of every tracked method always was `inner_fn_name`. This PR improves the function name to be `<fn_name>_`. This is not perfect but much more useful than the same name for every tracked method.

An alternative is to use `std::any::type_name` and we could then try to detect if the type name is from a `TrackedTrait` but that seems complicated.