### PR TITLE
Pack `QueryEdge` memory layout

### DIFF
--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -91,7 +91,7 @@ impl ActiveQuery {
     ) {
         self.durability = self.durability.min(durability);
         self.changed_at = self.changed_at.max(changed_at);
-        self.input_outputs.insert(QueryEdge::Input(input));
+        self.input_outputs.insert(QueryEdge::input(input));
         self.accumulated_inputs = self.accumulated_inputs.or_else(|| match has_accumulated {
             true => InputAccumulatedValues::Any,
             false => accumulated_inputs.load(),
@@ -107,7 +107,7 @@ impl ActiveQuery {
     ) {
         self.durability = self.durability.min(durability);
         self.changed_at = self.changed_at.max(revision);
-        self.input_outputs.insert(QueryEdge::Input(input));
+        self.input_outputs.insert(QueryEdge::input(input));
     }
 
     pub(super) fn add_untracked_read(&mut self, changed_at: Revision) {
@@ -128,12 +128,12 @@ impl ActiveQuery {
 
     /// Adds a key to our list of outputs.
     pub(super) fn add_output(&mut self, key: DatabaseKeyIndex) {
-        self.input_outputs.insert(QueryEdge::Output(key));
+        self.input_outputs.insert(QueryEdge::output(key));
     }
 
     /// True if the given key was output by this query.
     pub(super) fn is_output(&self, key: DatabaseKeyIndex) -> bool {
-        self.input_outputs.contains(&QueryEdge::Output(key))
+        self.input_outputs.contains(&QueryEdge::output(key))
     }
 
     pub(super) fn disambiguate(&mut self, key: IdentityHash) -> Disambiguator {

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -7,7 +7,7 @@ use crate::key::DatabaseKeyIndex;
 use crate::plumbing::ZalsaLocal;
 use crate::sync::atomic::Ordering;
 use crate::zalsa::{MemoIngredientIndex, Zalsa, ZalsaDatabase};
-use crate::zalsa_local::{QueryEdge, QueryOriginRef};
+use crate::zalsa_local::{QueryEdgeKind, QueryOriginRef};
 use crate::{AsDynDatabase as _, Id, Revision};
 
 /// Result of memo validation.
@@ -399,8 +399,8 @@ where
                 // valid, then some later input I1 might never have executed at all, so verifying
                 // it is still up to date is meaningless.
                 for &edge in edges {
-                    match edge {
-                        QueryEdge::Input(dependency_index) => {
+                    match edge.kind() {
+                        QueryEdgeKind::Input(dependency_index) => {
                             match dependency_index.maybe_changed_after(
                                 dyn_db,
                                 zalsa,
@@ -413,7 +413,7 @@ where
                                 }
                             }
                         }
-                        QueryEdge::Output(dependency_index) => {
+                        QueryEdgeKind::Output(dependency_index) => {
                             // Subtle: Mark outputs as validated now, even though we may
                             // later find an input that requires us to re-execute the function.
                             // Even if it re-execute, the function will wind up writing the same value,

--- a/src/key.rs
+++ b/src/key.rs
@@ -12,8 +12,7 @@ use crate::{Database, Id};
 /// only for inserting into maps and the like.
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct DatabaseKeyIndex {
-    key_index: u32,
-    key_generation: u32,
+    key_index: Id,
     ingredient_index: IngredientIndex,
 }
 // ANCHOR_END: DatabaseKeyIndex
@@ -22,8 +21,7 @@ impl DatabaseKeyIndex {
     #[inline]
     pub(crate) fn new(ingredient_index: IngredientIndex, key_index: Id) -> Self {
         Self {
-            key_index: key_index.index(),
-            key_generation: key_index.generation(),
+            key_index,
             ingredient_index,
         }
     }
@@ -33,8 +31,7 @@ impl DatabaseKeyIndex {
     }
 
     pub const fn key_index(self) -> Id {
-        // SAFETY: `self.key_index` was returned by `Id::data`.
-        unsafe { Id::from_index(self.key_index) }.with_generation(self.key_generation)
+        self.key_index
     }
 
     pub(crate) fn maybe_changed_after(

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -638,6 +638,11 @@ impl std::fmt::Debug for QueryOrigin {
 }
 
 /// An input or output query edge.
+///
+/// This type is a packed version of `QueryEdgeKind`, tagging the `IngredientIndex`
+/// in `key` with a discriminator for the input and output variants without increasing
+/// the size of the type. Notably, this type is 12 bytes as opposed to the 16 byte
+/// `QueryEdgeKind`, which is meaningful as inputs and outputs are stored contiguously.
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct QueryEdge {
     key: DatabaseKeyIndex,


### PR DESCRIPTION
If we reserve a bit in `IngredientIndex` we can avoid an extra discriminator byte for each `QueryEdge` in the `input_outputs` list, which is quite meaningful.