### PR TITLE
chore: Normalize imports style

### DIFF
--- a/benches/dataflow.rs
+++ b/benches/dataflow.rs
@@ -2,10 +2,11 @@
 //!
 //! This benchmark simulates a (very simplified) version of a real dataflow analysis using fixpoint
 //! iteration.
-use codspeed_criterion_compat::{criterion_group, criterion_main, BatchSize, Criterion};
-use salsa::{CycleRecoveryAction, Database as Db, Setter};
 use std::collections::BTreeSet;
 use std::iter::IntoIterator;
+
+use codspeed_criterion_compat::{criterion_group, criterion_main, BatchSize, Criterion};
+use salsa::{CycleRecoveryAction, Database as Db, Setter};
 
 include!("shims/global_alloc_overwrite.rs");
 

--- a/components/salsa-macros/src/accumulator.rs
+++ b/components/salsa-macros/src/accumulator.rs
@@ -1,10 +1,8 @@
 use proc_macro2::TokenStream;
 
-use crate::{
-    hygiene::Hygiene,
-    options::{AllowedOptions, Options},
-    token_stream_with_error,
-};
+use crate::hygiene::Hygiene;
+use crate::options::{AllowedOptions, Options};
+use crate::token_stream_with_error;
 
 // #[salsa::accumulator(jar = Jar0)]
 // struct Accumulator(DataType);

--- a/components/salsa-macros/src/db.rs
+++ b/components/salsa-macros/src/db.rs
@@ -1,7 +1,8 @@
 use proc_macro2::TokenStream;
 use syn::parse::Nothing;
 
-use crate::{hygiene::Hygiene, token_stream_with_error};
+use crate::hygiene::Hygiene;
+use crate::token_stream_with_error;
 
 // Source:
 //

--- a/components/salsa-macros/src/fn_util.rs
+++ b/components/salsa-macros/src/fn_util.rs
@@ -1,4 +1,5 @@
-use crate::{hygiene::Hygiene, xform::ChangeLt};
+use crate::hygiene::Hygiene;
+use crate::xform::ChangeLt;
 
 /// Returns a vector of ids representing the function arguments.
 /// Prefers to reuse the names given by the user, if possible.

--- a/components/salsa-macros/src/input.rs
+++ b/components/salsa-macros/src/input.rs
@@ -1,10 +1,9 @@
-use crate::{
-    hygiene::Hygiene,
-    options::Options,
-    salsa_struct::{SalsaStruct, SalsaStructAllowedOptions},
-    token_stream_with_error,
-};
 use proc_macro2::TokenStream;
+
+use crate::hygiene::Hygiene;
+use crate::options::Options;
+use crate::salsa_struct::{SalsaStruct, SalsaStructAllowedOptions};
+use crate::token_stream_with_error;
 
 /// For an entity struct `Foo` with fields `f1: T1, ..., fN: TN`, we generate...
 ///

--- a/components/salsa-macros/src/interned.rs
+++ b/components/salsa-macros/src/interned.rs
@@ -1,11 +1,9 @@
-use crate::{
-    db_lifetime,
-    hygiene::Hygiene,
-    options::Options,
-    salsa_struct::{SalsaStruct, SalsaStructAllowedOptions},
-    token_stream_with_error,
-};
 use proc_macro2::TokenStream;
+
+use crate::hygiene::Hygiene;
+use crate::options::Options;
+use crate::salsa_struct::{SalsaStruct, SalsaStructAllowedOptions};
+use crate::{db_lifetime, token_stream_with_error};
 
 /// For an entity struct `Foo` with fields `f1: T1, ..., fN: TN`, we generate...
 ///

--- a/components/salsa-macros/src/options.rs
+++ b/components/salsa-macros/src/options.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 
-use syn::{ext::IdentExt, spanned::Spanned};
+use syn::ext::IdentExt;
+use syn::spanned::Spanned;
 
 /// "Options" are flags that can be supplied to the various salsa related
 /// macros. They are listed like `(ref, no_eq, foo=bar)` etc. The commas

--- a/components/salsa-macros/src/salsa_struct.rs
+++ b/components/salsa-macros/src/salsa_struct.rs
@@ -25,11 +25,10 @@
 //! * data method `impl Foo { fn data(&self, db: &dyn crate::Db) -> FooData { FooData { f: self.f(db), ... } } }`
 //!     * this could be optimized, particularly for interned fields
 
-use crate::{
-    db_lifetime,
-    options::{AllowedOptions, Options},
-};
 use proc_macro2::{Ident, Literal, Span, TokenStream};
+
+use crate::db_lifetime;
+use crate::options::{AllowedOptions, Options};
 
 pub(crate) struct SalsaStruct<'s, A: SalsaStructAllowedOptions> {
     struct_item: &'s syn::ItemStruct,

--- a/components/salsa-macros/src/supertype.rs
+++ b/components/salsa-macros/src/supertype.rs
@@ -1,5 +1,6 @@
-use crate::token_stream_with_error;
 use proc_macro2::TokenStream;
+
+use crate::token_stream_with_error;
 
 /// The implementation of the `supertype` macro.
 ///

--- a/components/salsa-macros/src/tracked.rs
+++ b/components/salsa-macros/src/tracked.rs
@@ -1,4 +1,5 @@
-use syn::{spanned::Spanned, Item};
+use syn::spanned::Spanned;
+use syn::Item;
 
 use crate::token_stream_with_error;
 

--- a/components/salsa-macros/src/tracked_fn.rs
+++ b/components/salsa-macros/src/tracked_fn.rs
@@ -1,8 +1,11 @@
 use proc_macro2::{Literal, Span, TokenStream};
 use quote::ToTokens;
-use syn::{spanned::Spanned, ItemFn};
+use syn::spanned::Spanned;
+use syn::ItemFn;
 
-use crate::{db_lifetime, fn_util, hygiene::Hygiene, options::Options};
+use crate::hygiene::Hygiene;
+use crate::options::Options;
+use crate::{db_lifetime, fn_util};
 
 // Source:
 //

--- a/components/salsa-macros/src/tracked_impl.rs
+++ b/components/salsa-macros/src/tracked_impl.rs
@@ -2,9 +2,12 @@ use std::collections::HashSet;
 
 use proc_macro2::TokenStream;
 use quote::ToTokens;
-use syn::{parse::Nothing, visit_mut::VisitMut};
+use syn::parse::Nothing;
+use syn::visit_mut::VisitMut;
 
