### PR TITLE
Add API to dump memory usage

### DIFF
--- a/src/accumulator/accumulated_map.rs
+++ b/src/accumulator/accumulated_map.rs
@@ -1,6 +1,6 @@
 use std::ops;
 
-use rustc_hash::FxHashMap;
+use rustc_hash::FxBuildHasher;
 
 use crate::accumulator::accumulated::Accumulated;
 use crate::accumulator::{Accumulator, AnyAccumulated};
@@ -9,7 +9,7 @@ use crate::IngredientIndex;
 
 #[derive(Default)]
 pub struct AccumulatedMap {
-    map: FxHashMap<IngredientIndex, Box<dyn AnyAccumulated>>,
+    map: hashbrown::HashMap<IngredientIndex, Box<dyn AnyAccumulated>, FxBuildHasher>,
 }
 
 impl std::fmt::Debug for AccumulatedMap {
@@ -49,6 +49,10 @@ impl AccumulatedMap {
 
     pub fn clear(&mut self) {
         self.map.clear()
+    }
+
+    pub fn allocation_size(&self) -> usize {
+        self.map.allocation_size()
     }
 }
 

--- a/src/cycle.rs
+++ b/src/cycle.rs
@@ -49,6 +49,8 @@
 //! cycle head may then iterate, which may result in a new set of iterations on the inner cycle,
 //! for each iteration of the outer cycle.
 
+use std::mem;
+
 use thin_vec::{thin_vec, ThinVec};
 
 use crate::key::DatabaseKeyIndex;
@@ -209,6 +211,10 @@ impl CycleHeads {
                 self.0.push(*head);
             }
         }
+    }
+
+    pub(crate) fn allocation_size(&self) -> usize {
+        mem::size_of_val(self.0.as_slice())
     }
 }
 

--- a/src/cycle.rs
+++ b/src/cycle.rs
@@ -49,8 +49,6 @@
 //! cycle head may then iterate, which may result in a new set of iterations on the inner cycle,
 //! for each iteration of the outer cycle.
 
-use std::mem;
-
 use thin_vec::{thin_vec, ThinVec};
 
 use crate::key::DatabaseKeyIndex;
@@ -213,8 +211,9 @@ impl CycleHeads {
         }
     }
 
+    #[cfg(feature = "salsa_unstable")]
     pub(crate) fn allocation_size(&self) -> usize {
-        mem::size_of_val(self.0.as_slice())
+        std::mem::size_of_val(self.0.as_slice())
     }
 }
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,6 +1,8 @@
 use std::any::Any;
 use std::borrow::Cow;
 
+use hashbrown::HashMap;
+
 use crate::zalsa::{IngredientIndex, ZalsaDatabase};
 use crate::{Durability, Revision};
 
@@ -132,4 +134,99 @@ impl dyn Database {
         let views = self.zalsa().views();
         views.downcaster_for().downcast(self)
     }
