### PR TITLE
Gate loom dependency under feature flag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Check (without default features)
         run: cargo check --workspace --no-default-features
       - name: Check (loom)
-        run: RUSTFLAGS="--cfg loom" cargo check --workspace
+        run: RUSTFLAGS="--cfg loom" cargo check --workspace --features loom
 
   miri:
     name: Miri

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,12 +30,13 @@ rayon = { version = "1.10.0", optional = true }
 # Stuff we want Update impls for by default
 compact_str = { version = "0.9", optional = true }
 thin-vec = "0.2.13"
-loom = "0.7.2"
+loom = { version = "0.7.2", optional = true }
 
 [features]
 default = ["salsa_unstable", "rayon", "macros"]
 # FIXME: remove `salsa_unstable` before 1.0.
 salsa_unstable = []
+loom = ["dep:loom"]
 macros = ["dep:salsa-macros"]
 
 # This interlocks the `salsa-macros` and `salsa` versions together

--- a/justfile
+++ b/justfile
@@ -5,6 +5,6 @@ miri:
     cargo +nightly miri test --no-fail-fast --all-features
 
 loom:
-    RUSTFLAGS="--cfg loom" cargo check --workspace
+    RUSTFLAGS="--cfg loom" cargo check --workspace --features loom
 
 all: test miri


### PR DESCRIPTION
This makes sure the dependency is not included on unsupported platforms (https://github.com/astral-sh/ruff/pull/17895). `cfg(loom)` is still required to enable loom to ensure it is not accidentally enabled when testing with `--all-features`.