### PR TITLE
panic with string message again for cycle panics

### DIFF
--- a/src/cycle.rs
+++ b/src/cycle.rs
@@ -49,9 +49,6 @@
 //! cycle head may then iterate, which may result in a new set of iterations on the inner cycle,
 //! for each iteration of the outer cycle.
 
-use core::fmt;
-use std::panic;
-
 use thin_vec::{thin_vec, ThinVec};
 
 use crate::key::DatabaseKeyIndex;
@@ -61,48 +58,6 @@ use crate::sync::OnceLock;
 ///
 /// Should only be relevant in case of a badly configured cycle recovery.
 pub const MAX_ITERATIONS: IterationCount = IterationCount(200);
-
-pub struct UnexpectedCycle {
-    backtrace: std::backtrace::Backtrace,
-    query_trace: Option<crate::Backtrace>,
-}
-
-impl fmt::Display for UnexpectedCycle {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("cycle detected but no cycle handler found\n")?;
-        self.backtrace.fmt(f)?;
-        if let Some(query_trace) = &self.query_trace {
-            f.write_str("\n")?;
-            query_trace.fmt(f)?;
-        }
-        Ok(())
-    }
-}
-
-impl UnexpectedCycle {
-    pub(crate) fn throw() -> ! {
-        // We use resume and not panic here to avoid running the panic
-        // hook (that is to avoid printing the backtrace).
-        panic::resume_unwind(Box::new(Self {
-            backtrace: std::backtrace::Backtrace::capture(),
-            query_trace: crate::Backtrace::capture(),
-        }));
-    }
-
-    /// Runs `f`, and catches any salsa cycle.
-    pub fn catch<F, T>(f: F) -> Result<T, UnexpectedCycle>
-    where
-        F: FnOnce() -> T + panic::UnwindSafe,
-    {
-        match panic::catch_unwind(f) {
-            Ok(t) => Ok(t),
-            Err(payload) => match payload.downcast() {
-                Ok(cycle) => Err(*cycle),
-                Err(payload) => panic::resume_unwind(payload),
-            },
-        }
-    }
-}
 
 /// Return value from a cycle recovery function.
 #[derive(Debug)]

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -1,4 +1,4 @@
-use crate::cycle::{CycleHeads, CycleRecoveryStrategy, IterationCount, UnexpectedCycle};
+use crate::cycle::{CycleHeads, CycleRecoveryStrategy, IterationCount};
 use crate::function::memo::Memo;
 use crate::function::sync::ClaimResult;
 use crate::function::{Configuration, IngredientImpl, VerifyResult};
@@ -161,7 +161,13 @@ where
                 }
                 // no provisional value; create/insert/return initial provisional value
                 return match C::CYCLE_STRATEGY {
-                    CycleRecoveryStrategy::Panic => UnexpectedCycle::throw(),
+                    CycleRecoveryStrategy::Panic => zalsa_local.with_query_stack(|stack| {
+                        panic!(
+                            "dependency graph cycle when querying {database_key_index:#?}, \
+                            set cycle_fn/cycle_initial to fixpoint iterate.\n\
+                            Query stack:\n{stack:#?}",
+                        );
+                    }),
                     CycleRecoveryStrategy::Fixpoint => {
                         tracing::debug!(
                             "hit cycle at {database_key_index:#?}, \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ pub use salsa_macros::{accumulator, db, input, interned, tracked, Supertype, Upd
 pub use self::accumulator::Accumulator;
 pub use self::active_query::Backtrace;
 pub use self::cancelled::Cancelled;
-pub use self::cycle::{CycleRecoveryAction, UnexpectedCycle};
+pub use self::cycle::CycleRecoveryAction;
 pub use self::database::{AsDynDatabase, Database};
 pub use self::database_impl::DatabaseImpl;
 pub use self::durability::Durability;

--- a/tests/cycle_initial_call_back_into_cycle.rs
+++ b/tests/cycle_initial_call_back_into_cycle.rs
@@ -1,7 +1,5 @@
 //! Calling back into the same cycle from your cycle initial function will trigger another cycle.
 
-use salsa::UnexpectedCycle;
-
 #[salsa::tracked]
 fn initial_value(db: &dyn salsa::Database) -> u32 {
     query(db)
@@ -30,8 +28,9 @@ fn cycle_fn(
 }
 
 #[test_log::test]
+#[should_panic(expected = "dependency graph cycle")]
 fn the_test() {
     let db = salsa::DatabaseImpl::default();
 
-    UnexpectedCycle::catch(|| query(&db)).unwrap_err();
+    query(&db);
 }


### PR DESCRIPTION
Switch back to regular panic with string message, instead of `resume_unwind` with custom payload, for cycle panics.

This avoids having the default behavior be silent panic with no information, and allows the use of a panic hook to collect additional information, if needed.

It's not clear what the use case is for catching cycle panics specifically and treating them differently from other panics; they are not more recoverable.

Fixes https://github.com/salsa-rs/salsa/issues/891