### PR TITLE
Store `cycle_heads` in a side map instead of inside the memo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ indexmap = "2"
 parking_lot = "0.12"
 portable-atomic = "1"
 rustc-hash = "2"
-smallvec = "1"
+smallvec = { version = "1", features = ["const_new"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 # parallel map

--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::AtomicBool;
 
 use crate::accumulator::accumulated_map::InputAccumulatedValues;
+use crate::cycle::CycleHeads;
 use crate::function::memo::Memo;
 use crate::function::{Configuration, IngredientImpl};
 use crate::revision::AtomicRevision;
@@ -71,7 +72,6 @@ where
             accumulated: Default::default(),
             accumulated_inputs: Default::default(),
             verified_final: AtomicBool::new(true),
-            cycle_heads: Default::default(),
         };
 
         let memo_ingredient_index = self.memo_ingredient_index(zalsa, key);
@@ -98,7 +98,13 @@ where
             memo.tracing_debug(),
             key
         );
-        self.insert_memo(zalsa, key, memo, memo_ingredient_index);
+        self.insert_memo(
+            zalsa,
+            self.database_key_index(key),
+            memo,
+            memo_ingredient_index,
+            CycleHeads::default(),
+        );
 
         // Record that the current query *specified* a value for this cell.
         let database_key_index = self.database_key_index(key);

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -10,6 +10,7 @@ use parking_lot::{Mutex, RwLock};
 use portable_atomic::AtomicU64;
 use rustc_hash::FxHashMap;
 
+use crate::cycle::CycleHeadsMap;
 use crate::ingredient::{Ingredient, Jar};
 use crate::nonce::{Nonce, NonceGenerator};
 use crate::runtime::Runtime;
@@ -149,6 +150,8 @@ pub struct Zalsa {
     /// The runtime for this particular salsa database handle.
     /// Each handle gets its own runtime, but the runtimes have shared state between them.
     runtime: Runtime,
+
+    pub(crate) cycle_heads_map: CycleHeadsMap,
 }
 
 /// All fields on Zalsa are locked behind [`Mutex`]es and [`RwLock`]s and cannot enter
@@ -169,6 +172,7 @@ impl Zalsa {
             ingredients_requiring_reset: boxcar::Vec::new(),
             runtime: Runtime::default(),
             memo_ingredient_indices: Default::default(),
+            cycle_heads_map: Default::default(),
         }
     }
 


### PR DESCRIPTION
Since most queries don't have cycles (and even those that do get removed from the map when the cycle is verified), this saves memory.

The details were tricky to get right (and it took multiple attempts), but I think I nailed it now.

This saves 20mb on rust-analyzer.

Accumulators are another feature that may benefit from the same treatment, but that's for another PR.