### PR TITLE
Make interned's last_interned_at equal Revision::MAX if they are interned outside a quer

### DIFF
--- a/src/revision.rs
+++ b/src/revision.rs
@@ -17,24 +17,34 @@ pub struct Revision {
 }
 
 impl Revision {
+    #[inline]
+    pub(crate) fn max() -> Self {
+        Self::from(usize::MAX)
+    }
+
+    #[inline]
     pub(crate) fn start() -> Self {
         Self::from(START)
     }
 
+    #[inline]
     pub(crate) fn from(g: usize) -> Self {
         Self {
             generation: NonZeroUsize::new(g).unwrap(),
         }
     }
 
+    #[inline]
     pub(crate) fn from_opt(g: usize) -> Option<Self> {
         NonZeroUsize::new(g).map(|generation| Self { generation })
     }
 
+    #[inline]
     pub(crate) fn next(self) -> Revision {
         Self::from(self.generation.get() + 1)
     }
 
+    #[inline]
     fn as_usize(self) -> usize {
         self.generation.get()
     }

--- a/tests/intern_access_in_different_revision.rs
+++ b/tests/intern_access_in_different_revision.rs
@@ -1,0 +1,28 @@
+use salsa::{Durability, Setter};
+
+#[salsa::interned(no_lifetime)]
+struct Interned {
+    field: u32,
+}
+
+#[salsa::input]
+struct Input {
+    field: i32,
+}
+
+#[test]
+fn the_test() {
+    let mut db = salsa::DatabaseImpl::default();
+    let input = Input::builder(-123456)
+        .field_durability(Durability::HIGH)
+        .new(&db);
+    // Create an intern in an early revision.
+    let interned = Interned::new(&db, 0xDEADBEEF);
+    // Trigger a new revision.
+    input
+        .set_field(&mut db)
+        .with_durability(Durability::HIGH)
+        .to(123456);
+    // Read the interned value
+    let _ = interned.field(&db);
+}


### PR DESCRIPTION
There is an assert that `last_interned_at >= last_changed_revision`, and it can fail without this, see the added test.

CC @ibraheemdev, you introduced this assert in #602.