### PR TITLE
chore: Adjust `#[inline]` annotations

### DIFF
--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -66,7 +66,6 @@ pub(crate) struct ActiveQuery {
 }
 
 impl ActiveQuery {
-    #[inline]
     pub(super) fn add_read(
         &mut self,
         input: DatabaseKeyIndex,
@@ -287,12 +286,14 @@ impl std::fmt::Debug for QueryStack {
 impl ops::Deref for QueryStack {
     type Target = [ActiveQuery];
 
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         &self.stack[..self.len]
     }
 }
 
 impl ops::DerefMut for QueryStack {
+    #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.stack[..self.len]
     }

--- a/src/database.rs
+++ b/src/database.rs
@@ -81,6 +81,7 @@ pub trait Database: Send + AsDynDatabase + Any + ZalsaDatabase {
     }
 
     /// Execute `op` with the database in thread-local storage for debug print-outs.
+    #[inline(always)]
     fn attach<R>(&self, op: impl FnOnce(&Self) -> R) -> R
     where
         Self: Sized,
@@ -89,6 +90,7 @@ pub trait Database: Send + AsDynDatabase + Any + ZalsaDatabase {
     }
 
     #[doc(hidden)]
+    #[inline(always)]
     fn zalsa_register_downcaster(&self) {
         // The no-op downcaster is special cased in view caster construction.
     }
@@ -113,10 +115,12 @@ pub trait AsDynDatabase {
 }
 
 impl<T: Database> AsDynDatabase for T {
+    #[inline(always)]
     fn as_dyn_database(&self) -> &dyn Database {
         self
     }
 
+    #[inline(always)]
     fn as_dyn_database_mut(&mut self) -> &mut dyn Database {
         self
     }

--- a/src/database_impl.rs
+++ b/src/database_impl.rs
@@ -21,6 +21,7 @@ impl DatabaseImpl {
 
 impl Database for DatabaseImpl {
     /// Default behavior: tracing debug log the event.
+    #[inline(always)]
     fn salsa_event(&self, event: &dyn Fn() -> Event) {
         tracing::debug!("salsa_event({:?})", event());
     }
@@ -28,10 +29,12 @@ impl Database for DatabaseImpl {
 
 // SAFETY: The `storage` and `storage_mut` fields return a reference to the same storage field owned by `self`.
 unsafe impl HasStorage for DatabaseImpl {
+    #[inline(always)]
     fn storage(&self) -> &Storage<Self> {
         &self.storage
     }
 
+    #[inline(always)]
     fn storage_mut(&mut self) -> &mut Storage<Self> {
         &mut self.storage
     }

--- a/src/function.rs
+++ b/src/function.rs
@@ -157,6 +157,7 @@ where
         }
     }
 
+    #[inline]
     pub fn database_key_index(&self, key: Id) -> DatabaseKeyIndex {
         DatabaseKeyIndex::new(self.index, key)
     }

--- a/src/function/accumulated.rs
+++ b/src/function/accumulated.rs
@@ -96,7 +96,7 @@ where
         key: Id,
     ) -> (Option<&'db AccumulatedMap>, InputAccumulatedValues) {
         // NEXT STEP: stash and refactor `fetch` to return an `&Memo` so we can make this work
-        let memo = self.refresh_memo(db, key);
+        let memo = self.refresh_memo(db, db.zalsa(), key);
         (
             memo.revisions.accumulated.as_deref(),
             memo.revisions.accumulated_inputs.load(),

--- a/src/function/lru.rs
+++ b/src/function/lru.rs
@@ -20,11 +20,9 @@ impl Lru {
 
     #[inline(always)]
     pub(super) fn record_use(&self, index: Id) {
-        if self.capacity.is_none() {
-            // LRU is disabled
-            return;
+        if self.capacity.is_some() {
+            self.insert(index);
         }
-        self.insert(index);
     }
 
     #[inline(never)]

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -92,6 +92,7 @@ where
         }
     }
 
+    #[inline(never)]
     fn maybe_changed_after_cold<'db>(
         &'db self,
         zalsa: &Zalsa,

--- a/src/input.rs
+++ b/src/input.rs
@@ -272,17 +272,17 @@ impl<C> Slot for Value<C>
 where
     C: Configuration,
 {
-    #[inline]
+    #[inline(always)]
     unsafe fn memos(&self, _current_revision: Revision) -> &crate::table::memo::MemoTable {
         &self.memos
     }
 
-    #[inline]
+    #[inline(always)]
     fn memos_mut(&mut self) -> &mut crate::table::memo::MemoTable {
         &mut self.memos
     }
 
-    #[inline]
+    #[inline(always)]
     unsafe fn syncs(&self, _current_revision: Revision) -> &SyncTable {
         &self.syncs
     }

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -426,17 +426,17 @@ impl<C> Slot for Value<C>
 where
     C: Configuration,
 {
-    #[inline]
+    #[inline(always)]
     unsafe fn memos(&self, _current_revision: Revision) -> &MemoTable {
         &self.memos
     }
 
-    #[inline]
+    #[inline(always)]
     fn memos_mut(&mut self) -> &mut MemoTable {
         &mut self.memos
     }
 
-    #[inline]
+    #[inline(always)]
     unsafe fn syncs(&self, _current_revision: Revision) -> &crate::table::sync::SyncTable {
         &self.syncs
     }

--- a/src/key.rs
+++ b/src/key.rs
@@ -17,6 +17,7 @@ pub struct DatabaseKeyIndex {
 // ANCHOR_END: DatabaseKeyIndex
 
 impl DatabaseKeyIndex {
+    #[inline]
     pub(crate) fn new(ingredient_index: IngredientIndex, key_index: Id) -> Self {
         Self {
             key_index,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -148,6 +148,7 @@ impl<Db: Database> Storage<Db> {
 
 #[allow(clippy::undocumented_unsafe_blocks)] // TODO(#697) document safety
 unsafe impl<T: HasStorage> ZalsaDatabase for T {
+    #[inline(always)]
     fn zalsa(&self) -> &Zalsa {
         &self.storage().handle.zalsa_impl
     }
@@ -163,10 +164,12 @@ unsafe impl<T: HasStorage> ZalsaDatabase for T {
         zalsa
     }
 
+    #[inline(always)]
     fn zalsa_local(&self) -> &ZalsaLocal {
         &self.storage().zalsa_local
     }
 
+    #[inline(always)]
     fn fork_db(&self) -> Box<dyn Database> {
         Box::new(self.clone())
     }

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -853,7 +853,7 @@ impl<C> Slot for Value<C>
 where
     C: Configuration,
 {
-    #[inline]
+    #[inline(always)]
     unsafe fn memos(&self, current_revision: Revision) -> &crate::table::memo::MemoTable {
         // Acquiring the read lock here with the current revision
         // ensures that there is no danger of a race
@@ -862,12 +862,12 @@ where
         &self.memos
     }
 
-    #[inline]
+    #[inline(always)]
     fn memos_mut(&mut self) -> &mut crate::table::memo::MemoTable {
         &mut self.memos
     }
 
-    #[inline]
+    #[inline(always)]
     unsafe fn syncs(&self, current_revision: Revision) -> &crate::table::sync::SyncTable {
         // Acquiring the read lock here with the current revision
         // ensures that there is no danger of a race

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -225,6 +225,7 @@ impl Zalsa {
     ///
     /// Cancellation will automatically be triggered by salsa on any query
     /// invocation.
+    #[inline]
     pub(crate) fn unwind_if_revision_cancelled(&self, db: &(impl Database + ?Sized)) {
         db.salsa_event(&|| crate::Event::new(crate::EventKind::WillCheckCancellation));
         if self.runtime().load_cancellation_flag() {
@@ -419,6 +420,7 @@ where
 
     /// Get a reference to the ingredient in the database.
     /// If the ingredient is not already in the cache, it will be created.
+    #[inline(never)]
     pub fn get_or_create<'s>(
         &self,
         db: &'s dyn Database,

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -101,6 +101,7 @@ impl ZalsaLocal {
     }
 
     /// Executes a closure within the context of the current active query stacks.
+    #[inline(always)]
     pub(crate) fn with_query_stack<R>(
         &self,
         c: impl UnwindSafe + FnOnce(&mut QueryStack) -> R,
@@ -157,7 +158,7 @@ impl ZalsaLocal {
     }
 
     /// Register that currently active query reads the given input
-    #[inline]
+    #[inline(always)]
     pub(crate) fn report_tracked_read(
         &self,
         input: DatabaseKeyIndex,
@@ -186,6 +187,7 @@ impl ZalsaLocal {
     }
 
     /// Register that currently active query reads the given input
+    #[inline(always)]
     pub(crate) fn report_tracked_read_simple(
         &self,
         input: DatabaseKeyIndex,
@@ -208,6 +210,7 @@ impl ZalsaLocal {
     /// # Parameters
     ///
     /// * `current_revision`, the current revision
+    #[inline(always)]
     pub(crate) fn report_untracked_read(&self, current_revision: Revision) {
         self.with_query_stack(|stack| {
             if let Some(top_query) = stack.last_mut() {


### PR DESCRIPTION
A lot of attached calls/definitions seem to hover around the default inlining limit making the codspeed reports difficult to interpret at times, generally these should benefit from being inlined either way as the "attached" code paths are quite hot.

Aside from those, this PR touches up on a lot of other call sites for instructing inlining behavior, as just changing the attached calls has a negative impact overall on the remainder of the inlining behaviors. These additional explicit annotations bring things back in line.