### PR TITLE
Relax synstructure version requirement

### DIFF
--- a/components/salsa-macros/Cargo.toml
+++ b/components/salsa-macros/Cargo.toml
@@ -12,7 +12,7 @@ description = "Procedural macros for the salsa crate"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0"
-quote = "1.0"
-syn = { version = "2.0.101", features = ["full", "visit-mut"] }
-synstructure = "0.13.2"
+proc-macro2 = "1.0.0"
+quote = "1.0.0"
+syn = { version = "2.0.81", features = ["full", "visit-mut"] }
+synstructure = "0.13"


### PR DESCRIPTION
This causes r-a not to build against salsa due to chalk-derive demanding a different version https://github.com/rust-lang/chalk/blob/master/chalk-derive/Cargo.toml#L15C15-L16C24

Reading the cargo docs it seems specifying a `0.a.b` version (unlike a `1.a.b` version) sets a strict requirement where as leaving off the patch component allows the patch to move up.