### PR TITLE
better debug name for interned query arguments

### DIFF
--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -139,7 +139,7 @@ macro_rules! setup_tracked_fn {
                             file: file!(),
                             line: line!(),
                         };
-                        const DEBUG_NAME: &'static str = "Configuration";
+                        const DEBUG_NAME: &'static str = concat!(stringify!($fn_name), "_arguments");
 
                         type Fields<$db_lt> = ($($input_ty),*);
 

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -139,7 +139,7 @@ macro_rules! setup_tracked_fn {
                             file: file!(),
                             line: line!(),
                         };
-                        const DEBUG_NAME: &'static str = concat!(stringify!($fn_name), "_arguments");
+                        const DEBUG_NAME: &'static str = concat!(stringify!($fn_name), "::interned_arguments");
 
                         type Fields<$db_lt> = ($($input_ty),*);
 

--- a/tests/cycle_output.rs
+++ b/tests/cycle_output.rs
@@ -141,10 +141,10 @@ fn revalidate_no_changes() {
         [
             "salsa_event(DidSetCancellationFlag)",
             "salsa_event(DidValidateMemoizedValue { database_key: read_value(Id(403)) })",
-            "salsa_event(DidReinternValue { key: Configuration(Id(800)), revision: R2 })",
+            "salsa_event(DidReinternValue { key: query_d_arguments(Id(800)), revision: R2 })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_d(Id(800)) })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_b(Id(0)) })",
-            "salsa_event(DidReinternValue { key: Configuration(Id(800)), revision: R2 })",
+            "salsa_event(DidReinternValue { key: query_d_arguments(Id(800)), revision: R2 })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_a(Id(0)) })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_b(Id(0)) })",
         ]"#]]);
@@ -171,7 +171,7 @@ fn revalidate_with_change_after_output_read() {
         [
             "salsa_event(DidSetCancellationFlag)",
             "salsa_event(DidValidateMemoizedValue { database_key: read_value(Id(403)) })",
-            "salsa_event(DidReinternValue { key: Configuration(Id(800)), revision: R2 })",
+            "salsa_event(DidReinternValue { key: query_d_arguments(Id(800)), revision: R2 })",
             "salsa_event(WillExecute { database_key: query_d(Id(800)) })",
             "salsa_event(WillExecute { database_key: query_a(Id(0)) })",
             "salsa_event(DidValidateMemoizedValue { database_key: read_value(Id(400)) })",

--- a/tests/cycle_output.rs
+++ b/tests/cycle_output.rs
@@ -141,10 +141,10 @@ fn revalidate_no_changes() {
         [
             "salsa_event(DidSetCancellationFlag)",
             "salsa_event(DidValidateMemoizedValue { database_key: read_value(Id(403)) })",
-            "salsa_event(DidReinternValue { key: query_d_arguments(Id(800)), revision: R2 })",
+            "salsa_event(DidReinternValue { key: query_d::interned_arguments(Id(800)), revision: R2 })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_d(Id(800)) })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_b(Id(0)) })",
-            "salsa_event(DidReinternValue { key: query_d_arguments(Id(800)), revision: R2 })",
+            "salsa_event(DidReinternValue { key: query_d::interned_arguments(Id(800)), revision: R2 })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_a(Id(0)) })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_b(Id(0)) })",
         ]"#]]);
@@ -171,7 +171,7 @@ fn revalidate_with_change_after_output_read() {
         [
             "salsa_event(DidSetCancellationFlag)",
             "salsa_event(DidValidateMemoizedValue { database_key: read_value(Id(403)) })",
-            "salsa_event(DidReinternValue { key: query_d_arguments(Id(800)), revision: R2 })",
+            "salsa_event(DidReinternValue { key: query_d::interned_arguments(Id(800)), revision: R2 })",
             "salsa_event(WillExecute { database_key: query_d(Id(800)) })",
             "salsa_event(WillExecute { database_key: query_a(Id(0)) })",
             "salsa_event(DidValidateMemoizedValue { database_key: read_value(Id(400)) })",

--- a/tests/preverify-struct-with-leaked-data-2.rs
+++ b/tests/preverify-struct-with-leaked-data-2.rs
@@ -64,7 +64,7 @@ fn test_leaked_inputs_ignored() {
         [
             "WillCheckCancellation",
             "WillExecute { database_key: function(Id(0)) }",
-            "DidInternValue { key: counter_field_arguments(Id(800)), revision: R1 }",
+            "DidInternValue { key: counter_field::interned_arguments(Id(800)), revision: R1 }",
             "WillCheckCancellation",
             "WillExecute { database_key: counter_field(Id(800)) }",
         ]"#]]);
@@ -83,7 +83,7 @@ fn test_leaked_inputs_ignored() {
         [
             "DidSetCancellationFlag",
             "WillCheckCancellation",
-            "DidReinternValue { key: counter_field_arguments(Id(800)), revision: R2 }",
+            "DidReinternValue { key: counter_field::interned_arguments(Id(800)), revision: R2 }",
             "WillCheckCancellation",
             "WillExecute { database_key: counter_field(Id(800)) }",
             "WillExecute { database_key: function(Id(0)) }",

--- a/tests/preverify-struct-with-leaked-data-2.rs
+++ b/tests/preverify-struct-with-leaked-data-2.rs
@@ -64,7 +64,7 @@ fn test_leaked_inputs_ignored() {
         [
             "WillCheckCancellation",
             "WillExecute { database_key: function(Id(0)) }",
-            "DidInternValue { key: Configuration(Id(800)), revision: R1 }",
+            "DidInternValue { key: counter_field_arguments(Id(800)), revision: R1 }",
             "WillCheckCancellation",
             "WillExecute { database_key: counter_field(Id(800)) }",
         ]"#]]);
@@ -83,7 +83,7 @@ fn test_leaked_inputs_ignored() {
         [
             "DidSetCancellationFlag",
             "WillCheckCancellation",
-            "DidReinternValue { key: Configuration(Id(800)), revision: R2 }",
+            "DidReinternValue { key: counter_field_arguments(Id(800)), revision: R2 }",
             "WillCheckCancellation",
             "WillExecute { database_key: counter_field(Id(800)) }",
             "WillExecute { database_key: function(Id(0)) }",


### PR DESCRIPTION
The debug name `Configuration` isn't very helpful when debugging salsa. Use a name constructed from the query name.

I'm open to suggestions on how to avoid collisions with actual query names. e.g. we could prefix the name with two underscores or similar.