### PR TITLE
Remove default `PartialOrd` and `Ord` derives for salsa structs

### DIFF
--- a/components/salsa-macro-rules/src/setup_input_struct.rs
+++ b/components/salsa-macro-rules/src/setup_input_struct.rs
@@ -60,7 +60,7 @@ macro_rules! setup_input_struct {
         ]
     ) => {
         $(#[$attr])*
-        #[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+        #[derive(Copy, Clone, PartialEq, Eq, Hash)]
         $vis struct $Struct(salsa::Id);
 
         #[allow(clippy::all)]

--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -72,7 +72,7 @@ macro_rules! setup_interned_struct {
         ]
     ) => {
         $(#[$attr])*
-        #[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+        #[derive(Copy, Clone, PartialEq, Eq, Hash)]
         $vis struct $Struct< $($db_lt_arg)? >(
             $Id,
             std::marker::PhantomData < & $interior_lt salsa::plumbing::interned::Value <$StructWithStatic> >

--- a/components/salsa-macro-rules/src/setup_tracked_struct.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_struct.rs
@@ -91,7 +91,7 @@ macro_rules! setup_tracked_struct {
         ]
     ) => {
         $(#[$attr])*
-        #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[derive(Copy, Clone, PartialEq, Eq, Hash)]
         $vis struct $Struct<$db_lt>(
             salsa::Id,
             std::marker::PhantomData < & $db_lt salsa::plumbing::tracked_struct::Value < $Struct<'static> > >

--- a/tests/tracked_with_struct_ord.rs
+++ b/tests/tracked_with_struct_ord.rs
@@ -1,0 +1,37 @@
+//! Test that `PartialOrd` and `Ord` can be derived for tracked structs
+
+use salsa::{Database, DatabaseImpl};
+use test_log::test;
+
+#[salsa::input]
+#[derive(PartialOrd, Ord)]
+struct Input {
+    value: usize,
+}
+
+#[salsa::tracked(debug)]
+#[derive(Ord, PartialOrd)]
+struct MyTracked<'db> {
+    value: usize,
+}
+
+#[salsa::tracked]
+fn create_tracked(db: &dyn Database, input: Input) -> MyTracked<'_> {
+    MyTracked::new(db, input.value(db))
+}
+
+#[test]
+fn execute() {
+    DatabaseImpl::new().attach(|db| {
+        let input1 = Input::new(db, 20);
+        let input2 = Input::new(db, 10);
+
+        // Compares by ID and not by value.
+        assert!(input1 <= input2);
+
+        let t0: MyTracked = create_tracked(db, input1);
+        let t1: MyTracked = create_tracked(db, input2);
+
+        assert!(t0 <= t1);
+    })
+}


### PR DESCRIPTION
Salsa IDs have no semantical ordering and ordering two salsa-structs may result in different ordering when the program is run multiple times. Whether this matter or not depends on the specific use case. 

Because of this, it feels safer to let users explicitly opt-in to an ID based `Ord` implementation by adding a `derive(PartialOrd, Ord)` to their structs. This also allows users to not provide an `Ord` implementations for types where ordering isn't semantically meaningful.
