### PR TITLE
[refactor] Simplify `fetch_hot`

### DIFF
--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -4,8 +4,8 @@ use crate::function::{Configuration, IngredientImpl, VerifyResult};
 use crate::runtime::StampedValue;
 use crate::table::sync::ClaimResult;
 use crate::zalsa::{MemoIngredientIndex, Zalsa, ZalsaDatabase};
-use crate::zalsa_local::QueryRevisions;
-use crate::{AsDynDatabase as _, Id};
+use crate::zalsa_local::{ActiveQueryGuard, QueryRevisions, ZalsaLocal};
+use crate::{AsDynDatabase as _, DatabaseKeyIndex, Id};
 
 impl<C> IngredientImpl<C>
 where
@@ -87,17 +87,15 @@ where
 
         let shallow_update = self.shallow_verify_memo(zalsa, database_key_index, memo)?;
 
-        if self.validate_may_be_provisional(db, zalsa, database_key_index, memo)
-            || self.validate_same_iteration(db, database_key_index, memo)
-        {
+        if self.validate_may_be_provisional(db, zalsa, database_key_index, memo) {
             self.update_shallow(db, zalsa, database_key_index, memo, shallow_update);
 
             // SAFETY: memo is present in memo_map and we have verified that it is
             // still valid for the current revision.
-            return unsafe { Some(self.extend_memo_lifetime(memo)) };
+            unsafe { Some(self.extend_memo_lifetime(memo)) }
+        } else {
+            None
         }
-
-        None
     }
 
     fn fetch_cold<'db>(
@@ -173,15 +171,14 @@ where
             ClaimResult::Claimed(guard) => guard,
         };
 
-        // Push the query on the stack.
-        let active_query = db.zalsa_local().push_query(database_key_index, 0);
+        let mut active_query = LazyActiveQuery::new(database_key_index, db.zalsa_local());
 
         // Now that we've claimed the item, check again to see if there's a "hot" value.
         let opt_old_memo = self.get_memo_from_table_for(zalsa, id, memo_ingredient_index);
         if let Some(old_memo) = opt_old_memo {
             if old_memo.value.is_some() {
                 if let VerifyResult::Unchanged(_, cycle_heads) =
-                    self.deep_verify_memo(db, zalsa, old_memo, &active_query)
+                    self.deep_verify_memo(db, zalsa, old_memo, &mut active_query)
                 {
                     if cycle_heads.is_empty() {
                         // SAFETY: memo is present in memo_map and we have verified that it is
@@ -192,8 +189,38 @@ where
             }
         }
 
-        let memo = self.execute(db, active_query, opt_old_memo);
+        let memo = self.execute(db, active_query.into_inner(), opt_old_memo);
 
         Some(memo)
+    }
+}
+
+pub(super) struct LazyActiveQuery<'me> {
+    guard: Option<ActiveQueryGuard<'me>>,
+    zalsa_local: &'me ZalsaLocal,
+    database_key_index: DatabaseKeyIndex,
+}
+
+impl<'me> LazyActiveQuery<'me> {
+    pub(super) fn new(database_key_index: DatabaseKeyIndex, zalsa_local: &'me ZalsaLocal) -> Self {
+        Self {
+            guard: None,
+            zalsa_local,
+            database_key_index,
+        }
+    }
+
+    pub(super) const fn database_key_index(&self) -> DatabaseKeyIndex {
+        self.database_key_index
+    }
+
+    pub(super) fn get(&mut self) -> &ActiveQueryGuard<'me> {
+        self.guard
+            .get_or_insert_with(|| self.zalsa_local.push_query(self.database_key_index, 0))
+    }
+
+    pub(super) fn into_inner(self) -> ActiveQueryGuard<'me> {
+        self.guard
+            .unwrap_or_else(|| self.zalsa_local.push_query(self.database_key_index, 0))
     }
 }

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -333,11 +333,9 @@ where
             old_memo = old_memo.tracing_debug()
         );
 
-        let mut is_shallow_update_possible = false;
-        if let Some(shallow_update) = self.shallow_verify_memo(zalsa, database_key_index, old_memo)
-        {
-            is_shallow_update_possible = true;
-
+        let shallow_update = self.shallow_verify_memo(zalsa, database_key_index, old_memo);
+        let shallow_update_possible = shallow_update.is_some();
+        if let Some(shallow_update) = shallow_update {
             if self.validate_may_be_provisional(db, zalsa, database_key_index, old_memo)
                 || self.validate_same_iteration(db, database_key_index, old_memo)
             {
@@ -372,7 +370,7 @@ where
                 let is_provisional = old_memo.may_be_provisional();
 
                 // If the value is from the same revision but is still provisional, consider it changed
-                if is_shallow_update_possible && old_memo.may_be_provisional() {
+                if shallow_update_possible && is_provisional {
                     return VerifyResult::Changed;
                 }
 


### PR DESCRIPTION
The basic promise of `fetch_hot` is to do the minimal amount of work for the common case and fall back to `fetch_cold` 
which repeats some of the checks for the rare cases where `fetch_hot` wasn't successful (because we failed to claim a guard, or a deep update is required).

This PR simplifies `fetch_hot` by moving the `same_iteration` check for cycle handling into `fetch_cold` (which has the advantage that `maybe_changed_after` also uses it). 
Moving the check wasn't as trivial as I hoped because it's important that we don't push the new query until after verifying if the memo is a provisional value from the same iteration. 

## Performance 
Codspeed reports a 2-3% perf improvement for most benchmarks.

There's a 1% perf improvement on Red Knot's incremental benchmarks https://codspeed.io/astral-sh/ruff/branches/micha%2Ftest-salsa-perf
