### PR TITLE
perf: Use a `Vec` for `CycleHeads`

### DIFF
--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -94,6 +94,17 @@ impl ActiveQuery {
         self.cycle_heads.extend(cycle_heads);
     }
 
+    pub(super) fn add_read_simple(
+        &mut self,
+        input: InputDependencyIndex,
+        durability: Durability,
+        revision: Revision,
+    ) {
+        self.input_outputs.insert(QueryEdge::Input(input));
+        self.durability = self.durability.min(durability);
+        self.changed_at = self.changed_at.max(revision);
+    }
+
     pub(super) fn add_untracked_read(&mut self, changed_at: Revision) {
         self.untracked_read = true;
         self.durability = Durability::MIN;

--- a/src/cycle.rs
+++ b/src/cycle.rs
@@ -127,21 +127,16 @@ impl CycleHeads {
             }
         }
     }
-}
 
-impl std::iter::Extend<DatabaseKeyIndex> for CycleHeads {
-    fn extend<T: IntoIterator<Item = DatabaseKeyIndex>>(&mut self, iter: T) {
-        let mut iter = iter.into_iter();
-        if let Some(first) = iter.next() {
+    pub(crate) fn extend(&mut self, other: &Self) {
+        if let Some(other) = &other.0 {
             let heads = &mut **self.0.get_or_insert_with(|| Box::new(Vec::new()));
-            if !heads.contains(&first) {
-                heads.push(first);
-            }
-            for head in iter {
+            heads.reserve(other.len());
+            other.iter().for_each(|&head| {
                 if !heads.contains(&head) {
                     heads.push(head);
                 }
-            }
+            });
         }
     }
 }

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -383,10 +383,9 @@ where
             //    from cycle heads. We will handle our own memo (and the rest of our cycle) on a
             //    future iteration; first the outer cycle head needs to verify itself.
 
-            let found = cycle_heads
+            let in_heads = cycle_heads
                 .iter()
-                .position(|&head| head == database_key_index);
-            let in_heads = found
+                .position(|&head| head == database_key_index)
                 .inspect(|&head| _ = cycle_heads.swap_remove(head))
                 .is_some();
 

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -239,13 +239,12 @@ where
         zalsa: &Zalsa,
         memo: &Memo<C::Output<'_>>,
     ) -> bool {
-        for cycle_head in &memo.revisions.cycle_heads {
-            if zalsa
+        if (&memo.revisions.cycle_heads).into_iter().any(|cycle_head| {
+            zalsa
                 .lookup_ingredient(cycle_head.ingredient_index)
                 .is_provisional_cycle_head(db.as_dyn_database(), cycle_head.key_index)
-            {
-                return false;
-            }
+        }) {
+            return false;
         }
         // Relaxed is sufficient here because there are no other writes we need to ensure have
         // happened before marking this memo as verified-final.

--- a/src/input.rs
+++ b/src/input.rs
@@ -11,8 +11,7 @@ pub mod singleton;
 use input_field::FieldIngredientImpl;
 
 use crate::{
-    accumulator::accumulated_map::InputAccumulatedValues,
-    cycle::{CycleRecoveryStrategy, EMPTY_CYCLE_HEADS},
+    cycle::CycleRecoveryStrategy,
     function::VerifyResult,
     id::{AsId, FromIdWithDb},
     ingredient::{fmt_index, Ingredient},
@@ -178,12 +177,10 @@ impl<C: Configuration> IngredientImpl<C> {
         let id = id.as_id();
         let value = Self::data(zalsa, id);
         let stamp = &value.stamps[field_index];
-        zalsa_local.report_tracked_read(
+        zalsa_local.report_tracked_read_simple(
             InputDependencyIndex::new(field_ingredient_index, id),
             stamp.durability,
             stamp.changed_at,
-            InputAccumulatedValues::Empty,
-            &EMPTY_CYCLE_HEADS,
         );
         &value.fields
     }

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -1,7 +1,5 @@
 use dashmap::SharedValue;
 
-use crate::accumulator::accumulated_map::InputAccumulatedValues;
-use crate::cycle::EMPTY_CYCLE_HEADS;
 use crate::durability::Durability;
 use crate::function::VerifyResult;
 use crate::ingredient::fmt_index;
@@ -180,12 +178,10 @@ where
         C::Fields<'db>: HashEqLike<Key>,
     {
         let zalsa_local = db.zalsa_local();
-        zalsa_local.report_tracked_read(
+        zalsa_local.report_tracked_read_simple(
             InputDependencyIndex::for_table(self.ingredient_index),
             Durability::MAX,
             self.reset_at,
-            InputAccumulatedValues::Empty,
-            &EMPTY_CYCLE_HEADS,
         );
 
         // Optimization to only get read lock on the map if the data has already been interned.

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -4,8 +4,7 @@ use crossbeam_queue::SegQueue;
 use tracked_field::FieldIngredientImpl;
 
 use crate::{
-    accumulator::accumulated_map::InputAccumulatedValues,
-    cycle::{CycleRecoveryStrategy, EMPTY_CYCLE_HEADS},
+    cycle::CycleRecoveryStrategy,
     function::VerifyResult,
     ingredient::{fmt_index, Ingredient, Jar},
     key::{DatabaseKeyIndex, InputDependencyIndex},
@@ -677,12 +676,10 @@ where
 
         let field_changed_at = data.revisions[relative_tracked_index];
 
-        zalsa_local.report_tracked_read(
+        zalsa_local.report_tracked_read_simple(
             InputDependencyIndex::new(field_ingredient_index, id),
             data.durability,
             field_changed_at,
-            InputAccumulatedValues::Empty,
-            &EMPTY_CYCLE_HEADS,
         );
 
         unsafe { self.to_self_ref(&data.fields) }
@@ -704,12 +701,10 @@ where
         data.read_lock(zalsa.current_revision());
 
         // Add a dependency on the tracked struct itself.
-        zalsa_local.report_tracked_read(
+        zalsa_local.report_tracked_read_simple(
             InputDependencyIndex::new(self.ingredient_index, id),
             data.durability,
             data.created_at,
-            InputAccumulatedValues::Empty,
-            &EMPTY_CYCLE_HEADS,
         );
 
         unsafe { self.to_self_ref(&data.fields) }

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -183,6 +183,24 @@ impl ZalsaLocal {
         })
     }
 
+    /// Register that currently active query reads the given input
+    pub(crate) fn report_tracked_read_simple(
+        &self,
+        input: InputDependencyIndex,
+        durability: Durability,
+        changed_at: Revision,
+    ) {
+        debug!(
+            "report_tracked_read(input={:?}, durability={:?}, changed_at={:?})",
+            input, durability, changed_at
+        );
+        self.with_query_stack(|stack| {
+            if let Some(top_query) = stack.last_mut() {
+                top_query.add_read_simple(input, durability, changed_at);
+            }
+        })
+    }
+
     /// Register that the current query read an untracked value
     ///
     /// # Parameters

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -1,4 +1,4 @@
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use tracing::debug;
 
 use crate::accumulator::accumulated_map::{
@@ -324,7 +324,6 @@ pub(crate) struct QueryRevisions {
 
 impl QueryRevisions {
     pub(crate) fn fixpoint_initial(query: DatabaseKeyIndex, revision: Revision) -> Self {
-        let cycle_heads = FxHashSet::from_iter([query]).into();
         Self {
             changed_at: revision,
             durability: Durability::MAX,
@@ -332,7 +331,7 @@ impl QueryRevisions {
             tracked_struct_ids: Default::default(),
             accumulated: Default::default(),
             accumulated_inputs: Default::default(),
-            cycle_heads,
+            cycle_heads: CycleHeads::from(query),
         }
     }
 


### PR DESCRIPTION
The number of cycle participants is generally low so a hashset likely has more overhead compared to a simple vec for such small numbers of elements.