### PR TITLE
Use `DatabaseKey` for interned events

### DIFF
--- a/components/salsa-macros/src/fn_util.rs
+++ b/components/salsa-macros/src/fn_util.rs
@@ -15,7 +15,7 @@ pub fn input_ids(hygiene: &Hygiene, sig: &syn::Signature, skip: usize) -> Vec<sy
                 }
             }
 
-            hygiene.ident(&format!("input{}", index))
+            hygiene.ident(&format!("input{index}"))
         })
         .collect()
 }

--- a/components/salsa-macros/src/hygiene.rs
+++ b/components/salsa-macros/src/hygiene.rs
@@ -53,7 +53,7 @@ impl Hygiene {
     pub(crate) fn ident(&self, text: &str) -> syn::Ident {
         // Make the default be `foo_` rather than `foo` -- this helps detect
         // cases where people wrote `foo` instead of `#foo` or `$foo` in the generated code.
-        let mut buffer = format!("{}_", text);
+        let mut buffer = format!("{text}_");
 
         while self.user_tokens.contains(&buffer) {
             buffer.push('_');

--- a/components/salsa-macros/src/options.rs
+++ b/components/salsa-macros/src/options.rs
@@ -354,7 +354,7 @@ impl<A: AllowedOptions> syn::parse::Parse for Options<A> {
             } else {
                 return Err(syn::Error::new(
                     ident.span(),
-                    format!("unrecognized option `{}`", ident),
+                    format!("unrecognized option `{ident}`"),
                 ));
             }
 

--- a/components/salsa-macros/src/salsa_struct.rs
+++ b/components/salsa-macros/src/salsa_struct.rs
@@ -358,15 +358,12 @@ impl<'s> SalsaField<'s> {
         if BANNED_FIELD_NAMES.iter().any(|n| *n == field_name_str) {
             return Err(syn::Error::new(
                 field_name.span(),
-                format!(
-                    "the field name `{}` is disallowed in salsa structs",
-                    field_name_str
-                ),
+                format!("the field name `{field_name_str}` is disallowed in salsa structs",),
             ));
         }
 
         let get_name = Ident::new(&field_name_str, field_name.span());
-        let set_name = Ident::new(&format!("set_{}", field_name_str), field_name.span());
+        let set_name = Ident::new(&format!("set_{field_name_str}",), field_name.span());
         let mut result = SalsaField {
             field,
             has_tracked_attr: false,

--- a/examples/lazy-input/main.rs
+++ b/examples/lazy-input/main.rs
@@ -31,7 +31,7 @@ fn main() -> Result<()> {
         let sum = compile(&db, initial);
         let diagnostics = compile::accumulated::<Diagnostic>(&db, initial);
         if diagnostics.is_empty() {
-            println!("Sum is: {}", sum);
+            println!("Sum is: {sum}");
         } else {
             for diagnostic in diagnostics {
                 println!("{}", diagnostic.0);
@@ -39,7 +39,7 @@ fn main() -> Result<()> {
         }
 
         for log in db.logs.lock().unwrap().drain(..) {
-            eprintln!("{}", log);
+            eprintln!("{log}");
         }
 
         // Wait for file change events, the output can't change unless the
@@ -104,7 +104,7 @@ impl salsa::Database for LazyInputDatabase {
         // don't log boring events
         let event = event();
         if let salsa::EventKind::WillExecute { .. } = event.kind {
-            self.logs.lock().unwrap().push(format!("{:?}", event));
+            self.logs.lock().unwrap().push(format!("{event:?}"));
         }
     }
 }
@@ -177,8 +177,7 @@ fn parse(db: &dyn Db, input: File) -> ParsedFile<'_> {
                 db,
                 input,
                 Report::new(e).wrap_err(format!(
-                    "First line ({}) could not be parsed as an integer",
-                    line
+                    "First line ({line}) could not be parsed as an integer"
                 )),
             );
             0
@@ -196,7 +195,7 @@ fn parse(db: &dyn Db, input: File) -> ParsedFile<'_> {
                     Diagnostic::push_error(
                         db,
                         input,
-                        Report::new(err).wrap_err(format!("Failed to parse path: {}", path)),
+                        Report::new(err).wrap_err(format!("Failed to parse path: {path}")),
                     );
                     return None;
                 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,7 +1,7 @@
 use std::thread::ThreadId;
 
 use crate::key::DatabaseKeyIndex;
-use crate::{Id, Revision};
+use crate::Revision;
 
 /// The `Event` struct identifies various notable things that can
 /// occur during salsa execution. Instances of this struct are given
@@ -101,8 +101,8 @@ pub enum EventKind {
 
     /// Indicates that a value was newly interned.
     DidInternValue {
-        // The ID of the interned value.
-        id: Id,
+        // The key of the interned value.
+        key: DatabaseKeyIndex,
 
         // The revision the value was interned in.
         revision: Revision,
@@ -110,8 +110,8 @@ pub enum EventKind {
 
     /// Indicates that a previously interned value was read in a new revision.
     DidReinternValue {
-        // The ID of the interned value.
-        id: Id,
+        // The key of the interned value.
+        key: DatabaseKeyIndex,
 
         // The revision the value was interned in.
         revision: Revision,

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -138,8 +138,7 @@ where
                         panic!(
                             "dependency graph cycle when querying {database_key_index:#?}, \
                             set cycle_fn/cycle_initial to fixpoint iterate.\n\
-                            Query stack:\n{:#?}",
-                            stack,
+                            Query stack:\n{stack:#?}",
                         );
                     }),
                     CycleRecoveryStrategy::Fixpoint => {

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -114,8 +114,7 @@ where
                     panic!(
                         "dependency graph cycle when validating {database_key_index:#?}, \
                             set cycle_fn/cycle_initial to fixpoint iterate.\n\
-                            Query stack:\n{:#?}",
-                        stack,
+                            Query stack:\n{stack:#?}",
                     );
                 }),
                 CycleRecoveryStrategy::FallbackImmediate => {

--- a/tests/accumulate-chain.rs
+++ b/tests/accumulate-chain.rs
@@ -53,6 +53,6 @@ fn accumulate_chain() {
                     "log d",
                 ),
             ]"#]]
-        .assert_eq(&format!("{:#?}", logs));
+        .assert_eq(&format!("{logs:#?}"));
     })
 }

--- a/tests/accumulate-dag.rs
+++ b/tests/accumulate-dag.rs
@@ -24,7 +24,7 @@ fn push_logs(db: &dyn Database, input: MyInput) {
 fn push_a_logs(db: &dyn Database, input: MyInput) {
     let count = input.field_a(db);
     for i in 0..count {
-        Log(format!("log_a({} of {})", i, count)).accumulate(db);
+        Log(format!("log_a({i} of {count})")).accumulate(db);
     }
 }
 
@@ -34,7 +34,7 @@ fn push_b_logs(db: &dyn Database, input: MyInput) {
     push_a_logs(db, input);
     let count = input.field_b(db);
     for i in 0..count {
-        Log(format!("log_b({} of {})", i, count)).accumulate(db);
+        Log(format!("log_b({i} of {count})")).accumulate(db);
     }
 }
 
@@ -62,6 +62,6 @@ fn accumulate_a_called_twice() {
                     "log_b(2 of 3)",
                 ),
             ]"#]]
-        .assert_eq(&format!("{:#?}", logs));
+        .assert_eq(&format!("{logs:#?}"));
     })
 }

--- a/tests/accumulate-execution-order.rs
+++ b/tests/accumulate-execution-order.rs
@@ -60,6 +60,6 @@ fn accumulate_execution_order() {
                     "log c",
                 ),
             ]"#]]
-        .assert_eq(&format!("{:#?}", logs));
+        .assert_eq(&format!("{logs:#?}"));
     })
 }

