### PR TITLE
Use html directory for mdbook artifact

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -36,7 +36,7 @@ jobs:
         id: deployment
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./book/book
+          path: ./book/book/html
   deploy:
     name: Deploy
     runs-on: ubuntu-latest


### PR DESCRIPTION
The artifacts currently contain a `html` directory and a `linkcheck` directory with just an empty cache file, so uploading just the `html` directory will fix the book url's.

Fixes #752

