### PR TITLE
Short-circuit `block-on` if same thread

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -175,6 +175,11 @@ impl Runtime {
         let dg = self.dependency_graph.lock();
         let thread_id = thread::current().id();
 
+        // Cycle in the same thread.
+        if thread_id == other_id {
+            return BlockResult::Cycle;
+        }
+
         if dg.depends_on(other_id, thread_id) {
             return BlockResult::Cycle;
         }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -172,13 +172,13 @@ impl Runtime {
         other_id: ThreadId,
         query_mutex_guard: QueryMutexGuard,
     ) -> BlockResult {
-        let dg = self.dependency_graph.lock();
         let thread_id = thread::current().id();
-
         // Cycle in the same thread.
         if thread_id == other_id {
             return BlockResult::Cycle;
         }
+
+        let dg = self.dependency_graph.lock();
 
         if dg.depends_on(other_id, thread_id) {
             return BlockResult::Cycle;


### PR DESCRIPTION
Early return from `block_on` if both the current and other thread are the same to skip the need to traverse the dependency tree (which requires a lock)