### PR TITLE
Hide generated structs of tracked functions from docs via `#[doc(hidden)]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `#[doc(hidden)]` auto-generated tracked-fn structs ([#917](https://github.com/salsa-rs/salsa/pull/917))
+
 ## [0.22.0](https://github.com/salsa-rs/salsa/compare/salsa-v0.21.1...salsa-v0.22.0) - 2025-05-23
 
 ### Fixed

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -369,6 +369,7 @@ macro_rules! setup_tracked_fn {
         // The struct needs be last in the macro expansion in order to make the tracked
         // function's ident be identified as a function, not a struct, during semantic highlighting.
         // for more details, see https://github.com/salsa-rs/salsa/pull/612.
+        #[doc(hidden)]
         #[allow(non_camel_case_types)]
         $vis struct $fn_name {
             _priv: std::convert::Infallible,


### PR DESCRIPTION
Salsa also supports tracked methods and tracked associated methods, neither of which produce equivalent user-observable structs, so arguably neither should track functions, and the generated structs don't really provide a usable API anyway.