### PR TITLE
fix: Fix incorrect `values_equal` signature

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -61,7 +61,7 @@ pub trait Configuration: Any {
     /// the older one.
     ///
     /// This invokes user code in form of the `Eq` impl.
-    fn values_equal(old_value: &Self::Output<'_>, new_value: &Self::Output<'_>) -> bool;
+    fn values_equal<'db>(old_value: &Self::Output<'db>, new_value: &Self::Output<'db>) -> bool;
 
     /// Convert from the id used internally to the value that execute is expecting.
     /// This is a no-op if the input to the function is a salsa struct.

--- a/src/function/backdate.rs
+++ b/src/function/backdate.rs
@@ -9,11 +9,11 @@ where
     /// If the value/durability of this memo is equal to what is found in `revisions`/`value`,
     /// then update `revisions.changed_at` to match `self.revisions.changed_at`. This is invoked
     /// on an old memo when a new memo has been produced to check whether there have been changed.
-    pub(super) fn backdate_if_appropriate(
+    pub(super) fn backdate_if_appropriate<'db>(
         &self,
-        old_memo: &Memo<C::Output<'_>>,
+        old_memo: &Memo<C::Output<'db>>,
         revisions: &mut QueryRevisions,
-        value: &C::Output<'_>,
+        value: &C::Output<'db>,
     ) {
         if let Some(old_value) = &old_memo.value {
             // Careful: if the value became less durable than it

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -24,7 +24,7 @@ where
         &'db self,
         db: &'db C::DbView,
         mut active_query: ActiveQueryGuard<'db>,
-        opt_old_memo: Option<&Memo<C::Output<'_>>>,
+        opt_old_memo: Option<&Memo<C::Output<'db>>>,
     ) -> &'db Memo<C::Output<'db>> {
         let zalsa = db.zalsa();
         let revision_now = zalsa.current_revision();

--- a/src/update.rs
+++ b/src/update.rs
@@ -130,12 +130,6 @@ pub fn always_update<T>(
 /// have been part of a tracked struct whose values were mutated,
 /// thus invalidating the `'db` lifetime (from a stacked borrows perspective).
 /// Either way, the `Eq` implementation would be invalid.
-#[diagnostic::on_unimplemented(
-    message = "My Message for `ImportantTrait` implemented for `{Self}`",
-    label = "My Label",
-    note = "Note 1",
-    note = "Note 2"
-)]
 pub unsafe trait Update {
     /// # Returns
     ///


### PR DESCRIPTION
cc https://github.com/salsa-rs/salsa/pull/820
unsure why this didn't fail CI anywhere. Rust is weird when it comes to lifetimes and trait functions