+
+    /// Returns information about any Salsa structs.
+    pub fn structs_info(&self) -> Vec<IngredientInfo> {
+        self.zalsa()
+            .ingredients()
+            .filter_map(|ingredient| {
+                let mut size_of_fields = 0;
+                let mut size_of_metadata = 0;
+                let mut instances = 0;
+
+                for slot in ingredient.memory_usage(self)? {
+                    instances += 1;
+                    size_of_fields += slot.size_of_fields;
+                    size_of_metadata += slot.size_of_metadata;
+                }
+
+                Some(IngredientInfo {
+                    count: instances,
+                    size_of_fields,
+                    size_of_metadata,
+                    debug_name: ingredient.debug_name(),
+                })
+            })
+            .collect()
+    }
+
+    /// Returns information about any memoized Salsa queries.
+    ///
+    /// The returned map holds memory usage information for memoized values of a given query, keyed
+    /// by its `(input, output)` type names.
+    pub fn queries_info(&self) -> HashMap<(&'static str, &'static str), IngredientInfo> {
+        let mut queries = HashMap::new();
+
+        for input_ingredient in self.zalsa().ingredients() {
+            let Some(input_info) = input_ingredient.memory_usage(self) else {
+                continue;
+            };
+
+            for input in input_info {
+                for output in input.memos {
+                    let info = queries
+                        .entry((input.debug_name, output.debug_name))
+                        .or_insert(IngredientInfo {
+                            debug_name: output.debug_name,
+                            ..Default::default()
+                        });
+
+                    info.count += 1;
+                    info.size_of_fields += output.size_of_fields;
+                    info.size_of_metadata += output.size_of_metadata;
+                }
+            }
+        }
+
+        queries
+    }
+}
+
+/// Information about instances of a particular Salsa ingredient.
+#[derive(Default, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct IngredientInfo {
+    debug_name: &'static str,
+    count: usize,
+    size_of_metadata: usize,
+    size_of_fields: usize,
+}
+
+impl IngredientInfo {
+    /// Returns the debug name of the ingredient.
+    pub fn debug_name(&self) -> &'static str {
+        self.debug_name
+    }
+
+    /// Returns the total size of the fields of any instances of this ingredient, in bytes.
+    pub fn size_of_fields(&self) -> usize {
+        self.size_of_fields
+    }
+
+    /// Returns the total size of Salsa metadata of any instances of this ingredient, in bytes.
+    pub fn size_of_metadata(&self) -> usize {
+        self.size_of_metadata
+    }
+
+    /// Returns the number of instances of this ingredient.
+    pub fn count(&self) -> usize {
+        self.count
+    }
+}
+
+/// Memory usage information about a particular instance of struct, input or output.
+pub struct SlotInfo {
+    pub(crate) debug_name: &'static str,
+    pub(crate) size_of_metadata: usize,
+    pub(crate) size_of_fields: usize,
+    pub(crate) memos: Vec<SlotInfo>,
 }

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -1,10 +1,9 @@
 use std::any::Any;
 use std::fmt::{Debug, Formatter};
-use std::mem::{self, transmute};
+use std::mem::transmute;
 use std::ptr::NonNull;
 
 use crate::cycle::{empty_cycle_heads, CycleHead, CycleHeads, IterationCount, ProvisionalStatus};
-use crate::database::SlotInfo;
 use crate::function::{Configuration, IngredientImpl};
 use crate::hash::FxHashSet;
 use crate::ingredient::{Ingredient, WaitForResult};
@@ -318,13 +317,14 @@ impl<V: Send + Sync + Any> crate::table::memo::Memo for Memo<V> {
         self.revisions.origin.as_ref()
     }
 