--- a/tests/accumulate-from-tracked-fn.rs
+++ b/tests/accumulate-from-tracked-fn.rs
@@ -26,7 +26,7 @@ fn compute(db: &dyn salsa::Database, input: List) {
     );
     let result = if let Some(next) = input.next(db) {
         let next_integers = compute::accumulated::<Integers>(db, next);
-        eprintln!("{:?}", next_integers);
+        eprintln!("{next_integers:?}");
         let v = input.value(db) + next_integers.iter().map(|a| a.0).sum::<u32>();
         eprintln!("input={:?} v={:?}", input.value(db), v);
         v
@@ -34,7 +34,7 @@ fn compute(db: &dyn salsa::Database, input: List) {
         input.value(db)
     };
     Integers(result).accumulate(db);
-    eprintln!("pushed result {:?}", result);
+    eprintln!("pushed result {result:?}");
 }
 
 #[test]

--- a/tests/accumulate-no-duplicates.rs
+++ b/tests/accumulate-no-duplicates.rs
@@ -100,6 +100,6 @@ fn accumulate_no_duplicates() {
                     "log e",
                 ),
             ]"#]]
-        .assert_eq(&format!("{:#?}", logs));
+        .assert_eq(&format!("{logs:#?}"));
     })
 }

--- a/tests/accumulate-reuse-workaround.rs
+++ b/tests/accumulate-reuse-workaround.rs
@@ -20,7 +20,7 @@ struct Integers(u32);
 
 #[salsa::tracked]
 fn compute(db: &dyn LogDatabase, input: List) -> u32 {
-    db.push_log(format!("compute({:?})", input,));
+    db.push_log(format!("compute({input:?})",));
 
     // always pushes 0
     Integers(0).accumulate(db);
@@ -39,7 +39,7 @@ fn compute(db: &dyn LogDatabase, input: List) -> u32 {
 
 #[salsa::tracked(return_ref)]
 fn accumulated(db: &dyn LogDatabase, input: List) -> Vec<u32> {
-    db.push_log(format!("accumulated({:?})", input));
+    db.push_log(format!("accumulated({input:?})"));
     compute::accumulated::<Integers>(db, input)
         .into_iter()
         .map(|a| a.0)

--- a/tests/accumulate-reuse.rs
+++ b/tests/accumulate-reuse.rs
@@ -20,7 +20,7 @@ struct Integers(u32);
 
 #[salsa::tracked]
 fn compute(db: &dyn LogDatabase, input: List) -> u32 {
-    db.push_log(format!("compute({:?})", input,));
+    db.push_log(format!("compute({input:?})",));
 
     // always pushes 0
     Integers(0).accumulate(db);

--- a/tests/accumulate.rs
+++ b/tests/accumulate.rs
@@ -36,20 +36,20 @@ fn push_logs(db: &dyn LogDatabase, input: MyInput) {
 #[salsa::tracked]
 fn push_a_logs(db: &dyn LogDatabase, input: MyInput) {
     let field_a = input.field_a(db);
-    db.push_log(format!("push_a_logs({})", field_a));
+    db.push_log(format!("push_a_logs({field_a})"));
 
     for i in 0..field_a {
-        Log(format!("log_a({} of {})", i, field_a)).accumulate(db);
+        Log(format!("log_a({i} of {field_a})")).accumulate(db);
     }
 }
 
 #[salsa::tracked]
 fn push_b_logs(db: &dyn LogDatabase, input: MyInput) {
     let field_a = input.field_b(db);
-    db.push_log(format!("push_b_logs({})", field_a));
+    db.push_log(format!("push_b_logs({field_a})"));
 
     for i in 0..field_a {
-        Log(format!("log_b({} of {})", i, field_a)).accumulate(db);
+        Log(format!("log_b({i} of {field_a})")).accumulate(db);
     }
 }
 
@@ -86,7 +86,7 @@ fn accumulate_once() {
                 "log_b(2 of 3)",
             ),
         ]"#]]
-    .assert_eq(&format!("{:#?}", logs));
+    .assert_eq(&format!("{logs:#?}"));
 }
 
 #[test]
@@ -114,7 +114,7 @@ fn change_a_from_2_to_0() {
                 "log_b(2 of 3)",
             ),
         ]"#]]
-    .assert_eq(&format!("{:#?}", logs));
+    .assert_eq(&format!("{logs:#?}"));
     db.assert_logs(expect![[r#"
         [
             "push_logs(a = 2, b = 3)",
@@ -137,7 +137,7 @@ fn change_a_from_2_to_0() {
                 "log_b(2 of 3)",
             ),
         ]"#]]
-    .assert_eq(&format!("{:#?}", logs));
+    .assert_eq(&format!("{logs:#?}"));
     db.assert_logs(expect![[r#"
         [
             "push_logs(a = 0, b = 3)",
@@ -169,7 +169,7 @@ fn change_a_from_2_to_1() {
                 "log_b(2 of 3)",
             ),
         ]"#]]
-    .assert_eq(&format!("{:#?}", logs));
+    .assert_eq(&format!("{logs:#?}"));
     db.assert_logs(expect![[r#"
         [
             "push_logs(a = 2, b = 3)",
@@ -195,7 +195,7 @@ fn change_a_from_2_to_1() {
                 "log_b(2 of 3)",
             ),
         ]"#]]
-    .assert_eq(&format!("{:#?}", logs));
+    .assert_eq(&format!("{logs:#?}"));
     db.assert_logs(expect![[r#"
         [
             "push_logs(a = 1, b = 3)",
@@ -219,7 +219,7 @@ fn get_a_logs_after_changing_b() {
                 "log_a(1 of 2)",
             ),
         ]"#]]
-    .assert_eq(&format!("{:#?}", logs));
+    .assert_eq(&format!("{logs:#?}"));
     db.assert_logs(expect![[r#"
         [
             "push_a_logs(2)",

--- a/tests/accumulated_backdate.rs
+++ b/tests/accumulated_backdate.rs
@@ -41,7 +41,7 @@ fn backdate() {
     let input = File::new(&db, "0".to_string());
 
     let logs = compile::accumulated::<Log>(&db, input);
-    expect![[r#"[]"#]].assert_eq(&format!("{:#?}", logs));
+    expect![[r#"[]"#]].assert_eq(&format!("{logs:#?}"));
 
     input.set_content(&mut db).to("a".to_string());
     let logs = compile::accumulated::<Log>(&db, input);
@@ -52,7 +52,7 @@ fn backdate() {
                 "invalid digit found in string",
             ),
         ]"#]]
-    .assert_eq(&format!("{:#?}", logs));
+    .assert_eq(&format!("{logs:#?}"));
 }
 
 #[test]
@@ -68,10 +68,10 @@ fn backdate_no_diagnostics() {
                 "invalid digit found in string",
             ),
         ]"#]]
-    .assert_eq(&format!("{:#?}", logs));
+    .assert_eq(&format!("{logs:#?}"));
 
     input.set_content(&mut db).to("0".to_string());
     let logs = compile::accumulated::<Log>(&db, input);
 
-    expect![[r#"[]"#]].assert_eq(&format!("{:#?}", logs));
+    expect![[r#"[]"#]].assert_eq(&format!("{logs:#?}"));
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -33,7 +33,7 @@ pub trait LogDatabase: HasLogger + Database {
     /// it is meant to be run from outside any tracked functions.
     fn assert_logs(&self, expected: expect_test::Expect) {
         let logs = std::mem::take(&mut *self.logger().logs.lock().unwrap());
-        expected.assert_eq(&format!("{:#?}", logs));
+        expected.assert_eq(&format!("{logs:#?}"));
     }
 
     /// Asserts the length of the logs,

--- a/tests/cycle_accumulate.rs
+++ b/tests/cycle_accumulate.rs
@@ -72,7 +72,7 @@ fn accumulate_once() {
                 "file fn: issue 1",
             ),
         ]"#]]
-    .assert_eq(&format!("{:#?}", diagnostics));
+    .assert_eq(&format!("{diagnostics:#?}"));
 }
 
 #[test]
@@ -101,7 +101,7 @@ fn accumulate_with_dep() {
                 "file file_a: issue 1",
             ),
         ]"#]]
-    .assert_eq(&format!("{:#?}", diagnostics));
+    .assert_eq(&format!("{diagnostics:#?}"));
 }
 
 #[test]
@@ -136,7 +136,7 @@ fn accumulate_with_cycle() {
                 "file file_a: issue 2",
             ),
         ]"#]]
-    .assert_eq(&format!("{:#?}", diagnostics));
+    .assert_eq(&format!("{diagnostics:#?}"));
 }
 
 #[test]
@@ -171,7 +171,7 @@ fn accumulate_with_cycle_second_revision() {
                 "file file_a: issue 2",
             ),
         ]"#]]
-    .assert_eq(&format!("{:#?}", diagnostics));
+    .assert_eq(&format!("{diagnostics:#?}"));
 
     file_b.set_issues(&mut db).to(vec![2, 3]);
 
@@ -205,7 +205,7 @@ fn accumulate_with_cycle_second_revision() {
                 "file file_b: issue 3",
             ),
         ]"#]]
-    .assert_eq(&format!("{:#?}", diagnostics));
+    .assert_eq(&format!("{diagnostics:#?}"));
 }
 
 #[test]
@@ -234,7 +234,7 @@ fn accumulate_add_cycle() {
                 "file file_a: issue 1",
             ),
         ]"#]]
-    .assert_eq(&format!("{:#?}", diagnostics));
+    .assert_eq(&format!("{diagnostics:#?}"));
 
     file_a.set_dependencies(&mut db).to(vec![file_b]);
 
@@ -262,7 +262,7 @@ fn accumulate_add_cycle() {
                 "file file_b: issue 2",
             ),
         ]"#]]
-    .assert_eq(&format!("{:#?}", diagnostics));
+    .assert_eq(&format!("{diagnostics:#?}"));
 }
 
 #[test]
@@ -297,7 +297,7 @@ fn accumulate_remove_cycle() {
                 "file file_a: issue 2",
             ),
         ]"#]]
-    .assert_eq(&format!("{:#?}", diagnostics));
+    .assert_eq(&format!("{diagnostics:#?}"));
 
     file_a.set_dependencies(&mut db).to(vec![]);
 
@@ -320,5 +320,5 @@ fn accumulate_remove_cycle() {
                 "file file_a: issue 1",
             ),
         ]"#]]
-    .assert_eq(&format!("{:#?}", diagnostics));
+    .assert_eq(&format!("{diagnostics:#?}"));
 }

--- a/tests/deletion-cascade.rs
+++ b/tests/deletion-cascade.rs
@@ -15,7 +15,7 @@ struct MyInput {
 
 #[salsa::tracked]
 fn final_result(db: &dyn LogDatabase, input: MyInput) -> u32 {
-    db.push_log(format!("final_result({:?})", input));
+    db.push_log(format!("final_result({input:?})"));
     let mut sum = 0;
     for tracked_struct in create_tracked_structs(db, input) {
         sum += contribution_from_struct(db, tracked_struct);
@@ -30,7 +30,7 @@ struct MyTracked<'db> {
 
 #[salsa::tracked]
 fn create_tracked_structs(db: &dyn LogDatabase, input: MyInput) -> Vec<MyTracked<'_>> {
-    db.push_log(format!("intermediate_result({:?})", input));
+    db.push_log(format!("intermediate_result({input:?})"));
     (0..input.field(db))
         .map(|i| MyTracked::new(db, i))
         .collect()

--- a/tests/deletion.rs
+++ b/tests/deletion.rs
@@ -15,7 +15,7 @@ struct MyInput {
 
 #[salsa::tracked]
 fn final_result(db: &dyn LogDatabase, input: MyInput) -> u32 {
-    db.push_log(format!("final_result({:?})", input));
+    db.push_log(format!("final_result({input:?})"));
     let mut sum = 0;
     for tracked_struct in create_tracked_structs(db, input) {
         sum += contribution_from_struct(db, tracked_struct);
@@ -30,7 +30,7 @@ struct MyTracked<'db> {
 
 #[salsa::tracked]
 fn create_tracked_structs(db: &dyn LogDatabase, input: MyInput) -> Vec<MyTracked<'_>> {
-    db.push_log(format!("intermediate_result({:?})", input));
+    db.push_log(format!("intermediate_result({input:?})"));
     (0..input.field(db))
         .map(|i| MyTracked::new(db, i))
         .collect()

--- a/tests/elided-lifetime-in-tracked-fn.rs
+++ b/tests/elided-lifetime-in-tracked-fn.rs
@@ -14,7 +14,7 @@ struct MyInput {
 
 #[salsa::tracked]
 fn final_result(db: &dyn LogDatabase, input: MyInput) -> u32 {
-    db.push_log(format!("final_result({:?})", input));
+    db.push_log(format!("final_result({input:?})"));
     intermediate_result(db, input).field(db) * 2
 }
 
@@ -25,7 +25,7 @@ struct MyTracked<'db> {
 
 #[salsa::tracked]
 fn intermediate_result(db: &dyn LogDatabase, input: MyInput) -> MyTracked<'_> {
-    db.push_log(format!("intermediate_result({:?})", input));
+    db.push_log(format!("intermediate_result({input:?})"));
     MyTracked::new(db, input.field(db) / 2)
 }
 

--- a/tests/expect_reuse_field_x_of_a_tracked_struct_changes_but_fn_depends_on_field_y.rs
+++ b/tests/expect_reuse_field_x_of_a_tracked_struct_changes_but_fn_depends_on_field_y.rs
@@ -15,13 +15,13 @@ struct MyInput {
 
 #[salsa::tracked]
 fn final_result_depends_on_x(db: &dyn LogDatabase, input: MyInput) -> u32 {
-    db.push_log(format!("final_result_depends_on_x({:?})", input));
+    db.push_log(format!("final_result_depends_on_x({input:?})"));
     intermediate_result(db, input).x(db) * 2
 }
 
 #[salsa::tracked]
 fn final_result_depends_on_y(db: &dyn LogDatabase, input: MyInput) -> u32 {
-    db.push_log(format!("final_result_depends_on_y({:?})", input));
+    db.push_log(format!("final_result_depends_on_y({input:?})"));
     intermediate_result(db, input).y(db) * 2
 }
 

--- a/tests/expect_reuse_field_x_of_an_input_changes_but_fn_depends_on_field_y.rs
+++ b/tests/expect_reuse_field_x_of_an_input_changes_but_fn_depends_on_field_y.rs
@@ -16,13 +16,13 @@ struct MyInput {
 
 #[salsa::tracked]
 fn result_depends_on_x(db: &dyn LogDatabase, input: MyInput) -> u32 {
-    db.push_log(format!("result_depends_on_x({:?})", input));
+    db.push_log(format!("result_depends_on_x({input:?})"));
     input.x(db) + 1
 }
 
 #[salsa::tracked]
 fn result_depends_on_y(db: &dyn LogDatabase, input: MyInput) -> u32 {
-    db.push_log(format!("result_depends_on_y({:?})", input));
+    db.push_log(format!("result_depends_on_y({input:?})"));
     input.y(db) - 1
 }
 

--- a/tests/hello_world.rs
+++ b/tests/hello_world.rs
@@ -14,7 +14,7 @@ struct MyInput {
 
 #[salsa::tracked]
 fn final_result(db: &dyn LogDatabase, input: MyInput) -> u32 {
-    db.push_log(format!("final_result({:?})", input));
+    db.push_log(format!("final_result({input:?})"));
     intermediate_result(db, input).field(db) * 2
 }
 
@@ -25,7 +25,7 @@ struct MyTracked<'db> {
 
 #[salsa::tracked]
 fn intermediate_result(db: &dyn LogDatabase, input: MyInput) -> MyTracked<'_> {
-    db.push_log(format!("intermediate_result({:?})", input));
+    db.push_log(format!("intermediate_result({input:?})"));
     MyTracked::new(db, input.field(db) / 2)
 }
 

--- a/tests/interned-revisions.rs
+++ b/tests/interned-revisions.rs
@@ -40,11 +40,11 @@ fn test_intern_new() {
         [
             "WillCheckCancellation",
             "WillExecute { database_key: function(Id(0)) }",
-            "DidInternValue { id: Id(400), revision: R1 }",
+            "DidInternValue { key: Interned(Id(400)), revision: R1 }",
             "DidSetCancellationFlag",
             "WillCheckCancellation",
             "WillExecute { database_key: function(Id(0)) }",
-            "DidInternValue { id: Id(401), revision: R2 }",
+            "DidInternValue { key: Interned(Id(401)), revision: R2 }",
         ]"#]]);
 }
 
@@ -64,7 +64,7 @@ fn test_reintern() {
         [
             "WillCheckCancellation",
             "WillExecute { database_key: function(Id(0)) }",
-            "DidInternValue { id: Id(400), revision: R1 }",
+            "DidInternValue { key: Interned(Id(400)), revision: R1 }",
         ]"#]]);
 
     assert_eq!(result_in_rev_1.field1(&db), 0);
@@ -78,7 +78,7 @@ fn test_reintern() {
             "DidSetCancellationFlag",
             "WillCheckCancellation",
             "WillExecute { database_key: function(Id(0)) }",
-            "DidReinternValue { id: Id(400), revision: R2 }",
+            "DidReinternValue { key: Interned(Id(400)), revision: R2 }",
         ]"#]]);
 
     assert_eq!(result_in_rev_2.field1(&db), 0);
@@ -108,7 +108,7 @@ fn test_durability() {
         [
             "WillCheckCancellation",
             "WillExecute { database_key: function(Id(0)) }",
-            "DidInternValue { id: Id(400), revision: R1 }",
+            "DidInternValue { key: Interned(Id(400)), revision: R1 }",
             "DidSetCancellationFlag",
             "WillCheckCancellation",
             "DidValidateMemoizedValue { database_key: function(Id(0)) }",

--- a/tests/preverify-struct-with-leaked-data-2.rs
+++ b/tests/preverify-struct-with-leaked-data-2.rs
@@ -64,7 +64,7 @@ fn test_leaked_inputs_ignored() {
         [
             "WillCheckCancellation",
             "WillExecute { database_key: function(Id(0)) }",
-            "DidInternValue { id: Id(800), revision: R1 }",
+            "DidInternValue { key: Configuration(Id(800)), revision: R1 }",
             "WillCheckCancellation",
             "WillExecute { database_key: counter_field(Id(800)) }",
         ]"#]]);
@@ -83,7 +83,7 @@ fn test_leaked_inputs_ignored() {
         [
             "DidSetCancellationFlag",
             "WillCheckCancellation",
-            "DidReinternValue { id: Id(800), revision: R2 }",
+            "DidReinternValue { key: Configuration(Id(800)), revision: R2 }",
             "WillCheckCancellation",
             "WillExecute { database_key: counter_field(Id(800)) }",
             "WillExecute { database_key: function(Id(0)) }",

--- a/tests/singleton.rs
+++ b/tests/singleton.rs
@@ -41,7 +41,7 @@ fn twice() {
 fn debug() {
     salsa::DatabaseImpl::new().attach(|db| {
         let input = MyInput::new(db, 3, 4);
-        let actual = format!("{:?}", input);
+        let actual = format!("{input:?}");
         let expected = expect!["MyInput { [salsa id]: Id(0), field: 3, id_field: 4 }"];
         expected.assert_eq(&actual);
     });

--- a/tests/tracked_fn_read_own_entity.rs
+++ b/tests/tracked_fn_read_own_entity.rs
@@ -14,7 +14,7 @@ struct MyInput {
 
 #[salsa::tracked]
 fn final_result(db: &dyn LogDatabase, input: MyInput) -> u32 {
-    db.push_log(format!("final_result({:?})", input));
+    db.push_log(format!("final_result({input:?})"));
     intermediate_result(db, input).field(db) * 2
 }
 
@@ -25,7 +25,7 @@ struct MyTracked<'db> {
 
 #[salsa::tracked]
 fn intermediate_result(db: &dyn LogDatabase, input: MyInput) -> MyTracked<'_> {
-    db.push_log(format!("intermediate_result({:?})", input));
+    db.push_log(format!("intermediate_result({input:?})"));
     let tracked = MyTracked::new(db, input.field(db) / 2);
     let _ = tracked.field(db); // read the field of an entity we created
     tracked

--- a/tests/tracked_fn_return_ref.rs
+++ b/tests/tracked_fn_return_ref.rs
@@ -7,9 +7,7 @@ struct Input {
 
 #[salsa::tracked(return_ref)]
 fn test(db: &dyn salsa::Database, input: Input) -> Vec<String> {
-    (0..input.number(db))
-        .map(|i| format!("test {}", i))
-        .collect()
+    (0..input.number(db)).map(|i| format!("test {i}")).collect()
 }
 
 #[test]

--- a/tests/tracked_method_inherent_return_ref.rs
+++ b/tests/tracked_method_inherent_return_ref.rs
@@ -9,9 +9,7 @@ struct Input {
 impl Input {
     #[salsa::tracked(return_ref)]
     fn test(self, db: &dyn salsa::Database) -> Vec<String> {
-        (0..self.number(db))
-            .map(|i| format!("test {}", i))
-            .collect()
+        (0..self.number(db)).map(|i| format!("test {i}")).collect()
     }
 }
 

--- a/tests/tracked_method_trait_return_ref.rs
+++ b/tests/tracked_method_trait_return_ref.rs
@@ -13,9 +13,7 @@ trait Trait {
 impl Trait for Input {
     #[salsa::tracked(return_ref)]
     fn test(self, db: &dyn salsa::Database) -> Vec<String> {
-        (0..self.number(db))
-            .map(|i| format!("test {}", i))
-            .collect()
+        (0..self.number(db)).map(|i| format!("test {i}")).collect()
     }
 }
 


### PR DESCRIPTION
Similar to other events, use `DatabaseKey` for interned events.
This has the advantage that logging the event reveals the id *and the struct name*

## Test plan

See updated snapshot tests
