### PR TITLE
Pass cycle heads as out parameter for `maybe_changed_after`

### DIFF
--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -7,6 +7,7 @@ use std::panic::UnwindSafe;
 
 use accumulated::{Accumulated, AnyAccumulated};
 
+use crate::cycle::CycleHeads;
 use crate::function::VerifyResult;
 use crate::ingredient::{Ingredient, Jar};
 use crate::loom::sync::Arc;
@@ -105,7 +106,7 @@ impl<A: Accumulator> Ingredient for IngredientImpl<A> {
         _db: &dyn Database,
         _input: Id,
         _revision: Revision,
-        _in_cycle: bool,
+        _cycle_heads: &mut CycleHeads,
     ) -> VerifyResult {
         panic!("nothing should ever depend on an accumulator directly")
     }

--- a/src/cycle.rs
+++ b/src/cycle.rs
@@ -152,6 +152,22 @@ impl CycleHeads {
     }
 
     #[inline]
+    pub(crate) fn push_initial(&mut self, database_key_index: DatabaseKeyIndex) {
+        if let Some(existing) = self
+            .0
+            .iter()
+            .find(|candidate| candidate.database_key_index == database_key_index)
+        {
+            assert_eq!(existing.iteration_count, 0);
+        } else {
+            self.0.push(CycleHead {
+                database_key_index,
+                iteration_count: 0,
+            });
+        }
+    }
+
+    #[inline]
     pub(crate) fn extend(&mut self, other: &Self) {
         self.0.reserve(other.0.len());
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -5,7 +5,7 @@ use std::ptr::NonNull;
 pub(crate) use maybe_changed_after::VerifyResult;
 
 use crate::accumulator::accumulated_map::{AccumulatedMap, InputAccumulatedValues};
-use crate::cycle::{CycleHeadKind, CycleRecoveryAction, CycleRecoveryStrategy};
+use crate::cycle::{CycleHeadKind, CycleHeads, CycleRecoveryAction, CycleRecoveryStrategy};
 use crate::function::delete::DeletedEntries;
 use crate::function::sync::{ClaimResult, SyncTable};
 use crate::ingredient::Ingredient;
@@ -233,11 +233,11 @@ where
         db: &dyn Database,
         input: Id,
         revision: Revision,
-        in_cycle: bool,
+        cycle_heads: &mut CycleHeads,
     ) -> VerifyResult {
         // SAFETY: The `db` belongs to the ingredient as per caller invariant
         let db = unsafe { self.view_caster.downcast_unchecked(db) };
-        self.maybe_changed_after(db, input, revision, in_cycle)
+        self.maybe_changed_after(db, input, revision, cycle_heads)
     }
 
     /// True if the input `input` contains a memo that cites itself as a cycle head.

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -176,9 +176,14 @@ where
         let opt_old_memo = self.get_memo_from_table_for(zalsa, id, memo_ingredient_index);
         if let Some(old_memo) = opt_old_memo {
             if old_memo.value.is_some() {
-                if let VerifyResult::Unchanged(_, cycle_heads) =
-                    self.deep_verify_memo(db, zalsa, old_memo, self.database_key_index(id))
-                {
+                let mut cycle_heads = CycleHeads::default();
+                if let VerifyResult::Unchanged(_) = self.deep_verify_memo(
+                    db,
+                    zalsa,
+                    old_memo,
+                    self.database_key_index(id),
+                    &mut cycle_heads,
+                ) {
                     if cycle_heads.is_empty() {
                         // SAFETY: memo is present in memo_map and we have verified that it is
                         // still valid for the current revision.

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -219,19 +219,14 @@ impl<V> Memo<V> {
     /// The caller is responsible to update the memo's `accumulated` state if their accumulated
     /// values have changed since.
     #[inline]
-    pub(super) fn mark_as_verified(
-        &self,
-        zalsa: &Zalsa,
-        revision_now: Revision,
-        database_key_index: DatabaseKeyIndex,
-    ) {
+    pub(super) fn mark_as_verified(&self, zalsa: &Zalsa, database_key_index: DatabaseKeyIndex) {
         zalsa.event(&|| {
             Event::new(EventKind::DidValidateMemoizedValue {
                 database_key: database_key_index,
             })
         });
 
-        self.verified_at.store(revision_now);
+        self.verified_at.store(zalsa.current_revision());
     }
 
     pub(super) fn mark_outputs_as_verified(

--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -125,7 +125,7 @@ where
         }
 
         let database_key_index = self.database_key_index(key);
-        memo.mark_as_verified(zalsa, zalsa.current_revision(), database_key_index);
+        memo.mark_as_verified(zalsa, database_key_index);
         memo.revisions
             .accumulated_inputs
             .store(InputAccumulatedValues::Empty);

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -2,7 +2,7 @@ use std::any::{Any, TypeId};
 use std::fmt;
 
 use crate::accumulator::accumulated_map::{AccumulatedMap, InputAccumulatedValues};
-use crate::cycle::{CycleHeadKind, CycleRecoveryStrategy};
+use crate::cycle::{CycleHeadKind, CycleHeads, CycleRecoveryStrategy};
 use crate::function::VerifyResult;
 use crate::loom::sync::Arc;
 use crate::plumbing::IngredientIndices;
@@ -63,7 +63,7 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
         db: &'db dyn Database,
         input: Id,
         revision: Revision,
-        in_cycle: bool,
+        cycle_heads: &mut CycleHeads,
     ) -> VerifyResult;
 
     /// Is the value for `input` in this ingredient a cycle head that is still provisional?

--- a/src/input.rs
+++ b/src/input.rs
@@ -9,6 +9,7 @@ pub mod singleton;
 
 use input_field::FieldIngredientImpl;
 
+use crate::cycle::CycleHeads;
 use crate::function::VerifyResult;
 use crate::id::{AsId, FromId, FromIdWithDb};
 use crate::ingredient::Ingredient;
@@ -217,7 +218,7 @@ impl<C: Configuration> Ingredient for IngredientImpl<C> {
         _db: &dyn Database,
         _input: Id,
         _revision: Revision,
-        _in_cycle: bool,
+        _cycle_heads: &mut CycleHeads,
     ) -> VerifyResult {
         // Input ingredients are just a counter, they store no data, they are immortal.
         // Their *fields* are stored in function ingredients elsewhere.

--- a/src/input/input_field.rs
+++ b/src/input/input_field.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::marker::PhantomData;
 
+use crate::cycle::CycleHeads;
 use crate::function::VerifyResult;
 use crate::ingredient::Ingredient;
 use crate::input::{Configuration, IngredientImpl, Value};
@@ -54,7 +55,7 @@ where
         db: &dyn Database,
         input: Id,
         revision: Revision,
-        _in_cycle: bool,
+        _cycle_heads: &mut CycleHeads,
     ) -> VerifyResult {
         let zalsa = db.zalsa();
         let value = <IngredientImpl<C>>::data(zalsa, input);

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 
 use dashmap::SharedValue;
 
+use crate::cycle::CycleHeads;
 use crate::durability::Durability;
 use crate::function::VerifyResult;
 use crate::hash::FxDashMap;
@@ -396,13 +397,13 @@ where
         db: &dyn Database,
         input: Id,
         revision: Revision,
-        _in_cycle: bool,
+        _cycle_heads: &mut CycleHeads,
     ) -> VerifyResult {
         let zalsa = db.zalsa();
         let value = zalsa.table().get::<Value<C>>(input);
         if value.first_interned_at > revision {
             // The slot was reused.
-            return VerifyResult::changed();
+            return VerifyResult::Changed;
         }
 
         // The slot is valid in this revision but we have to sync the value's revision.

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,5 +1,6 @@
 use core::fmt;
 
+use crate::cycle::CycleHeads;
 use crate::function::VerifyResult;
 use crate::zalsa::{IngredientIndex, Zalsa};
 use crate::{Database, Id};
@@ -38,13 +39,13 @@ impl DatabaseKeyIndex {
         db: &dyn Database,
         zalsa: &Zalsa,
         last_verified_at: crate::Revision,
-        in_cycle: bool,
+        cycle_heads: &mut CycleHeads,
     ) -> VerifyResult {
         // SAFETY: The `db` belongs to the ingredient
         unsafe {
             zalsa
                 .lookup_ingredient(self.ingredient_index)
-                .maybe_changed_after(db, self.key_index, last_verified_at, in_cycle)
+                .maybe_changed_after(db, self.key_index, last_verified_at, cycle_heads)
         }
     }
 

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -10,6 +10,7 @@ use std::{fmt, mem};
 use crossbeam_queue::SegQueue;
 use tracked_field::FieldIngredientImpl;
 
+use crate::cycle::CycleHeads;
 use crate::function::VerifyResult;
 use crate::id::{AsId, FromId};
 use crate::ingredient::{Ingredient, Jar};
@@ -761,7 +762,7 @@ where
         db: &dyn Database,
         input: Id,
         revision: Revision,
-        _in_cycle: bool,
+        _cycle_heads: &mut CycleHeads,
     ) -> VerifyResult {
         let zalsa = db.zalsa();
         let data = Self::data(zalsa.table(), input);

--- a/src/tracked_struct/tracked_field.rs
+++ b/src/tracked_struct/tracked_field.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use crate::cycle::CycleHeads;
 use crate::function::VerifyResult;
 use crate::ingredient::Ingredient;
 use crate::loom::sync::Arc;
@@ -59,7 +60,7 @@ where
         db: &'db dyn Database,
         input: Id,
         revision: crate::Revision,
-        _in_cycle: bool,
+        _cycle_heads: &mut CycleHeads,
     ) -> VerifyResult {
         let zalsa = db.zalsa();
         let data = <super::IngredientImpl<C>>::data(zalsa.table(), input);

--- a/tests/cycle_output.rs
+++ b/tests/cycle_output.rs
@@ -152,11 +152,11 @@ fn revalidate_no_changes() {
             "salsa_event(DidValidateMemoizedValue { database_key: read_value(Id(400)) })",
             "salsa_event(DidReinternValue { key: query_d::interned_arguments(Id(800)), revision: R2 })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_d(Id(800)) })",
+            "salsa_event(DidValidateMemoizedValue { database_key: query_b(Id(0)) })",
+            "salsa_event(DidReinternValue { key: query_d::interned_arguments(Id(800)), revision: R2 })",
             "salsa_event(DidValidateMemoizedValue { database_key: read_value(Id(401)) })",
             "salsa_event(DidValidateMemoizedValue { database_key: read_value(Id(402)) })",
             "salsa_event(DidValidateMemoizedValue { database_key: read_value(Id(403)) })",
-            "salsa_event(DidValidateMemoizedValue { database_key: query_b(Id(0)) })",
-            "salsa_event(DidReinternValue { key: query_d::interned_arguments(Id(800)), revision: R2 })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_a(Id(0)) })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_b(Id(0)) })",
         ]"#]]);


### PR DESCRIPTION
Started off as investigating whether an out parameter for this would be more performant but I also believe this change makes it more easy to reason about where and how we are changing the cycle heads in verification. There is now one area where we remove from them, and 2 areas where we extend them where as before it was semi hidden due to us constructing empty cycle heads.