### PR TITLE
perf: speed-up cycle-retry logic

### DIFF
--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -146,12 +146,14 @@ impl<V> Memo<V> {
         zalsa: &Zalsa,
         database_key_index: DatabaseKeyIndex,
     ) -> bool {
-        if !self.may_be_provisional() {
-            return false;
-        };
         if self.revisions.cycle_heads.is_empty() {
             return false;
         }
+
+        if !self.may_be_provisional() {
+            return false;
+        };
+
         return provisional_retry_cold(zalsa, database_key_index, &self.revisions.cycle_heads);
 
         #[inline(never)]


### PR DESCRIPTION
* Avoid an atomic load in the most common case where the query isn't participating in a 
cycle.
* Only perform the test in `fetch_cold` (with_retry) because memos returned by `fetch_hot` are always finalized.