### PR TITLE
shrink_to_fit `IdentityMap` before storing it

### DIFF
--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -48,7 +48,7 @@ pub(crate) struct ActiveQuery {
 
     /// Map from tracked struct keys (which include the hash + disambiguator) to their
     /// final id.
-    pub(crate) tracked_struct_ids: IdentityMap,
+    tracked_struct_ids: IdentityMap,
 
     /// Stores the values accumulated to the given ingredient.
     /// The type of accumulated value is erased but known to the ingredient.
@@ -150,6 +150,14 @@ impl ActiveQuery {
 
     pub(super) fn iteration_count(&self) -> u32 {
         self.iteration_count
+    }
+
+    pub(crate) fn tracked_struct_ids(&self) -> &IdentityMap {
+        &self.tracked_struct_ids
+    }
+
+    pub(crate) fn tracked_struct_ids_mut(&mut self) -> &mut IdentityMap {
+        &mut self.tracked_struct_ids
     }
 }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -188,9 +188,10 @@ where
         &'db self,
         zalsa: &'db Zalsa,
         id: Id,
-        memo: memo::Memo<C::Output<'db>>,
+        mut memo: memo::Memo<C::Output<'db>>,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> &'db memo::Memo<C::Output<'db>> {
+        memo.revisions.tracked_struct_ids.shrink_to_fit();
         // We convert to a `NonNull` here as soon as possible because we are going to alias
         // into the `Box`, which is a `noalias` type.
         // FIXME: Use `Box::into_non_null` once stable

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -285,7 +285,7 @@ impl ZalsaLocal {
             let top_query = stack
                 .last()
                 .expect("cannot create a tracked struct ID outside of a tracked function");
-            top_query.tracked_struct_ids.get(identity)
+            top_query.tracked_struct_ids().get(identity)
         })
     }
 
@@ -295,7 +295,7 @@ impl ZalsaLocal {
             let top_query = stack
                 .last_mut()
                 .expect("cannot store a tracked struct ID outside of a tracked function");
-            top_query.tracked_struct_ids.insert(identity, id);
+            top_query.tracked_struct_ids_mut().insert(identity, id);
         })
     }
 
@@ -509,8 +509,10 @@ impl ActiveQueryGuard<'_> {
             #[cfg(debug_assertions)]
             assert_eq!(stack.len(), self.push_len);
             let frame = stack.last_mut().unwrap();
-            assert!(frame.tracked_struct_ids.is_empty());
-            frame.tracked_struct_ids.clone_from(tracked_struct_ids);
+            assert!(frame.tracked_struct_ids().is_empty());
+            frame
+                .tracked_struct_ids_mut()
+                .clone_from(tracked_struct_ids);
         })
     }
 


### PR DESCRIPTION
Notable we do not do this for cycles, given there the memo is likely temporary anyways