### PR TITLE
chore: Fix ci not always running

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,15 +1,7 @@
 name: Test
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
-    paths:
-      - "**.rs"
-      - "**/Cargo.*"
-      - ".github/workflows/test.yml"
-      - "tests/compile-fail/**.stderr"
   merge_group:
 
 concurrency:


### PR DESCRIPTION
The paths filter is incompatible with our merge group setup