### PR TITLE
Add option to track heap memory usage of memos

### DIFF
--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -55,6 +55,9 @@ macro_rules! setup_tracked_fn {
         // If true, the input needs an interner (because it has >1 argument).
         needs_interner: $needs_interner:tt,
 
+        // The function used to implement `C::heap_size`.
+        heap_size_fn: $($heap_size_fn:path)?,
+
         // LRU capacity (a literal, maybe 0)
         lru: $lru:tt,
 
@@ -195,6 +198,12 @@ macro_rules! setup_tracked_fn {
                 const CYCLE_STRATEGY: $zalsa::CycleRecoveryStrategy = $zalsa::CycleRecoveryStrategy::$cycle_recovery_strategy;
 
                 $($values_equal)+
+
+                $(
+                    fn heap_size(value: &Self::Output<'_>) -> usize {
+                        $heap_size_fn(value)
+                    }
+                )?
 
                 fn execute<$db_lt>($db: &$db_lt Self::DbView, ($($input_id),*): ($($interned_input_ty),*)) -> Self::Output<$db_lt> {
                     $($assert_return_type_is_update)*

--- a/components/salsa-macros/src/accumulator.rs
+++ b/components/salsa-macros/src/accumulator.rs
@@ -45,6 +45,7 @@ impl AllowedOptions for Accumulator {
     const CONSTRUCTOR_NAME: bool = false;
     const ID: bool = false;
     const REVISIONS: bool = false;
+    const HEAP_SIZE: bool = false;
 }
 
 struct StructMacro {

--- a/components/salsa-macros/src/input.rs
+++ b/components/salsa-macros/src/input.rs
@@ -64,6 +64,8 @@ impl crate::options::AllowedOptions for InputStruct {
     const ID: bool = false;
 
     const REVISIONS: bool = false;
+
+    const HEAP_SIZE: bool = false;
 }
 
 impl SalsaStructAllowedOptions for InputStruct {

--- a/components/salsa-macros/src/interned.rs
+++ b/components/salsa-macros/src/interned.rs
@@ -64,6 +64,8 @@ impl crate::options::AllowedOptions for InternedStruct {
     const ID: bool = true;
 
     const REVISIONS: bool = true;
+
+    const HEAP_SIZE: bool = false;
 }
 
 impl SalsaStructAllowedOptions for InternedStruct {

--- a/components/salsa-macros/src/tracked_fn.rs
+++ b/components/salsa-macros/src/tracked_fn.rs
@@ -57,6 +57,8 @@ impl crate::options::AllowedOptions for TrackedFn {
     const ID: bool = false;
 
     const REVISIONS: bool = false;
+
+    const HEAP_SIZE: bool = true;
 }
 
 struct Macro {
@@ -97,6 +99,7 @@ impl Macro {
             self.cycle_recovery()?;
         let is_specifiable = self.args.specify.is_some();
         let requires_update = self.args.non_update_return_type.is_none();
+        let heap_size_fn = self.args.heap_size_fn.iter();
         let eq = if let Some(token) = &self.args.no_eq {
             if self.args.cycle_fn.is_some() {
                 return Err(syn::Error::new_spanned(
@@ -217,6 +220,7 @@ impl Macro {
                 is_specifiable: #is_specifiable,
                 values_equal: {#eq},
                 needs_interner: #needs_interner,
+                heap_size_fn: #(#heap_size_fn)*,
                 lru: #lru,
                 return_mode: #return_mode,
                 assert_return_type_is_update: { #assert_return_type_is_update },

--- a/components/salsa-macros/src/tracked_struct.rs
+++ b/components/salsa-macros/src/tracked_struct.rs
@@ -60,6 +60,8 @@ impl crate::options::AllowedOptions for TrackedStruct {
     const ID: bool = false;
 
     const REVISIONS: bool = false;
+
+    const HEAP_SIZE: bool = false;
 }
 
 impl SalsaStructAllowedOptions for TrackedStruct {

--- a/src/function/backdate.rs
+++ b/src/function/backdate.rs
@@ -12,7 +12,7 @@ where
     /// on an old memo when a new memo has been produced to check whether there have been changed.
     pub(super) fn backdate_if_appropriate<'db>(
         &self,
-        old_memo: &Memo<C::Output<'db>>,
+        old_memo: &Memo<'db, C>,
         index: DatabaseKeyIndex,
         revisions: &mut QueryRevisions,
         value: &C::Output<'db>,

--- a/src/function/delete.rs
+++ b/src/function/delete.rs
@@ -7,7 +7,7 @@ use crate::function::Configuration;
 /// once the next revision starts. See the comment on the field
 /// `deleted_entries` of [`FunctionIngredient`][] for more details.
 pub(super) struct DeletedEntries<C: Configuration> {
-    memos: boxcar::Vec<SharedBox<Memo<C::Output<'static>>>>,
+    memos: boxcar::Vec<SharedBox<Memo<'static, C>>>,
 }
 
 #[allow(clippy::undocumented_unsafe_blocks)] // TODO(#697) document safety
@@ -27,13 +27,10 @@ impl<C: Configuration> DeletedEntries<C> {
     /// # Safety
     ///
     /// The memo must be valid and safe to free when the `DeletedEntries` list is cleared or dropped.
-    pub(super) unsafe fn push(&self, memo: NonNull<Memo<C::Output<'_>>>) {
+    pub(super) unsafe fn push(&self, memo: NonNull<Memo<'_, C>>) {
         // Safety: The memo must be valid and safe to free when the `DeletedEntries` list is cleared or dropped.
-        let memo = unsafe {
-            std::mem::transmute::<NonNull<Memo<C::Output<'_>>>, NonNull<Memo<C::Output<'static>>>>(
-                memo,
-            )
-        };
+        let memo =
+            unsafe { std::mem::transmute::<NonNull<Memo<'_, C>>, NonNull<Memo<'static, C>>>(memo) };
 
         self.memos.push(SharedBox(memo));
     }

--- a/src/function/diff_outputs.rs
+++ b/src/function/diff_outputs.rs
@@ -18,7 +18,7 @@ where
         &self,
         zalsa: &Zalsa,
         key: DatabaseKeyIndex,
-        old_memo: &Memo<C::Output<'_>>,
+        old_memo: &Memo<'_, C>,
         revisions: &mut QueryRevisions,
     ) {
         let (QueryOriginRef::Derived(edges) | QueryOriginRef::DerivedUntracked(edges)) =

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -24,8 +24,8 @@ where
         &'db self,
         db: &'db C::DbView,
         active_query: ActiveQueryGuard<'db>,
-        opt_old_memo: Option<&Memo<C::Output<'db>>>,
-    ) -> &'db Memo<C::Output<'db>> {
+        opt_old_memo: Option<&Memo<'db, C>>,
+    ) -> &'db Memo<'db, C> {
         let database_key_index = active_query.database_key_index;
         let id = database_key_index.key_index();
 
@@ -121,7 +121,7 @@ where
         &'db self,
         db: &'db C::DbView,
         mut active_query: ActiveQueryGuard<'db>,
-        opt_old_memo: Option<&Memo<C::Output<'db>>>,
+        opt_old_memo: Option<&Memo<'db, C>>,
         zalsa: &'db Zalsa,
         id: Id,
         memo_ingredient_index: MemoIngredientIndex,
@@ -133,7 +133,7 @@ where
         // Our provisional value from the previous iteration, when doing fixpoint iteration.
         // Initially it's set to None, because the initial provisional value is created lazily,
         // only when a cycle is actually encountered.
-        let mut opt_last_provisional: Option<&Memo<<C as Configuration>::Output<'db>>> = None;
+        let mut opt_last_provisional: Option<&Memo<'db, C>> = None;
         loop {
             let previous_memo = opt_last_provisional.or(opt_old_memo);
             let (mut new_value, mut revisions) = Self::execute_query(
@@ -257,7 +257,7 @@ where
     fn execute_query<'db>(
         db: &'db C::DbView,
         active_query: ActiveQueryGuard<'db>,
-        opt_old_memo: Option<&Memo<C::Output<'db>>>,
+        opt_old_memo: Option<&Memo<'db, C>>,
         current_revision: Revision,
         id: Id,
     ) -> (C::Output<'db>, QueryRevisions) {

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -43,7 +43,7 @@ where
         zalsa: &'db Zalsa,
         zalsa_local: &'db ZalsaLocal,
         id: Id,
-    ) -> &'db Memo<C::Output<'db>> {
+    ) -> &'db Memo<'db, C> {
         let memo_ingredient_index = self.memo_ingredient_index(zalsa, id);
         loop {
             if let Some(memo) = self
@@ -63,7 +63,7 @@ where
         zalsa: &'db Zalsa,
         id: Id,
         memo_ingredient_index: MemoIngredientIndex,
-    ) -> Option<&'db Memo<C::Output<'db>>> {
+    ) -> Option<&'db Memo<'db, C>> {
         let memo = self.get_memo_from_table_for(zalsa, id, memo_ingredient_index)?;
 
         memo.value.as_ref()?;
@@ -91,7 +91,7 @@ where
         db: &'db C::DbView,
         id: Id,
         memo_ingredient_index: MemoIngredientIndex,
-    ) -> Option<&'db Memo<C::Output<'db>>> {
+    ) -> Option<&'db Memo<'db, C>> {
         let memo = self.fetch_cold(zalsa, zalsa_local, db, id, memo_ingredient_index)?;
 
         // If we get back a provisional cycle memo, and it's provisional on any cycle heads
@@ -117,7 +117,7 @@ where
         db: &'db C::DbView,
         id: Id,
         memo_ingredient_index: MemoIngredientIndex,
-    ) -> Option<&'db Memo<C::Output<'db>>> {
+    ) -> Option<&'db Memo<'db, C>> {
         let database_key_index = self.database_key_index(id);
         // Try to claim this query: if someone else has claimed it already, go back and start again.
         let claim_guard = match self.sync_table.try_claim(zalsa, id) {

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -192,7 +192,7 @@ where
         &self,
         zalsa: &Zalsa,
         database_key_index: DatabaseKeyIndex,
-        memo: &Memo<C::Output<'_>>,
+        memo: &Memo<'_, C>,
     ) -> ShallowUpdate {
         tracing::debug!(
             "{database_key_index:?}: shallow_verify_memo(memo = {memo:#?})",
@@ -227,7 +227,7 @@ where
         &self,
         zalsa: &Zalsa,
         database_key_index: DatabaseKeyIndex,
-        memo: &Memo<C::Output<'_>>,
+        memo: &Memo<'_, C>,
         update: ShallowUpdate,
     ) {
         if let ShallowUpdate::HigherDurability = update {
@@ -247,7 +247,7 @@ where
         zalsa: &Zalsa,
         zalsa_local: &ZalsaLocal,
         database_key_index: DatabaseKeyIndex,
-        memo: &Memo<C::Output<'_>>,
+        memo: &Memo<'_, C>,
     ) -> bool {
         !memo.may_be_provisional()
             || self.validate_provisional(zalsa, database_key_index, memo)
@@ -261,7 +261,7 @@ where
         &self,
         zalsa: &Zalsa,
         database_key_index: DatabaseKeyIndex,
-        memo: &Memo<C::Output<'_>>,
+        memo: &Memo<'_, C>,
     ) -> bool {
         tracing::trace!(
             "{database_key_index:?}: validate_provisional(memo = {memo:#?})",
@@ -322,7 +322,7 @@ where
         zalsa: &Zalsa,
         zalsa_local: &ZalsaLocal,
         database_key_index: DatabaseKeyIndex,
-        memo: &Memo<C::Output<'_>>,
+        memo: &Memo<'_, C>,
     ) -> bool {
         tracing::trace!(
             "{database_key_index:?}: validate_same_iteration(memo = {memo:#?})",
@@ -373,7 +373,7 @@ where
         &self,
         db: &C::DbView,
         zalsa: &Zalsa,
-        old_memo: &Memo<C::Output<'_>>,
+        old_memo: &Memo<'_, C>,
         database_key_index: DatabaseKeyIndex,
         cycle_heads: &mut CycleHeads,
     ) -> VerifyResult {

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -185,7 +185,7 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
     /// Returns memory usage information about any instances of the ingredient,
     /// if applicable.
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(&self, _db: &dyn Database) -> Option<Vec<crate::SlotInfo>> {
+    fn memory_usage(&self, _db: &dyn Database) -> Option<Vec<crate::database::SlotInfo>> {
         None
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -244,7 +244,7 @@ impl<C: Configuration> Ingredient for IngredientImpl<C> {
 
     /// Returns memory usage information about any inputs.
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(&self, db: &dyn Database) -> Option<Vec<crate::SlotInfo>> {
+    fn memory_usage(&self, db: &dyn Database) -> Option<Vec<crate::database::SlotInfo>> {
         let memory_usage = self
             .entries(db)
             // SAFETY: The memo table belongs to a value that we allocated, so it
@@ -303,11 +303,11 @@ where
     ///
     /// The `MemoTable` must belong to a `Value` of the correct type.
     #[cfg(feature = "salsa_unstable")]
-    unsafe fn memory_usage(&self, memo_table_types: &MemoTableTypes) -> crate::SlotInfo {
+    unsafe fn memory_usage(&self, memo_table_types: &MemoTableTypes) -> crate::database::SlotInfo {
         // SAFETY: The caller guarantees this is the correct types table.
         let memos = unsafe { memo_table_types.attach_memos(&self.memos) };
 
-        crate::SlotInfo {
+        crate::database::SlotInfo {
             debug_name: C::DEBUG_NAME,
             size_of_metadata: std::mem::size_of::<Self>() - std::mem::size_of::<C::Fields>(),
             size_of_fields: std::mem::size_of::<C::Fields>(),

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -198,14 +198,14 @@ where
     /// The `MemoTable` must belong to a `Value` of the correct type. Additionally, the
     /// lock must be held for the shard containing the value.
     #[cfg(all(not(feature = "shuttle"), feature = "salsa_unstable"))]
-    unsafe fn memory_usage(&self, memo_table_types: &MemoTableTypes) -> crate::SlotInfo {
+    unsafe fn memory_usage(&self, memo_table_types: &MemoTableTypes) -> crate::database::SlotInfo {
         // SAFETY: The caller guarantees we hold the lock for the shard containing the value, so we
         // have at-least read-only access to the value's memos.
         let memos = unsafe { &*self.memos.get() };
         // SAFETY: The caller guarantees this is the correct types table.
         let memos = unsafe { memo_table_types.attach_memos(memos) };
 
-        crate::SlotInfo {
+        crate::database::SlotInfo {
             debug_name: C::DEBUG_NAME,
             size_of_metadata: std::mem::size_of::<Self>() - std::mem::size_of::<C::Fields<'_>>(),
             size_of_fields: std::mem::size_of::<C::Fields<'_>>(),
@@ -855,7 +855,7 @@ where
 
     /// Returns memory usage information about any interned values.
     #[cfg(all(not(feature = "shuttle"), feature = "salsa_unstable"))]
-    fn memory_usage(&self, db: &dyn Database) -> Option<Vec<crate::SlotInfo>> {
+    fn memory_usage(&self, db: &dyn Database) -> Option<Vec<crate::database::SlotInfo>> {
         use parking_lot::lock_api::RawMutex;
 
         for shard in self.shards.iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub use parallel::{join, par_map};
 pub use salsa_macros::{accumulator, db, input, interned, tracked, Supertype, Update};
 
 #[cfg(feature = "salsa_unstable")]
-pub use self::database::{IngredientInfo, SlotInfo};
+pub use self::database::IngredientInfo;
 
 pub use self::accumulator::Accumulator;
 pub use self::active_query::Backtrace;

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -24,7 +24,7 @@ pub trait Memo: Any + Send + Sync {
 
     /// Returns memory usage information about the memoized value.
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(&self) -> crate::SlotInfo;
+    fn memory_usage(&self) -> crate::database::MemoInfo;
 }
 
 /// Data for a memoized entry.
@@ -112,12 +112,15 @@ impl Memo for DummyMemo {
     }
 
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(&self) -> crate::SlotInfo {
-        crate::SlotInfo {
+    fn memory_usage(&self) -> crate::database::MemoInfo {
+        crate::database::MemoInfo {
             debug_name: "dummy",
-            size_of_metadata: 0,
-            size_of_fields: 0,
-            memos: Vec::new(),
+            output: crate::database::SlotInfo {
+                debug_name: "dummy",
+                size_of_metadata: 0,
+                size_of_fields: 0,
+                memos: Vec::new(),
+            },
         }
     }
 }
@@ -279,7 +282,7 @@ impl MemoTableWithTypes<'_> {
     }
 
     #[cfg(feature = "salsa_unstable")]
-    pub(crate) fn memory_usage(&self) -> Vec<crate::SlotInfo> {
+    pub(crate) fn memory_usage(&self) -> Vec<crate::database::MemoInfo> {
         let mut memory_usage = Vec::new();
         let memos = self.memos.memos.read();
         for (index, memo) in memos.iter().enumerate() {

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -855,7 +855,7 @@ where
 
     /// Returns memory usage information about any tracked structs.
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(&self, db: &dyn Database) -> Option<Vec<crate::SlotInfo>> {
+    fn memory_usage(&self, db: &dyn Database) -> Option<Vec<crate::database::SlotInfo>> {
         let memory_usage = self
             .entries(db)
             // SAFETY: The memo table belongs to a value that we allocated, so it
@@ -929,11 +929,11 @@ where
     ///
     /// The `MemoTable` must belong to a `Value` of the correct type.
     #[cfg(feature = "salsa_unstable")]
-    unsafe fn memory_usage(&self, memo_table_types: &MemoTableTypes) -> crate::SlotInfo {
+    unsafe fn memory_usage(&self, memo_table_types: &MemoTableTypes) -> crate::database::SlotInfo {
         // SAFETY: The caller guarantees this is the correct types table.
         let memos = unsafe { memo_table_types.attach_memos(&self.memos) };
 
-        crate::SlotInfo {
+        crate::database::SlotInfo {
             debug_name: C::DEBUG_NAME,
             size_of_metadata: mem::size_of::<Self>() - mem::size_of::<C::Fields<'_>>(),
             size_of_fields: mem::size_of::<C::Fields<'_>>(),

--- a/tests/compile-fail/accumulator_incompatibles.rs
+++ b/tests/compile-fail/accumulator_incompatibles.rs
@@ -25,4 +25,7 @@ struct AccWithRevisions(u32);
 #[salsa::accumulator(constructor = Constructor)]
 struct AccWithConstructor(u32);
 
+#[salsa::accumulator(heap_size = size)]
+struct AccWithHeapSize(u32);
+
 fn main() {}

--- a/tests/compile-fail/accumulator_incompatibles.stderr
+++ b/tests/compile-fail/accumulator_incompatibles.stderr
@@ -51,3 +51,9 @@ error: `constructor` option not allowed here
    |
 25 | #[salsa::accumulator(constructor = Constructor)]
    |                      ^^^^^^^^^^^
+
+error: `heap_size` option not allowed here
+  --> tests/compile-fail/accumulator_incompatibles.rs:28:22
+   |
+28 | #[salsa::accumulator(heap_size = size)]
+   |                      ^^^^^^^^^

--- a/tests/compile-fail/input_struct_incompatibles.rs
+++ b/tests/compile-fail/input_struct_incompatibles.rs
@@ -25,4 +25,7 @@ struct InputWithTrackedField {
     field: u32,
 }
 
+#[salsa::input(heap_size = size)]
+struct InputWithHeapSize(u32);
+
 fn main() {}

--- a/tests/compile-fail/input_struct_incompatibles.stderr
+++ b/tests/compile-fail/input_struct_incompatibles.stderr
@@ -47,6 +47,12 @@ error: `#[tracked]` cannot be used with `#[salsa::input]`
 25 | |     field: u32,
    | |______________^
 
+error: `heap_size` option not allowed here
+  --> tests/compile-fail/input_struct_incompatibles.rs:28:16
+   |
+28 | #[salsa::input(heap_size = size)]
+   |                ^^^^^^^^^
+
 error: cannot find attribute `tracked` in this scope
   --> tests/compile-fail/input_struct_incompatibles.rs:24:7
    |

--- a/tests/compile-fail/interned_struct_incompatibles.rs
+++ b/tests/compile-fail/interned_struct_incompatibles.rs
@@ -39,4 +39,9 @@ struct InternedWithZeroRevisions {
     field: u32,
 }
 
+#[salsa::interned(heap_size = size)]
+struct AccWithHeapSize {
+    field: u32,
+}
+
 fn main() {}

--- a/tests/compile-fail/interned_struct_incompatibles.stderr
+++ b/tests/compile-fail/interned_struct_incompatibles.stderr
@@ -41,6 +41,12 @@ error: `#[tracked]` cannot be used with `#[salsa::interned]`
 34 | |     field: u32,
    | |______________^
 
+error: `heap_size` option not allowed here
+  --> tests/compile-fail/interned_struct_incompatibles.rs:42:19
+   |
+42 | #[salsa::interned(heap_size = size)]
+   |                   ^^^^^^^^^
+
 error: cannot find attribute `tracked` in this scope
   --> tests/compile-fail/interned_struct_incompatibles.rs:33:7
    |

--- a/tests/compile-fail/tracked_struct_incompatibles.rs
+++ b/tests/compile-fail/tracked_struct_incompatibles.rs
@@ -33,4 +33,9 @@ struct TrackedStructWithRevisions {
     field: u32,
 }
 
+#[salsa::tracked(heap_size = size)]
+struct TrackedStructWithHeapSize {
+    field: u32,
+}
+
 fn main() {}

--- a/tests/compile-fail/tracked_struct_incompatibles.stderr
+++ b/tests/compile-fail/tracked_struct_incompatibles.stderr
@@ -39,3 +39,9 @@ error: `revisions` option not allowed here
    |
 31 | #[salsa::tracked(revisions = 12)]
    |                  ^^^^^^^^^
+
+error: `heap_size` option not allowed here
+  --> tests/compile-fail/tracked_struct_incompatibles.rs:36:18
+   |
+36 | #[salsa::tracked(heap_size = size)]
+   |                  ^^^^^^^^^


### PR DESCRIPTION
`#[salsa::tracked(heap_size)]` will require the return type of a tracked function to implement the [`get_size2::GetSize`](https://docs.rs/get-size2/latest/get_size2/trait.GetSize.html) trait, and include the heap size in the new memory usage APIs. I'm not sure `get-size2` is the best crate to use, but it seems relatively comprehensive, and integrating it into ty was relatively simple with its derive macros. Note that it's not actually a dependency of salsa, it's just called by the generated proc-macro code.