-use crate::{hygiene::Hygiene, tracked_fn::FnArgs, xform::ChangeSelfPath};
+use crate::hygiene::Hygiene;
+use crate::tracked_fn::FnArgs;
+use crate::xform::ChangeSelfPath;
 
 pub(crate) fn tracked_impl(
     args: proc_macro::TokenStream,

--- a/components/salsa-macros/src/tracked_struct.rs
+++ b/components/salsa-macros/src/tracked_struct.rs
@@ -1,10 +1,9 @@
-use crate::{
-    db_lifetime,
-    hygiene::Hygiene,
-    options::Options,
-    salsa_struct::{SalsaStruct, SalsaStructAllowedOptions},
-};
 use proc_macro2::TokenStream;
+
+use crate::db_lifetime;
+use crate::hygiene::Hygiene;
+use crate::options::Options;
+use crate::salsa_struct::{SalsaStruct, SalsaStructAllowedOptions};
 
 /// For an entity struct `Foo` with fields `f1: T1, ..., fN: TN`, we generate...
 ///

--- a/components/salsa-macros/src/xform.rs
+++ b/components/salsa-macros/src/xform.rs
@@ -1,7 +1,9 @@
 use std::collections::HashSet;
 
 use quote::ToTokens;
-use syn::{punctuated::Punctuated, spanned::Spanned, visit_mut::VisitMut};
+use syn::punctuated::Punctuated;
+use syn::spanned::Spanned;
+use syn::visit_mut::VisitMut;
 
 pub(crate) struct ChangeLt<'a> {
     from: Option<&'a str>,

--- a/examples/calc/compile.rs
+++ b/examples/calc/compile.rs
@@ -1,4 +1,6 @@
-use crate::{ir::SourceProgram, parser::parse_statements, type_check::type_check_program};
+use crate::ir::SourceProgram;
+use crate::parser::parse_statements;
+use crate::type_check::type_check_program;
 
 #[salsa::tracked]
 pub fn compile(db: &dyn crate::Db, source_program: SourceProgram) {

--- a/examples/calc/type_check.rs
+++ b/examples/calc/type_check.rs
@@ -1,11 +1,12 @@
-use crate::ir::{
-    Diagnostic, Expression, Function, FunctionId, Program, Span, StatementData, VariableId,
-};
 #[cfg(test)]
 use expect_test::expect;
 use salsa::Accumulator;
 #[cfg(test)]
 use test_log::test;
+
+use crate::ir::{
+    Diagnostic, Expression, Function, FunctionId, Program, Span, StatementData, VariableId,
+};
 
 // ANCHOR: parse_statements
 #[salsa::tracked]
@@ -112,7 +113,9 @@ fn check_string(
 ) {
     use salsa::{Database, Setter};
 
-    use crate::{db::CalcDatabaseImpl, ir::SourceProgram, parser::parse_statements};
+    use crate::db::CalcDatabaseImpl;
+    use crate::ir::SourceProgram;
+    use crate::parser::parse_statements;
 
     // Create the database
     let mut db = CalcDatabaseImpl::default();

--- a/examples/lazy-input/main.rs
+++ b/examples/lazy-input/main.rs
@@ -1,19 +1,15 @@
 #![allow(unreachable_patterns)]
 // FIXME(rust-lang/rust#129031): regression in nightly
-use std::{
-    path::PathBuf,
-    sync::{Arc, Mutex},
-    time::Duration,
-};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use crossbeam_channel::{unbounded, Sender};
-use dashmap::{mapref::entry::Entry, DashMap};
+use dashmap::mapref::entry::Entry;
+use dashmap::DashMap;
 use eyre::{eyre, Context, Report, Result};
-use notify_debouncer_mini::{
-    new_debouncer,
-    notify::{RecommendedWatcher, RecursiveMode},
-    DebounceEventResult, Debouncer,
-};
+use notify_debouncer_mini::notify::{RecommendedWatcher, RecursiveMode};
+use notify_debouncer_mini::{new_debouncer, DebounceEventResult, Debouncer};
 use salsa::{Accumulator, Setter, Storage};
 
 // ANCHOR: main

--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -1,22 +1,17 @@
 //! Basic test of accumulator functionality.
 
-use std::{
-    any::{Any, TypeId},
-    fmt,
-    marker::PhantomData,
-    panic::UnwindSafe,
-};
+use std::any::{Any, TypeId};
+use std::fmt;
+use std::marker::PhantomData;
+use std::panic::UnwindSafe;
 
-use accumulated::Accumulated;
-use accumulated::AnyAccumulated;
+use accumulated::{Accumulated, AnyAccumulated};
 
-use crate::{
-    function::VerifyResult,
-    ingredient::{fmt_index, Ingredient, Jar},
-    plumbing::IngredientIndices,
-    zalsa::{IngredientIndex, Zalsa},
-    Database, Id, Revision,
-};
+use crate::function::VerifyResult;
+use crate::ingredient::{fmt_index, Ingredient, Jar};
+use crate::plumbing::IngredientIndices;
+use crate::zalsa::{IngredientIndex, Zalsa};
+use crate::{Database, Id, Revision};
 
 mod accumulated;
 pub(crate) mod accumulated_map;

--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -15,8 +15,7 @@ use crate::{
     ingredient::{fmt_index, Ingredient, Jar},
     plumbing::IngredientIndices,
     zalsa::{IngredientIndex, Zalsa},
-    zalsa_local::QueryOrigin,
-    Database, DatabaseKeyIndex, Id, Revision,
+    Database, Id, Revision,
 };
 
 mod accumulated;
@@ -107,35 +106,6 @@ impl<A: Accumulator> Ingredient for IngredientImpl<A> {
         _revision: Revision,
     ) -> VerifyResult {
         panic!("nothing should ever depend on an accumulator directly")
-    }
-
-    fn is_provisional_cycle_head<'db>(&'db self, _db: &'db dyn Database, _input: Id) -> bool {
-        false
-    }
-
-    fn wait_for(&self, _db: &dyn Database, _key_index: Id) -> bool {
-        true
-    }
-
-    fn origin(&self, _db: &dyn Database, _key_index: crate::Id) -> Option<QueryOrigin> {
-        None
-    }
-
-    fn mark_validated_output(
-        &self,
-        _db: &dyn Database,
-        _executor: DatabaseKeyIndex,
-        _output_key: crate::Id,
-    ) {
-    }
-
-    fn remove_stale_output(
-        &self,
-        _db: &dyn Database,
-        _executor: DatabaseKeyIndex,
-        _stale_output_key: crate::Id,
-        _provisional: bool,
-    ) {
     }
 
     fn fmt_index(&self, index: crate::Id, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/accumulator/accumulated.rs
+++ b/src/accumulator/accumulated.rs
@@ -1,7 +1,7 @@
 use std::any::Any;
 use std::fmt::Debug;
 
-use super::Accumulator;
+use crate::accumulator::Accumulator;
 
 #[derive(Clone, Debug)]
 pub(crate) struct Accumulated<A: Accumulator> {

--- a/src/accumulator/accumulated_map.rs
+++ b/src/accumulator/accumulated_map.rs
@@ -1,13 +1,11 @@
-use std::{
-    ops,
-    sync::atomic::{AtomicBool, Ordering},
-};
+use std::ops;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use rustc_hash::FxHashMap;
 
+use crate::accumulator::accumulated::Accumulated;
+use crate::accumulator::{Accumulator, AnyAccumulated};
 use crate::IngredientIndex;
-
-use super::{accumulated::Accumulated, Accumulator, AnyAccumulated};
 
 #[derive(Default)]
 pub struct AccumulatedMap {

--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -2,21 +2,17 @@ use std::ops::Not;
 use std::sync::atomic::AtomicBool;
 use std::{mem, ops};
 
-use super::zalsa_local::{QueryEdges, QueryOrigin, QueryRevisions};
-use crate::accumulator::accumulated_map::AtomicInputAccumulatedValues;
-use crate::runtime::Stamp;
-use crate::tracked_struct::{DisambiguatorMap, IdentityHash, IdentityMap};
-use crate::zalsa_local::QueryEdge;
-use crate::{
-    accumulator::accumulated_map::{AccumulatedMap, InputAccumulatedValues},
-    cycle::CycleHeads,
-    durability::Durability,
-    hash::FxIndexSet,
-    key::DatabaseKeyIndex,
-    tracked_struct::Disambiguator,
-    Revision,
+use crate::accumulator::accumulated_map::{
+    AccumulatedMap, AtomicInputAccumulatedValues, InputAccumulatedValues,
 };
-use crate::{Accumulator, IngredientIndex};
+use crate::cycle::CycleHeads;
+use crate::durability::Durability;
+use crate::hash::FxIndexSet;
+use crate::key::DatabaseKeyIndex;
+use crate::runtime::Stamp;
+use crate::tracked_struct::{Disambiguator, DisambiguatorMap, IdentityHash, IdentityMap};
+use crate::zalsa_local::{QueryEdge, QueryEdges, QueryOrigin, QueryRevisions};
+use crate::{Accumulator, IngredientIndex, Revision};
 
 #[derive(Debug)]
 pub(crate) struct ActiveQuery {

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -1,4 +1,5 @@
-use std::{cell::Cell, ptr::NonNull};
+use std::cell::Cell;
+use std::ptr::NonNull;
 
 use crate::Database;
 

--- a/src/cancelled.rs
+++ b/src/cancelled.rs
@@ -1,7 +1,5 @@
-use std::{
-    fmt,
-    panic::{self, UnwindSafe},
-};
+use std::fmt;
+use std::panic::{self, UnwindSafe};
 
 /// A panic payload indicating that execution of a salsa query was cancelled.
 ///

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,9 +1,8 @@
-use std::{any::Any, borrow::Cow};
+use std::any::Any;
+use std::borrow::Cow;
 
-use crate::{
-    zalsa::{IngredientIndex, ZalsaDatabase},
-    Durability, Event, Revision,
-};
+use crate::zalsa::{IngredientIndex, ZalsaDatabase};
+use crate::{Durability, Event, Revision};
 
 /// The trait implemented by all Salsa databases.
 /// You can create your own subtraits of this trait using the `#[salsa::db]`(`crate::db`) procedural macro.

--- a/src/database_impl.rs
+++ b/src/database_impl.rs
@@ -1,4 +1,5 @@
-use crate::{storage::HasStorage, Database, Event, Storage};
+use crate::storage::HasStorage;
+use crate::{Database, Event, Storage};
 
 /// Default database implementation that you can use if you don't
 /// require any custom user data.

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,6 +1,7 @@
 use std::thread::ThreadId;
 
-use crate::{key::DatabaseKeyIndex, Id, Revision};
+use crate::key::DatabaseKeyIndex;
+use crate::{Id, Revision};
 
 /// The `Event` struct identifies various notable things that can
 /// occur during salsa execution. Instances of this struct are given

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,25 +1,22 @@
-use std::{any::Any, fmt, ptr::NonNull};
-
-use crate::{
-    accumulator::accumulated_map::{AccumulatedMap, InputAccumulatedValues},
-    cycle::{CycleRecoveryAction, CycleRecoveryStrategy},
-    ingredient::fmt_index,
-    key::DatabaseKeyIndex,
-    plumbing::MemoIngredientMap,
-    salsa_struct::SalsaStructInDb,
-    table::sync::ClaimResult,
-    table::Table,
-    views::DatabaseDownCaster,
-    zalsa::{IngredientIndex, MemoIngredientIndex, Zalsa},
-    zalsa_local::QueryOrigin,
-    Database, Id, Revision,
-};
-
-use self::delete::DeletedEntries;
-
-use super::ingredient::Ingredient;
+use std::any::Any;
+use std::fmt;
+use std::ptr::NonNull;
 
 pub(crate) use maybe_changed_after::VerifyResult;
+
+use crate::accumulator::accumulated_map::{AccumulatedMap, InputAccumulatedValues};
+use crate::cycle::{CycleRecoveryAction, CycleRecoveryStrategy};
+use crate::function::delete::DeletedEntries;
+use crate::ingredient::{fmt_index, Ingredient};
+use crate::key::DatabaseKeyIndex;
+use crate::plumbing::MemoIngredientMap;
+use crate::salsa_struct::SalsaStructInDb;
+use crate::table::sync::ClaimResult;
+use crate::table::Table;
+use crate::views::DatabaseDownCaster;
+use crate::zalsa::{IngredientIndex, MemoIngredientIndex, Zalsa};
+use crate::zalsa_local::QueryOrigin;
+use crate::{Database, Id, Revision};
 
 mod accumulated;
 mod backdate;

--- a/src/function.rs
+++ b/src/function.rs
@@ -312,6 +312,10 @@ where
         C::DEBUG_NAME
     }
 
+    fn cycle_recovery_strategy(&self) -> CycleRecoveryStrategy {
+        C::CYCLE_STRATEGY
+    }
+
     fn accumulated<'db>(
         &'db self,
         db: &'db dyn Database,

--- a/src/function/accumulated.rs
+++ b/src/function/accumulated.rs
@@ -1,12 +1,10 @@
-use super::{Configuration, IngredientImpl};
-use crate::accumulator::accumulated_map::InputAccumulatedValues;
+use crate::accumulator::accumulated_map::{AccumulatedMap, InputAccumulatedValues};
+use crate::accumulator::{self};
+use crate::function::{Configuration, IngredientImpl};
+use crate::hash::FxHashSet;
+use crate::zalsa::ZalsaDatabase;
 use crate::zalsa_local::QueryOrigin;
-use crate::{
-    accumulator::{self, accumulated_map::AccumulatedMap},
-    hash::FxHashSet,
-    zalsa::ZalsaDatabase,
-    AsDynDatabase, DatabaseKeyIndex, Id,
-};
+use crate::{AsDynDatabase, DatabaseKeyIndex, Id};
 
 impl<C> IngredientImpl<C>
 where

--- a/src/function/backdate.rs
+++ b/src/function/backdate.rs
@@ -1,6 +1,6 @@
+use crate::function::memo::Memo;
+use crate::function::{Configuration, IngredientImpl};
 use crate::zalsa_local::QueryRevisions;
-
-use super::{memo::Memo, Configuration, IngredientImpl};
 
 impl<C> IngredientImpl<C>
 where

--- a/src/function/delete.rs
+++ b/src/function/delete.rs
@@ -1,7 +1,7 @@
 use std::ptr::NonNull;
 
-use super::memo::Memo;
-use super::Configuration;
+use crate::function::memo::Memo;
+use crate::function::Configuration;
 
 /// Stores the list of memos that have been deleted so they can be freed
 /// once the next revision starts. See the comment on the field

--- a/src/function/diff_outputs.rs
+++ b/src/function/diff_outputs.rs
@@ -1,8 +1,9 @@
-use super::{memo::Memo, Configuration, IngredientImpl};
-use crate::{
-    hash::FxHashSet, zalsa::Zalsa, zalsa_local::QueryRevisions, AsDynDatabase as _, Database,
-    DatabaseKeyIndex, Event, EventKind,
-};
+use crate::function::memo::Memo;
+use crate::function::{Configuration, IngredientImpl};
+use crate::hash::FxHashSet;
+use crate::zalsa::Zalsa;
+use crate::zalsa_local::QueryRevisions;
+use crate::{AsDynDatabase as _, Database, DatabaseKeyIndex, Event, EventKind};
 
 impl<C> IngredientImpl<C>
 where

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -1,11 +1,9 @@
-use crate::{
-    cycle::{CycleRecoveryStrategy, MAX_ITERATIONS},
-    zalsa::ZalsaDatabase,
-    zalsa_local::ActiveQueryGuard,
-    Database, Event, EventKind,
-};
-
-use super::{memo::Memo, Configuration, IngredientImpl};
+use crate::cycle::{CycleRecoveryStrategy, MAX_ITERATIONS};
+use crate::function::memo::Memo;
+use crate::function::{Configuration, IngredientImpl};
+use crate::zalsa::ZalsaDatabase;
+use crate::zalsa_local::ActiveQueryGuard;
+use crate::{Database, Event, EventKind};
 
 impl<C> IngredientImpl<C>
 where

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -1,13 +1,11 @@
-use super::{memo::Memo, Configuration, IngredientImpl, VerifyResult};
-use crate::zalsa::MemoIngredientIndex;
-use crate::{
-    accumulator::accumulated_map::InputAccumulatedValues,
-    runtime::StampedValue,
-    table::sync::ClaimResult,
-    zalsa::{Zalsa, ZalsaDatabase},
-    zalsa_local::QueryRevisions,
-    AsDynDatabase as _, Id,
-};
+use crate::accumulator::accumulated_map::InputAccumulatedValues;
+use crate::function::memo::Memo;
+use crate::function::{Configuration, IngredientImpl, VerifyResult};
+use crate::runtime::StampedValue;
+use crate::table::sync::ClaimResult;
+use crate::zalsa::{MemoIngredientIndex, Zalsa, ZalsaDatabase};
+use crate::zalsa_local::QueryRevisions;
+use crate::{AsDynDatabase as _, Id};
 
 impl<C> IngredientImpl<C>
 where

--- a/src/function/inputs.rs
+++ b/src/function/inputs.rs
@@ -1,6 +1,7 @@
-use crate::{zalsa::Zalsa, zalsa_local::QueryOrigin, Id};
-
-use super::{Configuration, IngredientImpl};
+use crate::function::{Configuration, IngredientImpl};
+use crate::zalsa::Zalsa;
+use crate::zalsa_local::QueryOrigin;
+use crate::Id;
 
 impl<C> IngredientImpl<C>
 where

--- a/src/function/lru.rs
+++ b/src/function/lru.rs
@@ -1,8 +1,9 @@
 use std::num::NonZeroUsize;
 
-use crate::{hash::FxLinkedHashSet, Id};
-
 use parking_lot::Mutex;
+
+use crate::hash::FxLinkedHashSet;
+use crate::Id;
 
 pub(super) struct Lru {
     capacity: Option<NonZeroUsize>,

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -1,15 +1,14 @@
-use crate::{
-    accumulator::accumulated_map::InputAccumulatedValues,
-    cycle::{CycleHeads, CycleRecoveryStrategy},
-    key::DatabaseKeyIndex,
-    table::sync::ClaimResult,
-    zalsa::{MemoIngredientIndex, Zalsa, ZalsaDatabase},
-    zalsa_local::{ActiveQueryGuard, QueryEdge, QueryOrigin},
-    AsDynDatabase as _, Id, Revision,
-};
 use std::sync::atomic::Ordering;
 
-use super::{memo::Memo, Configuration, IngredientImpl};
+use crate::accumulator::accumulated_map::InputAccumulatedValues;
+use crate::cycle::{CycleHeads, CycleRecoveryStrategy};
+use crate::function::memo::Memo;
+use crate::function::{Configuration, IngredientImpl};
+use crate::key::DatabaseKeyIndex;
+use crate::table::sync::ClaimResult;
+use crate::zalsa::{MemoIngredientIndex, Zalsa, ZalsaDatabase};
+use crate::zalsa_local::{ActiveQueryGuard, QueryEdge, QueryOrigin};
+use crate::{AsDynDatabase as _, Id, Revision};
 
 /// Result of memo validation.
 pub enum VerifyResult {

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -1,25 +1,19 @@
 #![allow(clippy::undocumented_unsafe_blocks)] // TODO(#697) document safety
 
 use std::any::Any;
-use std::fmt::Debug;
-use std::fmt::Formatter;
+use std::fmt::{Debug, Formatter};
 use std::ptr::NonNull;
 use std::sync::atomic::Ordering;
 
 use crate::accumulator::accumulated_map::InputAccumulatedValues;
+use crate::cycle::{CycleHeads, CycleRecoveryStrategy, EMPTY_CYCLE_HEADS};
+use crate::function::{Configuration, IngredientImpl};
+use crate::key::DatabaseKeyIndex;
 use crate::revision::AtomicRevision;
 use crate::table::memo::MemoTable;
-use crate::zalsa::MemoIngredientIndex;
-use crate::zalsa_local::QueryOrigin;
-use crate::{
-    cycle::{CycleHeads, CycleRecoveryStrategy, EMPTY_CYCLE_HEADS},
-    key::DatabaseKeyIndex,
-    zalsa::Zalsa,
-    zalsa_local::QueryRevisions,
-    Event, EventKind, Id, Revision,
-};
-
-use super::{Configuration, IngredientImpl};
+use crate::zalsa::{MemoIngredientIndex, Zalsa};
+use crate::zalsa_local::{QueryOrigin, QueryRevisions};
+use crate::{Event, EventKind, Id, Revision};
 
 impl<C: Configuration> IngredientImpl<C> {
     /// Memos have to be stored internally using `'static` as the database lifetime.

--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -111,9 +111,9 @@ where
     /// and `key` is a value that was specified by `executor`.
     /// Marks `key` as valid in the current revision since if `executor` had re-executed,
     /// it would have specified `key` again.
-    pub(super) fn validate_specified_value<Db: ?Sized + Database>(
+    pub(super) fn validate_specified_value(
         &self,
-        db: &Db,
+        db: &dyn Database,
         executor: DatabaseKeyIndex,
         key: Id,
     ) {

--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -1,15 +1,13 @@
 use std::sync::atomic::AtomicBool;
 
-use crate::{
-    accumulator::accumulated_map::InputAccumulatedValues,
-    revision::AtomicRevision,
-    tracked_struct::TrackedStructInDb,
-    zalsa::ZalsaDatabase,
-    zalsa_local::{QueryOrigin, QueryRevisions},
-    AsDynDatabase as _, Database, DatabaseKeyIndex, Id,
-};
-
-use super::{memo::Memo, Configuration, IngredientImpl};
+use crate::accumulator::accumulated_map::InputAccumulatedValues;
+use crate::function::memo::Memo;
+use crate::function::{Configuration, IngredientImpl};
+use crate::revision::AtomicRevision;
+use crate::tracked_struct::TrackedStructInDb;
+use crate::zalsa::ZalsaDatabase;
+use crate::zalsa_local::{QueryOrigin, QueryRevisions};
+use crate::{AsDynDatabase as _, Database, DatabaseKeyIndex, Id};
 
 impl<C> IngredientImpl<C>
 where

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -5,6 +5,7 @@ use std::{
 
 use crate::{
     accumulator::accumulated_map::{AccumulatedMap, InputAccumulatedValues},
+    cycle::CycleRecoveryStrategy,
     function::VerifyResult,
     plumbing::IngredientIndices,
     table::Table,
@@ -66,29 +67,19 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
     ///
     /// In the case of nested cycles, we are not asking here whether the value is provisional due
     /// to the outer cycle being unresolved, only whether its own cycle remains provisional.
-    fn is_provisional_cycle_head<'db>(&'db self, db: &'db dyn Database, input: Id) -> bool;
+    fn is_provisional_cycle_head<'db>(&'db self, db: &'db dyn Database, input: Id) -> bool {
+        _ = (db, input);
+        false
+    }
 
     /// Invoked when the current thread needs to wait for a result for the given `key_index`.
     ///
     /// A return value of `true` indicates that a result is now available. A return value of
     /// `false` means that a cycle was encountered; the waited-on query is either already claimed
     /// by the current thread, or by a thread waiting on the current thread.
-    fn wait_for(&self, db: &dyn Database, key_index: Id) -> bool;
-
-    /// What were the inputs (if any) that were used to create the value at `key_index`.
-    fn origin(&self, db: &dyn Database, key_index: Id) -> Option<QueryOrigin>;
-
-    /// What values were accumulated during the creation of the value at `key_index`
-    /// (if any).
-    ///
-    /// In practice, returns `Some` only for tracked function ingredients.
-    fn accumulated<'db>(
-        &'db self,
-        db: &'db dyn Database,
-        key_index: Id,
-    ) -> (Option<&'db AccumulatedMap>, InputAccumulatedValues) {
+    fn wait_for(&self, db: &dyn Database, key_index: Id) -> bool {
         _ = (db, key_index);
-        (None, InputAccumulatedValues::Any)
+        true
     }
 
     /// Invoked when the value `output_key` should be marked as valid in the current revision.
@@ -99,7 +90,10 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
         db: &'db dyn Database,
         executor: DatabaseKeyIndex,
         output_key: crate::Id,
-    );
+    ) {
+        let _ = (db, executor, output_key);
+        unreachable!("only tracked struct and function ingredients can have validatable outputs")
+    }
 
     /// Invoked when the value `stale_output` was output by `executor` in a previous
     /// revision, but was NOT output in the current revision.
@@ -111,7 +105,10 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
         executor: DatabaseKeyIndex,
         stale_output_key: Id,
         provisional: bool,
-    );
+    ) {
+        let _ = (db, executor, stale_output_key, provisional);
+        unreachable!("only tracked struct ingredients can have stale outputs")
+    }
 
     /// Returns the [`IngredientIndex`] of this ingredient.
     fn ingredient_index(&self) -> IngredientIndex;
@@ -142,6 +139,31 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
     }
 
     fn fmt_index(&self, index: crate::Id, fmt: &mut fmt::Formatter<'_>) -> fmt::Result;
+    // Function ingredient methods
+
+    /// If this ingredient is a participant in a cycle, what is its cycle recovery strategy?
+    /// (Really only relevant to [`crate::function::FunctionIngredient`],
+    /// since only function ingredients push themselves onto the active query stack.)
+    fn cycle_recovery_strategy(&self) -> CycleRecoveryStrategy {
+        unreachable!("only function ingredients can be part of a cycle")
+    }
+
+    /// What were the inputs (if any) that were used to create the value at `key_index`.
+    fn origin(&self, db: &dyn Database, key_index: Id) -> Option<QueryOrigin> {
+        let _ = (db, key_index);
+        unreachable!("only function ingredients have origins")
+    }
+
+    /// What values were accumulated during the creation of the value at `key_index`
+    /// (if any).
+    fn accumulated<'db>(
+        &'db self,
+        db: &'db dyn Database,
+        key_index: Id,
+    ) -> (Option<&'db AccumulatedMap>, InputAccumulatedValues) {
+        let _ = (db, key_index);
+        (None, InputAccumulatedValues::Empty)
+    }
 }
 
 impl dyn Ingredient {

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -1,20 +1,14 @@
-use std::{
-    any::{Any, TypeId},
-    fmt,
-};
+use std::any::{Any, TypeId};
+use std::fmt;
 
-use crate::{
-    accumulator::accumulated_map::{AccumulatedMap, InputAccumulatedValues},
-    cycle::CycleRecoveryStrategy,
-    function::VerifyResult,
-    plumbing::IngredientIndices,
-    table::Table,
-    zalsa::{transmute_data_mut_ptr, transmute_data_ptr, IngredientIndex, Zalsa},
-    zalsa_local::QueryOrigin,
-    Database, DatabaseKeyIndex, Id,
-};
-
-use super::Revision;
+use crate::accumulator::accumulated_map::{AccumulatedMap, InputAccumulatedValues};
+use crate::cycle::CycleRecoveryStrategy;
+use crate::function::VerifyResult;
+use crate::plumbing::IngredientIndices;
+use crate::table::Table;
+use crate::zalsa::{transmute_data_mut_ptr, transmute_data_ptr, IngredientIndex, Zalsa};
+use crate::zalsa_local::QueryOrigin;
+use crate::{Database, DatabaseKeyIndex, Id, Revision};
 
 /// A "jar" is a group of ingredients that are added atomically.
 /// Each type implementing jar can be added to the database at most once.

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,8 +1,6 @@
-use std::{
-    any::{Any, TypeId},
-    fmt,
-    ops::DerefMut,
-};
+use std::any::{Any, TypeId};
+use std::fmt;
+use std::ops::DerefMut;
 
 pub mod input_field;
 pub mod setter;
@@ -10,17 +8,17 @@ pub mod singleton;
 
 use input_field::FieldIngredientImpl;
 
-use crate::{
-    function::VerifyResult,
-    id::{AsId, FromIdWithDb},
-    ingredient::{fmt_index, Ingredient},
-    input::singleton::{Singleton, SingletonChoice},
-    key::DatabaseKeyIndex,
-    plumbing::{Jar, Stamp},
-    table::{memo::MemoTable, sync::SyncTable, Slot, Table},
-    zalsa::{IngredientIndex, Zalsa},
-    Database, Durability, Id, Revision, Runtime,
-};
+use crate::function::VerifyResult;
+use crate::id::{AsId, FromIdWithDb};
+use crate::ingredient::{fmt_index, Ingredient};
+use crate::input::singleton::{Singleton, SingletonChoice};
+use crate::key::DatabaseKeyIndex;
+use crate::plumbing::{Jar, Stamp};
+use crate::table::memo::MemoTable;
+use crate::table::sync::SyncTable;
+use crate::table::{Slot, Table};
+use crate::zalsa::{IngredientIndex, Zalsa};
+use crate::{Database, Durability, Id, Revision, Runtime};
 
 pub trait Configuration: Any {
     const DEBUG_NAME: &'static str;

--- a/src/input.rs
+++ b/src/input.rs
@@ -19,7 +19,6 @@ use crate::{
     plumbing::{Jar, Stamp},
     table::{memo::MemoTable, sync::SyncTable, Slot, Table},
     zalsa::{IngredientIndex, Zalsa},
-    zalsa_local::QueryOrigin,
     Database, Durability, Id, Revision, Runtime,
 };
 
@@ -215,44 +214,6 @@ impl<C: Configuration> Ingredient for IngredientImpl<C> {
         // Their *fields* are stored in function ingredients elsewhere.
         VerifyResult::unchanged()
     }
-
-    fn is_provisional_cycle_head<'db>(&'db self, _db: &'db dyn Database, _input: Id) -> bool {
-        false
-    }
-
-    fn wait_for(&self, _db: &dyn Database, _key_index: Id) -> bool {
-        true
-    }
-
-    fn origin(&self, _db: &dyn Database, _key_index: Id) -> Option<QueryOrigin> {
-        None
-    }
-
-    fn mark_validated_output(
-        &self,
-        _db: &dyn Database,
-        executor: DatabaseKeyIndex,
-        output_key: Id,
-    ) {
-        unreachable!(
-            "mark_validated_output({:?}, {:?}): input cannot be the output of a tracked function",
-            executor, output_key
-        );
-    }
-
-    fn remove_stale_output(
-        &self,
-        _db: &dyn Database,
-        executor: DatabaseKeyIndex,
-        stale_output_key: Id,
-        _provisional: bool,
-    ) {
-        unreachable!(
-            "remove_stale_output({:?}, {:?}): input cannot be the output of a tracked function",
-            executor, stale_output_key
-        );
-    }
-
     fn fmt_index(&self, index: Id, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt_index(C::DEBUG_NAME, index, fmt)
     }

--- a/src/input/input_field.rs
+++ b/src/input/input_field.rs
@@ -1,12 +1,11 @@
-use crate::function::VerifyResult;
-use crate::ingredient::{fmt_index, Ingredient};
-use crate::input::Configuration;
-use crate::zalsa::IngredientIndex;
-use crate::{Database, Id, Revision};
 use std::fmt;
 use std::marker::PhantomData;
 
-use super::{IngredientImpl, Value};
+use crate::function::VerifyResult;
+use crate::ingredient::{fmt_index, Ingredient};
+use crate::input::{Configuration, IngredientImpl, Value};
+use crate::zalsa::IngredientIndex;
+use crate::{Database, Id, Revision};
 
 /// Ingredient used to represent the fields of a `#[salsa::input]`.
 ///

--- a/src/input/input_field.rs
+++ b/src/input/input_field.rs
@@ -2,8 +2,7 @@ use crate::function::VerifyResult;
 use crate::ingredient::{fmt_index, Ingredient};
 use crate::input::Configuration;
 use crate::zalsa::IngredientIndex;
-use crate::zalsa_local::QueryOrigin;
-use crate::{Database, DatabaseKeyIndex, Id, Revision};
+use crate::{Database, Id, Revision};
 use std::fmt;
 use std::marker::PhantomData;
 
@@ -62,27 +61,6 @@ where
 
     fn wait_for(&self, _db: &dyn Database, _key_index: Id) -> bool {
         true
-    }
-
-    fn origin(&self, _db: &dyn Database, _key_index: Id) -> Option<QueryOrigin> {
-        None
-    }
-
-    fn mark_validated_output(
-        &self,
-        _db: &dyn Database,
-        _executor: DatabaseKeyIndex,
-        _output_key: Id,
-    ) {
-    }
-
-    fn remove_stale_output(
-        &self,
-        _db: &dyn Database,
-        _executor: DatabaseKeyIndex,
-        _stale_output_key: Id,
-        _provisional: bool,
-    ) {
     }
 
     fn fmt_index(&self, index: crate::Id, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -1,18 +1,5 @@
 #![allow(clippy::undocumented_unsafe_blocks)] // TODO(#697) document safety
 
-use dashmap::SharedValue;
-
-use crate::durability::Durability;
-use crate::function::VerifyResult;
-use crate::ingredient::fmt_index;
-use crate::plumbing::{IngredientIndices, Jar};
-use crate::revision::AtomicRevision;
-use crate::table::memo::MemoTable;
-use crate::table::sync::SyncTable;
-use crate::table::Slot;
-use crate::zalsa::{IngredientIndex, Zalsa};
-use crate::zalsa_local::QueryOrigin;
-use crate::{Database, DatabaseKeyIndex, Event, EventKind, Id};
 use std::any::TypeId;
 use std::fmt;
 use std::hash::{BuildHasher, Hash, Hasher};
@@ -20,9 +7,19 @@ use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU8, Ordering};
 
-use super::hash::FxDashMap;
-use super::ingredient::Ingredient;
-use super::Revision;
+use dashmap::SharedValue;
+
+use crate::durability::Durability;
+use crate::function::VerifyResult;
+use crate::hash::FxDashMap;
+use crate::ingredient::{fmt_index, Ingredient};
+use crate::plumbing::{IngredientIndices, Jar};
+use crate::revision::AtomicRevision;
+use crate::table::memo::MemoTable;
+use crate::table::sync::SyncTable;
+use crate::table::Slot;
+use crate::zalsa::{IngredientIndex, Zalsa};
+use crate::{Database, DatabaseKeyIndex, Event, EventKind, Id, Revision};
 
 pub trait Configuration: Sized + 'static {
     const DEBUG_NAME: &'static str;

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -404,50 +404,6 @@ where
         VerifyResult::unchanged()
     }
 
-    fn is_provisional_cycle_head<'db>(&'db self, _db: &'db dyn Database, _input: Id) -> bool {
-        false
-    }
-
-    fn wait_for(&self, _db: &dyn Database, _key_index: Id) -> bool {
-        true
-    }
-
-    fn origin(&self, _db: &dyn Database, _key_index: crate::Id) -> Option<QueryOrigin> {
-        None
-    }
-
-    fn mark_validated_output(
-        &self,
-        _db: &dyn Database,
-        executor: DatabaseKeyIndex,
-        output_key: crate::Id,
-    ) {
-        unreachable!(
-            "mark_validated_output({:?}, {:?}): input cannot be the output of a tracked function",
-            executor, output_key
-        );
-    }
-
-    fn remove_stale_output(
-        &self,
-        _db: &dyn Database,
-        executor: DatabaseKeyIndex,
-        stale_output_key: crate::Id,
-        _provisional: bool,
-    ) {
-        unreachable!(
-            "remove_stale_output({:?}, {:?}): interned ids are not outputs",
-            executor, stale_output_key
-        );
-    }
-
-    // Interned ingredients do not, normally, get deleted except when they are "reset" en masse.
-    // There ARE methods (e.g., `clear_deleted_entries` and `remove`) for deleting individual
-    // items, but those are only used for tracked struct ingredients.
-    fn requires_reset_for_new_revision(&self) -> bool {
-        false
-    }
-
     fn fmt_index(&self, index: crate::Id, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt_index(C::DEBUG_NAME, index, fmt)
     }

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,10 +1,8 @@
 use core::fmt;
 
-use crate::{
-    function::VerifyResult,
-    zalsa::{IngredientIndex, Zalsa},
-    Database, Id,
-};
+use crate::function::VerifyResult;
+use crate::zalsa::{IngredientIndex, Zalsa};
+use crate::{Database, Id};
 
 // ANCHOR: DatabaseKeyIndex
 /// An integer that uniquely identifies a particular query instance within the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,15 +33,18 @@ mod views;
 mod zalsa;
 mod zalsa_local;
 
+#[cfg(feature = "rayon")]
+pub use parallel::{join, par_map, scope, Scope};
+#[cfg(feature = "macros")]
+pub use salsa_macros::{accumulator, db, input, interned, tracked, Supertype, Update};
+
 pub use self::accumulator::Accumulator;
 pub use self::cancelled::Cancelled;
 pub use self::cycle::CycleRecoveryAction;
-pub use self::database::AsDynDatabase;
-pub use self::database::Database;
+pub use self::database::{AsDynDatabase, Database};
 pub use self::database_impl::DatabaseImpl;
 pub use self::durability::Durability;
-pub use self::event::Event;
-pub use self::event::EventKind;
+pub use self::event::{Event, EventKind};
 pub use self::id::Id;
 pub use self::input::setter::Setter;
 pub use self::key::DatabaseKeyIndex;
@@ -51,15 +54,9 @@ pub use self::storage::Storage;
 pub use self::update::Update;
 pub use self::zalsa::IngredientIndex;
 pub use crate::attach::with_attached_database;
-#[cfg(feature = "rayon")]
-pub use parallel::{join, par_map, scope, Scope};
-#[cfg(feature = "macros")]
-pub use salsa_macros::{accumulator, db, input, interned, tracked, Supertype, Update};
 
 pub mod prelude {
-    pub use crate::Accumulator;
-    pub use crate::Database;
-    pub use crate::Setter;
+    pub use crate::{Accumulator, Database, Setter};
 }
 
 /// Internal names used by salsa macros.
@@ -71,97 +68,60 @@ pub mod plumbing {
     pub use std::any::TypeId;
     pub use std::option::Option::{self, None, Some};
 
+    pub use salsa_macro_rules::{
+        macro_if, maybe_backdate, maybe_clone, maybe_cloned_ty, maybe_default, maybe_default_tt,
+        setup_accumulator_impl, setup_input_struct, setup_interned_struct, setup_method_body,
+        setup_tracked_fn, setup_tracked_struct, unexpected_cycle_initial,
+        unexpected_cycle_recovery,
+    };
+
     pub use crate::accumulator::Accumulator;
     pub use crate::array::Array;
-    pub use crate::attach::attach;
-    pub use crate::attach::with_attached_database;
-    pub use crate::cycle::CycleRecoveryAction;
-    pub use crate::cycle::CycleRecoveryStrategy;
-    pub use crate::database::current_revision;
-    pub use crate::database::Database;
+    pub use crate::attach::{attach, with_attached_database};
+    pub use crate::cycle::{CycleRecoveryAction, CycleRecoveryStrategy};
+    pub use crate::database::{current_revision, Database};
     pub use crate::function::values_equal;
-    pub use crate::id::AsId;
-    pub use crate::id::FromId;
-    pub use crate::id::FromIdWithDb;
-    pub use crate::id::Id;
-    pub use crate::ingredient::Ingredient;
-    pub use crate::ingredient::Jar;
+    pub use crate::id::{AsId, FromId, FromIdWithDb, Id};
+    pub use crate::ingredient::{Ingredient, Jar};
     pub use crate::key::DatabaseKeyIndex;
     pub use crate::memo_ingredient_indices::{
         IngredientIndices, MemoIngredientIndices, MemoIngredientMap, MemoIngredientSingletonIndex,
     };
     pub use crate::revision::Revision;
-    pub use crate::runtime::stamp;
-    pub use crate::runtime::Runtime;
-    pub use crate::runtime::Stamp;
-    pub use crate::runtime::StampedValue;
+    pub use crate::runtime::{stamp, Runtime, Stamp, StampedValue};
     pub use crate::salsa_struct::SalsaStructInDb;
-    pub use crate::storage::HasStorage;
-    pub use crate::storage::Storage;
+    pub use crate::storage::{HasStorage, Storage};
     pub use crate::tracked_struct::TrackedStructInDb;
-    pub use crate::update::always_update;
-    pub use crate::update::helper::Dispatch as UpdateDispatch;
-    pub use crate::update::helper::Fallback as UpdateFallback;
-    pub use crate::update::Update;
-    pub use crate::zalsa::transmute_data_ptr;
-    pub use crate::zalsa::views;
-    pub use crate::zalsa::IngredientCache;
-    pub use crate::zalsa::IngredientIndex;
-    pub use crate::zalsa::Zalsa;
-    pub use crate::zalsa::ZalsaDatabase;
+    pub use crate::update::helper::{Dispatch as UpdateDispatch, Fallback as UpdateFallback};
+    pub use crate::update::{always_update, Update};
+    pub use crate::zalsa::{
+        transmute_data_ptr, views, IngredientCache, IngredientIndex, Zalsa, ZalsaDatabase,
+    };
     pub use crate::zalsa_local::ZalsaLocal;
 
-    pub use salsa_macro_rules::macro_if;
-    pub use salsa_macro_rules::maybe_backdate;
-    pub use salsa_macro_rules::maybe_clone;
-    pub use salsa_macro_rules::maybe_cloned_ty;
-    pub use salsa_macro_rules::maybe_default;
-    pub use salsa_macro_rules::maybe_default_tt;
-    pub use salsa_macro_rules::setup_accumulator_impl;
-    pub use salsa_macro_rules::setup_input_struct;
-    pub use salsa_macro_rules::setup_interned_struct;
-    pub use salsa_macro_rules::setup_method_body;
-    pub use salsa_macro_rules::setup_tracked_fn;
-    pub use salsa_macro_rules::setup_tracked_struct;
-    pub use salsa_macro_rules::unexpected_cycle_initial;
-    pub use salsa_macro_rules::unexpected_cycle_recovery;
-
     pub mod accumulator {
-        pub use crate::accumulator::IngredientImpl;
-        pub use crate::accumulator::JarImpl;
+        pub use crate::accumulator::{IngredientImpl, JarImpl};
     }
 
     pub mod input {
         pub use crate::input::input_field::FieldIngredientImpl;
         pub use crate::input::setter::SetterImpl;
-        pub use crate::input::singleton::NotSingleton;
-        pub use crate::input::singleton::Singleton;
-        pub use crate::input::Configuration;
-        pub use crate::input::HasBuilder;
-        pub use crate::input::IngredientImpl;
-        pub use crate::input::JarImpl;
-        pub use crate::input::Value;
+        pub use crate::input::singleton::{NotSingleton, Singleton};
+        pub use crate::input::{Configuration, HasBuilder, IngredientImpl, JarImpl, Value};
     }
 
     pub mod interned {
-        pub use crate::interned::Configuration;
-        pub use crate::interned::HashEqLike;
-        pub use crate::interned::IngredientImpl;
-        pub use crate::interned::JarImpl;
-        pub use crate::interned::Lookup;
-        pub use crate::interned::Value;
+        pub use crate::interned::{
+            Configuration, HashEqLike, IngredientImpl, JarImpl, Lookup, Value,
+        };
     }
 
     pub mod function {
-        pub use crate::function::Configuration;
-        pub use crate::function::IngredientImpl;
+        pub use crate::function::{Configuration, IngredientImpl};
     }
 
     pub mod tracked_struct {
         pub use crate::tracked_struct::tracked_field::FieldIngredientImpl;
-        pub use crate::tracked_struct::Configuration;
-        pub use crate::tracked_struct::IngredientImpl;
-        pub use crate::tracked_struct::JarImpl;
-        pub use crate::tracked_struct::Value;
+        pub use crate::tracked_struct::{Configuration, IngredientImpl, JarImpl, Value};
     }
 }

--- a/src/nonce.rs
+++ b/src/nonce.rs
@@ -1,4 +1,6 @@
-use std::{marker::PhantomData, num::NonZeroU32, sync::atomic::AtomicU32};
+use std::marker::PhantomData;
+use std::num::NonZeroU32;
+use std::sync::atomic::AtomicU32;
 
 /// A type to generate nonces. Store it in a static and each nonce it produces will be unique from other nonces.
 /// The type parameter `T` just serves to distinguish different kinds of nonces.

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,16 +1,13 @@
-use std::{
-    sync::atomic::{AtomicBool, Ordering},
-    thread::ThreadId,
-};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::ThreadId;
 
 use parking_lot::Mutex;
 
-use crate::{
-    durability::Durability, key::DatabaseKeyIndex, table::Table, Cancelled, Database, Event,
-    EventKind, Revision,
-};
-
 use self::dependency_graph::DependencyGraph;
+use crate::durability::Durability;
+use crate::key::DatabaseKeyIndex;
+use crate::table::Table;
+use crate::{Cancelled, Database, Event, EventKind, Revision};
 
 mod dependency_graph;
 

--- a/src/runtime/dependency_graph.rs
+++ b/src/runtime/dependency_graph.rs
@@ -1,10 +1,11 @@
 use std::thread::ThreadId;
 
-use crate::key::DatabaseKeyIndex;
-use crate::runtime::WaitResult;
 use parking_lot::MutexGuard;
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
+
+use crate::key::DatabaseKeyIndex;
+use crate::runtime::WaitResult;
 
 #[derive(Debug, Default)]
 pub(super) struct DependencyGraph {
@@ -127,7 +128,8 @@ impl DependencyGraph {
 }
 
 mod edge {
-    use std::{sync::Arc, thread::ThreadId};
+    use std::sync::Arc;
+    use std::thread::ThreadId;
 
     use parking_lot::MutexGuard;
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,13 +1,13 @@
 //! Public API facades for the implementation details of [`Zalsa`] and [`ZalsaLocal`].
-use std::{marker::PhantomData, panic::RefUnwindSafe, sync::Arc};
+use std::marker::PhantomData;
+use std::panic::RefUnwindSafe;
+use std::sync::Arc;
 
 use parking_lot::{Condvar, Mutex};
 
-use crate::{
-    zalsa::{Zalsa, ZalsaDatabase},
-    zalsa_local::{self, ZalsaLocal},
-    Database, Event, EventKind,
-};
+use crate::zalsa::{Zalsa, ZalsaDatabase};
+use crate::zalsa_local::{self, ZalsaLocal};
+use crate::{Database, Event, EventKind};
 
 /// A handle to non-local database state.
 pub struct StorageHandle<Db> {

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,13 +1,11 @@
-use std::{
-    alloc::Layout,
-    any::{Any, TypeId},
-    cell::UnsafeCell,
-    marker::PhantomData,
-    mem::{self, MaybeUninit},
-    ptr::{self, NonNull},
-    slice,
-    sync::atomic::{AtomicUsize, Ordering},
-};
+use std::alloc::Layout;
+use std::any::{Any, TypeId};
+use std::cell::UnsafeCell;
+use std::marker::PhantomData;
+use std::mem::{self, MaybeUninit};
+use std::ptr::{self, NonNull};
+use std::slice;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use memo::MemoTable;
 use parking_lot::Mutex;

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -1,13 +1,12 @@
-use std::{
-    any::{Any, TypeId},
-    ptr::NonNull,
-    sync::atomic::{AtomicPtr, Ordering},
-};
+use std::any::{Any, TypeId};
+use std::ptr::NonNull;
+use std::sync::atomic::{AtomicPtr, Ordering};
 
 use parking_lot::RwLock;
 use thin_vec::ThinVec;
 
-use crate::{zalsa::MemoIngredientIndex, zalsa_local::QueryOrigin};
+use crate::zalsa::MemoIngredientIndex;
+use crate::zalsa_local::QueryOrigin;
 
 /// The "memo table" stores the memoized results of tracked function calls.
 /// Every tracked function must take a salsa struct as its first argument

--- a/src/table/sync.rs
+++ b/src/table/sync.rs
@@ -2,14 +2,11 @@ use std::thread::ThreadId;
 
 use parking_lot::Mutex;
 
-use crate::{
-    key::DatabaseKeyIndex,
-    runtime::{BlockResult, WaitResult},
-    zalsa::{MemoIngredientIndex, Zalsa},
-    Database,
-};
-
-use super::util;
+use crate::key::DatabaseKeyIndex;
+use crate::runtime::{BlockResult, WaitResult};
+use crate::table::util;
+use crate::zalsa::{MemoIngredientIndex, Zalsa};
+use crate::Database;
 
 /// Tracks the keys that are currently being processed; used to coordinate between
 /// worker threads.

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -1,22 +1,26 @@
 #![allow(clippy::undocumented_unsafe_blocks)] // TODO(#697) document safety
 
-use std::{any::TypeId, fmt, hash::Hash, marker::PhantomData, ops::DerefMut};
+use std::any::TypeId;
+use std::fmt;
+use std::hash::Hash;
+use std::marker::PhantomData;
+use std::ops::DerefMut;
 
 use crossbeam_queue::SegQueue;
 use tracked_field::FieldIngredientImpl;
 
-use crate::{
-    function::VerifyResult,
-    ingredient::{fmt_index, Ingredient, Jar},
-    key::DatabaseKeyIndex,
-    plumbing::ZalsaLocal,
-    revision::OptionalAtomicRevision,
-    runtime::StampedValue,
-    salsa_struct::SalsaStructInDb,
-    table::{memo::MemoTable, sync::SyncTable, Slot, Table},
-    zalsa::{IngredientIndex, Zalsa},
-    Database, Durability, Event, EventKind, Id, Revision,
-};
+use crate::function::VerifyResult;
+use crate::ingredient::{fmt_index, Ingredient, Jar};
+use crate::key::DatabaseKeyIndex;
+use crate::plumbing::ZalsaLocal;
+use crate::revision::OptionalAtomicRevision;
+use crate::runtime::StampedValue;
+use crate::salsa_struct::SalsaStructInDb;
+use crate::table::memo::MemoTable;
+use crate::table::sync::SyncTable;
+use crate::table::{Slot, Table};
+use crate::zalsa::{IngredientIndex, Zalsa};
+use crate::{Database, Durability, Event, EventKind, Id, Revision};
 
 pub mod tracked_field;
 

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -15,7 +15,6 @@ use crate::{
     salsa_struct::SalsaStructInDb,
     table::{memo::MemoTable, sync::SyncTable, Slot, Table},
     zalsa::{IngredientIndex, Zalsa},
-    zalsa_local::QueryOrigin,
     Database, Durability, Event, EventKind, Id, Revision,
 };
 
@@ -755,10 +754,6 @@ where
         true
     }
 
-    fn origin(&self, _db: &dyn Database, _key_index: crate::Id) -> Option<QueryOrigin> {
-        None
-    }
-
     fn mark_validated_output<'db>(
         &'db self,
         _db: &'db dyn Database,
@@ -781,7 +776,7 @@ where
         // `executor` creates a tracked struct `salsa_output_key`,
         // but it did not in the current revision.
         // In that case, we can delete `stale_output_key` and any data associated with it.
-        self.delete_entity(db.as_dyn_database(), stale_output_key, provisional);
+        self.delete_entity(db, stale_output_key, provisional);
     }
 
     fn fmt_index(&self, index: crate::Id, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/tracked_struct/tracked_field.rs
+++ b/src/tracked_struct/tracked_field.rs
@@ -59,41 +59,6 @@ where
         VerifyResult::changed_if(field_changed_at > revision)
     }
 
-    fn is_provisional_cycle_head<'db>(&'db self, _db: &'db dyn Database, _input: Id) -> bool {
-        false
-    }
-
-    fn wait_for(&self, _db: &dyn Database, _key_index: Id) -> bool {
-        true
-    }
-
-    fn origin(
-        &self,
-        _db: &dyn Database,
-        _key_index: crate::Id,
-    ) -> Option<crate::zalsa_local::QueryOrigin> {
-        None
-    }
-
-    fn mark_validated_output(
-        &self,
-        _db: &dyn Database,
-        _executor: crate::DatabaseKeyIndex,
-        _output_key: crate::Id,
-    ) {
-        panic!("tracked field ingredients have no outputs")
-    }
-
-    fn remove_stale_output(
-        &self,
-        _db: &dyn Database,
-        _executor: crate::DatabaseKeyIndex,
-        _stale_output_key: crate::Id,
-        _provisional: bool,
-    ) {
-        panic!("tracked field ingredients have no outputs")
-    }
-
     fn fmt_index(&self, index: crate::Id, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             fmt,

--- a/src/tracked_struct/tracked_field.rs
+++ b/src/tracked_struct/tracked_field.rs
@@ -1,8 +1,10 @@
 use std::marker::PhantomData;
 
-use crate::{function::VerifyResult, ingredient::Ingredient, zalsa::IngredientIndex, Database, Id};
-
-use super::{Configuration, Value};
+use crate::function::VerifyResult;
+use crate::ingredient::Ingredient;
+use crate::tracked_struct::{Configuration, Value};
+use crate::zalsa::IngredientIndex;
+use crate::{Database, Id};
 
 /// Created for each tracked struct.
 ///

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,12 +1,10 @@
 #![allow(clippy::undocumented_unsafe_blocks)] // TODO(#697) document safety
 
-use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
-    hash::{BuildHasher, Hash},
-    marker::PhantomData,
-    path::PathBuf,
-    sync::Arc,
-};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::hash::{BuildHasher, Hash};
+use std::marker::PhantomData;
+use std::path::PathBuf;
+use std::sync::Arc;
 
 #[cfg(feature = "rayon")]
 use rayon::iter::Either;

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -1,6 +1,3 @@
-use parking_lot::{Mutex, RwLock};
-use portable_atomic::AtomicU64;
-use rustc_hash::FxHashMap;
 use std::any::{Any, TypeId};
 use std::collections::hash_map;
 use std::marker::PhantomData;
@@ -8,6 +5,10 @@ use std::mem;
 use std::num::NonZeroU32;
 use std::panic::RefUnwindSafe;
 use std::sync::atomic::Ordering;
+
+use parking_lot::{Mutex, RwLock};
+use portable_atomic::AtomicU64;
+use rustc_hash::FxHashMap;
 
 use crate::ingredient::{Ingredient, Jar};
 use crate::nonce::{Nonce, NonceGenerator};

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -1,3 +1,7 @@
+use std::cell::RefCell;
+use std::panic::UnwindSafe;
+use std::sync::atomic::AtomicBool;
+
 use rustc_hash::FxHashMap;
 use tracing::debug;
 
@@ -9,18 +13,10 @@ use crate::cycle::CycleHeads;
 use crate::durability::Durability;
 use crate::key::DatabaseKeyIndex;
 use crate::runtime::{Stamp, StampedValue};
-use crate::table::PageIndex;
-use crate::table::Slot;
-use crate::table::Table;
+use crate::table::{PageIndex, Slot, Table};
 use crate::tracked_struct::{Disambiguator, Identity, IdentityHash, IdentityMap};
 use crate::zalsa::IngredientIndex;
-use crate::Accumulator;
-use crate::Cancelled;
-use crate::Id;
-use crate::Revision;
-use std::cell::RefCell;
-use std::panic::UnwindSafe;
-use std::sync::atomic::AtomicBool;
+use crate::{Accumulator, Cancelled, Id, Revision};
 
 /// State that is specific to a single execution thread.
 ///

--- a/tests/accumulate-reuse-workaround.rs
+++ b/tests/accumulate-reuse-workaround.rs
@@ -4,7 +4,6 @@
 
 mod common;
 use common::{LogDatabase, LoggerDatabase};
-
 use expect_test::expect;
 use salsa::{Accumulator, Setter};
 use test_log::test;

--- a/tests/accumulate-reuse.rs
+++ b/tests/accumulate-reuse.rs
@@ -5,7 +5,6 @@
 
 mod common;
 use common::{LogDatabase, LoggerDatabase};
-
 use expect_test::expect;
 use salsa::{Accumulator, Setter};
 use test_log::test;

--- a/tests/accumulate.rs
+++ b/tests/accumulate.rs
@@ -1,6 +1,5 @@
 mod common;
 use common::{LogDatabase, LoggerDatabase};
-
 use expect_test::expect;
 use salsa::{Accumulator, Setter};
 use test_log::test;

--- a/tests/accumulated_backdate.rs
+++ b/tests/accumulated_backdate.rs
@@ -3,7 +3,6 @@
 
 mod common;
 use common::LogDatabase;
-
 use expect_test::expect;
 use salsa::{Accumulator, Setter};
 use test_log::test;

--- a/tests/cycle_accumulate.rs
+++ b/tests/cycle_accumulate.rs
@@ -2,7 +2,6 @@ use std::collections::HashSet;
 
 mod common;
 use common::{LogDatabase, LoggerDatabase};
-
 use expect_test::expect;
 use salsa::{Accumulator, Setter};
 use test_log::test;

--- a/tests/dataflow.rs
+++ b/tests/dataflow.rs
@@ -2,9 +2,10 @@
 //!
 //! This test case is intended to simulate a (very simplified) version of a real dataflow analysis
 //! using fixpoint iteration.
-use salsa::{CycleRecoveryAction, Database as Db, Setter};
 use std::collections::BTreeSet;
 use std::iter::IntoIterator;
+
+use salsa::{CycleRecoveryAction, Database as Db, Setter};
 
 /// A Use of a symbol.
 #[salsa::input]

--- a/tests/deletion-cascade.rs
+++ b/tests/deletion-cascade.rs
@@ -4,7 +4,6 @@
 
 mod common;
 use common::LogDatabase;
-
 use expect_test::expect;
 use salsa::Setter;
 use test_log::test;

--- a/tests/deletion.rs
+++ b/tests/deletion.rs
@@ -4,7 +4,6 @@
 
 mod common;
 use common::LogDatabase;
-
 use expect_test::expect;
 use salsa::Setter;
 use test_log::test;

--- a/tests/elided-lifetime-in-tracked-fn.rs
+++ b/tests/elided-lifetime-in-tracked-fn.rs
@@ -3,7 +3,6 @@
 
 mod common;
 use common::LogDatabase;
-
 use expect_test::expect;
 use salsa::Setter;
 use test_log::test;

--- a/tests/expect_reuse_field_x_of_a_tracked_struct_changes_but_fn_depends_on_field_y.rs
+++ b/tests/expect_reuse_field_x_of_a_tracked_struct_changes_but_fn_depends_on_field_y.rs
@@ -5,7 +5,6 @@
 
 mod common;
 use common::LogDatabase;
-
 use expect_test::expect;
 use salsa::Setter;
 

--- a/tests/expect_reuse_field_x_of_an_input_changes_but_fn_depends_on_field_y.rs
+++ b/tests/expect_reuse_field_x_of_an_input_changes_but_fn_depends_on_field_y.rs
@@ -5,7 +5,6 @@
 
 mod common;
 use common::LogDatabase;
-
 use expect_test::expect;
 use salsa::Setter;
 

--- a/tests/hello_world.rs
+++ b/tests/hello_world.rs
@@ -3,7 +3,6 @@
 
 mod common;
 use common::LogDatabase;
-
 use expect_test::expect;
 use salsa::Setter;
 use test_log::test;

--- a/tests/input_setter_preserves_durability.rs
+++ b/tests/input_setter_preserves_durability.rs
@@ -1,7 +1,6 @@
-use test_log::test;
-
 use salsa::plumbing::ZalsaDatabase;
 use salsa::{Durability, Setter};
+use test_log::test;
 
 #[salsa::input]
 struct MyInput {

--- a/tests/interned-structs.rs
+++ b/tests/interned-structs.rs
@@ -1,9 +1,10 @@
 //! Test that a `tracked` fn on a `salsa::input`
 //! compiles and executes successfully.
 
+use std::path::{Path, PathBuf};
+
 use expect_test::expect;
 use salsa::plumbing::{AsId, FromId};
-use std::path::{Path, PathBuf};
 use test_log::test;
 
 #[salsa::interned(debug)]

--- a/tests/lru.rs
+++ b/tests/lru.rs
@@ -1,10 +1,8 @@
 //! Test that a `tracked` fn with lru options
 //! compiles and executes successfully.
 
-use std::sync::{
-    atomic::{AtomicUsize, Ordering},
-    Arc,
-};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 mod common;
 use common::LogDatabase;

--- a/tests/parallel/parallel_cancellation.rs
+++ b/tests/parallel/parallel_cancellation.rs
@@ -1,10 +1,8 @@
 //! Test for thread cancellation.
 
-use salsa::Cancelled;
-use salsa::Setter;
+use salsa::{Cancelled, Setter};
 
-use crate::setup::Knobs;
-use crate::setup::KnobsDatabase;
+use crate::setup::{Knobs, KnobsDatabase};
 
 #[salsa::input(debug)]
 struct MyInput {

--- a/tests/parallel/parallel_join.rs
+++ b/tests/parallel/parallel_join.rs
@@ -1,11 +1,9 @@
 #![cfg(feature = "rayon")]
 // test for rayon-like join interactions.
 
-use salsa::Cancelled;
-use salsa::Setter;
+use salsa::{Cancelled, Setter};
 
-use crate::setup::Knobs;
-use crate::setup::KnobsDatabase;
+use crate::setup::{Knobs, KnobsDatabase};
 
 #[salsa::input]
 struct ParallelInput {

--- a/tests/parallel/parallel_map.rs
+++ b/tests/parallel/parallel_map.rs
@@ -1,11 +1,9 @@
 #![cfg(feature = "rayon")]
 // test for rayon-like parallel map interactions.
 
-use salsa::Cancelled;
-use salsa::Setter;
+use salsa::{Cancelled, Setter};
 
-use crate::setup::Knobs;
-use crate::setup::KnobsDatabase;
+use crate::setup::{Knobs, KnobsDatabase};
 
 #[salsa::input]
 struct ParallelInput {

--- a/tests/parallel/parallel_scope.rs
+++ b/tests/parallel/parallel_scope.rs
@@ -1,11 +1,9 @@
 #![cfg(feature = "rayon")]
 // test for rayon-like scope interactions.
 
-use salsa::Cancelled;
-use salsa::Setter;
+use salsa::{Cancelled, Setter};
 
-use crate::setup::Knobs;
-use crate::setup::KnobsDatabase;
+use crate::setup::{Knobs, KnobsDatabase};
 
 #[salsa::input]
 struct ParallelInput {

--- a/tests/parallel/setup.rs
+++ b/tests/parallel/setup.rs
@@ -1,7 +1,5 @@
-use std::sync::{
-    atomic::{AtomicUsize, Ordering},
-    Arc,
-};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 use salsa::Database;
 

--- a/tests/singleton.rs
+++ b/tests/singleton.rs
@@ -3,7 +3,6 @@
 //! Singleton structs are created only once. Subsequent `get`s and `new`s after creation return the same `Id`.
 
 use expect_test::expect;
-
 use salsa::Database as _;
 use test_log::test;
 

--- a/tests/tracked_fn_on_input_with_high_durability.rs
+++ b/tests/tracked_fn_on_input_with_high_durability.rs
@@ -1,8 +1,7 @@
 #![allow(warnings)]
 
-use expect_test::expect;
-
 use common::{EventLoggerDatabase, HasLogger, LogDatabase, Logger};
+use expect_test::expect;
 use salsa::plumbing::HasStorage;
 use salsa::{Database, Durability, Event, EventKind, Setter};
 


### PR DESCRIPTION
Effectively reformatted everything with
```toml
imports_granularity = "Module"
group_imports = "StdExternalCrate"
reorder_imports = true
```