### PR TITLE
Set `validate_final` in `execute` after removing the last cycle head

### DIFF
--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -237,6 +237,11 @@ where
                     "{database_key_index:?}: execute: fixpoint iteration has a final value"
                 );
                 cycle_heads.remove(&database_key_index);
+
+                if cycle_heads.is_empty() {
+                    // If there are no more cycle heads, we can mark this as verified.
+                    revisions.verified_final.store(true, Ordering::Relaxed);
+                }
             }
 
             tracing::debug!("{database_key_index:?}: execute: result.revisions = {revisions:#?}");


### PR DESCRIPTION
We can set `validate_final` eagerly here instead of waiting for the next `maybe_validate_provisional`

I think this will help to mitigate some of the perf regression in my other PR
