### PR TITLE
Fix memo table growth condition

### DIFF
--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -212,10 +212,14 @@ impl MemoTableWithTypes<'_> {
     ) -> Option<NonNull<M>> {
         let memo_ingredient_index = memo_ingredient_index.as_usize();
         let mut memos = self.memos.memos.write();
-        let additional_len = memo_ingredient_index - memos.len() + 1;
-        memos.reserve(additional_len);
-        while memos.len() < memo_ingredient_index + 1 {
-            memos.push(MemoEntry::default());
+
+        // Grow the table if needed.
+        if memos.len() <= memo_ingredient_index {
+            let additional_len = memo_ingredient_index - memos.len() + 1;
+            memos.reserve(additional_len);
+            while memos.len() <= memo_ingredient_index {
+                memos.push(MemoEntry::default());
+            }
         }
 
         let memo_entry = &mut memos[memo_ingredient_index].atomic_memo;


### PR DESCRIPTION
The `additional_len` calculation assumes that `memos.len() <= memo_ingredient_index`, which is not true in light of concurrent inserts. We're seeing spurious overflow panics because of this. It looks like this was changed in https://github.com/salsa-rs/salsa/pull/803.