### PR TITLE
Restrict memo size assertion to targets with 64bit pointer size

### DIFF
--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -99,6 +99,7 @@ pub struct Memo<V> {
 
 // Memo's are stored a lot, make sure their size is doesn't randomly increase.
 #[cfg(not(feature = "shuttle"))]
+#[cfg(target_pointer_width = "64")]
 const _: [(); std::mem::size_of::<Memo<std::num::NonZeroUsize>>()] =
     [(); std::mem::size_of::<[usize; 13]>()];
 


### PR DESCRIPTION
This assertion failed when building for wasm

