### PR TITLE
Replace `ThreadId` usages with `ZalsaLocalid`

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -1,5 +1,6 @@
 use crate::key::DatabaseKeyIndex;
 use crate::loom::thread::{self, ThreadId};
+use crate::zalsa_local::ZalsaLocalId;
 use crate::Revision;
 
 /// The `Event` struct identifies various notable things that can
@@ -44,7 +45,7 @@ pub enum EventKind {
     /// before they have answered us.
     WillBlockOn {
         /// The id of the thread we will block on.
-        other_thread_id: ThreadId,
+        other_thread_id: ZalsaLocalId,
 
         /// The database-key for the affected value. Implements `Debug`.
         database_key: DatabaseKeyIndex,

--- a/src/function.rs
+++ b/src/function.rs
@@ -17,7 +17,7 @@ use crate::table::memo::MemoTableTypes;
 use crate::table::Table;
 use crate::views::DatabaseDownCaster;
 use crate::zalsa::{IngredientIndex, MemoIngredientIndex, Zalsa};
-use crate::zalsa_local::QueryOrigin;
+use crate::zalsa_local::{QueryOrigin, ZalsaLocalId};
 use crate::{Database, Id, Revision};
 
 mod accumulated;
@@ -260,8 +260,8 @@ where
     }
 
     /// Attempts to claim `key_index`, returning `false` if a cycle occurs.
-    fn wait_for(&self, zalsa: &Zalsa, key_index: Id) -> bool {
-        match self.sync_table.try_claim(zalsa, key_index) {
+    fn wait_for(&self, zalsa: &Zalsa, from_id: ZalsaLocalId, key_index: Id) -> bool {
+        match self.sync_table.try_claim(zalsa, from_id, key_index) {
             ClaimResult::Retry | ClaimResult::Claimed(_) => true,
             ClaimResult::Cycle => false,
         }

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -9,7 +9,7 @@ use crate::plumbing::IngredientIndices;
 use crate::table::memo::MemoTableTypes;
 use crate::table::Table;
 use crate::zalsa::{transmute_data_mut_ptr, transmute_data_ptr, IngredientIndex, Zalsa};
-use crate::zalsa_local::QueryOrigin;
+use crate::zalsa_local::{QueryOrigin, ZalsaLocalId};
 use crate::{Database, DatabaseKeyIndex, Id, Revision};
 
 /// A "jar" is a group of ingredients that are added atomically.
@@ -80,8 +80,8 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
     /// A return value of `true` indicates that a result is now available. A return value of
     /// `false` means that a cycle was encountered; the waited-on query is either already claimed
     /// by the current thread, or by a thread waiting on the current thread.
-    fn wait_for(&self, zalsa: &Zalsa, key_index: Id) -> bool {
-        _ = (zalsa, key_index);
+    fn wait_for(&self, zalsa: &Zalsa, from_id: ZalsaLocalId, key_index: Id) -> bool {
+        _ = (zalsa, from_id, key_index);
         true
     }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -54,8 +54,8 @@ impl<Db: Database> StorageHandle<Db> {
 
     pub fn into_storage(self) -> Storage<Db> {
         Storage {
+            zalsa_local: ZalsaLocal::new(self.zalsa_impl.next_local_id()),
             handle: self,
-            zalsa_local: ZalsaLocal::new(),
         }
     }
 }
@@ -109,9 +109,10 @@ impl<Db: Database> Storage<Db> {
     ///
     /// The `event_callback` function is invoked by the salsa runtime at various points during execution.
     pub fn new(event_callback: Option<Box<dyn Fn(crate::Event) + Send + Sync + 'static>>) -> Self {
+        let handle = StorageHandle::new(event_callback);
         Self {
-            handle: StorageHandle::new(event_callback),
-            zalsa_local: ZalsaLocal::new(),
+            zalsa_local: ZalsaLocal::new(handle.zalsa_impl.next_local_id()),
+            handle,
         }
     }
 
@@ -194,7 +195,7 @@ impl<Db: Database> Clone for Storage<Db> {
     fn clone(&self) -> Self {
         Self {
             handle: self.handle.clone(),
-            zalsa_local: ZalsaLocal::new(),
+            zalsa_local: ZalsaLocal::new(self.handle.zalsa_impl.next_local_id()),
         }
     }
 }

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -23,6 +23,8 @@ use crate::{Accumulator, Cancelled, Id, Revision};
 /// **Note also that all mutations to the database handle (and hence
 /// to the local-state) must be undone during unwinding.**
 pub struct ZalsaLocal {
+    id: ZalsaLocalId,
+
     /// Vector of active queries.
     ///
     /// Unwinding note: pushes onto this vector must be popped -- even
@@ -35,11 +37,16 @@ pub struct ZalsaLocal {
 }
 
 impl ZalsaLocal {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(id: ZalsaLocalId) -> Self {
         ZalsaLocal {
+            id,
             query_stack: RefCell::new(QueryStack::default()),
             most_recent_pages: RefCell::new(FxHashMap::default()),
         }
+    }
+
+    pub(crate) fn id(&self) -> ZalsaLocalId {
+        self.id
     }
 
     pub(crate) fn record_unfilled_pages(&mut self, table: &Table) {
@@ -564,5 +571,14 @@ impl Drop for ActiveQueryGuard<'_> {
                 self.push_len,
             );
         });
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub struct ZalsaLocalId(usize);
+
+impl ZalsaLocalId {
+    pub(crate) fn new(id: usize) -> Self {
+        ZalsaLocalId(id)
     }
 }


### PR DESCRIPTION
Experiment if this helps with performance. I may also need this to enforce a strict ordering between different threads that all run the same fixpoint iteration (`ThreadId::as_u64` is nightly)
