### PR TITLE
Print query stack when encountering unexpected cycle

### DIFF
--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -258,10 +258,25 @@ impl ActiveQuery {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub(crate) struct QueryStack {
     stack: Vec<ActiveQuery>,
     len: usize,
+}
+
+impl std::fmt::Debug for QueryStack {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if f.alternate() {
+            f.debug_list()
+                .entries(self.stack.iter().map(|q| q.database_key_index))
+                .finish()
+        } else {
+            f.debug_struct("QueryStack")
+                .field("stack", &self.stack)
+                .field("len", &self.len)
+                .finish()
+        }
+    }
 }
 
 impl ops::Deref for QueryStack {

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -162,10 +162,14 @@ where
                         )
                     })
                     .or_else(|| {
-                        panic!(
-                            "dependency graph cycle querying {database_key_index:#?}; \
-                             set cycle_fn/cycle_initial to fixpoint iterate"
-                        )
+                        db.zalsa_local().with_query_stack(|stack| {
+                            panic!(
+                                "dependency graph cycle when querying {database_key_index:#?}, \
+                                set cycle_fn/cycle_initial to fixpoint iterate.\n\
+                                Query stack:\n{:#?}",
+                                stack,
+                            );
+                        })
                     });
             }
             ClaimResult::Claimed(guard) => guard,

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -110,10 +110,14 @@ where
         ) {
             ClaimResult::Retry => return None,
             ClaimResult::Cycle => match C::CYCLE_STRATEGY {
-                CycleRecoveryStrategy::Panic => panic!(
-                    "dependency graph cycle validating {database_key_index:#?}; \
-                     set cycle_fn/cycle_initial to fixpoint iterate"
-                ),
+                CycleRecoveryStrategy::Panic => db.zalsa_local().with_query_stack(|stack| {
+                    panic!(
+                        "dependency graph cycle when validating {database_key_index:#?}, \
+                            set cycle_fn/cycle_initial to fixpoint iterate.\n\
+                            Query stack:\n{:#?}",
+                        stack,
+                    );
+                }),
                 CycleRecoveryStrategy::Fixpoint => {
                     return Some(VerifyResult::Unchanged(
                         InputAccumulatedValues::Empty,


### PR DESCRIPTION
Example output
```
dependency graph cycle when validating impl_self_ty_shim(Id(4000)), set cycle_fn/cycle_initial to fixpoint iterate.
Query stack:
[
    infer_shim(Id(4400)),
    trait_solve_shim(Id(6800)),
    trait_impls_in_deps_shim(Id(1c00)),
    trait_impls_in_crate_shim(Id(1c00)),
    impl_trait_shim(Id(4000)),
    impl_trait_with_diagnostics_shim(Id(4000)),
    impl_self_ty_shim(Id(4000)),
    impl_self_ty_with_diagnostics_shim(Id(4000)),
]
```