### PR TITLE
perf: Don't push an unnecessary active query for `deep_verify_memo`

### DIFF
--- a/src/interned.rs
+++ b/src/interned.rs
@@ -382,14 +382,15 @@ where
         input: Id,
         revision: Revision,
     ) -> VerifyResult {
-        let value = db.zalsa().table().get::<Value<C>>(input);
+        let zalsa = db.zalsa();
+        let value = zalsa.table().get::<Value<C>>(input);
         if value.first_interned_at > revision {
             // The slot was reused.
             return VerifyResult::Changed;
         }
 
         // The slot is valid in this revision but we have to sync the value's revision.
-        let current_revision = db.zalsa().current_revision();
+        let current_revision = zalsa.current_revision();
         value.last_interned_at.store(current_revision);
 
         db.salsa_event(&|| {


### PR DESCRIPTION
Turns out the only thing that makes use of the pushed query within the scope of the push and drop of the guard in `deep_verify_memo` is `function::Ingredient::maybe_changed_after` which itself already pushes the query if it needs to. So all of this is actually unnecessary.