### PR TITLE
Fix race in `MemoTableTypes`

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -66,6 +66,12 @@ pub mod shim {
     /// A polyfill for `std::sync::OnceLock`.
     pub struct OnceLock<T>(Mutex<bool>, UnsafeCell<MaybeUninit<T>>);
 
+    impl<T> Default for OnceLock<T> {
+        fn default() -> Self {
+            OnceLock::new()
+        }
+    }
+
     impl<T> OnceLock<T> {
         pub const fn new() -> OnceLock<T> {
             OnceLock(Mutex::new(false), UnsafeCell::new(MaybeUninit::uninit()))


### PR DESCRIPTION
Noticed this while reading the code. `boxcar::Vec::count` does not guarantee that there are `N` contiguous entries initialized, which the current code is assuming. It seems fine to just spin here because, from what I understand, `MemoTableTypes` is only setup the first time a query is called? I also don't think we've ever seen this bug in practice.