### PR TITLE
Add a basic loom test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ salsa-macros = { version = "0.21.1", path = "components/salsa-macros", optional 
 boxcar = "0.2.11"
 crossbeam-queue = "0.3.11"
 dashmap = { version = "6", features = ["raw-api"] }
+# the version of hashbrown used by dashmap
+hashbrown_14 = { version = "0.14", package = "hashbrown" }
 hashbrown = "0.15"
 hashlink = "0.10"
 indexmap = "2"

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -2,7 +2,6 @@ use std::hash::{BuildHasher, Hash};
 
 pub(crate) type FxHasher = std::hash::BuildHasherDefault<rustc_hash::FxHasher>;
 pub(crate) type FxIndexSet<K> = indexmap::IndexSet<K, FxHasher>;
-pub(crate) type FxDashMap<K, V> = dashmap::DashMap<K, V, FxHasher>;
 pub(crate) type FxLinkedHashSet<K> = hashlink::LinkedHashSet<K, FxHasher>;
 pub(crate) type FxHashSet<K> = std::collections::HashSet<K, FxHasher>;
 

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -10,12 +10,12 @@ use dashmap::SharedValue;
 
 use crate::durability::Durability;
 use crate::function::VerifyResult;
-use crate::hash::FxDashMap;
 use crate::id::{AsId, FromId};
 use crate::ingredient::Ingredient;
 use crate::loom::cell::Cell;
 use crate::loom::sync::atomic::{AtomicU8, Ordering};
 use crate::loom::sync::Arc;
+use crate::loom::sync::FxDashMap;
 use crate::plumbing::{IngredientIndices, Jar};
 use crate::revision::AtomicRevision;
 use crate::table::memo::{MemoTable, MemoTableTypes};

--- a/src/table.rs
+++ b/src/table.rs
@@ -221,6 +221,7 @@ impl Table {
     ///
     /// See [`Page::get_raw`][].
     // TODO: This could return an `&UnsafeCell<T>` directly, but loom's `UnsafeCell` is not `repr(C)`
+    #[inline]
     pub(crate) fn get_raw<T: Slot>(&self, id: Id) -> &UnsafeCell<MaybeUninit<T>> {
         let (page, slot) = split_id(id);
         let page_ref = self.page::<T>(page);

--- a/tests/loom/interned.rs
+++ b/tests/loom/interned.rs
@@ -1,0 +1,30 @@
+use loom::sync::Arc;
+
+#[salsa::interned(debug)]
+struct Interned<'db> {
+    data: usize,
+}
+
+#[test]
+fn test_intern_concurrent() {
+    loom::model(|| {
+        let db = Arc::new(salsa::DatabaseImpl::new());
+        let db2 = db.clone();
+
+        let handle = loom::thread::spawn(move || {
+            intern(&*db);
+        });
+
+        let handle2 = loom::thread::spawn(move || {
+            intern(&*db2);
+        });
+
+        handle.join().unwrap();
+        handle2.join().unwrap();
+    });
+}
+
+#[salsa::tracked]
+fn intern(db: &dyn salsa::Database) -> Interned<'_> {
+    Interned::new(db, 0)
+}

--- a/tests/loom/main.rs
+++ b/tests/loom/main.rs
@@ -1,0 +1,3 @@
+#![cfg(loom)]
+
+mod interned;


### PR DESCRIPTION
Fixes a couple issues when running under loom and adds a basic concurrency test. Unfortunately, this test is still very slow (it ran for >45 minutes and >20M iterations before I killed it on my machine), so I didn't add it to CI yet. It will probably only be practical for us to run very fine-grained unit tests under loom, or switch to something like shuttle for larger tests.