### PR TITLE
Use `Revision` and `Durability` directly in input `Value`

### DIFF
--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -141,7 +141,6 @@ impl ActiveQuery {
 
     pub(super) fn stamp(&self) -> Stamp {
         Stamp {
-            value: (),
             durability: self.durability,
             changed_at: self.changed_at,
         }

--- a/src/input/input_field.rs
+++ b/src/input/input_field.rs
@@ -59,7 +59,7 @@ where
     ) -> VerifyResult {
         let zalsa = db.zalsa();
         let value = <IngredientImpl<C>>::data(zalsa, input);
-        VerifyResult::changed_if(value.stamps[self.field_index].changed_at > revision)
+        VerifyResult::changed_if(value.revisions[self.field_index] > revision)
     }
 
     fn fmt_index(&self, index: crate::Id, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,7 @@ pub mod plumbing {
     pub use crate::attach::{attach, with_attached_database};
     pub use crate::cycle::{CycleRecoveryAction, CycleRecoveryStrategy};
     pub use crate::database::{current_revision, Database};
+    pub use crate::durability::Durability;
     pub use crate::id::{AsId, FromId, FromIdWithDb, Id};
     pub use crate::ingredient::{Ingredient, Jar, Location};
     pub use crate::key::DatabaseKeyIndex;
@@ -92,7 +93,7 @@ pub mod plumbing {
         NewMemoIngredientIndices,
     };
     pub use crate::revision::Revision;
-    pub use crate::runtime::{stamp, Runtime, Stamp, StampedValue};
+    pub use crate::runtime::{stamp, Runtime, Stamp};
     pub use crate::salsa_struct::SalsaStructInDb;
     pub use crate::storage::{HasStorage, Storage};
     pub use crate::tracked_struct::TrackedStructInDb;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -116,28 +116,15 @@ impl std::fmt::Debug for Running<'_> {
 }
 
 #[derive(Copy, Clone, Debug)]
-pub struct StampedValue<V> {
-    pub value: V,
+pub struct Stamp {
     pub durability: Durability,
     pub changed_at: Revision,
 }
 
-pub type Stamp = StampedValue<()>;
-
 pub fn stamp(revision: Revision, durability: Durability) -> Stamp {
-    StampedValue {
-        value: (),
+    Stamp {
         durability,
         changed_at: revision,
-    }
-}
-
-impl<V> StampedValue<V> {
-    // FIXME: Use or remove this.
-    #[allow(dead_code)]
-    pub(crate) fn merge_revision_info<U>(&mut self, other: &StampedValue<U>) {
-        self.durability = self.durability.min(other.durability);
-        self.changed_at = self.changed_at.max(other.changed_at);
     }
 }
 

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -17,7 +17,7 @@ use crate::ingredient::{Ingredient, Jar};
 use crate::key::DatabaseKeyIndex;
 use crate::plumbing::ZalsaLocal;
 use crate::revision::OptionalAtomicRevision;
-use crate::runtime::StampedValue;
+use crate::runtime::Stamp;
 use crate::salsa_struct::SalsaStructInDb;
 use crate::sync::Arc;
 use crate::table::memo::{MemoTable, MemoTableTypes, MemoTableWithTypesMut};
@@ -435,7 +435,7 @@ where
         zalsa: &'db Zalsa,
         zalsa_local: &'db ZalsaLocal,
         current_revision: Revision,
-        current_deps: &StampedValue<()>,
+        current_deps: &Stamp,
         fields: C::Fields<'db>,
     ) -> Id {
         let value = |_| Value {
@@ -496,7 +496,7 @@ where
         zalsa: &'db Zalsa,
         current_revision: Revision,
         mut id: Id,
-        current_deps: &StampedValue<()>,
+        current_deps: &Stamp,
         fields: C::Fields<'db>,
     ) -> Result<Id, C::Fields<'db>> {
         let data_raw = Self::data_raw(zalsa.table(), id);


### PR DESCRIPTION
`Stamp` contains a lot of padding bytes, wasting 7 bytes per field for inputs due to the array packing. By packing each field into a separate array we regain that space