### PR TITLE
fix: Dereferencing freed memos when verifying provisional memos

### DIFF
--- a/src/cycle.rs
+++ b/src/cycle.rs
@@ -132,10 +132,6 @@ impl CycleHeads {
         true
     }
 
-    pub(crate) fn clear(&mut self) {
-        self.0.clear();
-    }
-
     pub(crate) fn update_iteration_count(
         &mut self,
         cycle_head_index: DatabaseKeyIndex,

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -79,19 +79,24 @@ where
         id: Id,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> Option<&'db Memo<C::Output<'db>>> {
-        let memo_guard = self.get_memo_from_table_for(zalsa, id, memo_ingredient_index);
-        if let Some(memo) = memo_guard {
-            let database_key_index = self.database_key_index(id);
-            if memo.value.is_some()
-                && (self.validate_may_be_provisional(db, zalsa, database_key_index, memo)
-                    || self.validate_same_iteration(db, database_key_index, memo))
-                && self.shallow_verify_memo(db, zalsa, database_key_index, memo)
-            {
-                // SAFETY: memo is present in memo_map and we have verified that it is
-                // still valid for the current revision.
-                return unsafe { Some(self.extend_memo_lifetime(memo)) };
-            }
+        let memo = self.get_memo_from_table_for(zalsa, id, memo_ingredient_index)?;
+
+        memo.value.as_ref()?;
+
+        let database_key_index = self.database_key_index(id);
+
+        let shallow_update = self.shallow_verify_memo(zalsa, database_key_index, memo)?;
+
+        if self.validate_may_be_provisional(db, zalsa, database_key_index, memo)
+            || self.validate_same_iteration(db, database_key_index, memo)
+        {
+            self.update_shallow(db, zalsa, database_key_index, memo, shallow_update);
+
+            // SAFETY: memo is present in memo_map and we have verified that it is
+            // still valid for the current revision.
+            return unsafe { Some(self.extend_memo_lifetime(memo)) };
         }
+
         None
     }
 
@@ -120,10 +125,20 @@ where
                 if let Some(memo) = memo_guard {
                     if memo.value.is_some()
                         && memo.revisions.cycle_heads.contains(&database_key_index)
-                        && self.shallow_verify_memo(db, zalsa, database_key_index, memo)
                     {
-                        // SAFETY: memo is present in memo_map.
-                        return unsafe { Some(self.extend_memo_lifetime(memo)) };
+                        if let Some(shallow_update) =
+                            self.shallow_verify_memo(zalsa, database_key_index, memo)
+                        {
+                            self.update_shallow(
+                                db,
+                                zalsa,
+                                database_key_index,
+                                memo,
+                                shallow_update,
+                            );
+                            // SAFETY: memo is present in memo_map.
+                            return unsafe { Some(self.extend_memo_lifetime(memo)) };
+                        }
                     }
                 }
                 // no provisional value; create/insert/return initial provisional value

--- a/tests/cycle_tracked.rs
+++ b/tests/cycle_tracked.rs
@@ -1,0 +1,155 @@
+//! Tests for cycles where the cycle head is stored on a tracked struct.
+
+mod common;
+
+use crate::common::{EventLoggerDatabase, LogDatabase};
+use expect_test::expect;
+use salsa::{CycleRecoveryAction, Database, Setter};
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, salsa::Update)]
+struct Graph<'db> {
+    nodes: Vec<Node<'db>>,
+}
+
+impl<'db> Graph<'db> {
+    fn find_node(&self, db: &dyn salsa::Database, name: &str) -> Option<Node<'db>> {
+        self.nodes
+            .iter()
+            .find(|node| node.name(db) == name)
+            .copied()
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+struct Edge {
+    // Index into `graph.nodes`
+    to: usize,
+    cost: usize,
+}
+
+#[salsa::tracked(debug)]
+struct Node<'db> {
+    #[return_ref]
+    name: String,
+
+    #[return_ref]
+    #[tracked]
+    edges: Vec<Edge>,
+
+    graph: GraphInput,
+}
+
+#[salsa::input(debug)]
+struct GraphInput {
+    simple: bool,
+}
+
+#[salsa::tracked(return_ref)]
+fn create_graph(db: &dyn salsa::Database, input: GraphInput) -> Graph<'_> {
+    if input.simple(db) {
+        let a = Node::new(db, "a".to_string(), vec![], input);
+        let b = Node::new(db, "b".to_string(), vec![Edge { to: 0, cost: 20 }], input);
+        let c = Node::new(db, "c".to_string(), vec![Edge { to: 1, cost: 2 }], input);
+
+        Graph {
+            nodes: vec![a, b, c],
+        }
+    } else {
+        // ```
+        // flowchart TD
+        //
+        // A("a")
+        // B("b")
+        // C("c")
+        // D{"d"}
+        //
+        // B -- 20 --> D
+        // C -- 4 --> D
+        // D -- 4 --> A
+        // D -- 4 --> B
+        // ```
+        let a = Node::new(db, "a".to_string(), vec![], input);
+        let b = Node::new(db, "b".to_string(), vec![Edge { to: 3, cost: 20 }], input);
+        let c = Node::new(db, "c".to_string(), vec![Edge { to: 3, cost: 4 }], input);
+        let d = Node::new(
+            db,
+            "d".to_string(),
+            vec![Edge { to: 0, cost: 4 }, Edge { to: 1, cost: 4 }],
+            input,
+        );
+
+        Graph {
+            nodes: vec![a, b, c, d],
+        }
+    }
+}
+
+/// Computes the minimum cost from the node with offset `0` to the given node.
+#[salsa::tracked(cycle_fn=cycle_recover, cycle_initial=max_initial)]
+fn cost_to_start<'db>(db: &'db dyn Database, node: Node<'db>) -> usize {
+    let mut min_cost = None;
+    let graph = create_graph(db, node.graph(db));
+
+    for edge in node.edges(db) {
+        if edge.to == 0 {
+            if min_cost.is_none_or(|min| min > edge.cost) {
+                min_cost = Some(edge.cost);
+            }
+        }
+
+        let edge_cost_to_start = cost_to_start(db, graph.nodes[edge.to]);
+
+        // We hit a cycle, never take this edge because it will always be more expensive than
+        // any other edge
+        if edge_cost_to_start == usize::MAX {
+            continue;
+        }
+
+        let total_cost = edge.cost + edge_cost_to_start;
+        if min_cost.is_none_or(|min| min > total_cost) {
+            min_cost = Some(total_cost);
+        }
+    }
+
+    // If `None`, it means that there's no path from `node` to the start.
+    min_cost.unwrap_or(usize::MAX)
+}
+
+fn max_initial(_db: &dyn Database, _node: Node) -> usize {
+    usize::MAX
+}
+
+fn cycle_recover(
+    _db: &dyn Database,
+    _value: &usize,
+    _count: u32,
+    _inputs: Node,
+) -> CycleRecoveryAction<usize> {
+    CycleRecoveryAction::Iterate
+}
+
+#[test]
+fn main() {
+    let mut db = EventLoggerDatabase::default();
+
+    let input = GraphInput::new(&mut db, false);
+    let graph = create_graph(&db, input);
+    let c = graph.find_node(&db, "c").unwrap();
+
+    // Query the cost from `c` to `a`.
+    // There's a cycle between `b` and `d`, where `d` becomes the cycle head and `b` is a provisional, non finalized result.
+    assert_eq!(cost_to_start(&db, c), 8);
+
+    // Change the graph, this will remove `d`, leaving `b` pointing to a cycle head that's now collected.
+    // Querying the cost from `c` to `a` should try to verify the result of `b` and it is important
+    // that `b` doesn't try to dereference the cycle head (because its memo is now stored on a tracked
+    // struct that has been freed).
+    input.set_simple(&mut db).to(true);
+
+    let graph = create_graph(&db, input);
+    let c = graph.find_node(&db, "c").unwrap();
+
+    assert_eq!(cost_to_start(&db, c), 22);
+
+    db.assert_logs(expect![[r#""#]]);
+}


### PR DESCRIPTION
Fixes https://github.com/salsa-rs/salsa/issues/785

The root cause of #785 is that Salsa tries to load the memo of a cycle head that is stored on a tracked struct that has been freed. 

The main problem is that we tried to verify `validate_provisional` even in cases where the query is from a past revision, in which case we can't trust any inputs to still exist (and be valid). 

The fix in this PR is to change the order in which `shallow_verify` and `validate_provisional` are called. This requires extracting the *mutating* bits out of `shallow_verify` because we only want to call those if the struct isn't provisional (at least, that's what we did before and I tried to preserve this behavior). 


