### PR TITLE
fix: Use `changed_at` revision when updating fields

### DIFF
--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -553,7 +553,7 @@ where
         // to meet its safety invariant.
         unsafe {
             if C::update_fields(
-                current_revision,
+                current_deps.changed_at,
                 &mut data.revisions,
                 self.to_self_ptr(std::ptr::addr_of_mut!(data.fields)),
                 fields,
@@ -568,7 +568,7 @@ where
             }
         }
         if current_deps.durability < data.durability {
-            data.revisions = C::new_revisions(current_revision);
+            data.revisions = C::new_revisions(current_deps.changed_at);
             data.created_at = current_revision;
         }
         data.durability = current_deps.durability;


### PR DESCRIPTION
Setting the field's revision to `current_revision` when updating is not technically wrong, but its pessimizing. If all previous reads only observed a change of up to `changed_at`, then it's fine for us to do the same as nothing we derive from has read from `current_revision`.