### PR TITLE
Use explicit discriminants for `QueryOriginKind` for better comparisons

### DIFF
--- a/components/salsa-macro-rules/src/setup_input_struct.rs
+++ b/components/salsa-macro-rules/src/setup_input_struct.rs
@@ -200,7 +200,7 @@ macro_rules! setup_input_struct {
 
                 $(
                     #[must_use]
-                    $field_setter_vis fn $field_setter_id<'db, $Db>(self, db: &'db mut $Db) -> impl salsa::Setter<FieldTy = $field_ty> + 'db
+                    $field_setter_vis fn $field_setter_id<'db, $Db>(self, db: &'db mut $Db) -> impl salsa::Setter<FieldTy = $field_ty> + use<'db, $Db>
                     where
                         // FIXME(rust-lang/rust#65991): The `db` argument *should* have the type `dyn Database`
                         $Db: ?Sized + $zalsa::Database,

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -286,7 +286,7 @@ impl<V> Memo<V> {
         }
     }
 
-    pub(super) fn tracing_debug(&self) -> impl std::fmt::Debug + '_ {
+    pub(super) fn tracing_debug(&self) -> impl std::fmt::Debug + use<'_, V> {
         struct TracingDebug<'a, T> {
             memo: &'a Memo<T>,
         }

--- a/tests/cycle.rs
+++ b/tests/cycle.rs
@@ -37,7 +37,7 @@ struct Inputs {
 }
 
 impl Inputs {
-    fn values(self, db: &dyn Db) -> impl Iterator<Item = Value> + '_ {
+    fn values(self, db: &dyn Db) -> impl Iterator<Item = Value> + use<'_> {
         self.inputs(db).iter().map(|input| input.eval(db))
     }
 }


### PR DESCRIPTION
This won't really have an observable effect as its really micro-optimizing the tiniest thing ever, but given we already have a very specialized layout here we might as well push it to the limits.

This means if comparing for either `Derived` and `DerivedUntracked` in the same branch, instead of getting
```asm
        cmp     dil, 3
        sete    cl
        test    dil, dil
        sete    al
        or      al, cl
```
we get
```asm
        cmp     dil, 2
        setae   al
```
as we now only need to check a single bit