-    fn memory_usage(&self) -> SlotInfo {
-        let size_of = mem::size_of::<Memo<V>>() + self.revisions.allocation_size();
+    #[cfg(feature = "salsa_unstable")]
+    fn memory_usage(&self) -> crate::SlotInfo {
+        let size_of = std::mem::size_of::<Memo<V>>() + self.revisions.allocation_size();
 
-        SlotInfo {
-            size_of_metadata: size_of - mem::size_of::<V>(),
+        crate::SlotInfo {
+            size_of_metadata: size_of - std::mem::size_of::<V>(),
             debug_name: std::any::type_name::<V>(),
-            size_of_fields: mem::size_of::<V>(),
+            size_of_fields: std::mem::size_of::<V>(),
             memos: Vec::new(),
         }
     }

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -5,7 +5,6 @@ use crate::accumulator::accumulated_map::{AccumulatedMap, InputAccumulatedValues
 use crate::cycle::{
     empty_cycle_heads, CycleHeads, CycleRecoveryStrategy, IterationCount, ProvisionalStatus,
 };
-use crate::database::SlotInfo;
 use crate::function::VerifyResult;
 use crate::plumbing::IngredientIndices;
 use crate::runtime::Running;
@@ -185,7 +184,8 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
 
     /// Returns memory usage information about any instances of the ingredient,
     /// if applicable.
-    fn memory_usage(&self, _db: &dyn Database) -> Option<Vec<SlotInfo>> {
+    #[cfg(feature = "salsa_unstable")]
+    fn memory_usage(&self, _db: &dyn Database) -> Option<Vec<crate::SlotInfo>> {
         None
     }
 }

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -5,6 +5,7 @@ use crate::accumulator::accumulated_map::{AccumulatedMap, InputAccumulatedValues
 use crate::cycle::{
     empty_cycle_heads, CycleHeads, CycleRecoveryStrategy, IterationCount, ProvisionalStatus,
 };
+use crate::database::SlotInfo;
 use crate::function::VerifyResult;
 use crate::plumbing::IngredientIndices;
 use crate::runtime::Running;
@@ -180,6 +181,12 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
     ) -> (Option<&'db AccumulatedMap>, InputAccumulatedValues) {
         let _ = (db, key_index);
         (None, InputAccumulatedValues::Empty)
+    }
+
+    /// Returns memory usage information about any instances of the ingredient,
+    /// if applicable.
+    fn memory_usage(&self, _db: &dyn Database) -> Option<Vec<SlotInfo>> {
+        None
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ pub use self::accumulator::Accumulator;
 pub use self::active_query::Backtrace;
 pub use self::cancelled::Cancelled;
 pub use self::cycle::CycleRecoveryAction;
-pub use self::database::{AsDynDatabase, Database};
+pub use self::database::{AsDynDatabase, Database, SlotInfo};
 pub use self::database_impl::DatabaseImpl;
 pub use self::durability::Durability;
 pub use self::event::{Event, EventKind};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,11 +39,14 @@ pub use parallel::{join, par_map};
 #[cfg(feature = "macros")]
 pub use salsa_macros::{accumulator, db, input, interned, tracked, Supertype, Update};
 
+#[cfg(feature = "salsa_unstable")]
+pub use self::database::{IngredientInfo, SlotInfo};
+
 pub use self::accumulator::Accumulator;
 pub use self::active_query::Backtrace;
 pub use self::cancelled::Cancelled;
 pub use self::cycle::CycleRecoveryAction;
-pub use self::database::{AsDynDatabase, Database, SlotInfo};
+pub use self::database::{AsDynDatabase, Database};
 pub use self::database_impl::DatabaseImpl;
 pub use self::durability::Durability;
 pub use self::event::{Event, EventKind};

--- a/src/table.rs
+++ b/src/table.rs
@@ -253,6 +253,7 @@ impl Table {
         unsafe { page.memo_types.attach_memos_mut(memos) }
     }
 
+    #[cfg(feature = "salsa_unstable")]
     pub(crate) fn slots_of<T: Slot>(&self) -> impl Iterator<Item = &T> + '_ {
         self.pages
             .iter()
@@ -392,6 +393,7 @@ impl Page {
         PageView(self, PhantomData)
     }
 
+    #[cfg(feature = "salsa_unstable")]
     fn cast_type<T: Slot>(&self) -> Option<PageView<'_, T>> {
         if self.slot_type_id == TypeId::of::<T>() {
             Some(PageView(self, PhantomData))

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -6,7 +6,6 @@ use std::ptr::{self, NonNull};
 use portable_atomic::hint::spin_loop;
 use thin_vec::ThinVec;
 
-use crate::database::SlotInfo;
 use crate::sync::atomic::{AtomicPtr, Ordering};
 use crate::sync::{OnceLock, RwLock};
 use crate::{zalsa::MemoIngredientIndex, zalsa_local::QueryOriginRef};
@@ -24,7 +23,8 @@ pub trait Memo: Any + Send + Sync {
     fn origin(&self) -> QueryOriginRef<'_>;
 
     /// Returns memory usage information about the memoized value.
-    fn memory_usage(&self) -> SlotInfo;
+    #[cfg(feature = "salsa_unstable")]
+    fn memory_usage(&self) -> crate::SlotInfo;
 }
 
 /// Data for a memoized entry.
@@ -111,8 +111,9 @@ impl Memo for DummyMemo {
         unreachable!("should not get here")
     }
 
-    fn memory_usage(&self) -> SlotInfo {
-        SlotInfo {
+    #[cfg(feature = "salsa_unstable")]
+    fn memory_usage(&self) -> crate::SlotInfo {
+        crate::SlotInfo {
             debug_name: "dummy",
             size_of_metadata: 0,
             size_of_fields: 0,
@@ -277,7 +278,8 @@ impl MemoTableWithTypes<'_> {
         Some(unsafe { MemoEntryType::from_dummy(memo) })
     }
 
-    pub(crate) fn memory_usage(&self) -> Vec<SlotInfo> {
+    #[cfg(feature = "salsa_unstable")]
+    pub(crate) fn memory_usage(&self) -> Vec<crate::SlotInfo> {
         let mut memory_usage = Vec::new();
         let memos = self.memos.memos.read();
         for (index, memo) in memos.iter().enumerate() {

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -1,13 +1,12 @@
-use std::{
-    any::{Any, TypeId},
-    fmt::Debug,
-    mem,
-    ptr::{self, NonNull},
-};
+use std::any::{Any, TypeId};
+use std::fmt::Debug;
+use std::mem;
+use std::ptr::{self, NonNull};
 
 use portable_atomic::hint::spin_loop;
 use thin_vec::ThinVec;
 
+use crate::database::SlotInfo;
 use crate::sync::atomic::{AtomicPtr, Ordering};
 use crate::sync::{OnceLock, RwLock};
 use crate::{zalsa::MemoIngredientIndex, zalsa_local::QueryOriginRef};
@@ -23,6 +22,9 @@ pub(crate) struct MemoTable {
 pub trait Memo: Any + Send + Sync {
     /// Returns the `origin` of this memo
     fn origin(&self) -> QueryOriginRef<'_>;
+
+    /// Returns memory usage information about the memoized value.
+    fn memory_usage(&self) -> SlotInfo;
 }
 
 /// Data for a memoized entry.
@@ -53,7 +55,7 @@ pub struct MemoEntryType {
     data: OnceLock<MemoEntryTypeData>,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 struct MemoEntryTypeData {
     /// The `type_id` of the erased memo type `M`
     type_id: TypeId,
@@ -102,11 +104,20 @@ impl MemoEntryType {
 
 /// Dummy placeholder type that we use when erasing the memo type `M` in [`MemoEntryData`][].
 #[derive(Debug)]
-struct DummyMemo {}
+struct DummyMemo;
 
 impl Memo for DummyMemo {
     fn origin(&self) -> QueryOriginRef<'_> {
         unreachable!("should not get here")
+    }
+
+    fn memory_usage(&self) -> SlotInfo {
+        SlotInfo {
+            debug_name: "dummy",
+            size_of_metadata: 0,
+            size_of_fields: 0,
+            memos: Vec::new(),
+        }
     }
 }
 
@@ -146,7 +157,6 @@ impl MemoTableTypes {
                         "cannot provide an empty `MemoEntryType` for `MemoEntryType::set()`",
                     ),
                 )
-                .ok()
                 .expect("memo type should only be set once");
             break;
         }
@@ -156,7 +166,7 @@ impl MemoTableTypes {
     ///
     /// The types table must be the correct one of `memos`.
     #[inline]
-    pub(super) unsafe fn attach_memos<'a>(
+    pub(crate) unsafe fn attach_memos<'a>(
         &'a self,
         memos: &'a MemoTable,
     ) -> MemoTableWithTypes<'a> {
@@ -265,6 +275,26 @@ impl MemoTableWithTypes<'_> {
         let memo = NonNull::new(memo.atomic_memo.load(Ordering::Acquire))?;
         // SAFETY: `type_id` check asserted above
         Some(unsafe { MemoEntryType::from_dummy(memo) })
+    }
+
+    pub(crate) fn memory_usage(&self) -> Vec<SlotInfo> {
+        let mut memory_usage = Vec::new();
+        let memos = self.memos.memos.read();
+        for (index, memo) in memos.iter().enumerate() {
+            let Some(memo) = NonNull::new(memo.atomic_memo.load(Ordering::Acquire)) else {
+                continue;
+            };
+
+            let Some(type_) = self.types.types.get(index).and_then(MemoEntryType::load) else {
+                continue;
+            };
+
+            // SAFETY: The `TypeId` is asserted in `insert()`.
+            let dyn_memo: &dyn Memo = unsafe { (type_.to_dyn_fn)(memo).as_ref() };
+            memory_usage.push(dyn_memo.memory_usage());
+        }
+
+        memory_usage
     }
 }
 

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -23,7 +23,7 @@ use crate::sync::Arc;
 use crate::table::memo::{MemoTable, MemoTableTypes, MemoTableWithTypesMut};
 use crate::table::{Slot, Table};
 use crate::zalsa::{IngredientIndex, Zalsa};
-use crate::{Database, Durability, Event, EventKind, Id, Revision, SlotInfo};
+use crate::{Database, Durability, Event, EventKind, Id, Revision};
 
 pub mod tracked_field;
 
@@ -854,7 +854,8 @@ where
     }
 
     /// Returns memory usage information about any tracked structs.
-    fn memory_usage(&self, db: &dyn Database) -> Option<Vec<SlotInfo>> {
+    #[cfg(feature = "salsa_unstable")]
+    fn memory_usage(&self, db: &dyn Database) -> Option<Vec<crate::SlotInfo>> {
         let memory_usage = self
             .entries(db)
             // SAFETY: The memo table belongs to a value that we allocated, so it
@@ -927,11 +928,12 @@ where
     /// # Safety
     ///
     /// The `MemoTable` must belong to a `Value` of the correct type.
-    unsafe fn memory_usage(&self, memo_table_types: &MemoTableTypes) -> SlotInfo {
+    #[cfg(feature = "salsa_unstable")]
+    unsafe fn memory_usage(&self, memo_table_types: &MemoTableTypes) -> crate::SlotInfo {
         // SAFETY: The caller guarantees this is the correct types table.
         let memos = unsafe { memo_table_types.attach_memos(&self.memos) };
 
-        SlotInfo {
+        crate::SlotInfo {
             debug_name: C::DEBUG_NAME,
             size_of_metadata: mem::size_of::<Self>() - mem::size_of::<C::Fields<'_>>(),
             size_of_fields: mem::size_of::<C::Fields<'_>>(),

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -235,6 +235,12 @@ impl Zalsa {
             [memo_ingredient_index.as_usize()]
     }
 
+    pub(crate) fn ingredients(&self) -> impl Iterator<Item = &dyn Ingredient> {
+        self.ingredients_vec
+            .iter()
+            .map(|(_, ingredient)| ingredient.as_ref())
+    }
+
     /// Starts unwinding the stack if the current revision is cancelled.
     ///
     /// This method can be called by query implementations that perform

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -235,6 +235,7 @@ impl Zalsa {
             [memo_ingredient_index.as_usize()]
     }
 
+    #[cfg(feature = "salsa_unstable")]
     pub(crate) fn ingredients(&self) -> impl Iterator<Item = &dyn Ingredient> {
         self.ingredients_vec
             .iter()

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -1,5 +1,4 @@
 use std::cell::RefCell;
-use std::mem;
 use std::panic::UnwindSafe;
 use std::ptr::{self, NonNull};
 
@@ -349,6 +348,7 @@ pub(crate) struct QueryRevisions {
 }
 
 impl QueryRevisions {
+    #[cfg(feature = "salsa_unstable")]
     pub(crate) fn allocation_size(&self) -> usize {
         let QueryRevisions {
             changed_at: _,
@@ -364,7 +364,7 @@ impl QueryRevisions {
         if let QueryOriginRef::Derived(query_edges)
         | QueryOriginRef::DerivedUntracked(query_edges) = origin.as_ref()
         {
-            memory += mem::size_of_val(query_edges);
+            memory += std::mem::size_of_val(query_edges);
         }
 
         if let Some(extra) = extra.0.as_ref() {
@@ -447,6 +447,7 @@ struct QueryRevisionsExtraInner {
 }
 
 impl QueryRevisionsExtraInner {
+    #[cfg(feature = "salsa_unstable")]
     fn allocation_size(&self) -> usize {
         let QueryRevisionsExtraInner {
             accumulated,
@@ -457,7 +458,7 @@ impl QueryRevisionsExtraInner {
 
         accumulated.allocation_size()
             + cycle_heads.allocation_size()
-            + mem::size_of_val(tracked_struct_ids.as_slice())
+            + std::mem::size_of_val(tracked_struct_ids.as_slice())
     }
 }
 

--- a/tests/memory-usage.rs
+++ b/tests/memory-usage.rs
@@ -1,3 +1,5 @@
+use expect_test::expect;
+
 #[salsa::input]
 struct MyInput {
     field: u32,
@@ -53,74 +55,74 @@ fn test() {
 
     let structs_info = <dyn salsa::Database>::structs_info(&db);
 
-    assert_eq!(
-        format!("{structs_info:#?}"),
-        r#"[
-    IngredientInfo {
-        debug_name: "MyInput",
-        count: 3,
-        size_of_metadata: 84,
-        size_of_fields: 12,
-    },
-    IngredientInfo {
-        debug_name: "MyTracked",
-        count: 4,
-        size_of_metadata: 112,
-        size_of_fields: 16,
-    },
-    IngredientInfo {
-        debug_name: "MyInterned",
-        count: 3,
-        size_of_metadata: 156,
-        size_of_fields: 12,
-    },
-]"#
-    );
+    let expected = expect![[r#"
+        [
+            IngredientInfo {
+                debug_name: "MyInput",
+                count: 3,
+                size_of_metadata: 84,
+                size_of_fields: 12,
+            },
+            IngredientInfo {
+                debug_name: "MyTracked",
+                count: 4,
+                size_of_metadata: 112,
+                size_of_fields: 16,
+            },
+            IngredientInfo {
+                debug_name: "MyInterned",
+                count: 3,
+                size_of_metadata: 156,
+                size_of_fields: 12,
+            },
+        ]"#]];
+
+    expected.assert_eq(&format!("{structs_info:#?}"));
 
     let mut queries_info = <dyn salsa::Database>::queries_info(&db)
         .into_iter()
         .collect::<Vec<_>>();
     queries_info.sort();
 
-    assert_eq!(
-        format!("{queries_info:#?}"),
-        r#"[
-    (
-        (
-            "MyInput",
-            "(memory_usage::MyTracked, memory_usage::MyTracked)",
-        ),
-        IngredientInfo {
-            debug_name: "(memory_usage::MyTracked, memory_usage::MyTracked)",
-            count: 1,
-            size_of_metadata: 132,
-            size_of_fields: 16,
-        },
-    ),
-    (
-        (
-            "MyInput",
-            "memory_usage::MyInterned",
-        ),
-        IngredientInfo {
-            debug_name: "memory_usage::MyInterned",
-            count: 3,
-            size_of_metadata: 192,
-            size_of_fields: 24,
-        },
-    ),
-    (
-        (
-            "MyInput",
-            "memory_usage::MyTracked",
-        ),
-        IngredientInfo {
-            debug_name: "memory_usage::MyTracked",
-            count: 2,
-            size_of_metadata: 192,
-            size_of_fields: 16,
-        },
-    ),
-]"#
-    )
+    let expected = expect![[r#"
+        [
+            (
+                (
+                    "MyInput",
+                    "(memory_usage::MyTracked, memory_usage::MyTracked)",
+                ),
+                IngredientInfo {
+                    debug_name: "(memory_usage::MyTracked, memory_usage::MyTracked)",
+                    count: 1,
+                    size_of_metadata: 132,
+                    size_of_fields: 16,
+                },
+            ),
+            (
+                (
+                    "MyInput",
+                    "memory_usage::MyInterned",
+                ),
+                IngredientInfo {
+                    debug_name: "memory_usage::MyInterned",
+                    count: 3,
+                    size_of_metadata: 192,
+                    size_of_fields: 24,
+                },
+            ),
+            (
+                (
+                    "MyInput",
+                    "memory_usage::MyTracked",
+                ),
+                IngredientInfo {
+                    debug_name: "memory_usage::MyTracked",
+                    count: 2,
+                    size_of_metadata: 192,
+                    size_of_fields: 16,
+                },
+            ),
+        ]"#]];
+
+    expected.assert_eq(&format!("{queries_info:#?}"));
 }

--- a/tests/memory-usage.rs
+++ b/tests/memory-usage.rs
@@ -1,0 +1,126 @@
+#[salsa::input]
+struct MyInput {
+    field: u32,
+}
+
+#[salsa::tracked]
+struct MyTracked<'db> {
+    field: u32,
+}
+
+#[salsa::interned]
+struct MyInterned<'db> {
+    field: u32,
+}
+
+#[salsa::tracked]
+fn input_to_interned<'db>(db: &'db dyn salsa::Database, input: MyInput) -> MyInterned<'db> {
+    MyInterned::new(db, input.field(db))
+}
+
+#[salsa::tracked]
+fn input_to_tracked<'db>(db: &'db dyn salsa::Database, input: MyInput) -> MyTracked<'db> {
+    MyTracked::new(db, input.field(db))
+}
+
+#[salsa::tracked]
+fn input_to_tracked_tuple<'db>(
+    db: &'db dyn salsa::Database,
+    input: MyInput,
+) -> (MyTracked<'db>, MyTracked<'db>) {
+    (
+        MyTracked::new(db, input.field(db)),
+        MyTracked::new(db, input.field(db)),
+    )
+}
+
+#[test]
+fn test() {
+    let db = salsa::DatabaseImpl::new();
+
+    let input1 = MyInput::new(&db, 1);
+    let input2 = MyInput::new(&db, 2);
+    let input3 = MyInput::new(&db, 3);
+
+    let _tracked1 = input_to_tracked(&db, input1);
+    let _tracked2 = input_to_tracked(&db, input2);
+
+    let _tracked_tuple = input_to_tracked_tuple(&db, input1);
+
+    let _interned1 = input_to_interned(&db, input1);
+    let _interned2 = input_to_interned(&db, input2);
+    let _interned3 = input_to_interned(&db, input3);
+
+    let structs_info = <dyn salsa::Database>::structs_info(&db);
+
+    assert_eq!(
+        format!("{structs_info:#?}"),
+        r#"[
+    IngredientInfo {
+        debug_name: "MyInput",
+        count: 3,
+        size_of_metadata: 84,
+        size_of_fields: 12,
+    },
+    IngredientInfo {
+        debug_name: "MyTracked",
+        count: 4,
+        size_of_metadata: 112,
+        size_of_fields: 16,
+    },
+    IngredientInfo {
+        debug_name: "MyInterned",
+        count: 3,
+        size_of_metadata: 156,
+        size_of_fields: 12,
+    },
+]"#
+    );
+
+    let mut queries_info = <dyn salsa::Database>::queries_info(&db)
+        .into_iter()
+        .collect::<Vec<_>>();
+    queries_info.sort();
+
+    assert_eq!(
+        format!("{queries_info:#?}"),
+        r#"[
+    (
+        (
+            "MyInput",
+            "(memory_usage::MyTracked, memory_usage::MyTracked)",
+        ),
+        IngredientInfo {
+            debug_name: "(memory_usage::MyTracked, memory_usage::MyTracked)",
+            count: 1,
+            size_of_metadata: 132,
+            size_of_fields: 16,
+        },
+    ),
+    (
+        (
+            "MyInput",
+            "memory_usage::MyInterned",
+        ),
+        IngredientInfo {
+            debug_name: "memory_usage::MyInterned",
+            count: 3,
+            size_of_metadata: 192,
+            size_of_fields: 24,
+        },
+    ),
+    (
+        (
+            "MyInput",
+            "memory_usage::MyTracked",
+        ),
+        IngredientInfo {
+            debug_name: "memory_usage::MyTracked",
+            count: 2,
+            size_of_metadata: 192,
+            size_of_fields: 16,
+        },
+    ),
+]"#
+    )
+}


### PR DESCRIPTION
This PR adds the methods `<dyn Database>::{structs_info, queries_info}`, which allow accessing memory usage information about salsa structs and memos. In ty, this lets us generate a report that looks like this:

```
=======SALSA DUMP=======
`Definition`                                       metadata=7.21MB   fields=14.41MB  count=180134
`Expression`                                       metadata=4.42MB   fields=4.42MB   count=92086
`member_lookup_with_policy_::interned_arguments`   metadata=1.94MB   fields=2.21MB   count=34566
`class_member_with_policy_::interned_arguments`    metadata=1.56MB   fields=1.78MB   count=27820
`IntersectionType`                                 metadata=0.75MB   fields=1.50MB   count=13350
`OverloadLiteral`                                  metadata=1.19MB   fields=0.85MB   count=21181
...
`Definition -> ty_python_semantic::types::infer::TypeInference`
    metadata=24.41MB  fields=32.41MB  count=144690
`Expression -> ty_python_semantic::types::infer::TypeInference`
    metadata=28.34MB  fields=17.95MB  count=80115
`ScopeId -> ty_python_semantic::types::infer::TypeInference`
    metadata=14.34MB  fields=6.31MB   count=28170
`member_lookup_with_policy_::interned_arguments -> ty_python_semantic::place::PlaceAndQualifiers`
    metadata=4.92MB   fields=1.66MB   count=34566
...
```

One current limitation is that we cannot provide the name of the query function, only it's input and output types. The other is that this only reports the stack size of any struct fields, which makes this a lot less useful for anything even wrapped trivially in a `Box` or `Arc`. Ideally we would have some way of asking a type for it's heap allocation size (maybe using something like the [`get-size`](https://docs.rs/get-size/latest/get_size/) crate), but it would likely have to be opt-in to avoid breakage, and I'm not sure exactly how that would look (maybe a macro attribute, or feature flag?).

I'm not sure how others have been profiling salsa-related memory usage, but the above report has been extremely useful for us. Also unsure if this should be under the `salsa_unstable` feature.