### PR TITLE
Move salsa event system into `Zalsa`

### DIFF
--- a/components/salsa-macro-rules/src/setup_accumulator_impl.rs
+++ b/components/salsa-macro-rules/src/setup_accumulator_impl.rs
@@ -23,13 +23,12 @@ macro_rules! setup_accumulator_impl {
 
             // Suppress the lint against `cfg(loom)`.
             #[allow(unexpected_cfgs)]
-            fn $ingredient(db: &dyn $zalsa::Database) -> &$zalsa_struct::IngredientImpl<$Struct> {
+            fn $ingredient(zalsa: &$zalsa::Zalsa) -> &$zalsa_struct::IngredientImpl<$Struct> {
                 $zalsa::__maybe_lazy_static! {
                     static $CACHE: $zalsa::IngredientCache<$zalsa_struct::IngredientImpl<$Struct>> =
                         $zalsa::IngredientCache::new();
                 }
 
-                let zalsa = db.zalsa();
                 $CACHE.get_or_create(zalsa, || {
                     zalsa.add_or_lookup_jar_by_type::<$zalsa_struct::JarImpl<$Struct>>()
                 })
@@ -42,8 +41,8 @@ macro_rules! setup_accumulator_impl {
                 where
                     Db: ?Sized + $zalsa::Database,
                 {
-                    let db = db.as_dyn_database();
-                    $ingredient(db).push(db, self);
+                    let (zalsa, zalsa_local) = db.zalsas();
+                    $ingredient(zalsa).push(zalsa_local, self);
                 }
             }
         };

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -213,7 +213,7 @@ macro_rules! setup_tracked_fn {
                     $inner($db, $($input_id),*)
                 }
 
-                fn cycle_initial<$db_lt>(db: &$db_lt dyn $Db, ($($input_id),*): ($($input_ty),*)) -> Self::Output<$db_lt> {
+                fn cycle_initial<$db_lt>(db: &$db_lt Self::DbView, ($($input_id),*): ($($input_ty),*)) -> Self::Output<$db_lt> {
                     $($cycle_recovery_initial)*(db, $($input_id),*)
                 }
 
@@ -231,7 +231,7 @@ macro_rules! setup_tracked_fn {
                         if $needs_interner {
                             $Configuration::intern_ingredient(db).data(db.as_dyn_database(), key).clone()
                         } else {
-                            $zalsa::FromIdWithDb::from_id(key, db)
+                            $zalsa::FromIdWithDb::from_id(key, db.zalsa())
                         }
                     }
                 }

--- a/components/salsa-macro-rules/src/setup_tracked_struct.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_struct.rs
@@ -169,15 +169,18 @@ macro_rules! setup_tracked_struct {
             }
 
             impl $Configuration {
+                pub fn ingredient(db: &dyn $zalsa::Database) -> &$zalsa_struct::IngredientImpl<Self> {
+                    Self::ingredient_(db.zalsa())
+                }
+
                 // Suppress the lint against `cfg(loom)`.
                 #[allow(unexpected_cfgs)]
-                pub fn ingredient(db: &dyn $zalsa::Database) -> &$zalsa_struct::IngredientImpl<$Configuration> {
+                fn ingredient_(zalsa: &$zalsa::Zalsa) -> &$zalsa_struct::IngredientImpl<Self> {
                     $zalsa::__maybe_lazy_static! {
                         static CACHE: $zalsa::IngredientCache<$zalsa_struct::IngredientImpl<$Configuration>> =
                             $zalsa::IngredientCache::new();
                     }
 
-                    let zalsa = db.zalsa();
                     CACHE.get_or_create(zalsa, || {
                         zalsa.add_or_lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>()
                     })
@@ -216,8 +219,8 @@ macro_rules! setup_tracked_struct {
             }
 
             impl $zalsa::TrackedStructInDb for $Struct<'_> {
-                fn database_key_index(db: &dyn $zalsa::Database, id: $zalsa::Id) -> $zalsa::DatabaseKeyIndex {
-                    $Configuration::ingredient(db).database_key_index(id)
+                fn database_key_index(zalsa: &$zalsa::Zalsa, id: $zalsa::Id) -> $zalsa::DatabaseKeyIndex {
+                    $Configuration::ingredient_(zalsa).database_key_index(id)
                 }
             }
 

--- a/components/salsa-macros/src/supertype.rs
+++ b/components/salsa-macros/src/supertype.rs
@@ -59,9 +59,8 @@ fn enum_impl(enum_item: syn::ItemEnum) -> syn::Result<TokenStream> {
         impl #impl_generics zalsa::FromIdWithDb for #enum_name #type_generics
         #where_clause {
             #[inline]
-            fn from_id(__id: zalsa::Id, __db: &(impl ?Sized + zalsa::Database)) -> Self {
-                let __zalsa = __db.zalsa();
-                let __type_id = __zalsa.lookup_page_type_id(__id);
+            fn from_id(__id: zalsa::Id, zalsa: &zalsa::Zalsa) -> Self {
+                let __type_id = zalsa.lookup_page_type_id(__id);
                 <Self as zalsa::SalsaStructInDb>::cast(__id, __type_id).expect("invalid enum variant")
             }
         }

--- a/src/function/accumulated.rs
+++ b/src/function/accumulated.rs
@@ -31,7 +31,7 @@ where
         // are read from outside of salsa anyway so this is not a big deal.
         zalsa_local.report_untracked_read(zalsa.current_revision());
 
-        let Some(accumulator) = <accumulator::IngredientImpl<A>>::from_db(db) else {
+        let Some(accumulator) = <accumulator::IngredientImpl<A>>::from_zalsa(zalsa) else {
             return vec![];
         };
         let mut output = vec![];
@@ -69,7 +69,7 @@ where
             // output vector, we want to push in execution order, so reverse order to
             // ensure the first child that was executed will be the first child popped
             // from the stack.
-            let Some(origin) = ingredient.origin(db, k.key_index()) else {
+            let Some(origin) = ingredient.origin(zalsa, k.key_index()) else {
                 continue;
             };
 

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -13,7 +13,7 @@ where
 {
     pub fn fetch<'db>(&'db self, db: &'db C::DbView, id: Id) -> &'db C::Output<'db> {
         let (zalsa, zalsa_local) = db.zalsas();
-        zalsa.unwind_if_revision_cancelled(db);
+        zalsa.unwind_if_revision_cancelled(zalsa_local);
 
         let memo = self.refresh_memo(db, zalsa, id);
         // SAFETY: We just refreshed the memo so it is guaranteed to contain a value now.
@@ -43,7 +43,7 @@ where
         let memo_ingredient_index = self.memo_ingredient_index(zalsa, id);
         loop {
             if let Some(memo) = self
-                .fetch_hot(zalsa, db, id, memo_ingredient_index)
+                .fetch_hot(zalsa, id, memo_ingredient_index)
                 .or_else(|| self.fetch_cold(zalsa, db, id, memo_ingredient_index))
             {
                 // If we get back a provisional cycle memo, and it's provisional on any cycle heads
@@ -54,7 +54,7 @@ where
                 // That is only correct for fixpoint cycles, though: `FallbackImmediate` cycles
                 // never have provisional entries.
                 if C::CYCLE_STRATEGY == CycleRecoveryStrategy::FallbackImmediate
-                    || !memo.provisional_retry(db, zalsa, self.database_key_index(id))
+                    || !memo.provisional_retry(zalsa, self.database_key_index(id))
                 {
                     return memo;
                 }
@@ -66,7 +66,6 @@ where
     fn fetch_hot<'db>(
         &'db self,
         zalsa: &'db Zalsa,
-        db: &'db C::DbView,
         id: Id,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> Option<&'db Memo<C::Output<'db>>> {
@@ -79,7 +78,7 @@ where
         let shallow_update = self.shallow_verify_memo(zalsa, database_key_index, memo)?;
 
         if !memo.may_be_provisional() {
-            self.update_shallow(db, zalsa, database_key_index, memo, shallow_update);
+            self.update_shallow(zalsa, database_key_index, memo, shallow_update);
 
             // SAFETY: memo is present in memo_map and we have verified that it is
             // still valid for the current revision.
@@ -98,7 +97,7 @@ where
         memo_ingredient_index: MemoIngredientIndex,
     ) -> Option<&'db Memo<C::Output<'db>>> {
         // Try to claim this query: if someone else has claimed it already, go back and start again.
-        let _claim_guard = match self.sync_table.try_claim(db, zalsa, id) {
+        let _claim_guard = match self.sync_table.try_claim(zalsa, id) {
             ClaimResult::Retry => return None,
             ClaimResult::Cycle => {
                 let database_key_index = self.database_key_index(id);
@@ -113,13 +112,7 @@ where
                         if let Some(shallow_update) =
                             self.shallow_verify_memo(zalsa, database_key_index, memo)
                         {
-                            self.update_shallow(
-                                db,
-                                zalsa,
-                                database_key_index,
-                                memo,
-                                shallow_update,
-                            );
+                            self.update_shallow(zalsa, database_key_index, memo, shallow_update);
                             // SAFETY: memo is present in memo_map.
                             return unsafe { Some(self.extend_memo_lifetime(memo)) };
                         }

--- a/src/id.rs
+++ b/src/id.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::num::NonZeroU32;
 
-use crate::Database;
+use crate::zalsa::Zalsa;
 
 /// The `Id` of a salsa struct in the database [`Table`](`crate::table::Table`).
 ///
@@ -85,12 +85,12 @@ impl FromId for Id {
 /// Enums cannot use [`FromId`] because they need access to the DB to tell the `TypeId` of the variant,
 /// so they use this trait instead, that has a blanket implementation for `FromId`.
 pub trait FromIdWithDb {
-    fn from_id(id: Id, db: &(impl ?Sized + Database)) -> Self;
+    fn from_id(id: Id, zalsa: &Zalsa) -> Self;
 }
 
 impl<T: FromId> FromIdWithDb for T {
     #[inline]
-    fn from_id(id: Id, _db: &(impl ?Sized + Database)) -> Self {
+    fn from_id(id: Id, _zalsa: &Zalsa) -> Self {
         FromId::from_id(id)
     }
 }

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -70,8 +70,8 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
     ///
     /// In the case of nested cycles, we are not asking here whether the value is provisional due
     /// to the outer cycle being unresolved, only whether its own cycle remains provisional.
-    fn cycle_head_kind<'db>(&'db self, db: &'db dyn Database, input: Id) -> CycleHeadKind {
-        _ = (db, input);
+    fn cycle_head_kind(&self, zalsa: &Zalsa, input: Id) -> CycleHeadKind {
+        _ = (zalsa, input);
         CycleHeadKind::NotProvisional
     }
 
@@ -80,21 +80,21 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
     /// A return value of `true` indicates that a result is now available. A return value of
     /// `false` means that a cycle was encountered; the waited-on query is either already claimed
     /// by the current thread, or by a thread waiting on the current thread.
-    fn wait_for(&self, db: &dyn Database, key_index: Id) -> bool {
-        _ = (db, key_index);
+    fn wait_for(&self, zalsa: &Zalsa, key_index: Id) -> bool {
+        _ = (zalsa, key_index);
         true
     }
 
     /// Invoked when the value `output_key` should be marked as valid in the current revision.
     /// This occurs because the value for `executor`, which generated it, was marked as valid
     /// in the current revision.
-    fn mark_validated_output<'db>(
-        &'db self,
-        db: &'db dyn Database,
+    fn mark_validated_output(
+        &self,
+        zalsa: &Zalsa,
         executor: DatabaseKeyIndex,
         output_key: crate::Id,
     ) {
-        let _ = (db, executor, output_key);
+        let _ = (zalsa, executor, output_key);
         unreachable!("only tracked struct and function ingredients can have validatable outputs")
     }
 
@@ -102,13 +102,8 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
     /// revision, but was NOT output in the current revision.
     ///
     /// This hook is used to clear out the stale value so others cannot read it.
-    fn remove_stale_output(
-        &self,
-        db: &dyn Database,
-        executor: DatabaseKeyIndex,
-        stale_output_key: Id,
-    ) {
-        let _ = (db, executor, stale_output_key);
+    fn remove_stale_output(&self, zalsa: &Zalsa, executor: DatabaseKeyIndex, stale_output_key: Id) {
+        let _ = (zalsa, executor, stale_output_key);
         unreachable!("only tracked struct ingredients can have stale outputs")
     }
 
@@ -155,8 +150,8 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
     }
 
     /// What were the inputs (if any) that were used to create the value at `key_index`.
-    fn origin(&self, db: &dyn Database, key_index: Id) -> Option<QueryOrigin> {
-        let _ = (db, key_index);
+    fn origin(&self, zalsa: &Zalsa, key_index: Id) -> Option<QueryOrigin> {
+        let _ = (zalsa, key_index);
         unreachable!("only function ingredients have origins")
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -112,7 +112,7 @@ impl<C: Configuration> IngredientImpl<C> {
             })
         });
 
-        FromIdWithDb::from_id(id, db)
+        FromIdWithDb::from_id(id, zalsa)
     }
 
     /// Change the value of the field `field_index` to a new value.
@@ -152,13 +152,14 @@ impl<C: Configuration> IngredientImpl<C> {
     }
 
     /// Get the singleton input previously created (if any).
-    pub fn get_singleton_input(&self, db: &(impl ?Sized + Database)) -> Option<C::Struct>
+    #[doc(hidden)]
+    pub fn get_singleton_input(&self, zalsa: &Zalsa) -> Option<C::Struct>
     where
         C: Configuration<Singleton = Singleton>,
     {
         self.singleton
             .index()
-            .map(|id| FromIdWithDb::from_id(id, db))
+            .map(|id| FromIdWithDb::from_id(id, zalsa))
     }
 
     /// Access field of an input.

--- a/src/input/input_field.rs
+++ b/src/input/input_field.rs
@@ -61,10 +61,6 @@ where
         VerifyResult::changed_if(value.stamps[self.field_index].changed_at > revision)
     }
 
-    fn wait_for(&self, _db: &dyn Database, _key_index: Id) -> bool {
-        true
-    }
-
     fn fmt_index(&self, index: crate::Id, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             fmt,

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -221,7 +221,7 @@ where
                 // Sync the value's revision.
                 if value.last_interned_at.load() < current_revision {
                     value.last_interned_at.store(current_revision);
-                    db.salsa_event(&|| {
+                    zalsa.event(&|| {
                         Event::new(EventKind::DidReinternValue {
                             key: index,
                             revision: current_revision,
@@ -264,7 +264,7 @@ where
                 // Sync the value's revision.
                 if value.last_interned_at.load() < current_revision {
                     value.last_interned_at.store(current_revision);
-                    db.salsa_event(&|| {
+                    zalsa.event(&|| {
                         Event::new(EventKind::DidReinternValue {
                             key: index,
                             revision: current_revision,
@@ -323,7 +323,7 @@ where
                 let index = self.database_key_index(id);
                 zalsa_local.report_tracked_read_simple(index, durability, value.first_interned_at);
 
-                db.salsa_event(&|| {
+                zalsa.event(&|| {
                     Event::new(EventKind::DidInternValue {
                         key: index,
                         revision: current_revision,
@@ -364,7 +364,8 @@ where
     }
 
     pub fn reset(&mut self, db: &mut dyn Database) {
-        db.zalsa_mut().new_revision();
+        _ = db.zalsa_mut();
+        // We can clear the key_map now that we have cancelled all other handles.
         self.key_map.clear();
     }
 
@@ -412,7 +413,7 @@ where
             value.last_interned_at.load(),
         ));
 
-        db.salsa_event(&|| {
+        zalsa.event(&|| {
             let index = self.database_key_index(input);
 
             Event::new(EventKind::DidReinternValue {

--- a/src/key.rs
+++ b/src/key.rs
@@ -36,37 +36,32 @@ impl DatabaseKeyIndex {
     pub(crate) fn maybe_changed_after(
         &self,
         db: &dyn Database,
+        zalsa: &Zalsa,
         last_verified_at: crate::Revision,
         in_cycle: bool,
     ) -> VerifyResult {
         // SAFETY: The `db` belongs to the ingredient
         unsafe {
-            db.zalsa()
+            zalsa
                 .lookup_ingredient(self.ingredient_index)
                 .maybe_changed_after(db, self.key_index, last_verified_at, in_cycle)
         }
     }
 
-    pub(crate) fn remove_stale_output(
-        &self,
-        zalsa: &Zalsa,
-        db: &dyn Database,
-        executor: DatabaseKeyIndex,
-    ) {
+    pub(crate) fn remove_stale_output(&self, zalsa: &Zalsa, executor: DatabaseKeyIndex) {
         zalsa
             .lookup_ingredient(self.ingredient_index)
-            .remove_stale_output(db, executor, self.key_index)
+            .remove_stale_output(zalsa, executor, self.key_index)
     }
 
     pub(crate) fn mark_validated_output(
         &self,
         zalsa: &Zalsa,
-        db: &dyn Database,
         database_key_index: DatabaseKeyIndex,
     ) {
         zalsa
             .lookup_ingredient(self.ingredient_index)
-            .mark_validated_output(db, database_key_index, self.key_index)
+            .mark_validated_output(zalsa, database_key_index, self.key_index)
     }
 }
 

--- a/src/loom.rs
+++ b/src/loom.rs
@@ -4,12 +4,18 @@ pub use loom::{cell, thread, thread_local};
 /// A helper macro to work around the fact that most loom types are not `const` constructable.
 #[doc(hidden)]
 #[macro_export]
+#[cfg(loom)]
 macro_rules! __maybe_lazy_static {
     (static $name:ident: $t:ty = $init:expr $(;)?) => {
-        #[cfg(loom)]
         loom::lazy_static! { static ref $name: $t = $init; }
-
-        #[cfg(not(loom))]
+    };
+}
+/// A helper macro to work around the fact that most loom types are not `const` constructable.
+#[doc(hidden)]
+#[macro_export]
+#[cfg(not(loom))]
+macro_rules! __maybe_lazy_static {
+    (static $name:ident: $t:ty = $init:expr $(;)?) => {
         static $name: $t = $init;
     };
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -5,7 +5,7 @@ use crate::loom::sync::atomic::{AtomicBool, Ordering};
 use crate::loom::sync::{AtomicMut, Mutex};
 use crate::loom::thread::{self, ThreadId};
 use crate::table::Table;
-use crate::{Cancelled, Database, Event, EventKind, Revision};
+use crate::{Cancelled, Event, EventKind, Revision};
 
 mod dependency_graph;
 
@@ -167,7 +167,7 @@ impl Runtime {
     /// cancelled, so this function will panic with a `Cancelled` value.
     pub(crate) fn block_on<QueryMutexGuard>(
         &self,
-        db: &(impl Database + ?Sized),
+        zalsa: &crate::zalsa::Zalsa,
         database_key: DatabaseKeyIndex,
         other_id: ThreadId,
         query_mutex_guard: QueryMutexGuard,
@@ -179,7 +179,7 @@ impl Runtime {
             return BlockResult::Cycle;
         }
 
-        db.salsa_event(&|| {
+        zalsa.event(&|| {
             Event::new(EventKind::WillBlockOn {
                 other_thread_id: other_id,
                 database_key,

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -305,6 +305,7 @@ impl ZalsaLocal {
 
     #[cold]
     pub(crate) fn unwind_cancelled(&self, current_revision: Revision) {
+        // Why is this reporting an untracked read? We do not store the query revisions on unwind do we?
         self.report_untracked_read(current_revision);
         Cancelled::PendingWrite.throw();
     }

--- a/tests/tracked_struct_durability.rs
+++ b/tests/tracked_struct_durability.rs
@@ -94,9 +94,7 @@ fn execute() {
     }
 
     #[salsa::db]
-    impl salsa::Database for Database {
-        fn salsa_event(&self, _event: &dyn Fn() -> salsa::Event) {}
-    }
+    impl salsa::Database for Database {}
 
     #[salsa::db]
     impl Db for Database {


### PR DESCRIPTION
The existence of `Database::salsa_event` is incredibly annoying as a lot of internal code takes a `&dyn Database` solely to do event reporting where as usually a `&Zalsa` handle would otherwise suffice. This becomes even more annoying when mutable handles are involved as it requires some odd code structuring to avoid mutability xor shared errors, it also makes optimizations more difficult for the compiler due to dynamic dispatches it can't look through.

So this moves the trait method away to a separate callback that can be registered, and if not registered, can be skipped entirely.