### PR TITLE
Shard jar map

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,13 @@ description = "A generic framework for on-demand, incrementalized computation (e
 salsa-macro-rules = { version = "0.22.0", path = "components/salsa-macro-rules" }
 salsa-macros = { version = "0.22.0", path = "components/salsa-macros", optional = true }
 
-boxcar = "0.2.13"
+boxcar = { git = "https://github.com/ibraheemdev/boxcar", rev = "574c893f0a6d8b2cde17dd9933fd9e3d74ea8e0f" }
 crossbeam-queue = "0.3.11"
 crossbeam-utils = "0.8.21"
+dashmap = { version = "6", features = ["raw-api"] }
 hashbrown = "0.15"
+# The version of hashbrown used by dashmap.
+hashbrown_14 = { package = "hashbrown", version = "0.14" }
 hashlink = "0.10"
 indexmap = "2"
 intrusive-collections = "0.9.7"
@@ -51,7 +54,6 @@ salsa-macros = { version = "=0.22.0", path = "components/salsa-macros" }
 [dev-dependencies]
 # examples
 crossbeam-channel = "0.5.14"
-dashmap = { version = "6", features = ["raw-api"] }
 eyre = "0.6.8"
 notify-debouncer-mini = "0.4.1"
 ordered-float = "4.2.1"

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -242,6 +242,16 @@ macro_rules! setup_tracked_fn {
                     }
                 }
 
