### PR TITLE
Do manual trait casting

### DIFF
--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -318,7 +318,6 @@ macro_rules! setup_tracked_fn {
                     };
 
                     let fn_ingredient = <$zalsa::function::IngredientImpl<$Configuration>>::new(
-                        zalsa,
                         first_index,
                         memo_ingredient_indices,
                         $lru,

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -175,17 +175,21 @@ macro_rules! setup_tracked_fn {
             impl $Configuration {
                 fn fn_ingredient(db: &dyn $Db) -> &$zalsa::function::IngredientImpl<$Configuration> {
                     let zalsa = db.zalsa();
+                    Self::fn_ingredient_(db, zalsa)
+                }
 
+                #[inline]
+                fn fn_ingredient_<'z>(db: &dyn $Db, zalsa: &'z $zalsa::Zalsa) -> &'z $zalsa::function::IngredientImpl<$Configuration> {
                     // SAFETY: `lookup_jar_by_type` returns a valid ingredient index, and the first
                     // ingredient created by our jar is the function ingredient.
                     unsafe {
                         $FN_CACHE.get_or_create(zalsa, || zalsa.lookup_jar_by_type::<$fn_name>())
                     }
-                    .get_or_init(|| <dyn $Db as $Db>::zalsa_register_downcaster(db))
+                    .get_or_init(|| *<dyn $Db as $Db>::zalsa_register_upcaster(db))
                 }
 
                 pub fn fn_ingredient_mut(db: &mut dyn $Db) -> &mut $zalsa::function::IngredientImpl<Self> {
-                    let view = <dyn $Db as $Db>::zalsa_register_downcaster(db);
+                    let view = *<dyn $Db as $Db>::zalsa_register_upcaster(db);
                     let zalsa_mut = db.zalsa_mut();
                     let index = zalsa_mut.lookup_jar_by_type::<$fn_name>();
                     let (ingredient, _) = zalsa_mut.lookup_ingredient_mut(index);
@@ -199,7 +203,13 @@ macro_rules! setup_tracked_fn {
                         db: &dyn $Db,
                     ) -> &$zalsa::interned::IngredientImpl<$Configuration> {
                         let zalsa = db.zalsa();
-
+                        Self::intern_ingredient_(db, zalsa)
+                    }
+                    #[inline]
+                    fn intern_ingredient_<'z>(
+                        db: &dyn $Db,
+                        zalsa: &'z $zalsa::Zalsa
+                    ) -> &'z $zalsa::interned::IngredientImpl<$Configuration> {
                         // SAFETY: `lookup_jar_by_type` returns a valid ingredient index, and the second
                         // ingredient created by our jar is the interned ingredient (given `needs_interner`).
                         unsafe {
@@ -258,11 +268,12 @@ macro_rules! setup_tracked_fn {
                 }
 
                 fn id_to_input<$db_lt>(db: &$db_lt Self::DbView, key: salsa::Id) -> Self::Input<$db_lt> {
+                    let zalsa = db.zalsa();
                     $zalsa::macro_if! {
                         if $needs_interner {
-                            $Configuration::intern_ingredient(db).data(db.as_dyn_database(), key).clone()
+                            $Configuration::intern_ingredient_(db, zalsa).data(zalsa, key).clone()
                         } else {
-                            $zalsa::FromIdWithDb::from_id(key, db.zalsa())
+                            $zalsa::FromIdWithDb::from_id(key, zalsa)
                         }
                     }
                 }
@@ -309,6 +320,7 @@ macro_rules! setup_tracked_fn {
                     };
 
                     let fn_ingredient = <$zalsa::function::IngredientImpl<$Configuration>>::new(
+                        zalsa,
                         first_index,
                         memo_ingredient_indices,
                         $lru,
@@ -340,9 +352,10 @@ macro_rules! setup_tracked_fn {
                 ) -> Vec<&$db_lt A> {
                     use salsa::plumbing as $zalsa;
                     let key = $zalsa::macro_if! {
-                        if $needs_interner {
-                            $Configuration::intern_ingredient($db).intern_id($db.as_dyn_database(), ($($input_id),*), |_, data| data)
-                        } else {
+                        if $needs_interner {{
+                            let (zalsa, zalsa_local) = $db.zalsas();
+                            $Configuration::intern_ingredient($db).intern_id(zalsa, zalsa_local, ($($input_id),*), |_, data| data)
+                        }} else {
                             $zalsa::AsId::as_id(&($($input_id),*))
                         }
                     };
@@ -383,11 +396,15 @@ macro_rules! setup_tracked_fn {
                 let result = $zalsa::macro_if! {
                     if $needs_interner {
                         {
-                            let key = $Configuration::intern_ingredient($db).intern_id($db.as_dyn_database(), ($($input_id),*), |_, data| data);
-                            $Configuration::fn_ingredient($db).fetch($db, key)
+                            let (zalsa, zalsa_local) = $db.zalsas();
+                            let key = $Configuration::intern_ingredient_($db, zalsa).intern_id(zalsa, zalsa_local, ($($input_id),*), |_, data| data);
+                            $Configuration::fn_ingredient_($db, zalsa).fetch($db, zalsa, zalsa_local, key)
                         }
                     } else {
-                        $Configuration::fn_ingredient($db).fetch($db, $zalsa::AsId::as_id(&($($input_id),*)))
+                        {
+                            let (zalsa, zalsa_local) = $db.zalsas();
+                            $Configuration::fn_ingredient_($db, zalsa).fetch($db, zalsa, zalsa_local, $zalsa::AsId::as_id(&($($input_id),*)))
+                        }
                     }
                 };
 

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -185,11 +185,11 @@ macro_rules! setup_tracked_fn {
                     unsafe {
                         $FN_CACHE.get_or_create(zalsa, || zalsa.lookup_jar_by_type::<$fn_name>())
                     }
-                    .get_or_init(|| *<dyn $Db as $Db>::zalsa_register_upcaster(db))
+                    .get_or_init(|| *<dyn $Db as $Db>::zalsa_register_downcaster(db))
                 }
 
                 pub fn fn_ingredient_mut(db: &mut dyn $Db) -> &mut $zalsa::function::IngredientImpl<Self> {
-                    let view = *<dyn $Db as $Db>::zalsa_register_upcaster(db);
+                    let view = *<dyn $Db as $Db>::zalsa_register_downcaster(db);
                     let zalsa_mut = db.zalsa_mut();
                     let index = zalsa_mut.lookup_jar_by_type::<$fn_name>();
                     let (ingredient, _) = zalsa_mut.lookup_ingredient_mut(index);

--- a/components/salsa-macro-rules/src/setup_tracked_struct.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_struct.rs
@@ -282,8 +282,9 @@ macro_rules! setup_tracked_struct {
                     // FIXME(rust-lang/rust#65991): The `db` argument *should* have the type `dyn Database`
                     $Db: ?Sized + $zalsa::Database,
                 {
-                    $Configuration::ingredient(db.as_dyn_database()).new_struct(
-                        db.as_dyn_database(),
+                    let (zalsa, zalsa_local) = db.zalsas();
+                    $Configuration::ingredient_(zalsa).new_struct(
+                        zalsa,zalsa_local,
                         ($($field_id,)*)
                     )
                 }
@@ -295,8 +296,8 @@ macro_rules! setup_tracked_struct {
                         // FIXME(rust-lang/rust#65991): The `db` argument *should* have the type `dyn Database`
                         $Db: ?Sized + $zalsa::Database,
                     {
-                        let db = db.as_dyn_database();
-                        let fields = $Configuration::ingredient(db).tracked_field(db, self, $relative_tracked_index);
+                        let (zalsa, zalsa_local) = db.zalsas();
+                        let fields = $Configuration::ingredient_(zalsa).tracked_field(zalsa, zalsa_local, self, $relative_tracked_index);
                         $crate::return_mode_expression!(
                             $tracked_option,
                             $tracked_ty,
@@ -312,8 +313,8 @@ macro_rules! setup_tracked_struct {
                         // FIXME(rust-lang/rust#65991): The `db` argument *should* have the type `dyn Database`
                         $Db: ?Sized + $zalsa::Database,
                     {
-                        let db = db.as_dyn_database();
-                        let fields = $Configuration::ingredient(db).untracked_field(db, self);
+                        let zalsa = db.zalsa();
+                        let fields = $Configuration::ingredient_(zalsa).untracked_field(zalsa, self);
                         $crate::return_mode_expression!(
                             $untracked_option,
                             $untracked_ty,
@@ -335,7 +336,8 @@ macro_rules! setup_tracked_struct {
                     $(for<$db_lt> $field_ty: std::fmt::Debug),*
                 {
                     $zalsa::with_attached_database(|db| {
-                        let fields = $Configuration::ingredient(db).leak_fields(db, this);
+                        let zalsa = db.zalsa();
+                        let fields = $Configuration::ingredient_(zalsa).leak_fields(zalsa, this);
                         let mut f = f.debug_struct(stringify!($Struct));
                         let f = f.field("[salsa id]", &$zalsa::AsId::as_id(&this));
                         $(

--- a/components/salsa-macros/src/db.rs
+++ b/components/salsa-macros/src/db.rs
@@ -135,7 +135,9 @@ impl DbMacro {
             #[inline(never)]
             #[doc(hidden)]
             fn zalsa_register_downcaster(&self) -> &salsa::plumbing::DatabaseDownCaster<dyn #TraitPath> {
-                salsa::plumbing::views(self).add(<Self as #TraitPath>::downcast)
+                salsa::plumbing::views(self).add::<Self, dyn #TraitPath>(unsafe {
+                    ::std::mem::transmute(<Self as #TraitPath>::downcast as fn(_) -> _)
+                })
             }
         });
         input.items.push(parse_quote! {

--- a/components/salsa-macros/src/db.rs
+++ b/components/salsa-macros/src/db.rs
@@ -110,14 +110,14 @@ impl DbMacro {
         let trait_name = &input.ident;
         input.items.push(parse_quote! {
             #[doc(hidden)]
-            fn zalsa_register_upcaster(&self) -> &salsa::plumbing::DatabaseUpCaster<dyn #trait_name>;
+            fn zalsa_register_downcaster(&self) -> &salsa::plumbing::DatabaseDownCaster<dyn #trait_name>;
         });
 
-        let comment = format!(" upcast `Self` to a [`dyn {trait_name}`]");
+        let comment = format!(" downcast `Self` to a [`dyn {trait_name}`]");
         input.items.push(parse_quote! {
             #[doc = #comment]
             #[doc(hidden)]
-            fn upcast(&self) -> &dyn #trait_name where Self: Sized;
+            fn downcast(&self) -> &dyn #trait_name where Self: Sized;
         });
         Ok(())
     }
@@ -134,14 +134,14 @@ impl DbMacro {
             #[cold]
             #[inline(never)]
             #[doc(hidden)]
-            fn zalsa_register_upcaster(&self) -> &salsa::plumbing::DatabaseUpCaster<dyn #TraitPath> {
-                salsa::plumbing::views(self).add(<Self as #TraitPath>::upcast)
+            fn zalsa_register_downcaster(&self) -> &salsa::plumbing::DatabaseDownCaster<dyn #TraitPath> {
+                salsa::plumbing::views(self).add(<Self as #TraitPath>::downcast)
             }
         });
         input.items.push(parse_quote! {
             #[doc(hidden)]
             #[inline(always)]
-            fn upcast(&self) -> &dyn #TraitPath where Self: Sized {
+            fn downcast(&self) -> &dyn #TraitPath where Self: Sized {
                 self
             }
         });

--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -103,7 +103,7 @@ impl<A: Accumulator> Ingredient for IngredientImpl<A> {
     unsafe fn maybe_changed_after(
         &self,
         _zalsa: &crate::zalsa::Zalsa,
-        _db: crate::database::RawDatabasePointer<'_>,
+        _db: crate::database::RawDatabase<'_>,
         _input: Id,
         _revision: Revision,
         _cycle_heads: &mut CycleHeads,

--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -102,7 +102,8 @@ impl<A: Accumulator> Ingredient for IngredientImpl<A> {
 
     unsafe fn maybe_changed_after(
         &self,
-        _db: &dyn Database,
+        _zalsa: &crate::zalsa::Zalsa,
+        _db: crate::database::RawDatabasePointer<'_>,
         _input: Id,
         _revision: Revision,
         _cycle_heads: &mut CycleHeads,

--- a/src/database.rs
+++ b/src/database.rs
@@ -6,25 +6,25 @@ use crate::zalsa::{IngredientIndex, ZalsaDatabase};
 use crate::{Durability, Revision};
 
 #[derive(Copy, Clone)]
-pub struct RawDatabasePointer<'db> {
+pub struct RawDatabase<'db> {
     pub(crate) ptr: NonNull<()>,
     _marker: std::marker::PhantomData<&'db dyn Database>,
 }
 
-impl<'db, Db: Database + ?Sized> From<&'db Db> for RawDatabasePointer<'db> {
+impl<'db, Db: Database + ?Sized> From<&'db Db> for RawDatabase<'db> {
     #[inline]
     fn from(db: &'db Db) -> Self {
-        RawDatabasePointer {
+        RawDatabase {
             ptr: NonNull::from(db).cast(),
             _marker: std::marker::PhantomData,
         }
     }
 }
 
-impl<'db, Db: Database + ?Sized> From<&'db mut Db> for RawDatabasePointer<'db> {
+impl<'db, Db: Database + ?Sized> From<&'db mut Db> for RawDatabase<'db> {
     #[inline]
     fn from(db: &'db mut Db) -> Self {
-        RawDatabasePointer {
+        RawDatabase {
             ptr: NonNull::from(db).cast(),
             _marker: std::marker::PhantomData,
         }

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::ptr::NonNull;
 
-use crate::views::DatabaseUpCaster;
+use crate::views::DatabaseDownCaster;
 use crate::zalsa::{IngredientIndex, ZalsaDatabase};
 use crate::{Durability, Revision};
 
@@ -110,14 +110,14 @@ pub trait Database: Send + ZalsaDatabase + AsDynDatabase {
     #[cold]
     #[inline(never)]
     #[doc(hidden)]
-    fn zalsa_register_upcaster(&self) -> &DatabaseUpCaster<dyn Database> {
-        self.zalsa().views().upcaster_for::<dyn Database>()
+    fn zalsa_register_downcaster(&self) -> &DatabaseDownCaster<dyn Database> {
+        self.zalsa().views().downcaster_for::<dyn Database>()
         // The no-op downcaster is special cased in view caster construction.
     }
 
     #[doc(hidden)]
     #[inline(always)]
-    fn upcast(&self) -> &dyn Database
+    fn downcast(&self) -> &dyn Database
     where
         Self: Sized,
     {

--- a/src/function.rs
+++ b/src/function.rs
@@ -69,10 +69,9 @@ pub trait Configuration: Any {
     /// This invokes user code in form of the `Eq` impl.
     fn values_equal<'db>(old_value: &Self::Output<'db>, new_value: &Self::Output<'db>) -> bool;
 
-    // FIXME: This should take a `&Zalsa`
     /// Convert from the id used internally to the value that execute is expecting.
     /// This is a no-op if the input to the function is a salsa struct.
-    fn id_to_input(db: &Self::DbView, key: Id) -> Self::Input<'_>;
+    fn id_to_input(zalsa: &Zalsa, key: Id) -> Self::Input<'_>;
 
     /// Returns the size of any heap allocations in the output value, in bytes.
     fn heap_size(_value: &Self::Output<'_>) -> usize {

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -2,7 +2,7 @@ use crate::cycle::{CycleHeads, CycleRecoveryStrategy, IterationCount};
 use crate::function::memo::Memo;
 use crate::function::sync::ClaimResult;
 use crate::function::{Configuration, IngredientImpl, VerifyResult};
-use crate::zalsa::{MemoIngredientIndex, Zalsa, ZalsaDatabase};
+use crate::zalsa::{MemoIngredientIndex, Zalsa};
 use crate::zalsa_local::{QueryRevisions, ZalsaLocal};
 use crate::Id;
 
@@ -10,8 +10,13 @@ impl<C> IngredientImpl<C>
 where
     C: Configuration,
 {
-    pub fn fetch<'db>(&'db self, db: &'db C::DbView, id: Id) -> &'db C::Output<'db> {
-        let (zalsa, zalsa_local) = db.zalsas();
+    pub fn fetch<'db>(
+        &'db self,
+        db: &'db C::DbView,
+        zalsa: &'db Zalsa,
+        zalsa_local: &'db ZalsaLocal,
+        id: Id,
+    ) -> &'db C::Output<'db> {
         zalsa.unwind_if_revision_cancelled(zalsa_local);
 
         let database_key_index = self.database_key_index(id);

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -180,7 +180,7 @@ where
                             inserting and returning fixpoint initial value"
                         );
                         let revisions = QueryRevisions::fixpoint_initial(database_key_index);
-                        let initial_value = C::cycle_initial(db, C::id_to_input(db, id));
+                        let initial_value = C::cycle_initial(db, C::id_to_input(zalsa, id));
                         Some(self.insert_memo(
                             zalsa,
                             id,
@@ -194,7 +194,7 @@ where
                         );
                         let active_query =
                             zalsa_local.push_query(database_key_index, IterationCount::initial());
-                        let fallback_value = C::cycle_initial(db, C::id_to_input(db, id));
+                        let fallback_value = C::cycle_initial(db, C::id_to_input(zalsa, id));
                         let mut revisions = active_query.pop();
                         revisions.set_cycle_heads(CycleHeads::initial(database_key_index));
                         // We need this for `cycle_heads()` to work. We will unset this in the outer `execute()`.

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -7,7 +7,7 @@ use crate::key::DatabaseKeyIndex;
 use crate::sync::atomic::Ordering;
 use crate::zalsa::{MemoIngredientIndex, Zalsa, ZalsaDatabase};
 use crate::zalsa_local::{QueryEdgeKind, QueryOriginRef, ZalsaLocal};
-use crate::{AsDynDatabase as _, Id, Revision};
+use crate::{Id, Revision};
 
 /// Result of memo validation.
 pub enum VerifyResult {
@@ -434,8 +434,6 @@ where
                     return VerifyResult::Changed;
                 }
 
-                let dyn_db = db.as_dyn_database();
-
                 let mut inputs = InputAccumulatedValues::Empty;
                 // Fully tracked inputs? Iterate over the inputs and check them, one by one.
                 //
@@ -447,7 +445,7 @@ where
                     match edge.kind() {
                         QueryEdgeKind::Input(dependency_index) => {
                             match dependency_index.maybe_changed_after(
-                                dyn_db,
+                                db.into(),
                                 zalsa,
                                 old_memo.verified_at.load(),
                                 cycle_heads,

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -497,7 +497,7 @@ mod _memory_usage {
             unimplemented!()
         }
 
-        fn id_to_input(_: &Self::DbView, _: Id) -> Self::Input<'_> {
+        fn id_to_input(_: &Zalsa, _: Id) -> Self::Input<'_> {
             unimplemented!()
         }
 

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -185,7 +185,7 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
 impl dyn Ingredient {
     /// Equivalent to the `downcast` method on `Any`.
     ///
-    /// Because we do not have dyn-upcasting support, we need this workaround.
+    /// Because we do not have dyn-downcasting support, we need this workaround.
     pub fn assert_type<T: Any>(&self) -> &T {
         assert_eq!(
             self.type_id(),
@@ -201,7 +201,7 @@ impl dyn Ingredient {
 
     /// Equivalent to the `downcast` methods on `Any`.
     ///
-    /// Because we do not have dyn-upcasting support, we need this workaround.
+    /// Because we do not have dyn-downcasting support, we need this workaround.
     ///
     /// # Safety
     ///
@@ -220,7 +220,7 @@ impl dyn Ingredient {
 
     /// Equivalent to the `downcast` method on `Any`.
     ///
-    /// Because we do not have dyn-upcasting support, we need this workaround.
+    /// Because we do not have dyn-downcasting support, we need this workaround.
     pub fn assert_type_mut<T: Any>(&mut self) -> &mut T {
         assert_eq!(
             Any::type_id(self),

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -5,7 +5,7 @@ use crate::accumulator::accumulated_map::{AccumulatedMap, InputAccumulatedValues
 use crate::cycle::{
     empty_cycle_heads, CycleHeads, CycleRecoveryStrategy, IterationCount, ProvisionalStatus,
 };
-use crate::database::RawDatabasePointer;
+use crate::database::RawDatabase;
 use crate::function::VerifyResult;
 use crate::runtime::Running;
 use crate::sync::Arc;
@@ -49,7 +49,7 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
     unsafe fn maybe_changed_after(
         &self,
         zalsa: &crate::zalsa::Zalsa,
-        db: crate::database::RawDatabasePointer<'_>,
+        db: crate::database::RawDatabase<'_>,
         input: Id,
         revision: Revision,
         cycle_heads: &mut CycleHeads,
@@ -167,7 +167,7 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
     /// The passed in database needs to be the same one that the ingredient was created with.
     unsafe fn accumulated<'db>(
         &'db self,
-        db: RawDatabasePointer<'db>,
+        db: RawDatabase<'db>,
         key_index: Id,
     ) -> (Option<&'db AccumulatedMap>, InputAccumulatedValues) {
         let _ = (db, key_index);

--- a/src/input.rs
+++ b/src/input.rs
@@ -19,7 +19,7 @@ use crate::sync::Arc;
 use crate::table::memo::{MemoTable, MemoTableTypes};
 use crate::table::{Slot, Table};
 use crate::zalsa::{IngredientIndex, Zalsa};
-use crate::{Database, Durability, Id, Revision, Runtime};
+use crate::{zalsa_local, Durability, Id, Revision, Runtime};
 
 pub trait Configuration: Any {
     const DEBUG_NAME: &'static str;
@@ -104,13 +104,12 @@ impl<C: Configuration> IngredientImpl<C> {
 
     pub fn new_input(
         &self,
-        db: &dyn Database,
+        zalsa: &Zalsa,
+        zalsa_local: &zalsa_local::ZalsaLocal,
         fields: C::Fields,
         revisions: C::Revisions,
         durabilities: C::Durabilities,
     ) -> C::Struct {
-        let (zalsa, zalsa_local) = db.zalsas();
-
         let id = self.singleton.with_scope(|| {
             zalsa_local.allocate(zalsa, self.ingredient_index, |_| Value::<C> {
                 fields,
@@ -177,11 +176,11 @@ impl<C: Configuration> IngredientImpl<C> {
     /// The caller is responsible for selecting the appropriate element.
     pub fn field<'db>(
         &'db self,
-        db: &'db dyn crate::Database,
+        zalsa: &'db Zalsa,
+        zalsa_local: &'db zalsa_local::ZalsaLocal,
         id: C::Struct,
         field_index: usize,
     ) -> &'db C::Fields {
-        let (zalsa, zalsa_local) = db.zalsas();
         let field_ingredient_index = self.ingredient_index.successor(field_index);
         let id = id.as_id();
         let value = Self::data(zalsa, id);
@@ -197,17 +196,13 @@ impl<C: Configuration> IngredientImpl<C> {
 
     #[cfg(feature = "salsa_unstable")]
     /// Returns all data corresponding to the input struct.
-    pub fn entries<'db>(
-        &'db self,
-        db: &'db dyn crate::Database,
-    ) -> impl Iterator<Item = &'db Value<C>> {
-        db.zalsa().table().slots_of::<Value<C>>()
+    pub fn entries<'db>(&'db self, zalsa: &'db Zalsa) -> impl Iterator<Item = &'db Value<C>> {
+        zalsa.table().slots_of::<Value<C>>()
     }
 
     /// Peek at the field values without recording any read dependency.
     /// Used for debug printouts.
-    pub fn leak_fields<'db>(&'db self, db: &'db dyn Database, id: C::Struct) -> &'db C::Fields {
-        let zalsa = db.zalsa();
+    pub fn leak_fields<'db>(&'db self, zalsa: &'db Zalsa, id: C::Struct) -> &'db C::Fields {
         let id = id.as_id();
         let value = Self::data(zalsa, id);
         &value.fields
@@ -225,7 +220,8 @@ impl<C: Configuration> Ingredient for IngredientImpl<C> {
 
     unsafe fn maybe_changed_after(
         &self,
-        _db: &dyn Database,
+        _zalsa: &crate::zalsa::Zalsa,
+        _db: crate::database::RawDatabasePointer<'_>,
         _input: Id,
         _revision: Revision,
         _cycle_heads: &mut CycleHeads,
@@ -249,9 +245,9 @@ impl<C: Configuration> Ingredient for IngredientImpl<C> {
 
     /// Returns memory usage information about any inputs.
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(&self, db: &dyn Database) -> Option<Vec<crate::database::SlotInfo>> {
+    fn memory_usage(&self, db: &dyn crate::Database) -> Option<Vec<crate::database::SlotInfo>> {
         let memory_usage = self
-            .entries(db)
+            .entries(db.zalsa())
             // SAFETY: The memo table belongs to a value that we allocated, so it
             // has the correct type.
             .map(|value| unsafe { value.memory_usage(&self.memo_table_types) })

--- a/src/input.rs
+++ b/src/input.rs
@@ -221,7 +221,7 @@ impl<C: Configuration> Ingredient for IngredientImpl<C> {
     unsafe fn maybe_changed_after(
         &self,
         _zalsa: &crate::zalsa::Zalsa,
-        _db: crate::database::RawDatabasePointer<'_>,
+        _db: crate::database::RawDatabase<'_>,
         _input: Id,
         _revision: Revision,
         _cycle_heads: &mut CycleHeads,

--- a/src/input/input_field.rs
+++ b/src/input/input_field.rs
@@ -8,7 +8,7 @@ use crate::input::{Configuration, IngredientImpl, Value};
 use crate::sync::Arc;
 use crate::table::memo::MemoTableTypes;
 use crate::zalsa::IngredientIndex;
-use crate::{Database, Id, Revision};
+use crate::{Id, Revision};
 
 /// Ingredient used to represent the fields of a `#[salsa::input]`.
 ///
@@ -52,12 +52,12 @@ where
 
     unsafe fn maybe_changed_after(
         &self,
-        db: &dyn Database,
+        zalsa: &crate::zalsa::Zalsa,
+        _db: crate::database::RawDatabasePointer<'_>,
         input: Id,
         revision: Revision,
         _cycle_heads: &mut CycleHeads,
     ) -> VerifyResult {
-        let zalsa = db.zalsa();
         let value = <IngredientImpl<C>>::data(zalsa, input);
         VerifyResult::changed_if(value.revisions[self.field_index] > revision)
     }

--- a/src/input/input_field.rs
+++ b/src/input/input_field.rs
@@ -53,7 +53,7 @@ where
     unsafe fn maybe_changed_after(
         &self,
         zalsa: &crate::zalsa::Zalsa,
-        _db: crate::database::RawDatabasePointer<'_>,
+        _db: crate::database::RawDatabase<'_>,
         input: Id,
         revision: Revision,
         _cycle_heads: &mut CycleHeads,

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -795,7 +795,7 @@ where
     unsafe fn maybe_changed_after(
         &self,
         zalsa: &crate::zalsa::Zalsa,
-        _db: crate::database::RawDatabasePointer<'_>,
+        _db: crate::database::RawDatabase<'_>,
         input: Id,
         _revision: Revision,
         _cycle_heads: &mut CycleHeads,

--- a/src/key.rs
+++ b/src/key.rs
@@ -36,27 +36,18 @@ impl DatabaseKeyIndex {
 
     pub(crate) fn maybe_changed_after(
         &self,
-        db: crate::database::RawDatabasePointer<'_>,
+        db: crate::database::RawDatabase<'_>,
         zalsa: &Zalsa,
         last_verified_at: crate::Revision,
         cycle_heads: &mut CycleHeads,
     ) -> VerifyResult {
         // SAFETY: The `db` belongs to the ingredient
         unsafe {
-            // heer, `db` has to be either the correct type already, or a subtype (as far as trait
+            // here, `db` has to be either the correct type already, or a subtype (as far as trait
             // hierarchy is concerned)
             zalsa
                 .lookup_ingredient(self.ingredient_index())
-                .maybe_changed_after(
-                    zalsa,
-                    // lets say we do turn this into an opaque pair of data and vtable pointer
-                    // then we also need an downcast function, from our dbview to the ingredients
-                    // dbview
-                    db,
-                    self.key_index(),
-                    last_verified_at,
-                    cycle_heads,
-                )
+                .maybe_changed_after(zalsa, db, self.key_index(), last_verified_at, cycle_heads)
         }
     }
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -50,7 +50,7 @@ impl DatabaseKeyIndex {
                 .maybe_changed_after(
                     zalsa,
                     // lets say we do turn this into an opaque pair of data and vtable pointer
-                    // then we also need an upcast function, from our dbview to the ingredients
+                    // then we also need an downcast function, from our dbview to the ingredients
                     // dbview
                     db,
                     self.key_index(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ pub mod plumbing {
     pub use crate::tracked_struct::TrackedStructInDb;
     pub use crate::update::helper::{Dispatch as UpdateDispatch, Fallback as UpdateFallback};
     pub use crate::update::{always_update, Update};
-    pub use crate::views::DatabaseUpCaster;
+    pub use crate::views::DatabaseDownCaster;
     pub use crate::zalsa::{
         register_jar, transmute_data_ptr, views, ErasedJar, HasJar, IngredientIndex, JarKind,
         Zalsa, ZalsaDatabase,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub use self::accumulator::Accumulator;
 pub use self::active_query::Backtrace;
 pub use self::cancelled::Cancelled;
 pub use self::cycle::CycleRecoveryAction;
-pub use self::database::{AsDynDatabase, Database};
+pub use self::database::Database;
 pub use self::database_impl::DatabaseImpl;
 pub use self::durability::Durability;
 pub use self::event::{Event, EventKind};
@@ -109,7 +109,7 @@ pub mod plumbing {
     pub use crate::tracked_struct::TrackedStructInDb;
     pub use crate::update::helper::{Dispatch as UpdateDispatch, Fallback as UpdateFallback};
     pub use crate::update::{always_update, Update};
-    pub use crate::views::DatabaseDownCaster;
+    pub use crate::views::DatabaseUpCaster;
     pub use crate::zalsa::{
         register_jar, transmute_data_ptr, views, ErasedJar, HasJar, IngredientIndex, JarKind,
         Zalsa, ZalsaDatabase,

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -1,44 +1,91 @@
 use rayon::iter::{FromParallelIterator, IntoParallelIterator, ParallelIterator};
 
-use crate::Database;
+use crate::{database::RawDatabasePointer, views::DatabaseUpCaster, Database};
 
 pub fn par_map<Db, F, T, R, C>(db: &Db, inputs: impl IntoParallelIterator<Item = T>, op: F) -> C
 where
-    Db: Database + ?Sized,
+    Db: Database + ?Sized + Send,
     F: Fn(&Db, T) -> R + Sync + Send,
     T: Send,
     R: Send + Sync,
     C: FromParallelIterator<R>,
 {
+    let views = db.zalsa().views();
+    let caster = &views.upcaster_for::<Db>();
+    let db_caster = &views.base_database_upcaster();
     inputs
         .into_par_iter()
-        .map_with(DbForkOnClone(db.fork_db()), |db, element| {
-            op(db.0.as_view(), element)
-        })
+        .map_with(
+            DbForkOnClone(db.fork_db(), caster, db_caster),
+            |db, element| op(db.as_view(), element),
+        )
         .collect()
 }
 
-struct DbForkOnClone(Box<dyn Database>);
+struct DbForkOnClone<'views, Db: Database + ?Sized>(
+    RawDatabasePointer<'static>,
+    &'views DatabaseUpCaster<Db>,
+    &'views DatabaseUpCaster<dyn Database>,
+);
 
-impl Clone for DbForkOnClone {
-    fn clone(&self) -> Self {
-        DbForkOnClone(self.0.fork_db())
+// SAFETY: `T: Send` -> `&own T: Send`, `DbForkOnClone` is an owning pointer
+unsafe impl<Db: Send + Database + ?Sized> Send for DbForkOnClone<'_, Db> {}
+
+impl<Db: Database + ?Sized> DbForkOnClone<'_, Db> {
+    fn as_view(&self) -> &Db {
+        // SAFETY: The upcaster ensures that the pointer is valid for the lifetime of the view.
+        unsafe { self.1.upcast_unchecked(self.0) }
     }
 }
 
-pub fn join<A, B, RA, RB, Db: Database + ?Sized>(db: &Db, a: A, b: B) -> (RA, RB)
+impl<Db: Database + ?Sized> Drop for DbForkOnClone<'_, Db> {
+    fn drop(&mut self) {
+        // SAFETY: `caster` is derived from a `db` fitting for our database clone
+        let db = unsafe { self.1.upcast_mut_unchecked(self.0) };
+        // SAFETY: `db` has been box allocated and leaked by `fork_db`
+        _ = unsafe { Box::from_raw(db) };
+    }
+}
+
+impl<Db: Database + ?Sized> Clone for DbForkOnClone<'_, Db> {
+    fn clone(&self) -> Self {
+        DbForkOnClone(
+            // SAFETY: `caster` is derived from a `db` fitting for our database clone
+            unsafe { self.2.upcast_unchecked(self.0) }.fork_db(),
+            self.1,
+            self.2,
+        )
+    }
+}
+
+pub fn join<A, B, RA, RB, Db: Send + Database + ?Sized>(db: &Db, a: A, b: B) -> (RA, RB)
 where
     A: FnOnce(&Db) -> RA + Send,
     B: FnOnce(&Db) -> RB + Send,
     RA: Send,
     RB: Send,
 {
+    #[derive(Copy, Clone)]
+    struct AssertSend<T>(T);
+    // SAFETY: We send owning pointers over, which are Send, given the `Db` type parameter above is Send
+    unsafe impl<T> Send for AssertSend<T> {}
+
+    let caster = &db.zalsa().views().upcaster_for::<Db>();
     // we need to fork eagerly, as `rayon::join_context` gives us no option to tell whether we get
     // moved to another thread before the closure is executed
-    let db_a = db.fork_db();
-    let db_b = db.fork_db();
-    rayon::join(
-        move || a(db_a.as_view::<Db>()),
-        move || b(db_b.as_view::<Db>()),
-    )
+    let db_a = AssertSend(db.fork_db());
+    let db_b = AssertSend(db.fork_db());
+    let res = rayon::join(
+        // SAFETY: `caster` is derived from a `db` fitting for our database clone
+        move || a(unsafe { caster.upcast_unchecked({ db_a }.0) }),
+        // SAFETY: `caster` is derived from a `db` fitting for our database clone
+        move || b(unsafe { caster.upcast_unchecked({ db_b }.0) }),
+    );
+
+    // SAFETY: `db` has been box allocated and leaked by `fork_db`
+    // FIXME: Clean this mess up, RAII
+    _ = unsafe { Box::from_raw(caster.upcast_mut_unchecked(db_a.0)) };
+    // SAFETY: `db` has been box allocated and leaked by `fork_db`
+    _ = unsafe { Box::from_raw(caster.upcast_mut_unchecked(db_b.0)) };
+    res
 }

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -1,6 +1,6 @@
 use rayon::iter::{FromParallelIterator, IntoParallelIterator, ParallelIterator};
 
-use crate::{database::RawDatabasePointer, views::DatabaseDownCaster, Database};
+use crate::{database::RawDatabase, views::DatabaseDownCaster, Database};
 
 pub fn par_map<Db, F, T, R, C>(db: &Db, inputs: impl IntoParallelIterator<Item = T>, op: F) -> C
 where
@@ -12,7 +12,7 @@ where
 {
     let views = db.zalsa().views();
     let caster = &views.downcaster_for::<Db>();
-    let db_caster = &views.base_database_downcaster();
+    let db_caster = &views.downcaster_for::<dyn Database>();
     inputs
         .into_par_iter()
         .map_with(
@@ -23,7 +23,7 @@ where
 }
 
 struct DbForkOnClone<'views, Db: Database + ?Sized>(
-    RawDatabasePointer<'static>,
+    RawDatabase<'static>,
     &'views DatabaseDownCaster<Db>,
     &'views DatabaseDownCaster<dyn Database>,
 );

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -2,7 +2,7 @@
 use std::marker::PhantomData;
 use std::panic::RefUnwindSafe;
 
-use crate::database::RawDatabasePointer;
+use crate::database::RawDatabase;
 use crate::sync::{Arc, Condvar, Mutex};
 use crate::zalsa::{ErasedJar, HasJar, Zalsa, ZalsaDatabase};
 use crate::zalsa_local::{self, ZalsaLocal};
@@ -246,7 +246,7 @@ unsafe impl<T: HasStorage> ZalsaDatabase for T {
     }
 
     #[inline(always)]
-    fn fork_db(&self) -> RawDatabasePointer<'static> {
+    fn fork_db(&self) -> RawDatabase<'static> {
         Box::leak(Box::new(self.clone())).into()
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -2,6 +2,7 @@
 use std::marker::PhantomData;
 use std::panic::RefUnwindSafe;
 
+use crate::database::RawDatabasePointer;
 use crate::sync::{Arc, Condvar, Mutex};
 use crate::zalsa::{ErasedJar, HasJar, Zalsa, ZalsaDatabase};
 use crate::zalsa_local::{self, ZalsaLocal};
@@ -245,8 +246,8 @@ unsafe impl<T: HasStorage> ZalsaDatabase for T {
     }
 
     #[inline(always)]
-    fn fork_db(&self) -> Box<dyn Database> {
-        Box::new(self.clone())
+    fn fork_db(&self) -> RawDatabasePointer<'static> {
+        Box::leak(Box::new(self.clone())).into()
     }
 }
 

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -23,7 +23,7 @@ use crate::sync::Arc;
 use crate::table::memo::{MemoTable, MemoTableTypes, MemoTableWithTypesMut};
 use crate::table::{Slot, Table};
 use crate::zalsa::{IngredientIndex, Zalsa};
-use crate::{Database, Durability, Event, EventKind, Id, Revision};
+use crate::{Durability, Event, EventKind, Id, Revision};
 
 pub mod tracked_field;
 
@@ -375,11 +375,10 @@ where
 
     pub fn new_struct<'db>(
         &'db self,
-        db: &'db dyn Database,
+        zalsa: &'db Zalsa,
+        zalsa_local: &'db ZalsaLocal,
         mut fields: C::Fields<'db>,
     ) -> C::Struct<'db> {
-        let (zalsa, zalsa_local) = db.zalsas();
-
         let identity_hash = IdentityHash {
             ingredient_index: self.ingredient_index,
             hash: crate::hash::hash(&C::untracked_fields(&fields)),
@@ -734,11 +733,11 @@ where
     /// Used for debugging.
     pub fn leak_fields<'db>(
         &'db self,
-        db: &'db dyn Database,
+        zalsa: &'db Zalsa,
         s: C::Struct<'db>,
     ) -> &'db C::Fields<'db> {
         let id = AsId::as_id(&s);
-        let data = Self::data(db.zalsa().table(), id);
+        let data = Self::data(zalsa.table(), id);
         data.fields()
     }
 
@@ -748,11 +747,11 @@ where
     /// The caller is responsible for selecting the appropriate element.
     pub fn tracked_field<'db>(
         &'db self,
-        db: &'db dyn crate::Database,
+        zalsa: &'db Zalsa,
+        zalsa_local: &'db ZalsaLocal,
         s: C::Struct<'db>,
         relative_tracked_index: usize,
     ) -> &'db C::Fields<'db> {
-        let (zalsa, zalsa_local) = db.zalsas();
         let id = AsId::as_id(&s);
         let field_ingredient_index = self.ingredient_index.successor(relative_tracked_index);
         let data = Self::data(zalsa.table(), id);
@@ -776,10 +775,9 @@ where
     /// The caller is responsible for selecting the appropriate element.
     pub fn untracked_field<'db>(
         &'db self,
-        db: &'db dyn crate::Database,
+        zalsa: &'db Zalsa,
         s: C::Struct<'db>,
     ) -> &'db C::Fields<'db> {
-        let zalsa = db.zalsa();
         let id = AsId::as_id(&s);
         let data = Self::data(zalsa.table(), id);
 
@@ -794,11 +792,8 @@ where
 
     #[cfg(feature = "salsa_unstable")]
     /// Returns all data corresponding to the tracked struct.
-    pub fn entries<'db>(
-        &'db self,
-        db: &'db dyn crate::Database,
-    ) -> impl Iterator<Item = &'db Value<C>> {
-        db.zalsa().table().slots_of::<Value<C>>()
+    pub fn entries<'db>(&'db self, zalsa: &'db Zalsa) -> impl Iterator<Item = &'db Value<C>> {
+        zalsa.table().slots_of::<Value<C>>()
     }
 }
 
@@ -816,7 +811,8 @@ where
 
     unsafe fn maybe_changed_after(
         &self,
-        _db: &dyn Database,
+        _zalsa: &crate::zalsa::Zalsa,
+        _db: crate::database::RawDatabasePointer<'_>,
         _input: Id,
         _revision: Revision,
         _cycle_heads: &mut CycleHeads,
@@ -863,9 +859,9 @@ where
 
     /// Returns memory usage information about any tracked structs.
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(&self, db: &dyn Database) -> Option<Vec<crate::database::SlotInfo>> {
+    fn memory_usage(&self, db: &dyn crate::Database) -> Option<Vec<crate::database::SlotInfo>> {
         let memory_usage = self
-            .entries(db)
+            .entries(db.zalsa())
             // SAFETY: The memo table belongs to a value that we allocated, so it
             // has the correct type.
             .map(|value| unsafe { value.memory_usage(&self.memo_table_types) })

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -812,7 +812,7 @@ where
     unsafe fn maybe_changed_after(
         &self,
         _zalsa: &crate::zalsa::Zalsa,
-        _db: crate::database::RawDatabasePointer<'_>,
+        _db: crate::database::RawDatabase<'_>,
         _input: Id,
         _revision: Revision,
         _cycle_heads: &mut CycleHeads,

--- a/src/tracked_struct/tracked_field.rs
+++ b/src/tracked_struct/tracked_field.rs
@@ -58,7 +58,7 @@ where
     unsafe fn maybe_changed_after(
         &self,
         zalsa: &crate::zalsa::Zalsa,
-        _db: crate::database::RawDatabasePointer<'_>,
+        _db: crate::database::RawDatabase<'_>,
         input: Id,
         revision: crate::Revision,
         _cycle_heads: &mut CycleHeads,

--- a/src/tracked_struct/tracked_field.rs
+++ b/src/tracked_struct/tracked_field.rs
@@ -7,7 +7,7 @@ use crate::sync::Arc;
 use crate::table::memo::MemoTableTypes;
 use crate::tracked_struct::{Configuration, Value};
 use crate::zalsa::IngredientIndex;
-use crate::{Database, Id};
+use crate::Id;
 
 /// Created for each tracked struct.
 ///
@@ -55,14 +55,14 @@ where
         self.ingredient_index
     }
 
-    unsafe fn maybe_changed_after<'db>(
-        &'db self,
-        db: &'db dyn Database,
+    unsafe fn maybe_changed_after(
+        &self,
+        zalsa: &crate::zalsa::Zalsa,
+        _db: crate::database::RawDatabasePointer<'_>,
         input: Id,
         revision: crate::Revision,
         _cycle_heads: &mut CycleHeads,
     ) -> VerifyResult {
-        let zalsa = db.zalsa();
         let data = <super::IngredientImpl<C>>::data(zalsa.table(), input);
         let field_changed_at = data.revisions[self.field_index];
         VerifyResult::changed_if(field_changed_at > revision)

--- a/src/views.rs
+++ b/src/views.rs
@@ -1,10 +1,15 @@
-use std::any::{Any, TypeId};
+use std::{
+    any::{Any, TypeId},
+    marker::PhantomData,
+    mem,
+    ptr::NonNull,
+};
 
-use crate::Database;
+use crate::{database::RawDatabasePointer, Database};
 
 /// A `Views` struct is associated with some specific database type
 /// (a `DatabaseImpl<U>` for some existential `U`). It contains functions
-/// to downcast from `dyn Database` to `dyn DbView` for various traits `DbView` via this specific
+/// to upcast to `dyn DbView` for various traits `DbView` via this specific
 /// database type.
 /// None of these types are known at compilation time, they are all checked
 /// dynamically through `TypeId` magic.
@@ -13,6 +18,7 @@ pub struct Views {
     view_casters: boxcar::Vec<ViewCaster>,
 }
 
+#[derive(Copy, Clone)]
 struct ViewCaster {
     /// The id of the target type `dyn DbView` that we can cast to.
     target_type_id: TypeId,
@@ -20,50 +26,69 @@ struct ViewCaster {
     /// The name of the target type `dyn DbView` that we can cast to.
     type_name: &'static str,
 
-    /// Type-erased function pointer that downcasts from `dyn Database` to `dyn DbView`.
-    cast: ErasedDatabaseDownCasterSig,
+    /// Type-erased function pointer that upcasts to `dyn DbView`.
+    cast: ErasedDatabaseUpCasterSig,
 }
 
 impl ViewCaster {
-    fn new<DbView: ?Sized + Any>(func: unsafe fn(&dyn Database) -> &DbView) -> ViewCaster {
+    fn new<DbView: ?Sized + Any>(func: DatabaseUpCasterSigRaw<DbView>) -> ViewCaster {
         ViewCaster {
             target_type_id: TypeId::of::<DbView>(),
             type_name: std::any::type_name::<DbView>(),
             // SAFETY: We are type erasing for storage, taking care of unerasing before we call
             // the function pointer.
             cast: unsafe {
-                std::mem::transmute::<DatabaseDownCasterSig<DbView>, ErasedDatabaseDownCasterSig>(
-                    func,
-                )
+                mem::transmute::<DatabaseUpCasterSigRaw<DbView>, ErasedDatabaseUpCasterSig>(func)
             },
         }
     }
 }
 
-type ErasedDatabaseDownCasterSig = unsafe fn(&dyn Database) -> *const ();
-type DatabaseDownCasterSig<DbView> = unsafe fn(&dyn Database) -> &DbView;
+type ErasedDatabaseUpCasterSig = unsafe fn(RawDatabasePointer<'_>) -> NonNull<()>;
+type DatabaseUpCasterSigRaw<DbView> =
+    for<'db> unsafe fn(RawDatabasePointer<'db>) -> NonNull<DbView>;
+type DatabaseUpCasterSig<DbView> = for<'db> unsafe fn(RawDatabasePointer<'db>) -> &'db DbView;
+type DatabaseUpCasterSigMut<DbView> =
+    for<'db> unsafe fn(RawDatabasePointer<'db>) -> &'db mut DbView;
 
-pub struct DatabaseDownCaster<DbView: ?Sized>(TypeId, DatabaseDownCasterSig<DbView>);
+#[repr(transparent)]
+pub struct DatabaseUpCaster<DbView: ?Sized>(ViewCaster, PhantomData<fn() -> DbView>);
 
-impl<DbView: ?Sized + Any> DatabaseDownCaster<DbView> {
-    pub fn downcast<'db>(&self, db: &'db dyn Database) -> &'db DbView {
-        assert_eq!(
-            self.0,
-            db.type_id(),
-            "Database type does not match the expected type for this `Views` instance"
-        );
-        // SAFETY: We've asserted that the database is correct.
-        unsafe { (self.1)(db) }
+impl<DbView: ?Sized> Copy for DatabaseUpCaster<DbView> {}
+impl<DbView: ?Sized> Clone for DatabaseUpCaster<DbView> {
+    fn clone(&self) -> Self {
+        *self
     }
+}
 
-    /// Downcast `db` to `DbView`.
+impl<DbView: ?Sized + Any> DatabaseUpCaster<DbView> {
+    /// Upcast `db` to `DbView`.
     ///
     /// # Safety
     ///
     /// The caller must ensure that `db` is of the correct type.
-    pub unsafe fn downcast_unchecked<'db>(&self, db: &'db dyn Database) -> &'db DbView {
+    #[inline]
+    pub unsafe fn upcast_unchecked<'db>(&self, db: RawDatabasePointer<'db>) -> &'db DbView {
         // SAFETY: The caller must ensure that `db` is of the correct type.
-        unsafe { (self.1)(db) }
+        unsafe {
+            (mem::transmute::<ErasedDatabaseUpCasterSig, DatabaseUpCasterSig<DbView>>(self.0.cast))(
+                db,
+            )
+        }
+    }
+    /// Upcast `db` to `DbView`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `db` is of the correct type.
+    #[inline]
+    pub unsafe fn upcast_mut_unchecked<'db>(&self, db: RawDatabasePointer<'db>) -> &'db mut DbView {
+        // SAFETY: The caller must ensure that `db` is of the correct type.
+        unsafe {
+            (mem::transmute::<ErasedDatabaseUpCasterSig, DatabaseUpCasterSigMut<DbView>>(
+                self.0.cast,
+            ))(db)
+        }
     }
 }
 
@@ -71,58 +96,67 @@ impl Views {
     pub(crate) fn new<Db: Database>() -> Self {
         let source_type_id = TypeId::of::<Db>();
         let view_casters = boxcar::Vec::new();
-        // special case the no-op transformation, that way we skip out on reconstructing the wide pointer
-        view_casters.push(ViewCaster::new::<dyn Database>(|db| db));
+        view_casters.push(ViewCaster::new::<dyn Database>(|db| db.ptr.cast::<Db>()));
         Self {
             source_type_id,
             view_casters,
         }
     }
 
-    /// Add a new downcaster from `dyn Database` to `dyn DbView`.
-    pub fn add<DbView: ?Sized + Any>(
+    /// Add a new upcaster to `dyn DbView`.
+    pub fn add<Concrete: 'static, DbView: ?Sized + Any>(
         &self,
-        func: DatabaseDownCasterSig<DbView>,
-    ) -> DatabaseDownCaster<DbView> {
-        if let Some(view) = self.try_downcaster_for() {
-            return view;
+        func: fn(&Concrete) -> &DbView,
+    ) -> &DatabaseUpCaster<DbView> {
+        assert_eq!(self.source_type_id, TypeId::of::<Concrete>());
+        let target_type_id = TypeId::of::<DbView>();
+        if let Some((_, caster)) = self
+            .view_casters
+            .iter()
+            .find(|(_, u)| u.target_type_id == target_type_id)
+        {
+            // SAFETY: The type-erased function pointer is guaranteed to be valid for `DbView`
+            return unsafe { &*(caster as *const ViewCaster as *const DatabaseUpCaster<DbView>) };
         }
 
-        self.view_casters.push(ViewCaster::new::<DbView>(func));
-        DatabaseDownCaster(self.source_type_id, func)
+        // SAFETY: We are type erasing the function pointer for storage, and we will unerase it
+        // before we call it.
+        let caster = ViewCaster::new::<DbView>(unsafe {
+            mem::transmute::<fn(&Concrete) -> &DbView, DatabaseUpCasterSigRaw<DbView>>(func)
+        });
+        let idx = self.view_casters.push(caster);
+        // SAFETY: The type-erased function pointer is guaranteed to be valid for `DbView`
+        unsafe { &*(&raw const self.view_casters[idx]).cast::<DatabaseUpCaster<DbView>>() }
     }
 
-    /// Retrieve an downcaster function from `dyn Database` to `dyn DbView`.
+    #[inline]
+    pub fn base_database_upcaster(&self) -> &DatabaseUpCaster<dyn Database> {
+        // SAFETY: The type-erased function pointer is guaranteed to be valid for `dyn Database`
+        // since we created it with the same type.
+        unsafe { &*((&raw const self.view_casters[0]).cast::<DatabaseUpCaster<dyn Database>>()) }
+    }
+
+    /// Retrieve an upcaster function to `dyn DbView`.
     ///
     /// # Panics
     ///
     /// If the underlying type of `db` is not the same as the database type this upcasts was created for.
-    pub fn downcaster_for<DbView: ?Sized + Any>(&self) -> DatabaseDownCaster<DbView> {
-        self.try_downcaster_for().unwrap_or_else(|| {
-            panic!(
-                "No downcaster registered for type `{}` in `Views`",
-                std::any::type_name::<DbView>(),
-            )
-        })
-    }
-
-    /// Retrieve an downcaster function from `dyn Database` to `dyn DbView`, if it exists.
-    #[inline]
-    pub fn try_downcaster_for<DbView: ?Sized + Any>(&self) -> Option<DatabaseDownCaster<DbView>> {
+    pub fn upcaster_for<DbView: ?Sized + Any>(&self) -> &DatabaseUpCaster<DbView> {
         let view_type_id = TypeId::of::<DbView>();
         for (_, view) in self.view_casters.iter() {
             if view.target_type_id == view_type_id {
                 // SAFETY: We are unerasing the type erased function pointer having made sure the
-                // `TypeId` matches.
-                return Some(DatabaseDownCaster(self.source_type_id, unsafe {
-                    std::mem::transmute::<ErasedDatabaseDownCasterSig, DatabaseDownCasterSig<DbView>>(
-                        view.cast,
-                    )
-                }));
+                // TypeId matches.
+                return unsafe {
+                    &*((view as *const ViewCaster).cast::<DatabaseUpCaster<DbView>>())
+                };
             }
         }
 
-        None
+        panic!(
+            "No upcaster registered for type `{}` in `Views`",
+            std::any::type_name::<DbView>(),
+        );
     }
 }
 

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -5,6 +5,7 @@ use std::panic::RefUnwindSafe;
 use hashbrown::HashMap;
 use rustc_hash::FxHashMap;
 
+use crate::database::RawDatabasePointer;
 use crate::hash::TypeIdHasher;
 use crate::ingredient::{Ingredient, Jar};
 use crate::plumbing::SalsaStructInDb;
@@ -52,7 +53,7 @@ pub unsafe trait ZalsaDatabase: Any {
 
     /// Clone the database.
     #[doc(hidden)]
-    fn fork_db(&self) -> Box<dyn Database>;
+    fn fork_db(&self) -> RawDatabasePointer<'static>;
 }
 
 pub fn views<Db: ?Sized + Database>(db: &Db) -> &Views {

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -5,7 +5,7 @@ use std::panic::RefUnwindSafe;
 use hashbrown::HashMap;
 use rustc_hash::FxHashMap;
 
-use crate::database::RawDatabasePointer;
+use crate::database::RawDatabase;
 use crate::hash::TypeIdHasher;
 use crate::ingredient::{Ingredient, Jar};
 use crate::plumbing::SalsaStructInDb;
@@ -53,7 +53,7 @@ pub unsafe trait ZalsaDatabase: Any {
 
     /// Clone the database.
     #[doc(hidden)]
-    fn fork_db(&self) -> RawDatabasePointer<'static>;
+    fn fork_db(&self) -> RawDatabase<'static>;
 }
 
 pub fn views<Db: ?Sized + Database>(db: &Db) -> &Views {

--- a/tests/debug_db_contents.rs
+++ b/tests/debug_db_contents.rs
@@ -22,14 +22,15 @@ fn tracked_fn(db: &dyn salsa::Database, input: InputStruct) -> TrackedStruct<'_>
 
 #[test]
 fn execute() {
+    use salsa::plumbing::ZalsaDatabase;
     let db = salsa::DatabaseImpl::new();
 
     let _ = InternedStruct::new(&db, "Salsa".to_string());
     let _ = InternedStruct::new(&db, "Salsa2".to_string());
 
     // test interned structs
-    let interned = InternedStruct::ingredient(&db)
-        .entries(&db)
+    let interned = InternedStruct::ingredient(db.zalsa())
+        .entries(db.zalsa())
         .collect::<Vec<_>>();
 
     assert_eq!(interned.len(), 2);
@@ -40,7 +41,7 @@ fn execute() {
     let input = InputStruct::new(&db, 22);
 
     let inputs = InputStruct::ingredient(&db)
-        .entries(&db)
+        .entries(db.zalsa())
         .collect::<Vec<_>>();
 
     assert_eq!(inputs.len(), 1);
@@ -50,7 +51,7 @@ fn execute() {
     let computed = tracked_fn(&db, input).field(&db);
     assert_eq!(computed, 44);
     let tracked = TrackedStruct::ingredient(&db)
-        .entries(&db)
+        .entries(db.zalsa())
         .collect::<Vec<_>>();
 
     assert_eq!(tracked.len(), 1);

--- a/tests/interned-structs.rs
+++ b/tests/interned-structs.rs
@@ -132,13 +132,13 @@ fn interning_boxed() {
 
 #[test]
 fn interned_structs_have_public_ingredients() {
-    use salsa::plumbing::AsId;
+    use salsa::plumbing::{AsId, ZalsaDatabase};
 
     let db = salsa::DatabaseImpl::new();
     let s = InternedString::new(&db, String::from("Hello, world!"));
     let underlying_id = s.0;
 
-    let data = InternedString::ingredient(&db).data(&db, underlying_id.as_id());
+    let data = InternedString::ingredient(db.zalsa()).data(db.zalsa(), underlying_id.as_id());
     assert_eq!(data, &(String::from("Hello, world!"),));
 }
 

--- a/tests/interned-structs_self_ref.rs
+++ b/tests/interned-structs_self_ref.rs
@@ -181,7 +181,8 @@ const _: () = {
             String: zalsa_::interned::HashEqLike<T0>,
         {
             Configuration_::ingredient(db).intern(
-                db.as_dyn_database(),
+                db.zalsa(),
+                db.zalsa_local(),
                 StructKey::<'db>(data, std::marker::PhantomData::default()),
                 |id, data| {
                     StructData(
@@ -195,20 +196,20 @@ const _: () = {
         where
             Db_: ?Sized + zalsa_::Database,
         {
-            let fields = Configuration_::ingredient(db).fields(db.as_dyn_database(), self);
+            let fields = Configuration_::ingredient(db).fields(db.zalsa(), self);
             std::clone::Clone::clone((&fields.0))
         }
         fn other<Db_>(self, db: &'db Db_) -> InternedString<'db>
         where
             Db_: ?Sized + zalsa_::Database,
         {
-            let fields = Configuration_::ingredient(db).fields(db.as_dyn_database(), self);
+            let fields = Configuration_::ingredient(db).fields(db.zalsa(), self);
             std::clone::Clone::clone((&fields.1))
         }
         #[doc = r" Default debug formatting for this struct (may be useful if you define your own `Debug` impl)"]
         pub fn default_debug_fmt(this: Self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             zalsa_::with_attached_database(|db| {
-                let fields = Configuration_::ingredient(db).fields(db.as_dyn_database(), this);
+                let fields = Configuration_::ingredient(db).fields(db.zalsa(), this);
                 let mut f = f.debug_struct("InternedString");
                 let f = f.field("data", &fields.0);
                 let f = f.field("other", &fields.1);


### PR DESCRIPTION
This removes occurences of `dyn Database` internally where only the zalsas are needed for (hopefully) a perf increase.

Lastly it renames downcasting to upcasting, because thats what we are doing, `dyn Database` --downcast-> `Concrete` --upcast-->`dyn CustomDatabaseTrait`