### PR TITLE
Lazy finalization of cycle participants in `maybe_changed_after`

### DIFF
--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -397,110 +397,94 @@ where
 
                 let dyn_db = db.as_dyn_database();
 
-                let mut last_verified_at = old_memo.verified_at.load();
-                let mut first_iteration = true;
-                'cycle: loop {
-                    let mut inputs = InputAccumulatedValues::Empty;
-                    // Fully tracked inputs? Iterate over the inputs and check them, one by one.
-                    //
-                    // NB: It's important here that we are iterating the inputs in the order that
-                    // they executed. It's possible that if the value of some input I0 is no longer
-                    // valid, then some later input I1 might never have executed at all, so verifying
-                    // it is still up to date is meaningless.
-                    for &edge in edges.input_outputs.iter() {
-                        match edge {
-                            QueryEdge::Input(dependency_index) => {
-                                match dependency_index.maybe_changed_after(
-                                    dyn_db,
-                                    zalsa,
-                                    last_verified_at,
-                                    cycle_heads,
-                                ) {
-                                    VerifyResult::Changed => break 'cycle VerifyResult::Changed,
-                                    VerifyResult::Unchanged(input_accumulated) => {
-                                        inputs |= input_accumulated;
-                                    }
+                let last_verified_at = old_memo.verified_at.load();
+
+                let mut inputs = InputAccumulatedValues::Empty;
+                // Fully tracked inputs? Iterate over the inputs and check them, one by one.
+                //
+                // NB: It's important here that we are iterating the inputs in the order that
+                // they executed. It's possible that if the value of some input I0 is no longer
+                // valid, then some later input I1 might never have executed at all, so verifying
+                // it is still up to date is meaningless.
+                for &edge in edges.input_outputs.iter() {
+                    match edge {
+                        QueryEdge::Input(dependency_index) => {
+                            match dependency_index.maybe_changed_after(
+                                dyn_db,
+                                zalsa,
+                                last_verified_at,
+                                cycle_heads,
+                            ) {
+                                VerifyResult::Changed => return VerifyResult::Changed,
+                                VerifyResult::Unchanged(input_accumulated) => {
+                                    inputs |= input_accumulated;
                                 }
                             }
-                            QueryEdge::Output(dependency_index) => {
-                                // Subtle: Mark outputs as validated now, even though we may
-                                // later find an input that requires us to re-execute the function.
-                                // Even if it re-execute, the function will wind up writing the same value,
-                                // since all prior inputs were green. It's important to do this during
-                                // this loop, because it's possible that one of our input queries will
-                                // re-execute and may read one of our earlier outputs
-                                // (e.g., in a scenario where we do something like
-                                // `e = Entity::new(..); query(e);` and `query` reads a field of `e`).
-                                //
-                                // NB. Accumulators are also outputs, but the above logic doesn't
-                                // quite apply to them. Since multiple values are pushed, the first value
-                                // may be unchanged, but later values could be different.
-                                // In that case, however, the data accumulated
-                                // by this function cannot be read until this function is marked green,
-                                // so even if we mark them as valid here, the function will re-execute
-                                // and overwrite the contents.
-                                dependency_index.mark_validated_output(zalsa, database_key_index);
-                            }
                         }
-                    }
-
-                    // Possible scenarios here:
-                    //
-                    // 1. Cycle heads is empty. We traversed our full dependency graph and neither hit any
-                    //    cycles, nor found any changed dependencies. We can mark our memo verified and
-                    //    return Unchanged with empty cycle heads.
-                    //
-                    // 2. Cycle heads is non-empty, and does not contain our own key index. We are part of
-                    //    a cycle, and since we don't know if some other cycle participant that hasn't been
-                    //    traversed yet (that is, some other dependency of the cycle head, which is only a
-                    //    dependency of ours via the cycle) might still have changed, we can't yet mark our
-                    //    memo verified. We can return a provisional Unchanged, with cycle heads.
-                    //
-                    // 3. Cycle heads is non-empty, and contains only our own key index. We are the head of
-                    //    a cycle, and we've now traversed the entire cycle and found no changes, but no
-                    //    other cycle participants were verified (they would have all hit case 2 above). We
-                    //    can now safely mark our own memo as verified. Then we have to traverse the entire
-                    //    cycle again. This time, since our own memo is verified, there will be no cycle
-                    //    encountered, and the rest of the cycle will be able to verify itself.
-                    //
-                    // 4. Cycle heads is non-empty, and contains our own key index as well as other key
-                    //    indices. We are the head of a cycle nested within another cycle. We can't mark
-                    //    our own memo verified (for the same reason as in case 2: the full outer cycle
-                    //    hasn't been validated unchanged yet). We return Unchanged, with ourself removed
-                    //    from cycle heads. We will handle our own memo (and the rest of our cycle) on a
-                    //    future iteration; first the outer cycle head needs to verify itself.
-
-                    let was_in_heads = cycle_heads.remove(&database_key_index);
-                    let heads_non_empty = !cycle_heads.is_empty();
-                    if heads_non_empty {
-                        // case 2 / 4
-                        break 'cycle VerifyResult::Unchanged(inputs);
-                    } else if !first_iteration {
-                        // 3 (second loop turn)
-                        break 'cycle VerifyResult::Unchanged(inputs);
-                    } else {
-                        last_verified_at = zalsa.current_revision();
-
-                        old_memo.mark_as_verified(zalsa, database_key_index);
-                        old_memo.revisions.accumulated_inputs.store(inputs);
-
-                        if is_provisional {
-                            old_memo
-                                .revisions
-                                .verified_final
-                                .store(true, Ordering::Relaxed);
-                        }
-
-                        if was_in_heads {
-                            first_iteration = false;
-                            // case 3
-                            continue 'cycle;
-                        } else {
-                            // case 1
-                            break 'cycle VerifyResult::Unchanged(inputs);
+                        QueryEdge::Output(dependency_index) => {
+                            // Subtle: Mark outputs as validated now, even though we may
+                            // later find an input that requires us to re-execute the function.
+                            // Even if it re-execute, the function will wind up writing the same value,
+                            // since all prior inputs were green. It's important to do this during
+                            // this loop, because it's possible that one of our input queries will
+                            // re-execute and may read one of our earlier outputs
+                            // (e.g., in a scenario where we do something like
+                            // `e = Entity::new(..); query(e);` and `query` reads a field of `e`).
+                            //
+                            // NB. Accumulators are also outputs, but the above logic doesn't
+                            // quite apply to them. Since multiple values are pushed, the first value
+                            // may be unchanged, but later values could be different.
+                            // In that case, however, the data accumulated
+                            // by this function cannot be read until this function is marked green,
+                            // so even if we mark them as valid here, the function will re-execute
+                            // and overwrite the contents.
+                            dependency_index.mark_validated_output(zalsa, database_key_index);
                         }
                     }
                 }
+
+                // Possible scenarios here:
+                //
+                // 1. Cycle heads is empty. We traversed our full dependency graph and neither hit any
+                //    cycles, nor found any changed dependencies. We can mark our memo verified and
+                //    return Unchanged with empty cycle heads.
+                //
+                // 2. Cycle heads is non-empty, and does not contain our own key index. We are part of
+                //    a cycle, and since we don't know if some other cycle participant that hasn't been
+                //    traversed yet (that is, some other dependency of the cycle head, which is only a
+                //    dependency of ours via the cycle) might still have changed, we can't yet mark our
+                //    memo verified. We can return a provisional Unchanged, with cycle heads.
+                //
+                // 3. Cycle heads is non-empty, and contains only our own key index. We are the head of
+                //    a cycle, and we've now traversed the entire cycle and found no changes, but no
+                //    other cycle participants were verified (they would have all hit case 2 above). We
+                //    can now safely mark our own memo as verified. Then we have to traverse the entire
+                //    cycle again. This time, since our own memo is verified, there will be no cycle
+                //    encountered, and the rest of the cycle will be able to verify itself.
+                //
+                // 4. Cycle heads is non-empty, and contains our own key index as well as other key
+                //    indices. We are the head of a cycle nested within another cycle. We can't mark
+                //    our own memo verified (for the same reason as in case 2: the full outer cycle
+                //    hasn't been validated unchanged yet). We return Unchanged, with ourself removed
+                //    from cycle heads. We will handle our own memo (and the rest of our cycle) on a
+                //    future iteration; first the outer cycle head needs to verify itself.
+
+                cycle_heads.remove(&database_key_index);
+
+                // 1 and 3
+                if cycle_heads.is_empty() {
+                    old_memo.mark_as_verified(zalsa, database_key_index);
+                    old_memo.revisions.accumulated_inputs.store(inputs);
+
+                    if is_provisional {
+                        old_memo
+                            .revisions
+                            .verified_final
+                            .store(true, Ordering::Relaxed);
+                    }
+                }
+
+                VerifyResult::Unchanged(inputs)
             }
         }
     }

--- a/tests/cycle.rs
+++ b/tests/cycle.rs
@@ -881,7 +881,6 @@ fn cycle_unchanged() {
     db.assert_logs(expect![[r#"
         [
             "salsa_event(DidValidateMemoizedValue { database_key: min_iterate(Id(1)) })",
-            "salsa_event(DidValidateMemoizedValue { database_key: min_panic(Id(2)) })",
         ]"#]]);
 
     a.assert_value(&db, 45);
@@ -926,9 +925,6 @@ fn cycle_unchanged_nested() {
     db.assert_logs(expect![[r#"
         [
             "salsa_event(DidValidateMemoizedValue { database_key: min_iterate(Id(1)) })",
-            "salsa_event(DidValidateMemoizedValue { database_key: min_iterate(Id(3)) })",
-            "salsa_event(DidValidateMemoizedValue { database_key: min_panic(Id(4)) })",
-            "salsa_event(DidValidateMemoizedValue { database_key: min_panic(Id(2)) })",
         ]"#]]);
 
     a.assert_value(&db, 45);
@@ -991,9 +987,6 @@ fn cycle_unchanged_nested_intertwined() {
         db.assert_logs(expect![[r#"
             [
                 "salsa_event(DidValidateMemoizedValue { database_key: min_iterate(Id(1)) })",
-                "salsa_event(DidValidateMemoizedValue { database_key: min_iterate(Id(3)) })",
-                "salsa_event(DidValidateMemoizedValue { database_key: min_iterate(Id(4)) })",
-                "salsa_event(DidValidateMemoizedValue { database_key: min_panic(Id(2)) })",
             ]"#]]);
 
         a.assert_value(&db, 45);

--- a/tests/cycle_output.rs
+++ b/tests/cycle_output.rs
@@ -153,11 +153,6 @@ fn revalidate_no_changes() {
             "salsa_event(DidReinternValue { key: query_d::interned_arguments(Id(800)), revision: R2 })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_d(Id(800)) })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_b(Id(0)) })",
-            "salsa_event(DidReinternValue { key: query_d::interned_arguments(Id(800)), revision: R2 })",
-            "salsa_event(DidValidateMemoizedValue { database_key: read_value(Id(401)) })",
-            "salsa_event(DidValidateMemoizedValue { database_key: read_value(Id(402)) })",
-            "salsa_event(DidValidateMemoizedValue { database_key: read_value(Id(403)) })",
-            "salsa_event(DidValidateMemoizedValue { database_key: query_a(Id(0)) })",
         ]"#]]);
 }
 


### PR DESCRIPTION
- **Add failing test**
- **Fix const query with custom database trait**
- **Reduce cloning of sets in `ActiveQuery` and `QueryRevisions`**
- **Keep using an Arc<Slice>**
- **add test for high-durability dependency validation**
- **chore: fix clippy lints**
- **Add tests that panics when recreating a new salsa revision**
- **Remove deleted entries from `tracked_struct_ids`**
- **allocate values in a closure**
- **change disambiguator_map to FxHashMap**
- **remove read of "entity table"**
- **refactor `extend_memo_lifetime` to return memo**
- **return lifetime-extended memo, not value**
- **rework accumulator to store values in memos**
- **pacify the merciless clippy**
- **Add comments**
- **Clippy**
- **longer, more detailed comment**
- **fix error message to correctly reference `#[default]` instead of `#[id]`**
- **rewrite `Views` to be Miri compatible**
- **Satisfy clippy**
- **Satisfy nighty clippy**
- **Add way to intern structs from references**
- **Update components/salsa-macro-rules/src/setup_interned_struct.rs**
- **Update src/interned.rs**
- **Apply suggestions from code review**
- **Add impl Lookup for Path, Vec**
- **Add impl for Lookup Vec via [A; N]**
- **Apply suggestions from code review**
- **Remove obsolete type argument**
- **fix fmt**
- **fix: Replace `SelfTy` with actual type in tracked methods**
- **Satisfy nightly clippy**
- **fix new nightly lint: `clippy::unit_arg`**
- **Add `Lookup<Box<T>>` for `&T`**
- **Add IngredientIndex to KeyStruct**
- **Remove IngredientIndex from tracked_struct_ids, use KeyStruct field instead**
- **Fmt, lints**
- **Use named struct for disambiguation key**
- **fix: Inconsistent behaviour with lifetime elision on tracked fn**
- **Rename DisambiguationKey to IdentityHash, KeyStruct to Identity**
- **chore: ensure salsa-macros have a licence**
- **salsa-macros: handle invalid inputs in a way friendlier to rust-analyzer**
- **fix cargo fmt**
- **Improve the span used for salsa struct constructors**
- **add impl `Update` for `std::convert::Infallible`**
- **Emit struct in `#[tracked]` fn last for better IDE support**
- **Update components/salsa-macro-rules/src/setup_tracked_fn.rs**
- **Assign memo ingredients per salsa-struct-ingredient**
- **Modify struct ingredient lookups**
- **Add a test for tracked function with multiple salsa struct args**
- **Fix clippy**
- **Clean up code a bit**
- **Upgrade codspeed github action to v3**
- **chore: set `MIRIFLAGS` to -Zmiri-disable-isolation -Zmiri-retag-fields**
- **introduce parallel salsa**
- **internal: ignore parallel tests under miri**
- **Fix broken link in README.md**
- **Add accumulator benchmark**
- **Skip over queries without accumulated values**
- **Avoid unnecessary resizes of `visisted` set**
- **Use `inputs_outputs` len as approximation**
- **Bump expect-test to 1.5.0, annotate-snippets to 0.11.5**
- **Replace `AtomicCell<bool>` with `AtomicBool`**
- **Remove unused `Runtime::next_id` field**
- **Turn `Runtime::revisions` from `Vec` to `Box<FixedArray>`**
- **Deduplicate QueryStack prefix trimming**
- **Remove unnecessary `Option` from ZalsaLocal::query_stack**
- **Replace `Page` data Vec with boxed fixed array**
- **Replace `AtomicCell<usize>` with `AtomicUsize`**
- **Move asserts to index construction**
- **Give `Durability` niches**
- **`Runtime::revisions` does not need to be boxed**
- **Fix `Lookup<Vec<T>>` impls**
- **Apply suggestions from code review**
- **Run `rustfmt`**
- **Deduplicate ingredient indexing**
- **Reduce memo lookups needed for eviction**
- **Store `QueryEdges` edges in a `Box` as it is not cloned anyways**
- **Fix parallel_map::execute_cancellation test**
- **Improve safety comments on function/fetch**
- **Implement self-referential interning**
- **Split Lookup into two traits**
- **Add self-ref test**
- **Shrink `QueryRevisions` size by 3 words**
- **Cleanup**
- **Fix benchmarks accidentally re-using the same database**
- **Use proper setup for compare benches**
- **Fix mutating benchmark benching more than just mutation**
- **Encapsulate `DependencyIndex`**
- **Type `QueryEdge`**
- **Make `QueryEdge` an enum**
- **Remove unreachable unwraps via typing**
- **Remove unnecessary `Option` around `Storage::zalsa_impl`**
- **Remove PartialOrd, Ord implementations from keys**
- **Remove panicking paths from `maybe_changed_after`**
- **Simplify Event construction**
- **Describe deadlock risk for assemble closure in interning**
- **expose `Database::unwind_if_revision_cancelled`**
- **fix completions in `#[salsa::tracked]` functions**
- **bless ui tests**
- **fix `HashEqLike` for `Box<T>`**
- **add release workflow**
- **add guide of releasing**
- **Out of date comment in overview**
- **Do not allocate input singleton data for non-singleton inputs**
- **Update book/src/overview.md**
- **Do not re-hash already hashed keys disambiguator and struct identity maps**
- **Shrink `Identity` by a word**
- **Clarify manual hashmap usage**
- **Fix accumulated values for backdated queries**
- **Track only deps with accumulated_inpurts again**
- **fix grammar issue in comment**
- **feature: allow calling the ingredient method on interned structs**
- **feature: add optional lifetimes to interned structs**
- **internal: make `salsa::Id::from_u32` pub, but `#[doc(hidden)]`**
- **feature: add id paramater to interned structs**
- **Update components/salsa-macro-rules/src/setup_interned_struct.rs**
- **Clippy**
- **feature: add support for dumping database contents**
- **chore: feature flag debug methods**
- **make tracked structs coarse-grained by default**
- **ensure tracked struct ingredients are mapped correctly to tracked fields**
- **avoid creating ingredients for pure coarse-grained tracked structs**
- **only create ingredients for tracked fields**
- **Fix benchmarks**
- **Impl `HashEqLike<T>` for `&T`**
- **Fix LRU dropping memos too early**
- **Fix lru tests not trigger a revision**
- **Require `Update` trait for tracked function return values**
- **Add `Arc::ptr_eq` comparision to `Update for Arc<T>`**
- **feature: expose database contents as inherent method on Ingredients**
- **implement `HashEqLike<&T>` for `T`**
- **Fix Disambiguator- and IdentityMap hashing**
- **Use `Fallback` trick for tracked function `Update` constraint, implement `Update` for `smallvec` and `compact_str`**
- **Improve span of maybe_update dummy implementation for better diagnostics**
- **Drop unnecssary usages of `AtomicCell`**
- **Remove unnecessary `Mutex` from singleton initialization**
- **Replace `crossbeam` dependency with `crossbeam-queue`**
- **Add unit tests for AtomicInputAccumulatedValues and OptionalAtomicRevision**
- **Introduce `RefUnwindSafe` `StorageHandle`**
- **LRU eviction at revision bump**
- **Mark `MemoTable` methods that evict entries unsafe**
- **Drop unnecessary `AtomicRevision`**
- **`black_box` benchmark inputs and outputs**
- **Emit better diagnostic for invalid tracked function return types**
- **More test cases for `tracked_fn_return_ref`**
- **Deduplicate `Storage` and `StorageHandle` fields**
- **internal: switch to `boxcar` from `append-only-vec`**
- **ci: use `release-plz` for release**
- **fix: fix missing version in Cargo manifest**
- **Reduce typo count**
- **Fix unbalanced backticks in doc comments**
- **Remove dev dependency `derive-new`**
- **Update `hashbrown` (0.15) and `hashlink` (0.10)**
- **Split off revision bumping from `zalsa_mut` access**
- **Require mut Zalsa access for setting the lru limit**
- **Simplify `Ingredient::reset_for_new_revision` setup**
- **Allow trigger LRU eviction without increasing the current revision**
- **Automatically clear the cancellation flag when cancellation completes**
- **Reduce method delegation duplication**
- **Replace `IngredientCache` lock with atomic primitive**
- **Remove outdated FIXME**
- **Remove some `ZalsaDatabase::zalsa` calls**
- **update MSRV to 1.80 and test it in CI**
- **Prevent fragmention of table due to frequent `ZalsaLocal` reconstruction**
- **Enforce `unsafe_op_in_unsafe_fn`**
- **Tidy up Cargo.toml dependencies**
- **Skip book and benchmark CI runs for `merge_group`**
- **Don't clone strings in benchmarks**
- **Move `unwind_if_revision_cancelled` from `ZalsaLocal` to `Zalsa`**
- **Tracked struct recycling and coarse grained dependencies**
- **Fix bad-hash with in-place update**
- **created_at documentation**
- **Use `db.zalsa`**
- **implement `Update` trait for `hashbrown::HashMap`**
- **Track revisions for tracked fields only**
- **Cancel duplicate test workflow runs**
- **Fix book deployment**
- **Disable jemalloc decay in benches**
- **Fix book deployment take 2**
- **Introduce Salsa enums**
- **fix enums bug**
- **Trade off a bit of memory for more speed in `MemoIngredientIndices`**
- **Skip memo ingredient index mapping for non enum tracked functions**
- **internal: address review comments**
- **Replace a `DashMap` with `RwLock` as writing is rare for it**
- **Add small supertype input benchmark**
- **Merge pull request #3 from Veykril/veykril/push-tynvvyqoltqx**
- **Lazy fetching**
- **Don't load `verified_at` twice in `shallow_verify_memo`**
- **Remove some dynamically dispatched `Database::event` calls**
- **`#[inline(never)]` queries in benchmarks**
- **Add test for durability changes**
- **Remove unnecessary `current_revision` call from `setup_interned_struct`**
- **replace `arc-swap` with manual `AtomicPtr`**
- **more correct bounds on `Send` and `Sync` implementation `DeletedEntries`**
- **fix typo**
- **implement `Update` trait for `IndexMap`, and `IndexSet`**
- **Drop clone requirement for accumulated values**
- **Cleanup `Cargo.toml`s (#745)**
- **Option::replace instead of std::mem::replace (#746)**
- **perf: Some small perf things (#744)**
- **perf: Store view downcaster in function ingredients directly (#720)**
- **internal: use `portable-atomic` in `IngredientCache` to compile on `powerpc-unknown-linux-gnu` (#749)**
- **chore: Group versions of packages together for releases (#751)**
- **Have salsa not depend on salsa-macros (#750)**
- **chore: release v0.19.0 (#698)**
- **rewrite cycle handling to support fixed-point iteration (#603)**
- **chore: Pin `half` version to prevent CI failure (#757)**
- **chore: Use nextest for miri test runs (#758)**
- **feat: Drop `Debug` requirements and flip implementation defaults (#756)**
- **perf: Use a `Vec` for `CycleHeads` (#760)**
- **perf: Reduce unnecessary conditional work in `deep_verify_memo` (#759)**
- **chore: Remove dead code (#764)**
- **bug [salsa-macros]: Improve debug name of tracked methods (#755)**
- **Enable Garbage Collection for Interned Values (#602)**
- **Resolve unwind safety fixme (#761)**
- **refactor(perf): Pool `ActiveQuerys` in the query stack (#629)**
- **refactor: Remove some unnecessary panicking paths in cycle execution (#765)**
- **docs: update release steps (#705)**
- **Remove extra page indirection in `Table` (#710)**
- **update boxcar (#696)**
- **Replace memo queue with append-only vector (#767)**
- **refactor: Remove unnecessary query stack acess in `block_on` (#771)**
- **refactor: Use `ThinVec` for `MemoTable`, halving its size (#770)**
- **refactor: Move `verified_final` from `Memo` into `QueryRevisions` (#769)**
- **Use html directory for mdbook artifact (#774)**
- **Document most safety blocks (#776)**
- **Fix typo in comment (#777)**
- **refactor: Clean up `par_map` a bit (#742)**
- **fix: Use `changed_at` revision when updating fields (#778)**
- **chore: Normalize imports style (#779)**
- **chore: Implement `Lookup`/`HashEqLike` for `Arc` (#784)**
- **fix: `#[doc(hidden)]` `plumbing` module (#781)**
- **allow reuse of cached provisional memos within the same cycle iteration (#786)**
- **refactor: Keep edge condvar on stack instead of allocating it in an `Arc` (#773)**
- **refactor: Use `ThinVec` for `CycleHeads` (#787)**
- **fix: Dereferencing freed memos when verifying provisional memos (#788)**
- **[fix] Use `validate_maybe_provisional` instead of `validate_provisional` (#789)**
- **add WillIterateCycle event (#790)**
- **[refactor] Reuse the same stack for all cycles heads in `validate_same_iteration` (#791)**
- **[refactor] Simplify `fetch_hot` (#792)**
- **Remove incorrect `parallel_scope` API (#797)**
- **Print query stack when encountering unexpected cycle (#796)**
- **refactor: Discard unnecessary atomic load (#780)**
- **chore: `#[inline]` some things (#799)**
- **refactor: Inline/Outline more cold and slow paths (#805)**
- **perf: Don't push an unnecessary active query for `deep_verify_memo` (#806)**
- **chore: Implement `Update` for `ThinVec` (#807)**
- **Update compact_str from 0.8 to 0.9 (#794)**
- **Add a third cycle mode, equivalent to old Salsa cycle behavior (#801)**
- **Make interned's `last_interned_at` equal `Revision::MAX` if they are interned outside a query (#804)**
- **perf: Reduce memory usage by deduplicating type information (#803)**
- **chore: release v0.20.0 (#753)**
- **chore: Fix ci not always running (#810)**
- **Don't store the fields in the interned map (#812)**
- **[refactor] More `fetch_hot` simplification (#793)**
- **Use `DatabaseKey` for interned events (#813)**
- **refactor: Per ingredient sync table (#650)**
- **Force inline `fetch_hot` (#818)**
- **Include struct name in formatted input-field index (#819)**
- **squelch most clippy warnings in generated code (#809)**
- **Add a compile-fail test for a `'static` `!Update` struct (#820)**
- **cleanup: Remove unnecessary `Array` abstraction (#821)**
- **Attempt to fix codspeed (#823)**
- **fix: allow unused lifetimes in tracked_struct expansion (#824)**
- **refactor: Simplify ID conversions (#822)**
- **fix: Fix incorrect `values_equal` signature (#825)**
- **fix: correct debug output for tracked fields (#826)**
- **fix: Access to tracked-struct that was freed during fixpoint (#817)**
- **Implement a query stack `Backtrace` analog (#827)**
- **chore: release v0.21.0 (#811)**
- **chore: Change an `assert!` to `assert_eq!` (#828)**
- **feat: Make `attach` pub (#832)**
- **refactor: Clean up `function::execute` (#833)**
- **bug: Avoid panic in `Backtrace::capture` if `query_stack` is already borrowed (#835)**
- **better debug name for interned query arguments (#837)**
- **chore: release v0.21.1 (#829)**
- **refactor: Clean up some unsafety (#830)**
- **fix: change detection for fixpoint queries (#836)**
- **Add loom support (#842)**
- **gate loom dependency under feature flag (#844)**
- **fix: incorrect caching for queries participating in fixpoint (#843)**
- **Move salsa event system into `Zalsa` (#849)**
- **fix memo table growth condition (#850)**
- **Pass cycle heads as out parameter for `maybe_changed_after` (#852)**
- **Do not re-verify already verified memoized value in cycle verification (#851)**
- **Lazy verification of cycle participants in maybe_changed_after**