+                fn ingredients_count() -> usize {
+                    $zalsa::macro_if! {
+                        if $needs_interner {
+                            2
+                        } else {
+                            1
+                        }
+                    }
+                }
+
                 fn create_ingredients(
                     zalsa: &$zalsa::Zalsa,
                     first_index: $zalsa::IngredientIndex,

--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -43,6 +43,10 @@ impl<A: Accumulator> Default for JarImpl<A> {
 }
 
 impl<A: Accumulator> Jar for JarImpl<A> {
+    fn ingredients_count() -> usize {
+        1
+    }
+
     fn create_ingredients(
         _zalsa: &Zalsa,
         first_index: IngredientIndex,

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,4 +1,4 @@
-use std::hash::{BuildHasher, Hash};
+use std::hash::{BuildHasher, Hash, Hasher};
 
 pub(crate) type FxHasher = std::hash::BuildHasherDefault<rustc_hash::FxHasher>;
 pub(crate) type FxIndexSet<K> = indexmap::IndexSet<K, FxHasher>;
@@ -7,4 +7,25 @@ pub(crate) type FxHashSet<K> = std::collections::HashSet<K, FxHasher>;
 
 pub(crate) fn hash<T: Hash>(t: &T) -> u64 {
     FxHasher::default().hash_one(t)
+}
+
+// `TypeId` is a 128-bit hash internally, and it's `Hash` implementation
+// writes the lower 64-bits. Hashing it again would be unnecessary.
+#[derive(Default)]
+pub(crate) struct TypeIdHasher(u64);
+
+impl Hasher for TypeIdHasher {
+    fn write(&mut self, _: &[u8]) {
+        unreachable!("`TypeId` calls `write_u64`");
+    }
+
+    #[inline]
+    fn write_u64(&mut self, id: u64) {
+        self.0 = id;
+    }
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
 }

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -30,8 +30,15 @@ pub trait Jar: Any {
         IngredientIndices::empty()
     }
 
+    /// Returns the number of ingredients that `create_ingredients` will return.
+    fn ingredients_count() -> usize
+    where
+        Self: Sized;
+
     /// Create the ingredients given the index of the first one.
     /// All subsequent ingredients will be assigned contiguous indices.
+    ///
+    /// Note that the vector returned must be of length `ingredients_count`.
     fn create_ingredients(
         zalsa: &Zalsa,
         first_index: IngredientIndex,

--- a/src/input.rs
+++ b/src/input.rs
@@ -55,6 +55,10 @@ impl<C: Configuration> Default for JarImpl<C> {
 }
 
 impl<C: Configuration> Jar for JarImpl<C> {
+    fn ingredients_count() -> usize {
+        1 + C::FIELD_DEBUG_NAMES.len()
+    }
+
     fn create_ingredients(
         _zalsa: &Zalsa,
         struct_index: crate::zalsa::IngredientIndex,

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -201,6 +201,10 @@ impl<C: Configuration> Default for JarImpl<C> {
 }
 
 impl<C: Configuration> Jar for JarImpl<C> {
+    fn ingredients_count() -> usize {
+        1
+    }
+
     fn create_ingredients(
         _zalsa: &Zalsa,
         first_index: IngredientIndex,

--- a/src/memo_ingredient_indices.rs
+++ b/src/memo_ingredient_indices.rs
@@ -9,7 +9,7 @@ use crate::{Id, IngredientIndex};
 /// be viewed as a *set* of [`IngredientIndex`], where each instance of the enum can belong
 /// to one, potentially different, index. This is what this type represents: a set of
 /// `IngredientIndex`.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct IngredientIndices {
     indices: Box<[IngredientIndex]>,
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -5,6 +5,35 @@ pub mod shim {
     pub use shuttle::sync::*;
     pub use shuttle::{thread, thread_local};
 
+    /// A polyfill for `dashmap::DashMap`.
+    pub struct FxDashMap<K, V>(RwLock<HashTable<K, V>>, crate::hash::FxHasher);
+
+    type HashTable<K, V> = hashbrown_14::raw::RawTable<(K, dashmap::SharedValue<V>)>;
+
+    impl<K, V> Default for FxDashMap<K, V> {
+        fn default() -> FxDashMap<K, V> {
+            FxDashMap(RwLock::default(), crate::hash::FxHasher::default())
+        }
+    }
+
+    impl<K, V> FxDashMap<K, V> {
+        pub fn shards(&self) -> &[RwLock<HashTable<K, V>>] {
+            std::slice::from_ref(&self.0)
+        }
+
+        pub fn determine_shard(&self, _hash: usize) -> usize {
+            0
+        }
+
+        pub fn hasher(&self) -> &crate::hash::FxHasher {
+            &self.1
+        }
+
+        pub fn clear(&self) {
+            self.0.write().clear();
+        }
+    }
+
     /// A wrapper around shuttle's `Mutex` to mirror parking-lot's API.
     #[derive(Default, Debug)]
     pub struct Mutex<T>(shuttle::sync::Mutex<T>);
@@ -138,6 +167,8 @@ pub mod shim {
         pub use portable_atomic::AtomicU64;
         pub use std::sync::atomic::*;
     }
+
+    pub(crate) type FxDashMap<K, V> = dashmap::DashMap<K, V, crate::hash::FxHasher>;
 
     /// A wrapper around parking-lot's `Condvar` to mirror shuttle's API.
     pub struct Condvar(parking_lot::Condvar);

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -109,6 +109,10 @@ impl<C: Configuration> Default for JarImpl<C> {
 }
 
 impl<C: Configuration> Jar for JarImpl<C> {
+    fn ingredients_count() -> usize {
+        1 + C::TRACKED_FIELD_INDICES.len()
+    }
+
     fn create_ingredients(
         _zalsa: &Zalsa,
         struct_index: crate::zalsa::IngredientIndex,

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -1,5 +1,5 @@
 use std::any::{Any, TypeId};
-use std::hash::BuildHasher;
+use std::hash::{BuildHasher, BuildHasherDefault};
 use std::marker::PhantomData;
 use std::mem;
 use std::num::NonZeroU32;
@@ -8,11 +8,12 @@ use std::panic::RefUnwindSafe;
 use dashmap::SharedValue;
 use rustc_hash::FxHashMap;
 
+use crate::hash::TypeIdHasher;
 use crate::ingredient::{Ingredient, Jar};
 use crate::nonce::{Nonce, NonceGenerator};
 use crate::runtime::Runtime;
 use crate::sync::atomic::{AtomicU64, Ordering};
-use crate::sync::{FxDashMap, RwLock};
+use crate::sync::{DashMap, RwLock};
 use crate::table::memo::MemoTableWithTypes;
 use crate::table::Table;
 use crate::views::Views;
@@ -142,7 +143,7 @@ pub struct Zalsa {
     memo_ingredient_indices: RwLock<Vec<Vec<IngredientIndex>>>,
 
     /// Map from the type-id of an `impl Jar` to the index of its first ingredient.
-    jar_map: FxDashMap<TypeId, IngredientIndex>,
+    jar_map: DashMap<TypeId, IngredientIndex, BuildHasherDefault<TypeIdHasher>>,
 
     /// A map from the `IngredientIndex` to the `TypeId` of its ID struct.
     ///


### PR DESCRIPTION
Replaces the jar map with a `DashMap`. This depends on https://github.com/ibraheemdev/boxcar/pull/35, which allows us to claim multiple sequential ingredient indices without holding a global lock.

This should also help with https://github.com/salsa-rs/salsa/issues/918, because the slow path for accessing an uncached ingredient now goes through a sharded `DashMap` instead of a single `Mutex`, but I don't think we have benchmarks that use multiple databases yet (I'll add some). The ideal fix for that issue might also be to extend the `IngredientCache`, but this should at least help. We could also look into using [papaya](https://github.com/ibraheemdev/papaya) here (or more extreme, `ArcSwap`?), because the jar map is almost purely read-heavy after the table is initially filled.