### PR TITLE
Use generational identifiers for tracked structs

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -22,19 +22,19 @@ impl DatabaseKeyIndex {
     #[inline]
     pub(crate) fn new(ingredient_index: IngredientIndex, key_index: Id) -> Self {
         Self {
-            key_index: key_index.data(),
+            key_index: key_index.index(),
             key_generation: key_index.generation(),
             ingredient_index,
         }
     }
 
-    pub fn ingredient_index(self) -> IngredientIndex {
+    pub const fn ingredient_index(self) -> IngredientIndex {
         self.ingredient_index
     }
 
-    pub fn key_index(self) -> Id {
+    pub const fn key_index(self) -> Id {
         // SAFETY: `self.key_index` was returned by `Id::data`.
-        unsafe { Id::from_data(self.key_index) }.with_generation(self.key_generation)
+        unsafe { Id::from_index(self.key_index) }.with_generation(self.key_generation)
     }
 
     pub(crate) fn maybe_changed_after(

--- a/src/table.rs
+++ b/src/table.rs
@@ -400,13 +400,13 @@ fn make_id(page: PageIndex, slot: SlotIndex) -> Id {
     let page = page.0 as u32;
     let slot = slot.0 as u32;
     // SAFETY: `slot` is guaranteed to be small enough that the resulting Id won't be bigger than `Id::MAX_U32`
-    unsafe { Id::from_data((page << PAGE_LEN_BITS) | slot) }
+    unsafe { Id::from_index((page << PAGE_LEN_BITS) | slot) }
 }
 
 #[inline]
 fn split_id(id: Id) -> (PageIndex, SlotIndex) {
-    let data = id.data() as usize;
-    let slot = data & PAGE_LEN_MASK;
-    let page = data >> PAGE_LEN_BITS;
+    let index = id.index() as usize;
+    let slot = index & PAGE_LEN_MASK;
+    let page = index >> PAGE_LEN_BITS;
     (PageIndex::new(page), SlotIndex::new(slot))
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -400,13 +400,13 @@ fn make_id(page: PageIndex, slot: SlotIndex) -> Id {
     let page = page.0 as u32;
     let slot = slot.0 as u32;
     // SAFETY: `slot` is guaranteed to be small enough that the resulting Id won't be bigger than `Id::MAX_U32`
-    unsafe { Id::from_u32((page << PAGE_LEN_BITS) | slot) }
+    unsafe { Id::from_data((page << PAGE_LEN_BITS) | slot) }
 }
 
 #[inline]
 fn split_id(id: Id) -> (PageIndex, SlotIndex) {
-    let id = id.as_u32() as usize;
-    let slot = id & PAGE_LEN_MASK;
-    let page = id >> PAGE_LEN_BITS;
+    let data = id.data() as usize;
+    let slot = data & PAGE_LEN_MASK;
+    let page = data >> PAGE_LEN_BITS;
     (PageIndex::new(page), SlotIndex::new(slot))
 }

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -444,6 +444,11 @@ where
             // If the generation would overflow, we are forced to leak the slot. Note that this
             // shouldn't be a problem in general as sufficient bits are reserved for the generation.
             let Some(id) = id.next_generation() else {
+                tracing::info!(
+                    "leaking tracked struct {:?} due to generation oveflow",
+                    self.database_key_index(id)
+                );
+
                 continue;
             };
 
@@ -539,6 +544,10 @@ where
             // the unlikely case that the ID is already at its maximum generation, we are forced to leak
             // the previous slot and allocate a new value.
             if id.generation() == u32::MAX {
+                tracing::info!(
+                    "leaking tracked struct {:?} due to generation oveflow",
+                    self.database_key_index(id)
+                );
                 return Err(());
             }
 

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -76,13 +76,13 @@ crate::loom::maybe_lazy_static! {
 /// The database contains a number of jars, and each jar contains a number of ingredients.
 /// Each ingredient is given a unique index as the database is being created.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-pub struct IngredientIndex(u16);
+pub struct IngredientIndex(u32);
 
 impl IngredientIndex {
     /// Create an ingredient index from a usize.
     pub(crate) fn from(v: usize) -> Self {
-        assert!(v <= u16::MAX as usize);
-        Self(v as u16)
+        assert!(v <= u32::MAX as usize);
+        Self(v as u32)
     }
 
     /// Convert the ingredient index back into a usize.
@@ -90,18 +90,8 @@ impl IngredientIndex {
         self.0 as usize
     }
 
-    /// Convert the ingredient index back into a usize.
-    pub(crate) fn as_u16(self) -> u16 {
-        self.0
-    }
-
     pub fn successor(self, index: usize) -> Self {
-        let index = self
-            .0
-            .checked_add((1 + index) as u16)
-            .expect("exceeded maximum number of ingredients");
-
-        IngredientIndex(index)
+        IngredientIndex(self.0 + 1 + index as u32)
     }
 }
 
@@ -508,7 +498,7 @@ where
         let nonce = Nonce::<StorageNonce>::from_u32(unsafe {
             NonZeroU32::new_unchecked((cached_data >> u32::BITS) as u32)
         });
-        let mut index = IngredientIndex(cached_data as u16);
+        let mut index = IngredientIndex(cached_data as u32);
 
         if zalsa.nonce() != nonce {
             index = create_index();

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -295,11 +295,7 @@ impl ZalsaLocal {
             let top_query = stack
                 .last_mut()
                 .expect("cannot store a tracked struct ID outside of a tracked function");
-            let old_id = top_query.tracked_struct_ids.insert(identity, id);
-            assert!(
-                old_id.is_none(),
-                "overwrote a previous id for `{identity:?}`"
-            );
+            top_query.tracked_struct_ids.insert(identity, id);
         })
     }
 

--- a/tests/cycle_output.rs
+++ b/tests/cycle_output.rs
@@ -152,6 +152,9 @@ fn revalidate_no_changes() {
             "salsa_event(DidValidateMemoizedValue { database_key: read_value(Id(400)) })",
             "salsa_event(DidReinternValue { key: query_d::interned_arguments(Id(800)), revision: R2 })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_d(Id(800)) })",
+            "salsa_event(DidValidateMemoizedValue { database_key: read_value(Id(401)) })",
+            "salsa_event(DidValidateMemoizedValue { database_key: read_value(Id(402)) })",
+            "salsa_event(DidValidateMemoizedValue { database_key: read_value(Id(403)) })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_b(Id(0)) })",
         ]"#]]);
 }
@@ -193,12 +196,12 @@ fn revalidate_with_change_after_output_read() {
             "salsa_event(DidDiscard { key: read_value(Id(402)) })",
             "salsa_event(WillIterateCycle { database_key: query_b(Id(0)), iteration_count: 1, fell_back: false })",
             "salsa_event(WillExecute { database_key: query_a(Id(0)) })",
-            "salsa_event(WillExecute { database_key: read_value(Id(403)) })",
+            "salsa_event(WillExecute { database_key: read_value(Id(403g1)) })",
             "salsa_event(WillIterateCycle { database_key: query_b(Id(0)), iteration_count: 2, fell_back: false })",
             "salsa_event(WillExecute { database_key: query_a(Id(0)) })",
-            "salsa_event(WillExecute { database_key: read_value(Id(401)) })",
+            "salsa_event(WillExecute { database_key: read_value(Id(401g1)) })",
             "salsa_event(WillIterateCycle { database_key: query_b(Id(0)), iteration_count: 3, fell_back: false })",
             "salsa_event(WillExecute { database_key: query_a(Id(0)) })",
-            "salsa_event(WillExecute { database_key: read_value(Id(402)) })",
+            "salsa_event(WillExecute { database_key: read_value(Id(402g1)) })",
         ]"#]]);
 }

--- a/tests/tracked-struct-id-field-bad-hash.rs
+++ b/tests/tracked-struct-id-field-bad-hash.rs
@@ -1,6 +1,6 @@
 //! Test for a tracked struct where an untracked field has a
 //! very poorly chosen hash impl (always returns 0).
-//! This demonstrates that the `untracked fields on a struct
+//! This demonstrates that the untracked fields on a struct
 //! can change values and yet the struct can have the same
 //! id (because struct ids are based on the *hash* of the
 //! untracked fields).
@@ -62,6 +62,10 @@ fn with_tracked<'db>(db: &'db dyn Db, tracked: MyTracked<'db>) -> bool {
 }
 
 #[test]
+// Because tracked struct IDs are generational, the ID of the second tracked struct ends
+// up being different than the ID of the first. However, this test still has precedence
+// and represents valid behavior for IDs that get leaked.
+#[ignore]
 fn dependent_query() {
     let mut db = salsa::DatabaseImpl::new();
 
@@ -70,6 +74,7 @@ fn dependent_query() {
     assert!(with_tracked(&db, tracked));
 
     input.set_field(&mut db).to(false);
+
     // We now re-run the query that creates the tracked struct.
     // Salsa will re-use the `MyTracked` struct from the previous revision
     // because it thinks it is unchanged because of `BadHash`'s bad hash function.


### PR DESCRIPTION
Pack a generation into input IDs.

The generation of a tracked struct is incremented after it is reused, allowing us to avoid read dependencies. Generational IDs were originally meant for https://github.com/salsa-rs/salsa/pull/839, as adding the necessary read dependency on interned structs that may be reused introduced a large (~50%) regression to ty's incremental performance.

This increases the size of `Id` from a `u32` to a `u64`. However, if the generation is restricted to `u16`, and ingredient indices are restricted to `u16`, this does not increase the size of `DatabaseKeyIndex`, so the memory usage effect is limited (~5% increase to ty's peak memory usage). However, this should allow us to implement garbage collection for interned values without significant performance concerns, so memory usage over time should benefit.

If the generation exceeds `u16::MAX`, we can fallback to adding read dependencies on tracked structs. An alternative would be to leak the slot, which would also allow us to remove the `created_at` field on tracked structs and may alleviate the memory usage concerns. This might be more feasible if the generation stole a few more bits from ingredient indices (as the number of ingredients is effectively static for a given salsa program).

This has a small (~4%) performance improvement on ty's benchmarks.