### PR TITLE
Sam/compile err non update ref

### DIFF
--- a/src/update.rs
+++ b/src/update.rs
@@ -494,6 +494,7 @@ fallback_impl! { compact_str::CompactString, }
 
 macro_rules! tuple_impl {
     ($($t:ident),*; $($u:ident),*) => {
+        #[diagnostic::do_not_recommend]
         unsafe impl<$($t),*> Update for ($($t,)*)
         where
             $($t: Update,)*

--- a/tests/compile-fail/tracked_fn_return_ref.stderr
+++ b/tests/compile-fail/tracked_fn_return_ref.stderr
@@ -29,26 +29,62 @@ warning: elided lifetime has a name
 43 | ) -> ContainsRef<'_> {
    |                  ^^ this elided lifetime gets resolved as `'db`
 
-error: lifetime may not live long enough
+error[E0277]: the trait bound `&'db str: Update` is not satisfied
   --> tests/compile-fail/tracked_fn_return_ref.rs:15:67
    |
 15 | fn tracked_fn_return_ref<'db>(db: &'db dyn Db, input: MyInput) -> &'db str {
-   |                          --- lifetime `'db` defined here          ^ requires that `'db` must outlive `'static`
+   |                                                                   ^^^^^^^^ the trait `Update` is not implemented for `&'db str`
+   |
+   = help: the trait `Update` is implemented for `String`
+note: required by a bound in `<tracked_fn_return_ref::Configuration_ as salsa::function::Configuration>::execute::_assert_return_type_is_update::_assert_is_update`
+  --> tests/compile-fail/tracked_fn_return_ref.rs:14:1
+   |
+14 | #[salsa::tracked]
+   | ^^^^^^^^^^^^^^^^^ required by this bound in `_assert_is_update`
+   = note: this error originates in the attribute macro `salsa::tracked` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: lifetime may not live long enough
+error[E0277]: the trait bound `ContainsRef<'db>: Update` is not satisfied
   --> tests/compile-fail/tracked_fn_return_ref.rs:23:6
    |
-20 | fn tracked_fn_return_struct_containing_ref<'db>(
-   |                                            --- lifetime `'db` defined here
-...
 23 | ) -> ContainsRef<'db> {
-   |      ^^^^^^^^^^^ requires that `'db` must outlive `'static`
+   |      ^^^^^^^^^^^^^^^^ the trait `Update` is not implemented for `ContainsRef<'db>`
+   |
+   = help: the following other types implement trait `Update`:
+             Arc<T>
+             BTreeMap<K, V>
+             BTreeSet<K>
+             Box<T>
+             Box<[T]>
+             HashMap<K, V, S>
+             HashSet<K, S>
+             Infallible
+           and $N others
+note: required by a bound in `<tracked_fn_return_struct_containing_ref::Configuration_ as salsa::function::Configuration>::execute::_assert_return_type_is_update::_assert_is_update`
+  --> tests/compile-fail/tracked_fn_return_ref.rs:19:1
+   |
+19 | #[salsa::tracked]
+   | ^^^^^^^^^^^^^^^^^ required by this bound in `_assert_is_update`
+   = note: this error originates in the attribute macro `salsa::tracked` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: lifetime may not live long enough
+error[E0277]: the trait bound `ContainsRef<'db>: Update` is not satisfied
   --> tests/compile-fail/tracked_fn_return_ref.rs:43:6
    |
-40 | fn tracked_fn_return_struct_containing_ref_elided_explicit<'db>(
-   |                                                            --- lifetime `'db` defined here
-...
 43 | ) -> ContainsRef<'_> {
-   |      ^^^^^^^^^^^ requires that `'db` must outlive `'static`
+   |      ^^^^^^^^^^^^^^^ the trait `Update` is not implemented for `ContainsRef<'db>`
+   |
+   = help: the following other types implement trait `Update`:
+             Arc<T>
+             BTreeMap<K, V>
+             BTreeSet<K>
+             Box<T>
+             Box<[T]>
+             HashMap<K, V, S>
+             HashSet<K, S>
+             Infallible
+           and $N others
+note: required by a bound in `<tracked_fn_return_struct_containing_ref_elided_explicit::Configuration_ as salsa::function::Configuration>::execute::_assert_return_type_is_update::_assert_is_update`
+  --> tests/compile-fail/tracked_fn_return_ref.rs:39:1
+   |
+39 | #[salsa::tracked]
+   | ^^^^^^^^^^^^^^^^^ required by this bound in `_assert_is_update`
+   = note: this error originates in the attribute macro `salsa::tracked` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/tracked_fn_return_static.rs
+++ b/tests/tracked_fn_return_static.rs
@@ -6,16 +6,22 @@ use salsa::Database;
 #[salsa::input]
 struct Input {}
 
+#[derive(Clone, PartialEq)]
+struct NotUpdate<'a> {
+    _marker: std::marker::PhantomData<&'a ()>,
+}
+
 #[salsa::tracked]
-fn test(_db: &dyn salsa::Database, _: Input) -> &'static str {
-    "test"
+fn test(_db: &dyn salsa::Database, _: Input) -> NotUpdate<'static> {
+    NotUpdate {
+        _marker: std::marker::PhantomData,
+    }
 }
 
 #[test]
 fn invoke() {
     salsa::DatabaseImpl::new().attach(|db| {
         let input = Input::new(db);
-        let x: &str = test(db, input);
-        assert_eq!(x, "test");
+        test(db, input);
     })
 }

--- a/tests/tracked_fn_return_static.rs
+++ b/tests/tracked_fn_return_static.rs
@@ -1,0 +1,21 @@
+//! Test that a `tracked` function can return a
+//! non-`Update` type, so long as it has `'static` lifetime.
+
+use salsa::Database;
+
+#[salsa::input]
+struct Input {}
+
+#[salsa::tracked]
+fn test(_db: &dyn salsa::Database, _: Input) -> &'static str {
+    "test"
+}
+
+#[test]
+fn invoke() {
+    salsa::DatabaseImpl::new().attach(|db| {
+        let input = Input::new(db);
+        let x: &str = test(db, input);
+        assert_eq!(x, "test");
+    })
+}


### PR DESCRIPTION
I had a return type like `Result<Tracked<'db>, Error>` and the error message was complaining about `'db` not being `'static`. It took me a while to figure out that the `'db` wasn't the problem, it was that my `Error` type doesn't implement `Update`.

Since tracking down where the `'static` bound comes it's fairly obvious why, but for future people this might provide a slightly easier debugging experience.