### PR TITLE
bug: Avoid panic in `Backtrace::catpure` if `query_stack` is already mutably borrowed

### DIFF
--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -377,7 +377,7 @@ pub struct Backtrace(Box<[CapturedQuery]>);
 impl Backtrace {
     pub fn capture() -> Option<Self> {
         crate::with_attached_database(|db| {
-            db.zalsa_local().with_query_stack(|stack| {
+            db.zalsa_local().try_with_query_stack(|stack| {
                 Backtrace(
                     stack
                         .iter()
@@ -392,7 +392,7 @@ impl Backtrace {
                         .collect(),
                 )
             })
-        })
+        })?
     }
 }
 


### PR DESCRIPTION
This PR fixes a panic in `Backtrace::catpure` if `local_state.query_stack` is already mutably borrowed by
returning `None`. 

This was possible because some of our cycle queries used `with_query_stack` when panicking to include the query stack
and `with_query_stack` always aquired a mutable borrow. I split `with_query_stack` into a reference, mutable reference, and `try` variant
which should avoid this from triggering in most places
