### PR TITLE
refactor: Move `verified_final` from `Memo` into `QueryRevisions`

### DIFF
--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -1,4 +1,5 @@
 use std::ops::Not;
+use std::sync::atomic::AtomicBool;
 use std::{mem, ops};
 
 use super::zalsa_local::{QueryEdges, QueryOrigin, QueryRevisions};
@@ -74,9 +75,9 @@ impl ActiveQuery {
         accumulated: InputAccumulatedValues,
         cycle_heads: &CycleHeads,
     ) {
-        self.input_outputs.insert(QueryEdge::Input(input));
         self.durability = self.durability.min(durability);
         self.changed_at = self.changed_at.max(revision);
+        self.input_outputs.insert(QueryEdge::Input(input));
         self.accumulated_inputs |= accumulated;
         self.cycle_heads.extend(cycle_heads);
     }
@@ -87,9 +88,9 @@ impl ActiveQuery {
         durability: Durability,
         revision: Revision,
     ) {
-        self.input_outputs.insert(QueryEdge::Input(input));
         self.durability = self.durability.min(durability);
         self.changed_at = self.changed_at.max(revision);
+        self.input_outputs.insert(QueryEdge::Input(input));
     }
 
     pub(super) fn add_untracked_read(&mut self, changed_at: Revision) {
@@ -182,6 +183,7 @@ impl ActiveQuery {
             tracked_struct_ids,
             accumulated_inputs,
             accumulated,
+            verified_final: AtomicBool::new(cycle_heads.is_empty()),
             cycle_heads,
         }
     }

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -257,7 +257,7 @@ where
         }
         // Relaxed is sufficient here because there are no other writes we need to ensure have
         // happened before marking this memo as verified-final.
-        memo.verified_final.store(true, Ordering::Relaxed);
+        memo.revisions.verified_final.store(true, Ordering::Relaxed);
         true
     }
 

--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -72,6 +72,7 @@ where
             tracked_struct_ids: Default::default(),
             accumulated: Default::default(),
             accumulated_inputs: Default::default(),
+            verified_final: AtomicBool::new(true),
             cycle_heads: Default::default(),
         };
 
@@ -91,7 +92,6 @@ where
         let memo = Memo {
             value: Some(value),
             verified_at: AtomicRevision::from(revision),
-            verified_final: AtomicBool::new(true),
             revisions,
         };
 

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -20,6 +20,7 @@ use crate::Id;
 use crate::Revision;
 use std::cell::RefCell;
 use std::panic::UnwindSafe;
+use std::sync::atomic::AtomicBool;
 
 /// State that is specific to a single execution thread.
 ///
@@ -317,6 +318,9 @@ pub(crate) struct QueryRevisions {
     /// has any direct or indirect accumulated values.
     pub(super) accumulated_inputs: AtomicInputAccumulatedValues,
 
+    /// Are the `cycle_heads` verified to not be provisional anymore?
+    pub(super) verified_final: AtomicBool,
+
     /// This result was computed based on provisional values from
     /// these cycle heads. The "cycle head" is the query responsible
     /// for managing a fixpoint iteration. In a cycle like
@@ -337,6 +341,7 @@ impl QueryRevisions {
             tracked_struct_ids: Default::default(),
             accumulated: Default::default(),
             accumulated_inputs: Default::default(),
+            verified_final: AtomicBool::new(false),
             cycle_heads: CycleHeads::from(query),
         }
     }


### PR DESCRIPTION
This saves an entire usize per function `Memo`