### PR TITLE
feat: Make `attach` pub

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub use self::runtime::Runtime;
 pub use self::storage::{Storage, StorageHandle};
 pub use self::update::Update;
 pub use self::zalsa::IngredientIndex;
-pub use crate::attach::with_attached_database;
+pub use crate::attach::{attach, with_attached_database};
 
 pub mod prelude {
     pub use crate::{Accumulator, Database, Setter};


### PR DESCRIPTION
It's sometimes necessary to print salsa data outside a query. However, the output isn't very useful without a db attached
and salsa currently doesn't expose an API to attach the db. 

This PR makes `attach::attach` pub, so that user-code can attach a database when necessary. 

My specific use case is that I want to print a `salsa::Backtrace` that was captured earlier but the handler
isn't part of any salsa query. 

Alternatives: We could add a `Backtrace::display` method that accepts a specific `db`. 

Downsides: This exposes that each db is associated with a single thread. I think this
is something that's already observable to users anyway. 
