### PR TITLE
Add an option to tune interned garbage collection

### DIFF
--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -28,6 +28,9 @@ macro_rules! setup_interned_struct {
         // the salsa ID
         id: $Id:path,
 
+        // The minimum number of revisions to keep the value interned.
+        revisions: $($revisions:expr)?,
+
         // the lifetime used in the desugared interned struct.
         // if the `db_lt_arg`, is present, this is `db_lt_arg`, but otherwise,
         // it is `'static`.
@@ -129,6 +132,9 @@ macro_rules! setup_interned_struct {
                     line: line!(),
                 };
                 const DEBUG_NAME: &'static str = stringify!($Struct);
+                $(
+                    const REVISIONS: ::core::num::NonZeroUsize = ::core::num::NonZeroUsize::new($revisions).unwrap();
+                )?
                 type Fields<'a> = $StructDataIdent<'a>;
                 type Struct<'db> = $Struct< $($db_lt_arg)? >;
             }

--- a/components/salsa-macros/src/accumulator.rs
+++ b/components/salsa-macros/src/accumulator.rs
@@ -44,6 +44,7 @@ impl AllowedOptions for Accumulator {
     const LRU: bool = false;
     const CONSTRUCTOR_NAME: bool = false;
     const ID: bool = false;
+    const REVISIONS: bool = false;
 }
 
 struct StructMacro {

--- a/components/salsa-macros/src/input.rs
+++ b/components/salsa-macros/src/input.rs
@@ -62,6 +62,8 @@ impl crate::options::AllowedOptions for InputStruct {
     const CONSTRUCTOR_NAME: bool = true;
 
     const ID: bool = false;
+
+    const REVISIONS: bool = false;
 }
 
 impl SalsaStructAllowedOptions for InputStruct {

--- a/components/salsa-macros/src/interned.rs
+++ b/components/salsa-macros/src/interned.rs
@@ -62,6 +62,8 @@ impl crate::options::AllowedOptions for InternedStruct {
     const CONSTRUCTOR_NAME: bool = true;
 
     const ID: bool = true;
+
+    const REVISIONS: bool = true;
 }
 
 impl SalsaStructAllowedOptions for InternedStruct {
@@ -105,6 +107,7 @@ impl Macro {
         let generate_debug_impl = salsa_struct.generate_debug_impl();
         let has_lifetime = salsa_struct.generate_lifetime();
         let id = salsa_struct.id();
+        let revisions = salsa_struct.revisions();
 
         let (db_lt_arg, cfg, interior_lt) = if has_lifetime {
             (
@@ -140,6 +143,7 @@ impl Macro {
                     db_lt: #db_lt,
                     db_lt_arg: #db_lt_arg,
                     id: #id,
+                    revisions: #(#revisions)*,
                     interior_lt: #interior_lt,
                     new_fn: #new_fn,
                     field_options: [#(#field_options),*],

--- a/components/salsa-macros/src/salsa_struct.rs
+++ b/components/salsa-macros/src/salsa_struct.rs
@@ -133,6 +133,11 @@ where
         }
     }
 
+    /// Returns the `revisions` in `Options` as an optional iterator.
+    pub(crate) fn revisions(&self) -> impl Iterator<Item = &syn::Expr> + '_ {
+        self.args.revisions.iter()
+    }
+
     /// Disallow `#[tracked]` attributes on the fields of this struct.
     ///
     /// If an `#[tracked]` field is found, return an error.

--- a/components/salsa-macros/src/tracked_fn.rs
+++ b/components/salsa-macros/src/tracked_fn.rs
@@ -55,6 +55,8 @@ impl crate::options::AllowedOptions for TrackedFn {
     const CONSTRUCTOR_NAME: bool = false;
 
     const ID: bool = false;
+
+    const REVISIONS: bool = false;
 }
 
 struct Macro {

--- a/components/salsa-macros/src/tracked_struct.rs
+++ b/components/salsa-macros/src/tracked_struct.rs
@@ -57,6 +57,8 @@ impl crate::options::AllowedOptions for TrackedStruct {
     const CONSTRUCTOR_NAME: bool = true;
 
     const ID: bool = false;
+
+    const REVISIONS: bool = false;
 }
 
 impl SalsaStructAllowedOptions for TrackedStruct {

--- a/tests/compile-fail/accumulator_incompatibles.rs
+++ b/tests/compile-fail/accumulator_incompatibles.rs
@@ -19,6 +19,9 @@ struct AccWithRecover(u32);
 #[salsa::accumulator(lru = 12)]
 struct AccWithLru(u32);
 
+#[salsa::accumulator(revisions = 12)]
+struct AccWithRevisions(u32);
+
 #[salsa::accumulator(constructor = Constructor)]
 struct AccWithConstructor(u32);
 

--- a/tests/compile-fail/accumulator_incompatibles.stderr
+++ b/tests/compile-fail/accumulator_incompatibles.stderr
@@ -40,8 +40,14 @@ error: `lru` option not allowed here
 19 | #[salsa::accumulator(lru = 12)]
    |                      ^^^
 
-error: `constructor` option not allowed here
+error: `revisions` option not allowed here
   --> tests/compile-fail/accumulator_incompatibles.rs:22:22
    |
-22 | #[salsa::accumulator(constructor = Constructor)]
+22 | #[salsa::accumulator(revisions = 12)]
+   |                      ^^^^^^^^^
+
+error: `constructor` option not allowed here
+  --> tests/compile-fail/accumulator_incompatibles.rs:25:22
+   |
+25 | #[salsa::accumulator(constructor = Constructor)]
    |                      ^^^^^^^^^^^

--- a/tests/compile-fail/input_struct_incompatibles.rs
+++ b/tests/compile-fail/input_struct_incompatibles.rs
@@ -16,6 +16,9 @@ struct InputWithRecover(u32);
 #[salsa::input(lru =12)]
 struct InputWithLru(u32);
 
+#[salsa::input(revisions = 12)]
+struct InputWithRevisions(u32);
+
 #[salsa::input]
 struct InputWithTrackedField {
     #[tracked]

--- a/tests/compile-fail/input_struct_incompatibles.stderr
+++ b/tests/compile-fail/input_struct_incompatibles.stderr
@@ -34,17 +34,23 @@ error: `lru` option not allowed here
 16 | #[salsa::input(lru =12)]
    |                ^^^
 
-error: `#[tracked]` cannot be used with `#[salsa::input]`
-  --> tests/compile-fail/input_struct_incompatibles.rs:21:5
+error: `revisions` option not allowed here
+  --> tests/compile-fail/input_struct_incompatibles.rs:19:16
    |
-21 | /     #[tracked]
-22 | |     field: u32,
+19 | #[salsa::input(revisions = 12)]
+   |                ^^^^^^^^^
+
+error: `#[tracked]` cannot be used with `#[salsa::input]`
+  --> tests/compile-fail/input_struct_incompatibles.rs:24:5
+   |
+24 | /     #[tracked]
+25 | |     field: u32,
    | |______________^
 
 error: cannot find attribute `tracked` in this scope
-  --> tests/compile-fail/input_struct_incompatibles.rs:21:7
+  --> tests/compile-fail/input_struct_incompatibles.rs:24:7
    |
-21 |     #[tracked]
+24 |     #[tracked]
    |       ^^^^^^^
    |
 help: consider importing one of these attribute macros

--- a/tests/compile-fail/interned_struct_incompatibles.rs
+++ b/tests/compile-fail/interned_struct_incompatibles.rs
@@ -34,4 +34,9 @@ struct InternedWithTrackedField {
     field: u32,
 }
 
+#[salsa::interned(revisions = 0)]
+struct InternedWithZeroRevisions {
+    field: u32,
+}
+
 fn main() {}

--- a/tests/compile-fail/tracked_fn_incompatibles.rs
+++ b/tests/compile-fail/tracked_fn_incompatibles.rs
@@ -15,6 +15,11 @@ fn tracked_fn_with_db(db: &dyn Db, input: MyInput) -> u32 {
     input.field(db) * 2
 }
 
+#[salsa::tracked(revisions = 12)]
+fn tracked_fn_with_revisions(db: &dyn Db, input: MyInput) -> u32 {
+    input.field(db) * 2
+}
+
 #[salsa::tracked(constructor = TrackedFn3)]
 fn tracked_fn_with_constructor(db: &dyn Db, input: MyInput) -> u32 {
     input.field(db) * 2

--- a/tests/compile-fail/tracked_fn_incompatibles.stderr
+++ b/tests/compile-fail/tracked_fn_incompatibles.stderr
@@ -10,88 +10,94 @@ error: `db` option not allowed here
 13 | #[salsa::tracked(db = Db)]
    |                  ^^
 
-error: `constructor` option not allowed here
+error: `revisions` option not allowed here
   --> tests/compile-fail/tracked_fn_incompatibles.rs:18:18
    |
-18 | #[salsa::tracked(constructor = TrackedFn3)]
+18 | #[salsa::tracked(revisions = 12)]
+   |                  ^^^^^^^^^
+
+error: `constructor` option not allowed here
+  --> tests/compile-fail/tracked_fn_incompatibles.rs:23:18
+   |
+23 | #[salsa::tracked(constructor = TrackedFn3)]
    |                  ^^^^^^^^^^^
 
 error: #[salsa::tracked] must also be applied to the impl block for tracked methods
-  --> tests/compile-fail/tracked_fn_incompatibles.rs:27:55
+  --> tests/compile-fail/tracked_fn_incompatibles.rs:32:55
    |
-27 | fn tracked_fn_with_receiver_not_applied_to_impl_block(&self, db: &dyn Db) -> u32 {}
+32 | fn tracked_fn_with_receiver_not_applied_to_impl_block(&self, db: &dyn Db) -> u32 {}
    |                                                       ^^^^^
 
 error: only functions with a single salsa struct as their input can be specified
-  --> tests/compile-fail/tracked_fn_incompatibles.rs:29:18
+  --> tests/compile-fail/tracked_fn_incompatibles.rs:34:18
    |
-29 | #[salsa::tracked(specify)]
+34 | #[salsa::tracked(specify)]
    |                  ^^^^^^^
 
 error: must have a `'db` lifetime
-  --> tests/compile-fail/tracked_fn_incompatibles.rs:44:9
+  --> tests/compile-fail/tracked_fn_incompatibles.rs:49:9
    |
-44 |     db: &dyn Db,
+49 |     db: &dyn Db,
    |         ^
 
 error: must have a `'db_lifetime` lifetime
-  --> tests/compile-fail/tracked_fn_incompatibles.rs:52:9
+  --> tests/compile-fail/tracked_fn_incompatibles.rs:57:9
    |
-52 |     db: &dyn Db,
+57 |     db: &dyn Db,
    |         ^
 
 error: only a single lifetime parameter is accepted
-  --> tests/compile-fail/tracked_fn_incompatibles.rs:67:39
+  --> tests/compile-fail/tracked_fn_incompatibles.rs:72:39
    |
-67 | fn tracked_fn_with_multiple_lts<'db1, 'db2>(db: &'db1 dyn Db, interned: MyInterned<'db2>) -> u32 {
+72 | fn tracked_fn_with_multiple_lts<'db1, 'db2>(db: &'db1 dyn Db, interned: MyInterned<'db2>) -> u32 {
    |                                       ^^^^
 
 error: `self` parameter is only allowed in associated functions
-  --> tests/compile-fail/tracked_fn_incompatibles.rs:27:55
+  --> tests/compile-fail/tracked_fn_incompatibles.rs:32:55
    |
-27 | fn tracked_fn_with_receiver_not_applied_to_impl_block(&self, db: &dyn Db) -> u32 {}
+32 | fn tracked_fn_with_receiver_not_applied_to_impl_block(&self, db: &dyn Db) -> u32 {}
    |                                                       ^^^^^ not semantically valid as function parameter
    |
    = note: associated functions are those in `impl` or `trait` definitions
 
 error[E0415]: identifier `input` is bound more than once in this parameter list
-  --> tests/compile-fail/tracked_fn_incompatibles.rs:33:5
+  --> tests/compile-fail/tracked_fn_incompatibles.rs:38:5
    |
-33 |     input: MyInput,
+38 |     input: MyInput,
    |     ^^^^^ used as parameter more than once
 
 error[E0106]: missing lifetime specifier
-  --> tests/compile-fail/tracked_fn_incompatibles.rs:61:15
+  --> tests/compile-fail/tracked_fn_incompatibles.rs:66:15
    |
-61 |     interned: MyInterned,
+66 |     interned: MyInterned,
    |               ^^^^^^^^^^ expected named lifetime parameter
    |
 help: consider using the `'db` lifetime
    |
-61 |     interned: MyInterned<'db>,
+66 |     interned: MyInterned<'db>,
    |                         +++++
 
 error[E0308]: mismatched types
-  --> tests/compile-fail/tracked_fn_incompatibles.rs:24:46
+  --> tests/compile-fail/tracked_fn_incompatibles.rs:29:46
    |
-23 | #[salsa::tracked]
+28 | #[salsa::tracked]
    | ----------------- implicitly returns `()` as its body has no tail or `return` expression
-24 | fn tracked_fn_with_one_input(db: &dyn Db) -> u32 {}
+29 | fn tracked_fn_with_one_input(db: &dyn Db) -> u32 {}
    |                                              ^^^ expected `u32`, found `()`
 
 error[E0308]: mismatched types
-  --> tests/compile-fail/tracked_fn_incompatibles.rs:27:78
+  --> tests/compile-fail/tracked_fn_incompatibles.rs:32:78
    |
-27 | fn tracked_fn_with_receiver_not_applied_to_impl_block(&self, db: &dyn Db) -> u32 {}
+32 | fn tracked_fn_with_receiver_not_applied_to_impl_block(&self, db: &dyn Db) -> u32 {}
    |    --------------------------------------------------                        ^^^ expected `u32`, found `()`
    |    |
    |    implicitly returns `()` as its body has no tail or `return` expression
 
 error[E0308]: mismatched types
-  --> tests/compile-fail/tracked_fn_incompatibles.rs:34:6
+  --> tests/compile-fail/tracked_fn_incompatibles.rs:39:6
    |
-30 | fn tracked_fn_with_too_many_arguments_for_specify(
+35 | fn tracked_fn_with_too_many_arguments_for_specify(
    |    ---------------------------------------------- implicitly returns `()` as its body has no tail or `return` expression
 ...
-34 | ) -> u32 {
+39 | ) -> u32 {
    |      ^^^ expected `u32`, found `()`

--- a/tests/compile-fail/tracked_impl_incompatibles.rs
+++ b/tests/compile-fail/tracked_impl_incompatibles.rs
@@ -38,6 +38,11 @@ impl<'db> std::default::Default for MyTracked<'db> {
     fn default() -> Self {}
 }
 
+#[salsa::tracked(revisions = 32)]
+impl<'db> std::default::Default for MyTracked<'db> {
+    fn default() -> Self {}
+}
+
 #[salsa::tracked(constructor = Constructor)]
 impl<'db> std::default::Default for MyTracked<'db> {
     fn default() -> Self {}

--- a/tests/compile-fail/tracked_impl_incompatibles.stderr
+++ b/tests/compile-fail/tracked_impl_incompatibles.stderr
@@ -43,7 +43,13 @@ error: unexpected token
 error: unexpected token
   --> tests/compile-fail/tracked_impl_incompatibles.rs:41:18
    |
-41 | #[salsa::tracked(constructor = Constructor)]
+41 | #[salsa::tracked(revisions = 32)]
+   |                  ^^^^^^^^^
+
+error: unexpected token
+  --> tests/compile-fail/tracked_impl_incompatibles.rs:46:18
+   |
+46 | #[salsa::tracked(constructor = Constructor)]
    |                  ^^^^^^^^^^^
 
 error[E0119]: conflicting implementations of trait `Default` for type `MyTracked<'_>`
@@ -109,10 +115,19 @@ error[E0119]: conflicting implementations of trait `Default` for type `MyTracked
 42 | impl<'db> std::default::Default for MyTracked<'db> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `MyTracked<'_>`
 
-error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
+error[E0119]: conflicting implementations of trait `Default` for type `MyTracked<'_>`
   --> tests/compile-fail/tracked_impl_incompatibles.rs:47:1
    |
-47 | impl<'db> std::default::Default for [MyTracked<'db>; 12] {
+7  | impl<'db> std::default::Default for MyTracked<'db> {
+   | -------------------------------------------------- first implementation here
+...
+47 | impl<'db> std::default::Default for MyTracked<'db> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `MyTracked<'_>`
+
+error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
+  --> tests/compile-fail/tracked_impl_incompatibles.rs:52:1
+   |
+52 | impl<'db> std::default::Default for [MyTracked<'db>; 12] {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------------------
    |                                     |
    |                                     this is not defined in the current crate because arrays are always foreign
@@ -189,6 +204,14 @@ error[E0308]: mismatched types
   --> tests/compile-fail/tracked_impl_incompatibles.rs:48:21
    |
 48 |     fn default() -> Self {}
+   |        -------      ^^^^ expected `MyTracked<'_>`, found `()`
+   |        |
+   |        implicitly returns `()` as its body has no tail or `return` expression
+
+error[E0308]: mismatched types
+  --> tests/compile-fail/tracked_impl_incompatibles.rs:53:21
+   |
+53 |     fn default() -> Self {}
    |        -------      ^^^^ expected `[MyTracked<'_>; 12]`, found `()`
    |        |
    |        implicitly returns `()` as its body has no tail or `return` expression

--- a/tests/compile-fail/tracked_struct_incompatibles.rs
+++ b/tests/compile-fail/tracked_struct_incompatibles.rs
@@ -28,4 +28,9 @@ struct TrackedStructWithLru {
     field: u32,
 }
 
+#[salsa::tracked(revisions = 12)]
+struct TrackedStructWithRevisions {
+    field: u32,
+}
+
 fn main() {}

--- a/tests/compile-fail/tracked_struct_incompatibles.stderr
+++ b/tests/compile-fail/tracked_struct_incompatibles.stderr
@@ -33,3 +33,9 @@ error: `lru` option not allowed here
    |
 26 | #[salsa::tracked(lru = 12)]
    |                  ^^^
+
+error: `revisions` option not allowed here
+  --> tests/compile-fail/tracked_struct_incompatibles.rs:31:18
+   |
+31 | #[salsa::tracked(revisions = 12)]
+   |                  ^^^^^^^^^


### PR DESCRIPTION
Adds the ability to tune and disable interned value garbage collection via an attribute:

```rust
#[salsa::interned(revisions = <1 | 2 | ... | usize::MAX>)]
struct Interned<'db>;
```

`revisions` is the minimum number of active revisions that must pass before a stale value is considered for garbage collection. Note that an *active revision* is one in which an instance of the interned struct has been read, so consecutive writes that create new revisions in sequence do not invalidate all interned values. Currently this constant is hard-coded to 3 internally for no good reason. Setting it to `usize::MAX` will disable garbage collection altogether (cc @Veykril).

I'm torn on whether to hard-code `usize::MAX` as the immortal value or to make that more explicit, e.g. `salsa::interned(durability = "immortal")` or `salsa::interned(immortal)`.