### PR TITLE
Allow lifetimes in arguments in tracked fns with >1 parameters

### DIFF
--- a/tests/tracked_fn_interned_lifetime.rs
+++ b/tests/tracked_fn_interned_lifetime.rs
@@ -1,0 +1,14 @@
+#[salsa::interned]
+struct Interned<'db> {
+    field: i32,
+}
+
+#[salsa::tracked]
+fn foo<'a>(_db: &'a dyn salsa::Database, _: Interned<'_>, _: Interned<'a>) {}
+
+#[test]
+fn the_test() {
+    let db = salsa::DatabaseImpl::new();
+    let i = Interned::new(&db, 123);
+    foo(&db, i, i);
+}


### PR DESCRIPTION
This is needed for @jackh726's work on the new trait solver for rust-analyzer.