### PR TITLE
Add fetch span

### DIFF
--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -16,7 +16,7 @@ where
         zalsa.unwind_if_revision_cancelled(zalsa_local);
 
         let database_key_index = self.database_key_index(id);
-        let _span = tracing::debug_span!("fetch", query = ?database_key_index).entered();
+        let _span = tracing::debug_span!("fetch", query = ?{database_key_index}).entered();
 
         let memo = self.refresh_memo(db, zalsa, id);
         // SAFETY: We just refreshed the memo so it is guaranteed to contain a value now.

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -16,7 +16,8 @@ where
         zalsa.unwind_if_revision_cancelled(zalsa_local);
 
         let database_key_index = self.database_key_index(id);
-        let _span = tracing::debug_span!("fetch", query = ?{database_key_index}).entered();
+        #[cfg(debug_assertions)]
+        let _span = tracing::debug_span!("fetch", query = ?database_key_index).entered();
 
         let memo = self.refresh_memo(db, zalsa, id);
         // SAFETY: We just refreshed the memo so it is guaranteed to contain a value now.


### PR DESCRIPTION
I often find it hard to understand the query stack when debugging salsa. 

This PR adds a `fetch` span, including the ingredient. This gives a better sense for how salsa recurses and (when enter and exit logging is enabled), when a query completes.

This is a separate PR to see how it affects perf:

Example from a recent debugging sesison of mine (the thread id part is custom)

```
2025-05-21T13:37:38.146709Z DEBUG t2{thread_id=ThreadId(4)}:fetch{query=query_c(Id(0))}:fetch{query=query_b(Id(800))}: salsa::runtime: Block ThreadId(4) on ThreadId(3) because it depends on query_a(Id(400)) (currently running on that thread).
```
