### PR TITLE
make UnexpectedCycle backtrace fields public

### DIFF
--- a/src/cycle.rs
+++ b/src/cycle.rs
@@ -63,8 +63,8 @@ use crate::sync::OnceLock;
 pub const MAX_ITERATIONS: IterationCount = IterationCount(200);
 
 pub struct UnexpectedCycle {
-    backtrace: std::backtrace::Backtrace,
-    query_trace: Option<crate::Backtrace>,
+    pub backtrace: std::backtrace::Backtrace,
+    pub query_trace: Option<crate::Backtrace>,
 }
 
 impl fmt::Display for UnexpectedCycle {


### PR DESCRIPTION
In ty, we want to format these back-traces differently (as diagnostics), not just via `UnexpectedCycle::fmt`, so we need these fields to be public.