### PR TITLE
[refactor] More `fetch_hot` simplification

### DIFF
--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -77,7 +77,7 @@ where
 
         let shallow_update = self.shallow_verify_memo(zalsa, database_key_index, memo)?;
 
-        if self.validate_may_be_provisional(db, zalsa, database_key_index, memo) {
+        if !memo.may_be_provisional() {
             self.update_shallow(db, zalsa, database_key_index, memo, shallow_update);
 
             // SAFETY: memo is present in memo_map and we have verified that it is

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -67,7 +67,7 @@ where
 
             if let Some(shallow_update) = self.shallow_verify_memo(zalsa, database_key_index, memo)
             {
-                if self.validate_may_be_provisional(db, zalsa, database_key_index, memo) {
+                if !memo.may_be_provisional() {
                     self.update_shallow(db, zalsa, database_key_index, memo, shallow_update);
 
                     return if memo.revisions.changed_at > revision {
@@ -249,7 +249,9 @@ where
     ) -> bool {
         // Wouldn't it be nice if rust had an implication operator ...
         // may_be_provisional -> validate_provisional
-        !memo.may_be_provisional() || self.validate_provisional(db, zalsa, database_key_index, memo)
+        !memo.may_be_provisional()
+            || self.validate_provisional(db, zalsa, database_key_index, memo)
+            || self.validate_same_iteration(db, database_key_index, memo)
     }
 
     /// Check if this memo's cycle heads have all been finalized. If so, mark it verified final and
@@ -353,9 +355,7 @@ where
         let shallow_update = self.shallow_verify_memo(zalsa, database_key_index, old_memo);
         let shallow_update_possible = shallow_update.is_some();
         if let Some(shallow_update) = shallow_update {
-            if self.validate_may_be_provisional(db, zalsa, database_key_index, old_memo)
-                || self.validate_same_iteration(db, database_key_index, old_memo)
-            {
+            if self.validate_may_be_provisional(db, zalsa, database_key_index, old_memo) {
                 self.update_shallow(db, zalsa, database_key_index, old_memo, shallow_update);
 
                 return VerifyResult::unchanged();

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -236,9 +236,11 @@ where
         }
     }
 
-    /// Validates this memo if it is a provisional memo. Returns true for non provisional memos or
-    /// if the provisional memo has been successfully marked as verified final, that is, its
-    /// cycle heads have all been finalized.
+    /// Validates this memo if it is a provisional memo. Returns true for:
+    /// * non provisional memos
+    /// * provisional memos that have been successfully marked as verified final, that is, its
+    ///   cycle heads have all been finalized.
+    /// * provisional memos that have been created in the same revision and iteration and are part of the same cycle.
     #[inline]
     pub(super) fn validate_may_be_provisional(
         &self,
@@ -247,8 +249,6 @@ where
         database_key_index: DatabaseKeyIndex,
         memo: &Memo<C::Output<'_>>,
     ) -> bool {
-        // Wouldn't it be nice if rust had an implication operator ...
-        // may_be_provisional -> validate_provisional
         !memo.may_be_provisional()
             || self.validate_provisional(db, zalsa, database_key_index, memo)
             || self.validate_same_iteration(db, database_key_index, memo)


### PR DESCRIPTION
Move the `validate_maybe_provisional` out of `fetch_hot` and only test if the memo is provisional (in which case we shouldn't mark the memo as updated). 
Rely on `fetch_cold` to lazily validate the memo. 


Codspeed thinks this is slightly better in some benchmarks (but the results change between runs). There's no meaningful change in Red Knot's benchmarks. I think it simplifies the logic a tiny bit. But I'm also okay not landing this change.