### PR TITLE
Simple LRU garbage collection for interned values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,10 @@ salsa-macros = { version = "0.22.0", path = "components/salsa-macros", optional 
 
 boxcar = { version = "0.2.12" }
 crossbeam-queue = "0.3.11"
-dashmap = { version = "6", features = ["raw-api"] }
-# the version of hashbrown used by dashmap
-hashbrown_14 = { version = "0.14", package = "hashbrown" }
 hashbrown = "0.15"
 hashlink = "0.10"
 indexmap = "2"
+intrusive-collections = "0.9.7"
 parking_lot = "0.12"
 portable-atomic = "1"
 rustc-hash = "2"
@@ -52,6 +50,7 @@ salsa-macros = { version = "=0.22.0", path = "components/salsa-macros" }
 [dev-dependencies]
 # examples
 crossbeam-channel = "0.5.14"
+dashmap = { version = "6", features = ["raw-api"] }
 eyre = "0.6.8"
 notify-debouncer-mini = "0.4.1"
 ordered-float = "4.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ salsa-macros = { version = "0.22.0", path = "components/salsa-macros", optional 
 
 boxcar = { version = "0.2.12" }
 crossbeam-queue = "0.3.11"
+crossbeam-utils = "0.8.21"
 hashbrown = "0.15"
 hashlink = "0.10"
 indexmap = "2"

--- a/src/durability.rs
+++ b/src/durability.rs
@@ -87,14 +87,6 @@ impl Durability {
     pub(crate) fn index(self) -> usize {
         self.0 as usize
     }
-
-    pub(crate) fn as_u8(self) -> u8 {
-        self.0 as u8
-    }
-
-    pub(crate) fn from_u8(value: u8) -> Self {
-        Self(DurabilityVal::from(value))
-    }
 }
 
 impl Default for Durability {

--- a/src/event.rs
+++ b/src/event.rs
@@ -107,8 +107,17 @@ pub enum EventKind {
         revision: Revision,
     },
 
+    /// Indicates that a value was interned by reusing an existing slot.
+    DidReuseInternedValue {
+        // The key of the interned value.
+        key: DatabaseKeyIndex,
+
+        // The revision the value was interned in.
+        revision: Revision,
+    },
+
     /// Indicates that a previously interned value was read in a new revision.
-    DidReinternValue {
+    DidValidateInternedValue {
         // The key of the interned value.
         key: DatabaseKeyIndex,
 

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -99,6 +99,7 @@ pub struct Memo<V> {
 
 // Memo's are stored a lot, make sure their size is doesn't randomly increase.
 #[cfg(not(feature = "shuttle"))]
+#[cfg(target_pointer_width = "64")]
 const _: [(); std::mem::size_of::<Memo<std::num::NonZeroUsize>>()] =
     [(); std::mem::size_of::<[usize; 13]>()];
 

--- a/src/revision.rs
+++ b/src/revision.rs
@@ -24,8 +24,11 @@ impl Revision {
     }
 
     #[inline]
-    pub(crate) fn start() -> Self {
-        Self::from(START)
+    pub(crate) const fn start() -> Self {
+        Self {
+            // SAFETY: `START` is non-zero.
+            generation: unsafe { NonZeroUsize::new_unchecked(START) },
+        }
     }
 
     #[inline]
@@ -46,7 +49,7 @@ impl Revision {
     }
 
     #[inline]
-    fn as_usize(self) -> usize {
+    pub(crate) fn as_usize(self) -> usize {
         self.generation.get()
     }
 }

--- a/src/revision.rs
+++ b/src/revision.rs
@@ -74,6 +74,12 @@ impl From<Revision> for AtomicRevision {
 }
 
 impl AtomicRevision {
+    pub(crate) const fn start() -> Self {
+        Self {
+            data: AtomicUsize::new(START),
+        }
+    }
+
     pub(crate) fn load(&self) -> Revision {
         Revision {
             // SAFETY: We know that the value is non-zero because we only ever store `START` which 1, or a

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -5,35 +5,6 @@ pub mod shim {
     pub use shuttle::sync::*;
     pub use shuttle::{thread, thread_local};
 
-    /// A polyfill for `dashmap::DashMap`.
-    pub struct FxDashMap<K, V>(RwLock<HashTable<K, V>>, crate::hash::FxHasher);
-
-    type HashTable<K, V> = hashbrown_14::raw::RawTable<(K, dashmap::SharedValue<V>)>;
-
-    impl<K, V> Default for FxDashMap<K, V> {
-        fn default() -> FxDashMap<K, V> {
-            FxDashMap(RwLock::default(), crate::hash::FxHasher::default())
-        }
-    }
-
-    impl<K, V> FxDashMap<K, V> {
-        pub fn shards(&self) -> &[RwLock<HashTable<K, V>>] {
-            std::slice::from_ref(&self.0)
-        }
-
-        pub fn determine_shard(&self, _hash: usize) -> usize {
-            0
-        }
-
-        pub fn hasher(&self) -> &crate::hash::FxHasher {
-            &self.1
-        }
-
-        pub fn clear(&self) {
-            self.0.write().clear();
-        }
-    }
-
     /// A wrapper around shuttle's `Mutex` to mirror parking-lot's API.
     #[derive(Default, Debug)]
     pub struct Mutex<T>(shuttle::sync::Mutex<T>);
@@ -156,8 +127,6 @@ pub mod shim {
     pub use parking_lot::{Mutex, MutexGuard, RwLock};
     pub use std::sync::*;
     pub use std::{thread, thread_local};
-
-    pub(crate) type FxDashMap<K, V> = dashmap::DashMap<K, V, crate::hash::FxHasher>;
 
     pub mod atomic {
         pub use portable_atomic::AtomicU64;

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -28,6 +28,7 @@ pub mod tracked_field;
 
 // ANCHOR: Configuration
 /// Trait that defines the key properties of a tracked struct.
+///
 /// Implemented by the `#[salsa::tracked]` macro when applied
 /// to a struct.
 pub trait Configuration: Sized + 'static {

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -146,10 +146,14 @@ pub trait TrackedStructInDb: SalsaStructInDb {
 /// This ingredient only stores the "id" fields. It is a kind of "dressed up" interner;
 /// the active query + values of id fields are hashed to create the tracked
 /// struct id. The value fields are stored in [`crate::function::IngredientImpl`]
-/// instances keyed by the tracked struct id. Unlike normal interners, tracked
-/// struct indices can be deleted and reused aggressively: when a tracked
-/// function re-executes, any tracked structs that it created before but did
-/// not create this time can be deleted.
+/// instances keyed by the tracked struct id.
+///
+/// Unlike normal interned values, tracked struct indices can be deleted and reused aggressively
+/// without dependency edges on the creating query. When a tracked function is collected,
+/// any tracked structs it created can be deleted. Additionally, when a tracked function
+/// re-executes but does not create a tracked struct that was previously created, it can
+/// be deleted. No dependency edge is required as the lifetime of a tracked struct is tied
+/// directly to the query that created it.
 pub struct IngredientImpl<C>
 where
     C: Configuration,

--- a/tests/cycle_output.rs
+++ b/tests/cycle_output.rs
@@ -150,7 +150,7 @@ fn revalidate_no_changes() {
         [
             "salsa_event(DidSetCancellationFlag)",
             "salsa_event(DidValidateMemoizedValue { database_key: read_value(Id(400)) })",
-            "salsa_event(DidReinternValue { key: query_d::interned_arguments(Id(800)), revision: R2 })",
+            "salsa_event(DidValidateInternedValue { key: query_d::interned_arguments(Id(800)), revision: R2 })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_d(Id(800)) })",
             "salsa_event(DidValidateMemoizedValue { database_key: read_value(Id(401)) })",
             "salsa_event(DidValidateMemoizedValue { database_key: read_value(Id(402)) })",
@@ -180,9 +180,9 @@ fn revalidate_with_change_after_output_read() {
         [
             "salsa_event(DidSetCancellationFlag)",
             "salsa_event(DidValidateMemoizedValue { database_key: read_value(Id(400)) })",
-            "salsa_event(DidReinternValue { key: query_d::interned_arguments(Id(800)), revision: R2 })",
+            "salsa_event(DidValidateInternedValue { key: query_d::interned_arguments(Id(800)), revision: R2 })",
             "salsa_event(WillExecute { database_key: query_b(Id(0)) })",
-            "salsa_event(DidReinternValue { key: query_d::interned_arguments(Id(800)), revision: R2 })",
+            "salsa_event(DidValidateInternedValue { key: query_d::interned_arguments(Id(800)), revision: R2 })",
             "salsa_event(WillExecute { database_key: query_a(Id(0)) })",
             "salsa_event(WillExecute { database_key: query_d(Id(800)) })",
             "salsa_event(WillDiscardStaleOutput { execute_key: query_a(Id(0)), output_key: Output(Id(403)) })",

--- a/tests/interned-revisions.rs
+++ b/tests/interned-revisions.rs
@@ -13,8 +13,15 @@ struct Input {
 }
 
 #[salsa::interned]
+#[derive(Debug)]
 struct Interned<'db> {
     field1: usize,
+}
+
+#[salsa::interned]
+#[derive(Debug)]
+struct NestedInterned<'db> {
+    interned: Interned<'db>,
 }
 
 #[test]
@@ -78,7 +85,7 @@ fn test_reintern() {
             "DidSetCancellationFlag",
             "WillCheckCancellation",
             "WillExecute { database_key: function(Id(0)) }",
-            "DidReinternValue { key: Interned(Id(400)), revision: R2 }",
+            "DidValidateInternedValue { key: Interned(Id(400)), revision: R2 }",
         ]"#]]);
 
     assert_eq!(result_in_rev_2.field1(&db), 0);
@@ -113,4 +120,214 @@ fn test_durability() {
             "WillCheckCancellation",
             "DidValidateMemoizedValue { database_key: function(Id(0)) }",
         ]"#]]);
+}
+
+#[test]
+fn test_reuse() {
+    #[salsa::tracked]
+    fn function<'db>(db: &'db dyn Database, input: Input) -> Interned<'db> {
+        Interned::new(db, input.field1(db))
+    }
+
+    let mut db = common::EventLoggerDatabase::default();
+    let input = Input::new(&db, 0);
+
+    let result = function(&db, input);
+    assert_eq!(result.field1(&db), 0);
+
+    // Modify the input to bump the revision and intern a new value.
+    //
+    // The slot will not be reused for the first few revisions, but after
+    // that we should not allocate any more slots.
+    for i in 1..10 {
+        input.set_field1(&mut db).to(i);
+
+        let result = function(&db, input);
+        assert_eq!(result.field1(&db), i);
+    }
+
+    // Values that have been reused should be re-interned.
+    for i in 1..10 {
+        let result = function(&db, Input::new(&db, i));
+        assert_eq!(result.field1(&db), i);
+    }
+
+    db.assert_logs(expect![[r#"
+        [
+            "WillCheckCancellation",
+            "WillExecute { database_key: function(Id(0)) }",
+            "DidInternValue { key: Interned(Id(400)), revision: R1 }",
+            "DidSetCancellationFlag",
+            "WillCheckCancellation",
+            "WillExecute { database_key: function(Id(0)) }",
+            "DidInternValue { key: Interned(Id(401)), revision: R2 }",
+            "DidSetCancellationFlag",
+            "WillCheckCancellation",
+            "WillExecute { database_key: function(Id(0)) }",
+            "DidInternValue { key: Interned(Id(402)), revision: R3 }",
+            "DidSetCancellationFlag",
+            "WillCheckCancellation",
+            "WillExecute { database_key: function(Id(0)) }",
+            "DidReuseInternedValue { key: Interned(Id(400g1)), revision: R4 }",
+            "DidSetCancellationFlag",
+            "WillCheckCancellation",
+            "WillExecute { database_key: function(Id(0)) }",
+            "DidReuseInternedValue { key: Interned(Id(401g1)), revision: R5 }",
+            "DidSetCancellationFlag",
+            "WillCheckCancellation",
+            "WillExecute { database_key: function(Id(0)) }",
+            "DidReuseInternedValue { key: Interned(Id(402g1)), revision: R6 }",
+            "DidSetCancellationFlag",
+            "WillCheckCancellation",
+            "WillExecute { database_key: function(Id(0)) }",
+            "DidReuseInternedValue { key: Interned(Id(400g2)), revision: R7 }",
+            "DidSetCancellationFlag",
+            "WillCheckCancellation",
+            "WillExecute { database_key: function(Id(0)) }",
+            "DidReuseInternedValue { key: Interned(Id(401g2)), revision: R8 }",
+            "DidSetCancellationFlag",
+            "WillCheckCancellation",
+            "WillExecute { database_key: function(Id(0)) }",
+            "DidReuseInternedValue { key: Interned(Id(402g2)), revision: R9 }",
+            "DidSetCancellationFlag",
+            "WillCheckCancellation",
+            "WillExecute { database_key: function(Id(0)) }",
+            "DidReuseInternedValue { key: Interned(Id(400g3)), revision: R10 }",
+            "WillCheckCancellation",
+            "WillExecute { database_key: function(Id(1)) }",
+            "DidInternValue { key: Interned(Id(403)), revision: R10 }",
+            "WillCheckCancellation",
+            "WillExecute { database_key: function(Id(2)) }",
+            "DidInternValue { key: Interned(Id(404)), revision: R10 }",
+            "WillCheckCancellation",
+            "WillExecute { database_key: function(Id(3)) }",
+            "DidInternValue { key: Interned(Id(405)), revision: R10 }",
+            "WillCheckCancellation",
+            "WillExecute { database_key: function(Id(4)) }",
+            "DidInternValue { key: Interned(Id(406)), revision: R10 }",
+            "WillCheckCancellation",
+            "WillExecute { database_key: function(Id(5)) }",
+            "DidInternValue { key: Interned(Id(407)), revision: R10 }",
+            "WillCheckCancellation",
+            "WillExecute { database_key: function(Id(6)) }",
+            "DidInternValue { key: Interned(Id(408)), revision: R10 }",
+            "WillCheckCancellation",
+            "WillExecute { database_key: function(Id(7)) }",
+            "DidValidateInternedValue { key: Interned(Id(401g2)), revision: R10 }",
+            "WillCheckCancellation",
+            "WillExecute { database_key: function(Id(8)) }",
+            "DidValidateInternedValue { key: Interned(Id(402g2)), revision: R10 }",
+            "WillCheckCancellation",
+            "WillExecute { database_key: function(Id(9)) }",
+        ]"#]]);
+}
+
+#[test]
+fn test_reuse_interned_input() {
+    // A query that creates an interned value.
+    #[salsa::tracked]
+    fn create_interned<'db>(db: &'db dyn Database, input: Input) -> Interned<'db> {
+        Interned::new(db, input.field1(db))
+    }
+
+    #[salsa::tracked]
+    fn use_interned<'db>(db: &'db dyn Database, interned: Interned<'db>) -> usize {
+        interned.field1(db)
+    }
+
+    let mut db = common::EventLoggerDatabase::default();
+    let input = Input::new(&db, 0);
+
+    // Create and use I0 in R0.
+    let interned = create_interned(&db, input);
+    let result = use_interned(&db, interned);
+    assert_eq!(result, 0);
+
+    // Create and use I1 in a number of revisions, marking I0 as stale.
+    input.set_field1(&mut db).to(1);
+    for _ in 0..10 {
+        let interned = create_interned(&db, input);
+        let result = use_interned(&db, interned);
+        assert_eq!(result, 1);
+
+        // Trigger a new revision.
+        input.set_field1(&mut db).to(1);
+    }
+
+    // Create I2, reusing the stale slot of I0.
+    input.set_field1(&mut db).to(2);
+    let interned = create_interned(&db, input);
+
+    // Use I2. The function should not be memoized with the value of I0, despite I2 and I0
+    // sharing the same slot.
+    let result = use_interned(&db, interned);
+    assert_eq!(result, 2);
+}
+
+#[test]
+fn test_reuse_multiple_interned_input() {
+    // A query that creates an interned value.
+    #[salsa::tracked]
+    fn create_interned<'db>(db: &'db dyn Database, input: Input) -> Interned<'db> {
+        Interned::new(db, input.field1(db))
+    }
+
+    // A query that creates an interned value.
+    #[salsa::tracked]
+    fn create_nested_interned<'db>(
+        db: &'db dyn Database,
+        interned: Interned<'db>,
+    ) -> NestedInterned<'db> {
+        NestedInterned::new(db, interned)
+    }
+
+    #[salsa::tracked]
+    fn use_interned<'db>(db: &'db dyn Database, interned: Interned<'db>) -> usize {
+        interned.field1(db)
+    }
+
+    // A query that reads an interned value.
+    #[salsa::tracked]
+    fn use_nested_interned<'db>(
+        db: &'db dyn Database,
+        nested_interned: NestedInterned<'db>,
+    ) -> usize {
+        nested_interned.interned(db).field1(db)
+    }
+
+    let mut db = common::EventLoggerDatabase::default();
+    let input = Input::new(&db, 0);
+
+    // Create and use NI0, which wraps I0, in R0.
+    let interned = create_interned(&db, input);
+    let i0_id = salsa::plumbing::AsId::as_id(&interned);
+    let nested_interned = create_nested_interned(&db, interned);
+    let result = use_nested_interned(&db, nested_interned);
+    assert_eq!(result, 0);
+
+    // Create and use I1 in a number of revisions, marking I0 as stale.
+    input.set_field1(&mut db).to(1);
+    for _ in 0..10 {
+        let interned = create_interned(&db, input);
+        let result = use_interned(&db, interned);
+        assert_eq!(result, 1);
+
+        // Trigger a new revision.
+        input.set_field1(&mut db).to(1);
+    }
+
+    // Create I2, reusing the stale slot of I0.
+    input.set_field1(&mut db).to(2);
+    let interned = create_interned(&db, input);
+
+    let i2_id = salsa::plumbing::AsId::as_id(&interned);
+    assert_ne!(i0_id, i2_id);
+
+    // Create NI1 wrapping I2 instead of I0.
+    let nested_interned = create_nested_interned(&db, interned);
+
+    // Use NI1. The function should not be memoized with the value of NI0,
+    // despite I2 and I0 sharing the same ID.
+    let result = use_nested_interned(&db, nested_interned);
+    assert_eq!(result, 2);
 }

--- a/tests/preverify-struct-with-leaked-data-2.rs
+++ b/tests/preverify-struct-with-leaked-data-2.rs
@@ -83,7 +83,7 @@ fn test_leaked_inputs_ignored() {
         [
             "DidSetCancellationFlag",
             "WillCheckCancellation",
-            "DidReinternValue { key: counter_field::interned_arguments(Id(800)), revision: R2 }",
+            "DidValidateInternedValue { key: counter_field::interned_arguments(Id(800)), revision: R2 }",
             "WillCheckCancellation",
             "WillExecute { database_key: counter_field(Id(800)) }",
             "WillExecute { database_key: function(Id(0)) }",


### PR DESCRIPTION
Basic implementation of https://github.com/salsa-rs/salsa/issues/597.

The garbage collection strategy used here is very simple.
- Slots that have not been accessed in the last 3 *active revisions* are always reused, and nothing else. Active revisions are those in which interned values were actually read to avoid counting empty revisions.
- Slots are never swept proactively, though this would be simple to add as an option.
- We also cannot collect low durability values, which would require `&mut db`. This could be supported with the above.

This is by no means a perfect strategy, but we can always tune it as needed once the infrastructure is in place. We may also want to expose the `N` active revisions constant as a configuration option in the `#[interned]` macro (it seems somewhat related to durability).

The LRU list is sharded by hash, very similar to dashmap. There seems to be no performance difference from the previous implementation in multi-threaded `ty` benchmarks (though there was a significant regression without sharding). There is also no significant performance difference in single-threaded benchmarks thanks to https://github.com/salsa-rs/salsa/pull/864, which lets us avoid additional read dependencies.