### PR TITLE
Use `inventory` for static ingredient registration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,8 @@ jobs:
         run: cargo clippy --workspace --all-targets -- -D warnings
       - name: Test
         run: cargo nextest run --workspace --all-targets --no-fail-fast
+      - name: Test Manual Registration
+        run: cargo nextest run --workspace --tests --no-fail-fast --no-default-features --features macros
       - name: Test docs
         run: cargo test --workspace --doc
       - name: Check (without default features)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ hashbrown = "0.15"
 hashlink = "0.10"
 indexmap = "2"
 intrusive-collections = "0.9.7"
-papaya = "0.2.3"
 parking_lot = "0.12"
 portable-atomic = "1"
 rustc-hash = "2"
@@ -34,6 +33,7 @@ compact_str = { version = "0.9", optional = true }
 thin-vec = "0.2.13"
 
 shuttle = { version = "0.8.0", optional = true }
+inventory = "0.3.20"
 
 [features]
 default = ["salsa_unstable", "rayon", "macros"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ rustc-hash = "2"
 smallvec = "1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
+# Automatic ingredient registration.
+inventory = { version = "0.3.20", optional = true }
+
 # parallel map
 rayon = { version = "1.10.0", optional = true }
 
@@ -33,10 +36,10 @@ compact_str = { version = "0.9", optional = true }
 thin-vec = "0.2.13"
 
 shuttle = { version = "0.8.0", optional = true }
-inventory = "0.3.20"
 
 [features]
-default = ["salsa_unstable", "rayon", "macros"]
+default = ["salsa_unstable", "rayon", "macros", "inventory"]
+inventory = ["dep:inventory"]
 shuttle = ["dep:shuttle"]
 # FIXME: remove `salsa_unstable` before 1.0.
 salsa_unstable = []

--- a/components/salsa-macro-rules/src/setup_accumulator_impl.rs
+++ b/components/salsa-macro-rules/src/setup_accumulator_impl.rs
@@ -21,13 +21,19 @@ macro_rules! setup_accumulator_impl {
             use salsa::plumbing as $zalsa;
             use salsa::plumbing::accumulator as $zalsa_struct;
 
-            $zalsa::submit! {
-                $zalsa::ErasedJar::erase::<$zalsa_struct::JarImpl<$Struct>>($zalsa::ErasedJarKind::Struct)
+            impl $zalsa::HasJar for $Struct {
+                type Jar = $zalsa_struct::JarImpl<$Struct>;
+                const KIND: $zalsa::JarKind = $zalsa::JarKind::Struct;
+            }
+
+            $zalsa::register_jar! {
+                $zalsa::ErasedJar::erase::<$Struct>()
             }
 
             fn $ingredient(zalsa: &$zalsa::Zalsa) -> &$zalsa_struct::IngredientImpl<$Struct> {
-                static $CACHE: $zalsa::GlobalIngredientCache<$zalsa_struct::IngredientImpl<$Struct>> =
-                    $zalsa::GlobalIngredientCache::new();
+                static $CACHE: $zalsa::GlobalIngredientCache<
+                    $zalsa_struct::IngredientImpl<$Struct>,
+                > = $zalsa::GlobalIngredientCache::new();
 
                 $CACHE.get_or_create(zalsa, || {
                     zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Struct>>()

--- a/components/salsa-macro-rules/src/setup_accumulator_impl.rs
+++ b/components/salsa-macro-rules/src/setup_accumulator_impl.rs
@@ -21,14 +21,18 @@ macro_rules! setup_accumulator_impl {
             use salsa::plumbing as $zalsa;
             use salsa::plumbing::accumulator as $zalsa_struct;
 
+            $zalsa::submit! {
+                $zalsa::ErasedJar::erase::<$zalsa_struct::JarImpl<$Struct>>($zalsa::ErasedJarKind::Struct)
+            }
+
             fn $ingredient(zalsa: &$zalsa::Zalsa) -> &$zalsa_struct::IngredientImpl<$Struct> {
                 static $CACHE: $zalsa::IngredientCache<$zalsa_struct::IngredientImpl<$Struct>> =
                     $zalsa::IngredientCache::new();
 
                 $CACHE.get_or_create(zalsa, || {
-                    zalsa
-                        .lookup_jar_by_type::<$zalsa_struct::JarImpl<$Struct>>()
-                        .get_or_create()
+                    let index = zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Struct>>();
+                    let ingredient = zalsa.lookup_ingredient(index).assert_type();
+                    (index, ingredient)
                 })
             }
 

--- a/components/salsa-macro-rules/src/setup_accumulator_impl.rs
+++ b/components/salsa-macro-rules/src/setup_accumulator_impl.rs
@@ -26,13 +26,11 @@ macro_rules! setup_accumulator_impl {
             }
 
             fn $ingredient(zalsa: &$zalsa::Zalsa) -> &$zalsa_struct::IngredientImpl<$Struct> {
-                static $CACHE: $zalsa::IngredientCache<$zalsa_struct::IngredientImpl<$Struct>> =
-                    $zalsa::IngredientCache::new();
+                static $CACHE: $zalsa::GlobalIngredientCache<$zalsa_struct::IngredientImpl<$Struct>> =
+                    $zalsa::GlobalIngredientCache::new();
 
                 $CACHE.get_or_create(zalsa, || {
-                    let index = zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Struct>>();
-                    let ingredient = zalsa.lookup_ingredient(index).assert_type();
-                    (index, ingredient)
+                    zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Struct>>()
                 })
             }
 

--- a/components/salsa-macro-rules/src/setup_accumulator_impl.rs
+++ b/components/salsa-macro-rules/src/setup_accumulator_impl.rs
@@ -31,13 +31,11 @@ macro_rules! setup_accumulator_impl {
             }
 
             fn $ingredient(zalsa: &$zalsa::Zalsa) -> &$zalsa_struct::IngredientImpl<$Struct> {
-                static $CACHE: $zalsa::GlobalIngredientCache<
-                    $zalsa_struct::IngredientImpl<$Struct>,
-                > = $zalsa::GlobalIngredientCache::new();
+                static $CACHE: $zalsa::IngredientCache<$zalsa_struct::IngredientImpl<$Struct>> =
+                    $zalsa::IngredientCache::new();
 
                 $CACHE.get_or_create(zalsa, || {
-                    let index = zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Struct>>();
-                    (index, zalsa.lookup_ingredient(index).assert_type())
+                    zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Struct>>()
                 })
             }
 

--- a/components/salsa-macro-rules/src/setup_accumulator_impl.rs
+++ b/components/salsa-macro-rules/src/setup_accumulator_impl.rs
@@ -36,7 +36,8 @@ macro_rules! setup_accumulator_impl {
                 > = $zalsa::GlobalIngredientCache::new();
 
                 $CACHE.get_or_create(zalsa, || {
-                    zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Struct>>()
+                    let index = zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Struct>>();
+                    (index, zalsa.lookup_ingredient(index).assert_type())
                 })
             }
 

--- a/components/salsa-macro-rules/src/setup_input_struct.rs
+++ b/components/salsa-macro-rules/src/setup_input_struct.rs
@@ -74,8 +74,13 @@ macro_rules! setup_input_struct {
 
             type $Configuration = $Struct;
 
-            $zalsa::submit! {
-                $zalsa::ErasedJar::erase::<$zalsa_struct::JarImpl<$Configuration>>($zalsa::ErasedJarKind::Struct)
+            impl $zalsa::HasJar for $Struct {
+                type Jar = $zalsa_struct::JarImpl<$Configuration>;
+                const KIND: $zalsa::JarKind = $zalsa::JarKind::Struct;
+            }
+
+            $zalsa::register_jar! {
+                $zalsa::ErasedJar::erase::<$Struct>()
             }
 
             impl $zalsa_struct::Configuration for $Configuration {

--- a/components/salsa-macro-rules/src/setup_input_struct.rs
+++ b/components/salsa-macro-rules/src/setup_input_struct.rs
@@ -74,6 +74,10 @@ macro_rules! setup_input_struct {
 
             type $Configuration = $Struct;
 
+            $zalsa::submit! {
+                $zalsa::ErasedJar::erase::<$zalsa_struct::JarImpl<$Configuration>>($zalsa::ErasedJarKind::Struct)
+            }
+
             impl $zalsa_struct::Configuration for $Configuration {
                 const LOCATION: $zalsa::Location = $zalsa::Location {
                     file: file!(),
@@ -101,14 +105,16 @@ macro_rules! setup_input_struct {
                         $zalsa::IngredientCache::new();
 
                     CACHE.get_or_create(zalsa, || {
-                        zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>().get_or_create()
+                        let index = zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>();
+                        let ingredient = zalsa.lookup_ingredient(index).assert_type();
+                        (index, ingredient)
                     })
                 }
 
                 pub fn ingredient_mut(db: &mut dyn $zalsa::Database) -> (&mut $zalsa_struct::IngredientImpl<Self>, &mut $zalsa::Runtime) {
                     let zalsa_mut = db.zalsa_mut();
                     zalsa_mut.new_revision();
-                    let index = zalsa_mut.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>().get_or_create();
+                    let index = zalsa_mut.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>();
                     let (ingredient, runtime) = zalsa_mut.lookup_ingredient_mut(index);
                     let ingredient = ingredient.assert_type_mut::<$zalsa_struct::IngredientImpl<Self>>();
                     (ingredient, runtime)
@@ -149,8 +155,8 @@ macro_rules! setup_input_struct {
             impl $zalsa::SalsaStructInDb for $Struct {
                 type MemoIngredientMap = $zalsa::MemoIngredientSingletonIndex;
 
-                fn lookup_or_create_ingredient_index(aux: &$zalsa::Zalsa) -> $zalsa::IngredientIndices {
-                    aux.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>().get_or_create().into()
+                fn lookup_ingredient_index(aux: &$zalsa::Zalsa) -> $zalsa::IngredientIndices {
+                    aux.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>().into()
                 }
 
                 #[inline]

--- a/components/salsa-macro-rules/src/setup_input_struct.rs
+++ b/components/salsa-macro-rules/src/setup_input_struct.rs
@@ -106,12 +106,11 @@ macro_rules! setup_input_struct {
                 }
 
                 fn ingredient_(zalsa: &$zalsa::Zalsa) -> &$zalsa_struct::IngredientImpl<Self> {
-                    static CACHE: $zalsa::GlobalIngredientCache<$zalsa_struct::IngredientImpl<$Configuration>> =
-                        $zalsa::GlobalIngredientCache::new();
+                    static CACHE: $zalsa::IngredientCache<$zalsa_struct::IngredientImpl<$Configuration>> =
+                        $zalsa::IngredientCache::new();
 
                     CACHE.get_or_create(zalsa, || {
-                        let index = zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>();
-                        (index, zalsa.lookup_ingredient(index).assert_type())
+                        zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>()
                     })
                 }
 

--- a/components/salsa-macro-rules/src/setup_input_struct.rs
+++ b/components/salsa-macro-rules/src/setup_input_struct.rs
@@ -101,13 +101,11 @@ macro_rules! setup_input_struct {
                 }
 
                 fn ingredient_(zalsa: &$zalsa::Zalsa) -> &$zalsa_struct::IngredientImpl<Self> {
-                    static CACHE: $zalsa::IngredientCache<$zalsa_struct::IngredientImpl<$Configuration>> =
-                        $zalsa::IngredientCache::new();
+                    static CACHE: $zalsa::GlobalIngredientCache<$zalsa_struct::IngredientImpl<$Configuration>> =
+                        $zalsa::GlobalIngredientCache::new();
 
                     CACHE.get_or_create(zalsa, || {
-                        let index = zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>();
-                        let ingredient = zalsa.lookup_ingredient(index).assert_type();
-                        (index, ingredient)
+                        zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>()
                     })
                 }
 

--- a/components/salsa-macro-rules/src/setup_input_struct.rs
+++ b/components/salsa-macro-rules/src/setup_input_struct.rs
@@ -110,7 +110,8 @@ macro_rules! setup_input_struct {
                         $zalsa::GlobalIngredientCache::new();
 
                     CACHE.get_or_create(zalsa, || {
-                        zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>()
+                        let index = zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>();
+                        (index, zalsa.lookup_ingredient(index).assert_type())
                     })
                 }
 

--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -92,8 +92,13 @@ macro_rules! setup_interned_struct {
 
             type $Configuration = $StructWithStatic;
 
-            $zalsa::submit! {
-                $zalsa::ErasedJar::erase::<$zalsa_struct::JarImpl<$Configuration>>($zalsa::ErasedJarKind::Struct)
+            impl<$($db_lt_arg)?> $zalsa::HasJar for $Struct<$($db_lt_arg)?> {
+                type Jar = $zalsa_struct::JarImpl<$Configuration>;
+                const KIND: $zalsa::JarKind = $zalsa::JarKind::Struct;
+            }
+
+            $zalsa::register_jar! {
+                $zalsa::ErasedJar::erase::<$StructWithStatic>()
             }
 
             type $StructDataIdent<$db_lt> = ($($field_ty,)*);

--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -153,13 +153,12 @@ macro_rules! setup_interned_struct {
                 where
                     Db: ?Sized + $zalsa::Database,
                 {
-                    static CACHE: $zalsa::GlobalIngredientCache<$zalsa_struct::IngredientImpl<$Configuration>> =
-                        $zalsa::GlobalIngredientCache::new();
+                    static CACHE: $zalsa::IngredientCache<$zalsa_struct::IngredientImpl<$Configuration>> =
+                        $zalsa::IngredientCache::new();
 
                     let zalsa = db.zalsa();
                     CACHE.get_or_create(zalsa, || {
-                        let index = zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>();
-                        (index, zalsa.lookup_ingredient(index).assert_type())
+                        zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>()
                     })
                 }
             }

--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -92,6 +92,10 @@ macro_rules! setup_interned_struct {
 
             type $Configuration = $StructWithStatic;
 
+            $zalsa::submit! {
+                $zalsa::ErasedJar::erase::<$zalsa_struct::JarImpl<$Configuration>>($zalsa::ErasedJarKind::Struct)
+            }
+
             type $StructDataIdent<$db_lt> = ($($field_ty,)*);
 
             /// Key to use during hash lookups. Each field is some type that implements `Lookup<T>`
@@ -149,7 +153,9 @@ macro_rules! setup_interned_struct {
 
                     let zalsa = db.zalsa();
                     CACHE.get_or_create(zalsa, || {
-                        zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>().get_or_create()
+                        let index = zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>();
+                        let ingredient = zalsa.lookup_ingredient(index).assert_type();
+                        (index, ingredient)
                     })
                 }
             }
@@ -181,8 +187,8 @@ macro_rules! setup_interned_struct {
             impl< $($db_lt_arg)? > $zalsa::SalsaStructInDb for $Struct< $($db_lt_arg)? > {
                 type MemoIngredientMap = $zalsa::MemoIngredientSingletonIndex;
 
-                fn lookup_or_create_ingredient_index(aux: &$zalsa::Zalsa) -> $zalsa::IngredientIndices {
-                    aux.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>().get_or_create().into()
+                fn lookup_ingredient_index(aux: &$zalsa::Zalsa) -> $zalsa::IngredientIndices {
+                    aux.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>().into()
                 }
 
                 #[inline]

--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -148,14 +148,12 @@ macro_rules! setup_interned_struct {
                 where
                     Db: ?Sized + $zalsa::Database,
                 {
-                    static CACHE: $zalsa::IngredientCache<$zalsa_struct::IngredientImpl<$Configuration>> =
-                        $zalsa::IngredientCache::new();
+                    static CACHE: $zalsa::GlobalIngredientCache<$zalsa_struct::IngredientImpl<$Configuration>> =
+                        $zalsa::GlobalIngredientCache::new();
 
                     let zalsa = db.zalsa();
                     CACHE.get_or_create(zalsa, || {
-                        let index = zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>();
-                        let ingredient = zalsa.lookup_ingredient(index).assert_type();
-                        (index, ingredient)
+                        zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>()
                     })
                 }
             }

--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -158,7 +158,8 @@ macro_rules! setup_interned_struct {
 
                     let zalsa = db.zalsa();
                     CACHE.get_or_create(zalsa, || {
-                        zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>()
+                        let index = zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>();
+                        (index, zalsa.lookup_ingredient(index).assert_type())
                     })
                 }
             }

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -106,8 +106,8 @@ macro_rules! setup_tracked_fn {
                         std::marker::PhantomData<fn() -> &$db_lt ()>,
                     );
 
-                    static $INTERN_CACHE: $zalsa::IngredientCache<$zalsa::interned::IngredientImpl<$Configuration>> =
-                        $zalsa::IngredientCache::new();
+                    static $INTERN_CACHE: $zalsa::GlobalIngredientCache<$zalsa::interned::IngredientImpl<$Configuration>> =
+                        $zalsa::GlobalIngredientCache::new();
 
                     impl $zalsa::SalsaStructInDb for $InternedData<'_> {
                         type MemoIngredientMap = $zalsa::MemoIngredientSingletonIndex;
@@ -193,9 +193,7 @@ macro_rules! setup_tracked_fn {
                     ) -> &$zalsa::interned::IngredientImpl<$Configuration> {
                         let zalsa = db.zalsa();
                         $INTERN_CACHE.get_or_create(zalsa, || {
-                            let index = zalsa.lookup_jar_by_type::<$Configuration>().successor(0);
-                            let ingredient = zalsa.lookup_ingredient(index).assert_type();
-                            (index, ingredient)
+                            zalsa.lookup_jar_by_type::<$Configuration>().successor(0)
                         })
                     }
                 }

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -199,7 +199,8 @@ macro_rules! setup_tracked_fn {
                     ) -> &$zalsa::interned::IngredientImpl<$Configuration> {
                         let zalsa = db.zalsa();
                         $INTERN_CACHE.get_or_create(zalsa, || {
-                            zalsa.lookup_jar_by_type::<$fn_name>().successor(0)
+                            let index = zalsa.lookup_jar_by_type::<$fn_name>().successor(0);
+                            (index, zalsa.lookup_ingredient(index).assert_type())
                         })
                     }
                 }

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -274,14 +274,14 @@ macro_rules! setup_tracked_fn {
                     };
 
                     $zalsa::macro_if! { $needs_interner =>
-                        let intern_ingredient = <$zalsa::interned::IngredientImpl<$Configuration>>::new(
+                        let mut intern_ingredient = <$zalsa::interned::IngredientImpl<$Configuration>>::new(
                             first_index.successor(0)
                         );
                     }
 
                     let intern_ingredient_memo_types = $zalsa::macro_if! {
                         if $needs_interner {
-                            Some($zalsa::Ingredient::memo_table_types(&intern_ingredient))
+                            Some($zalsa::Ingredient::memo_table_types_mut(&mut intern_ingredient))
                         } else {
                             None
                         }

--- a/components/salsa-macro-rules/src/setup_tracked_struct.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_struct.rs
@@ -107,8 +107,8 @@ macro_rules! setup_tracked_struct {
             std::marker::PhantomData<fn() -> &$db_lt ()>
         );
 
-        #[allow(clippy::all)]
         #[allow(dead_code)]
+        #[allow(clippy::all)]
         const _: () = {
             use salsa::plumbing as $zalsa;
             use $zalsa::tracked_struct as $zalsa_struct;
@@ -116,8 +116,13 @@ macro_rules! setup_tracked_struct {
 
             type $Configuration = $Struct<'static>;
 
-            $zalsa::submit! {
-                $zalsa::ErasedJar::erase::<$zalsa_struct::JarImpl<$Configuration>>($zalsa::ErasedJarKind::Struct)
+            impl<$db_lt> $zalsa::HasJar for $Struct<$db_lt> {
+                type Jar = $zalsa_struct::JarImpl<$Configuration>;
+                const KIND: $zalsa::JarKind = $zalsa::JarKind::Struct;
+            }
+
+            $zalsa::register_jar! {
+                $zalsa::ErasedJar::erase::<$Struct<'static>>()
             }
 
             impl $zalsa_struct::Configuration for $Configuration {

--- a/components/salsa-macro-rules/src/setup_tracked_struct.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_struct.rs
@@ -197,7 +197,8 @@ macro_rules! setup_tracked_struct {
                         $zalsa::GlobalIngredientCache::new();
 
                     CACHE.get_or_create(zalsa, || {
-                        zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>()
+                        let index = zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>();
+                        (index, zalsa.lookup_ingredient(index).assert_type())
                     })
                 }
             }

--- a/components/salsa-macro-rules/src/setup_tracked_struct.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_struct.rs
@@ -188,13 +188,11 @@ macro_rules! setup_tracked_struct {
                 }
 
                 fn ingredient_(zalsa: &$zalsa::Zalsa) -> &$zalsa_struct::IngredientImpl<Self> {
-                    static CACHE: $zalsa::IngredientCache<$zalsa_struct::IngredientImpl<$Configuration>> =
-                        $zalsa::IngredientCache::new();
+                    static CACHE: $zalsa::GlobalIngredientCache<$zalsa_struct::IngredientImpl<$Configuration>> =
+                        $zalsa::GlobalIngredientCache::new();
 
                     CACHE.get_or_create(zalsa, || {
-                        let index = zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>();
-                        let ingredient = zalsa.lookup_ingredient(index).assert_type();
-                        (index, ingredient)
+                        zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>()
                     })
                 }
             }

--- a/components/salsa-macro-rules/src/setup_tracked_struct.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_struct.rs
@@ -193,12 +193,11 @@ macro_rules! setup_tracked_struct {
                 }
 
                 fn ingredient_(zalsa: &$zalsa::Zalsa) -> &$zalsa_struct::IngredientImpl<Self> {
-                    static CACHE: $zalsa::GlobalIngredientCache<$zalsa_struct::IngredientImpl<$Configuration>> =
-                        $zalsa::GlobalIngredientCache::new();
+                    static CACHE: $zalsa::IngredientCache<$zalsa_struct::IngredientImpl<$Configuration>> =
+                        $zalsa::IngredientCache::new();
 
                     CACHE.get_or_create(zalsa, || {
-                        let index = zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>();
-                        (index, zalsa.lookup_ingredient(index).assert_type())
+                        zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>()
                     })
                 }
             }

--- a/components/salsa-macro-rules/src/setup_tracked_struct.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_struct.rs
@@ -116,6 +116,10 @@ macro_rules! setup_tracked_struct {
 
             type $Configuration = $Struct<'static>;
 
+            $zalsa::submit! {
+                $zalsa::ErasedJar::erase::<$zalsa_struct::JarImpl<$Configuration>>($zalsa::ErasedJarKind::Struct)
+            }
+
             impl $zalsa_struct::Configuration for $Configuration {
                 const LOCATION: $zalsa::Location = $zalsa::Location {
                     file: file!(),
@@ -188,7 +192,9 @@ macro_rules! setup_tracked_struct {
                         $zalsa::IngredientCache::new();
 
                     CACHE.get_or_create(zalsa, || {
-                        zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>().get_or_create()
+                        let index = zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>();
+                        let ingredient = zalsa.lookup_ingredient(index).assert_type();
+                        (index, ingredient)
                     })
                 }
             }
@@ -210,8 +216,8 @@ macro_rules! setup_tracked_struct {
             impl $zalsa::SalsaStructInDb for $Struct<'_> {
                 type MemoIngredientMap = $zalsa::MemoIngredientSingletonIndex;
 
-                fn lookup_or_create_ingredient_index(aux: &$zalsa::Zalsa) -> $zalsa::IngredientIndices {
-                    aux.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>().get_or_create().into()
+                fn lookup_ingredient_index(aux: &$zalsa::Zalsa) -> $zalsa::IngredientIndices {
+                    aux.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>().into()
                 }
 
                 #[inline]

--- a/components/salsa-macros/src/db.rs
+++ b/components/salsa-macros/src/db.rs
@@ -110,7 +110,7 @@ impl DbMacro {
         let trait_name = &input.ident;
         input.items.push(parse_quote! {
             #[doc(hidden)]
-            fn zalsa_register_downcaster(&self);
+            fn zalsa_register_downcaster(&self) -> salsa::plumbing::DatabaseDownCaster<dyn #trait_name>;
         });
 
         let comment = format!(" Downcast a [`dyn Database`] to a [`dyn {trait_name}`]");
@@ -135,10 +135,11 @@ impl DbMacro {
         };
 
         input.items.push(parse_quote! {
+            #[cold]
+            #[inline(never)]
             #[doc(hidden)]
-            #[inline(always)]
-            fn zalsa_register_downcaster(&self)  {
-                salsa::plumbing::views(self).add(<Self as #TraitPath>::downcast);
+            fn zalsa_register_downcaster(&self) -> salsa::plumbing::DatabaseDownCaster<dyn #TraitPath> {
+                salsa::plumbing::views(self).add(<Self as #TraitPath>::downcast)
             }
         });
         input.items.push(parse_quote! {

--- a/components/salsa-macros/src/fn_util.rs
+++ b/components/salsa-macros/src/fn_util.rs
@@ -15,7 +15,7 @@ pub fn input_ids(hygiene: &Hygiene, sig: &syn::Signature, skip: usize) -> Vec<sy
                 }
             }
 
-            hygiene.ident(&format!("input{index}"))
+            hygiene.ident(format!("input{index}"))
         })
         .collect()
 }

--- a/components/salsa-macros/src/hygiene.rs
+++ b/components/salsa-macros/src/hygiene.rs
@@ -50,15 +50,23 @@ impl Hygiene {
     /// Generates an identifier similar to `text` but
     /// distinct from any identifiers that appear in the user's
     /// code.
-    pub(crate) fn ident(&self, text: &str) -> syn::Ident {
+    pub(crate) fn ident(&self, text: impl AsRef<str>) -> syn::Ident {
         // Make the default be `foo_` rather than `foo` -- this helps detect
         // cases where people wrote `foo` instead of `#foo` or `$foo` in the generated code.
-        let mut buffer = format!("{text}_");
+        let mut buffer = format!("{}_", text.as_ref());
 
         while self.user_tokens.contains(&buffer) {
             buffer.push('_');
         }
 
         syn::Ident::new(&buffer, proc_macro2::Span::call_site())
+    }
+
+    /// Generates an identifier similar to `text` but distinct from any identifiers
+    /// that appear in the user's code.
+    ///
+    /// The identifier must be unique relative to the `scope` identifier.
+    pub(crate) fn scoped_ident(&self, scope: &syn::Ident, text: &str) -> syn::Ident {
+        self.ident(format!("{scope}_{text}"))
     }
 }

--- a/components/salsa-macros/src/supertype.rs
+++ b/components/salsa-macros/src/supertype.rs
@@ -72,8 +72,8 @@ fn enum_impl(enum_item: syn::ItemEnum) -> syn::Result<TokenStream> {
             type MemoIngredientMap = zalsa::MemoIngredientIndices;
 
             #[inline]
-            fn lookup_or_create_ingredient_index(__zalsa: &zalsa::Zalsa) -> zalsa::IngredientIndices {
-                zalsa::IngredientIndices::merge([ #( <#variant_types as zalsa::SalsaStructInDb>::lookup_or_create_ingredient_index(__zalsa) ),* ])
+            fn lookup_ingredient_index(__zalsa: &zalsa::Zalsa) -> zalsa::IngredientIndices {
+                zalsa::IngredientIndices::merge([ #( <#variant_types as zalsa::SalsaStructInDb>::lookup_ingredient_index(__zalsa) ),* ])
             }
 
             #[inline]

--- a/components/salsa-macros/src/tracked_fn.rs
+++ b/components/salsa-macros/src/tracked_fn.rs
@@ -132,10 +132,10 @@ impl Macro {
         inner_fn.sig.ident = self.hygiene.ident("inner");
 
         let zalsa = self.hygiene.ident("zalsa");
-        let Configuration = self.hygiene.ident("Configuration");
-        let InternedData = self.hygiene.ident("InternedData");
-        let FN_CACHE = self.hygiene.ident("FN_CACHE");
-        let INTERN_CACHE = self.hygiene.ident("INTERN_CACHE");
+        let Configuration = self.hygiene.scoped_ident(fn_name, "Configuration");
+        let InternedData = self.hygiene.scoped_ident(fn_name, "InternedData");
+        let FN_CACHE = self.hygiene.scoped_ident(fn_name, "FN_CACHE");
+        let INTERN_CACHE = self.hygiene.scoped_ident(fn_name, "INTERN_CACHE");
         let inner = &inner_fn.sig.ident;
 
         let function_type = function_type(&item);

--- a/components/salsa-macros/src/tracked_impl.rs
+++ b/components/salsa-macros/src/tracked_impl.rs
@@ -99,7 +99,7 @@ impl Macro {
         });
 
         let InnerTrait = self.hygiene.ident("InnerTrait");
-        let inner_fn_name = self.hygiene.ident(&fn_item.sig.ident.to_string());
+        let inner_fn_name = self.hygiene.ident(fn_item.sig.ident.to_string());
 
         let AssociatedFunctionArguments {
             self_token,

--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -10,7 +10,7 @@ use accumulated::{Accumulated, AnyAccumulated};
 use crate::cycle::CycleHeads;
 use crate::function::VerifyResult;
 use crate::ingredient::{Ingredient, Jar};
-use crate::plumbing::{IngredientIndices, ZalsaLocal};
+use crate::plumbing::ZalsaLocal;
 use crate::sync::Arc;
 use crate::table::memo::MemoTableTypes;
 use crate::zalsa::{IngredientIndex, Zalsa};
@@ -44,9 +44,8 @@ impl<A: Accumulator> Default for JarImpl<A> {
 
 impl<A: Accumulator> Jar for JarImpl<A> {
     fn create_ingredients(
-        _zalsa: &Zalsa,
+        _zalsa: &mut Zalsa,
         first_index: IngredientIndex,
-        _dependencies: IngredientIndices,
     ) -> Vec<Box<dyn Ingredient>> {
         vec![Box::new(<IngredientImpl<A>>::new(first_index))]
     }
@@ -64,7 +63,7 @@ pub struct IngredientImpl<A: Accumulator> {
 impl<A: Accumulator> IngredientImpl<A> {
     /// Find the accumulator ingredient for `A` in the database, if any.
     pub fn from_zalsa(zalsa: &Zalsa) -> Option<&Self> {
-        let index = zalsa.lookup_jar_by_type::<JarImpl<A>>().get_or_create();
+        let index = zalsa.lookup_jar_by_type::<JarImpl<A>>();
         let ingredient = zalsa.lookup_ingredient(index).assert_type::<Self>();
         Some(ingredient)
     }

--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -114,7 +114,11 @@ impl<A: Accumulator> Ingredient for IngredientImpl<A> {
         A::DEBUG_NAME
     }
 
-    fn memo_table_types(&self) -> Arc<MemoTableTypes> {
+    fn memo_table_types(&self) -> &Arc<MemoTableTypes> {
+        unreachable!("accumulator does not allocate pages")
+    }
+
+    fn memo_table_types_mut(&mut self) -> &mut Arc<MemoTableTypes> {
         unreachable!("accumulator does not allocate pages")
     }
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,6 +1,7 @@
 use std::any::Any;
 use std::borrow::Cow;
 
+use crate::views::DatabaseDownCaster;
 use crate::zalsa::{IngredientIndex, ZalsaDatabase};
 use crate::{Durability, Revision};
 
@@ -80,9 +81,11 @@ pub trait Database: Send + AsDynDatabase + Any + ZalsaDatabase {
         crate::attach::attach(self, || op(self))
     }
 
+    #[cold]
+    #[inline(never)]
     #[doc(hidden)]
-    #[inline(always)]
-    fn zalsa_register_downcaster(&self) {
+    fn zalsa_register_downcaster(&self) -> DatabaseDownCaster<dyn Database> {
+        self.zalsa().views().downcaster_for::<dyn Database>()
         // The no-op downcaster is special cased in view caster construction.
     }
 

--- a/src/database_impl.rs
+++ b/src/database_impl.rs
@@ -7,7 +7,7 @@ use crate::{Database, Storage};
 /// require any custom user data.
 #[derive(Clone)]
 pub struct DatabaseImpl {
-    pub storage: Storage<Self>,
+    storage: Storage<Self>,
 }
 
 impl Default for DatabaseImpl {

--- a/src/database_impl.rs
+++ b/src/database_impl.rs
@@ -7,7 +7,7 @@ use crate::{Database, Storage};
 /// require any custom user data.
 #[derive(Clone)]
 pub struct DatabaseImpl {
-    storage: Storage<Self>,
+    pub storage: Storage<Self>,
 }
 
 impl Default for DatabaseImpl {

--- a/src/function.rs
+++ b/src/function.rs
@@ -3,6 +3,7 @@ use std::any::Any;
 use std::fmt;
 use std::ptr::NonNull;
 use std::sync::atomic::Ordering;
+use std::sync::OnceLock;
 pub(crate) use sync::SyncGuard;
 
 use crate::accumulator::accumulated_map::{AccumulatedMap, InputAccumulatedValues};
@@ -129,7 +130,7 @@ pub struct IngredientImpl<C: Configuration> {
     ///
     /// The supplied database must be be the same as the database used to construct the [`Views`]
     /// instances that this downcaster was derived from.
-    view_caster: DatabaseDownCaster<C::DbView>,
+    view_caster: OnceLock<DatabaseDownCaster<C::DbView>>,
 
     sync_table: SyncTable,
 
@@ -156,16 +157,33 @@ where
         index: IngredientIndex,
         memo_ingredient_indices: <C::SalsaStruct<'static> as SalsaStructInDb>::MemoIngredientMap,
         lru: usize,
-        view_caster: DatabaseDownCaster<C::DbView>,
     ) -> Self {
         Self {
             index,
             memo_ingredient_indices,
             lru: lru::Lru::new(lru),
             deleted_entries: Default::default(),
-            view_caster,
+            view_caster: OnceLock::new(),
             sync_table: SyncTable::new(index),
         }
+    }
+
+    /// Initialize the view-caster for this tracked function ingredient.
+    ///
+    /// This function must be called before the ingredient is accessed.
+    #[cold]
+    #[inline(never)]
+    pub fn init(&self, view_caster: DatabaseDownCaster<C::DbView>) -> &Self {
+        // Note that we must set this lazily as we don't have access to the database
+        // type when ingredients are registered into the `Zalsa`.
+        let _ = self.view_caster.set(view_caster);
+        self
+    }
+
+    /// Returns `true` if [`Self::init`] has already been called.
+    #[inline]
+    pub fn is_initialized(&self) -> bool {
+        self.view_caster.get().is_some()
     }
 
     #[inline]
@@ -226,6 +244,12 @@ where
     fn memo_ingredient_index(&self, zalsa: &Zalsa, id: Id) -> MemoIngredientIndex {
         self.memo_ingredient_indices.get_zalsa_id(zalsa, id)
     }
+
+    fn view_caster(&self) -> &DatabaseDownCaster<C::DbView> {
+        self.view_caster
+            .get()
+            .expect("tracked function ingredients cannot be accessed before calling `init`")
+    }
 }
 
 impl<C> Ingredient for IngredientImpl<C>
@@ -248,7 +272,7 @@ where
         cycle_heads: &mut CycleHeads,
     ) -> VerifyResult {
         // SAFETY: The `db` belongs to the ingredient as per caller invariant
-        let db = unsafe { self.view_caster.downcast_unchecked(db) };
+        let db = unsafe { self.view_caster().downcast_unchecked(db) };
         self.maybe_changed_after(db, input, revision, cycle_heads)
     }
 
@@ -352,7 +376,7 @@ where
         db: &'db dyn Database,
         key_index: Id,
     ) -> (Option<&'db AccumulatedMap>, InputAccumulatedValues) {
-        let db = self.view_caster.downcast(db);
+        let db = self.view_caster().downcast(db);
         self.accumulated_map(db, key_index)
     }
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -168,22 +168,17 @@ where
         }
     }
 
-    /// Initialize the view-caster for this tracked function ingredient.
-    ///
-    /// This function must be called before the ingredient is accessed.
-    #[cold]
-    #[inline(never)]
-    pub fn init(&self, view_caster: DatabaseDownCaster<C::DbView>) -> &Self {
+    /// Set the view-caster for this tracked function ingredient, if it has
+    /// not already been initialized.
+    #[inline]
+    pub fn get_or_init(
+        &self,
+        view_caster: impl FnOnce() -> DatabaseDownCaster<C::DbView>,
+    ) -> &Self {
         // Note that we must set this lazily as we don't have access to the database
         // type when ingredients are registered into the `Zalsa`.
-        let _ = self.view_caster.set(view_caster);
+        self.view_caster.get_or_init(view_caster);
         self
-    }
-
-    /// Returns `true` if [`Self::init`] has already been called.
-    #[inline]
-    pub fn is_initialized(&self) -> bool {
-        self.view_caster.get().is_some()
     }
 
     #[inline]

--- a/src/function.rs
+++ b/src/function.rs
@@ -363,7 +363,11 @@ where
         C::DEBUG_NAME
     }
 
-    fn memo_table_types(&self) -> Arc<MemoTableTypes> {
+    fn memo_table_types(&self) -> &Arc<MemoTableTypes> {
+        unreachable!("function does not allocate pages")
+    }
+
+    fn memo_table_types_mut(&mut self) -> &mut Arc<MemoTableTypes> {
         unreachable!("function does not allocate pages")
     }
 

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -466,7 +466,7 @@ mod _memory_usage {
     impl SalsaStructInDb for DummyStruct {
         type MemoIngredientMap = MemoIngredientSingletonIndex;
 
-        fn lookup_or_create_ingredient_index(_: &Zalsa) -> IngredientIndices {
+        fn lookup_ingredient_index(_: &Zalsa) -> IngredientIndices {
             unimplemented!()
         }
 

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -6,7 +6,6 @@ use crate::cycle::{
     empty_cycle_heads, CycleHeads, CycleRecoveryStrategy, IterationCount, ProvisionalStatus,
 };
 use crate::function::VerifyResult;
-use crate::plumbing::IngredientIndices;
 use crate::runtime::Running;
 use crate::sync::Arc;
 use crate::table::memo::MemoTableTypes;
@@ -18,33 +17,16 @@ use crate::{Database, DatabaseKeyIndex, Id, Revision};
 /// A "jar" is a group of ingredients that are added atomically.
 /// Each type implementing jar can be added to the database at most once.
 pub trait Jar: Any {
-    /// This creates the ingredient dependencies of this jar. We need to split this from `create_ingredients()`
-    /// because while `create_ingredients()` is called, a lock on the ingredient map is held (to guarantee
-    /// atomicity), so other ingredients could not be created.
-    ///
-    /// Only tracked fns use this.
-    fn create_dependencies(_zalsa: &Zalsa) -> IngredientIndices
-    where
-        Self: Sized,
-    {
-        IngredientIndices::empty()
-    }
-
     /// Create the ingredients given the index of the first one.
     /// All subsequent ingredients will be assigned contiguous indices.
     fn create_ingredients(
-        zalsa: &Zalsa,
+        zalsa: &mut Zalsa,
         first_index: IngredientIndex,
-        dependencies: IngredientIndices,
-    ) -> Vec<Box<dyn Ingredient>>
-    where
-        Self: Sized;
+    ) -> Vec<Box<dyn Ingredient>>;
 
     /// This returns the [`TypeId`] of the ID struct, that is, the struct that wraps `salsa::Id`
     /// and carry the name of the jar.
-    fn id_struct_type_id() -> TypeId
-    where
-        Self: Sized;
+    fn id_struct_type_id() -> TypeId;
 }
 
 pub struct Location {

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -15,9 +15,11 @@ use crate::zalsa_local::QueryOriginRef;
 use crate::{Database, DatabaseKeyIndex, Id, Revision};
 
 /// A "jar" is a group of ingredients that are added atomically.
+///
 /// Each type implementing jar can be added to the database at most once.
 pub trait Jar: Any {
     /// Create the ingredients given the index of the first one.
+    ///
     /// All subsequent ingredients will be assigned contiguous indices.
     fn create_ingredients(
         zalsa: &mut Zalsa,

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -133,7 +133,9 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
         );
     }
 
-    fn memo_table_types(&self) -> Arc<MemoTableTypes>;
+    fn memo_table_types(&self) -> &Arc<MemoTableTypes>;
+
+    fn memo_table_types_mut(&mut self) -> &mut Arc<MemoTableTypes>;
 
     fn fmt_index(&self, index: crate::Id, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt_index(self.debug_name(), index, fmt)

--- a/src/ingredient_cache.rs
+++ b/src/ingredient_cache.rs
@@ -1,0 +1,187 @@
+use std::marker::PhantomData;
+use std::mem;
+use std::num::NonZeroU32;
+
+use crate::nonce::Nonce;
+use crate::plumbing::Ingredient;
+use crate::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use crate::zalsa::{StorageNonce, Zalsa};
+use crate::IngredientIndex;
+
+/// Caches an ingredient index.
+///
+/// Unlike [`IngredientCache`], this is not restricted to a specific database.
+/// Note that ingredients are statically registered with `inventory`, so their
+/// indices should be stable across any databases.
+///
+/// If ingredient initialization is database dependent, e.g. for registering
+/// view casters, [`IngredientCache`] should be used instead.
+pub struct GlobalIngredientCache<I>
+where
+    I: Ingredient,
+{
+    ingredient_index: AtomicU32,
+    phantom: PhantomData<fn() -> I>,
+}
+
+impl<I> Default for GlobalIngredientCache<I>
+where
+    I: Ingredient,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<I> GlobalIngredientCache<I>
+where
+    I: Ingredient,
+{
+    const UNINITIALIZED: u32 = u32::MAX;
+
+    /// Create a new cache
+    pub const fn new() -> Self {
+        Self {
+            ingredient_index: AtomicU32::new(Self::UNINITIALIZED),
+            phantom: PhantomData,
+        }
+    }
+
+    /// Get a reference to the ingredient in the database.
+    ///
+    /// If the ingredient index is not already in the cache, it will be loaded and cached.
+    #[inline(always)]
+    pub fn get_or_create<'db>(
+        &self,
+        zalsa: &'db Zalsa,
+        load_index: impl Fn() -> IngredientIndex,
+    ) -> &'db I {
+        const _: () = assert!(
+            mem::size_of::<(Nonce<StorageNonce>, IngredientIndex)>() == mem::size_of::<u64>()
+        );
+
+        let mut ingredient_index = self.ingredient_index.load(Ordering::Acquire);
+        if ingredient_index == Self::UNINITIALIZED {
+            ingredient_index = self.get_or_create_index_slow(load_index).as_u32();
+        };
+
+        zalsa
+            .lookup_ingredient(IngredientIndex::from_unchecked(ingredient_index))
+            .assert_type()
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn get_or_create_index_slow(
+        &self,
+        load_index: impl Fn() -> IngredientIndex,
+    ) -> IngredientIndex {
+        let ingredient_index = load_index();
+
+        // It doesn't matter if we overwrite any stores, as `create_index` should
+        // always return the same index.
+        self.ingredient_index
+            .store(ingredient_index.as_u32(), Ordering::Release);
+
+        ingredient_index
+    }
+}
+
+/// Caches ingredient initialization in a specific database.
+///
+/// Optimized for the case of a single database.
+pub struct IngredientCache<I>
+where
+    I: Ingredient,
+{
+    // A packed representation of `Option<(Nonce<StorageNonce>, IngredientIndex)>`.
+    //
+    // This allows us to replace a lock in favor of an atomic load. This works thanks to `Nonce`
+    // having a niche, which means the entire type can fit into an `AtomicU64`.
+    cached_data: AtomicU64,
+    phantom: PhantomData<fn() -> I>,
+}
+
+impl<I> Default for IngredientCache<I>
+where
+    I: Ingredient,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<I> IngredientCache<I>
+where
+    I: Ingredient,
+{
+    const UNINITIALIZED: u64 = 0;
+
+    /// Create a new cache
+    pub const fn new() -> Self {
+        Self {
+            cached_data: AtomicU64::new(Self::UNINITIALIZED),
+            phantom: PhantomData,
+        }
+    }
+
+    /// Get a reference to the ingredient in the database.
+    ///
+    /// If the ingredient is not already in the cache, it will be created.
+    #[inline(always)]
+    pub fn get_or_create<'db>(
+        &self,
+        zalsa: &'db Zalsa,
+        create_index: impl Fn() -> (IngredientIndex, &'db I),
+    ) -> &'db I {
+        const _: () = assert!(
+            mem::size_of::<(Nonce<StorageNonce>, IngredientIndex)>() == mem::size_of::<u64>()
+        );
+
+        let cached_data = self.cached_data.load(Ordering::Acquire);
+        if cached_data == Self::UNINITIALIZED {
+            return self.get_or_create_index_slow(zalsa, create_index);
+        };
+
+        // Unpack our `u64` into the nonce and index.
+        let index = IngredientIndex::from_unchecked(cached_data as u32);
+
+        // SAFETY: We've checked against `UNINITIALIZED` (0) above and so the upper bits must be non-zero.
+        let nonce = Nonce::<StorageNonce>::from_u32(unsafe {
+            NonZeroU32::new_unchecked((cached_data >> u32::BITS) as u32)
+        });
+
+        // The data was cached for a different database, we have to ensure the ingredient was
+        // created in ours.
+        if zalsa.nonce() != nonce {
+            let (_, ingredient) = create_index();
+            return ingredient;
+        }
+
+        zalsa.lookup_ingredient(index).assert_type()
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn get_or_create_index_slow<'db>(
+        &self,
+        zalsa: &'db Zalsa,
+        create_index: impl Fn() -> (IngredientIndex, &'db I),
+    ) -> &'db I {
+        let (index, ingredient) = create_index();
+        let nonce = zalsa.nonce().into_u32().get() as u64;
+        let packed = (nonce << u32::BITS) | (index.as_u32() as u64);
+        debug_assert_ne!(packed, IngredientCache::<I>::UNINITIALIZED);
+
+        // Discard the result, whether we won over the cache or not doesn't matter.
+        _ = self.cached_data.compare_exchange(
+            IngredientCache::<I>::UNINITIALIZED,
+            packed,
+            Ordering::Release,
+            Ordering::Relaxed,
+        );
+
+        // Use our locally computed index regardless of which one was cached.
+        ingredient
+    }
+}

--- a/src/ingredient_cache.rs
+++ b/src/ingredient_cache.rs
@@ -1,195 +1,202 @@
-use std::marker::PhantomData;
-use std::mem;
-use std::num::NonZeroU32;
+pub use imp::IngredientCache;
 
-use crate::nonce::Nonce;
-use crate::plumbing::Ingredient;
-use crate::sync::atomic::{AtomicU64, Ordering};
-use crate::zalsa::{StorageNonce, Zalsa};
-use crate::IngredientIndex;
+#[cfg(feature = "inventory")]
+mod imp {
+    use crate::plumbing::Ingredient;
+    use crate::sync::atomic::{self, AtomicU32, Ordering};
+    use crate::zalsa::Zalsa;
+    use crate::IngredientIndex;
+
+    use std::marker::PhantomData;
+
+    /// Caches an ingredient index.
+    ///
+    /// Note that all ingredients are statically registered with `inventory`, so their
+    /// indices should be stable across any databases.
+    pub struct IngredientCache<I>
+    where
+        I: Ingredient,
+    {
+        ingredient_index: AtomicU32,
+        phantom: PhantomData<fn() -> I>,
+    }
+
+    impl<I> Default for IngredientCache<I>
+    where
+        I: Ingredient,
+    {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl<I> IngredientCache<I>
+    where
+        I: Ingredient,
+    {
+        const UNINITIALIZED: u32 = u32::MAX;
+
+        /// Create a new cache
+        pub const fn new() -> Self {
+            Self {
+                ingredient_index: atomic::AtomicU32::new(Self::UNINITIALIZED),
+                phantom: PhantomData,
+            }
+        }
+
+        /// Get a reference to the ingredient in the database.
+        ///
+        /// If the ingredient index is not already in the cache, it will be loaded and cached.
+        pub fn get_or_create<'db>(
+            &self,
+            zalsa: &'db Zalsa,
+            load_index: impl Fn() -> IngredientIndex,
+        ) -> &'db I {
+            let mut ingredient_index = self.ingredient_index.load(Ordering::Acquire);
+            if ingredient_index == Self::UNINITIALIZED {
+                ingredient_index = self.get_or_create_index_slow(load_index).as_u32();
+            };
+
+            zalsa
+                .lookup_ingredient(IngredientIndex::from_unchecked(ingredient_index))
+                .assert_type()
+        }
+
+        #[cold]
+        #[inline(never)]
+        fn get_or_create_index_slow(
+            &self,
+            load_index: impl Fn() -> IngredientIndex,
+        ) -> IngredientIndex {
+            let ingredient_index = load_index();
+
+            // It doesn't matter if we overwrite any stores, as `create_index` should
+            // always return the same index when the `inventory` feature is enabled.
+            self.ingredient_index
+                .store(ingredient_index.as_u32(), Ordering::Release);
+
+            ingredient_index
+        }
+    }
+}
 
 #[cfg(not(feature = "inventory"))]
-/// With manual registration, ingredient indices can vary across databases,
-/// so the `GlobalIngredientCache` optimization does not apply.
-pub use IngredientCache as GlobalIngredientCache;
+mod imp {
+    use crate::nonce::Nonce;
+    use crate::plumbing::Ingredient;
+    use crate::sync::atomic::{AtomicU64, Ordering};
+    use crate::zalsa::{StorageNonce, Zalsa};
+    use crate::IngredientIndex;
 
-/// Caches an ingredient index.
-///
-/// Unlike [`IngredientCache`], this is not restricted to a specific database.
-/// Note that all ingredients are statically registered with `inventory`, so their
-/// indices should be stable across any databases.
-///
-/// If ingredient initialization is database dependent, e.g. for registering
-/// view casters, [`IngredientCache`] should be used instead.
-#[cfg(feature = "inventory")]
-pub struct GlobalIngredientCache<I>
-where
-    I: Ingredient,
-{
-    ingredient_index: crate::sync::atomic::AtomicU32,
-    phantom: PhantomData<fn() -> I>,
-}
+    use std::marker::PhantomData;
+    use std::mem;
 
-#[cfg(feature = "inventory")]
-impl<I> Default for GlobalIngredientCache<I>
-where
-    I: Ingredient,
-{
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[cfg(feature = "inventory")]
-impl<I> GlobalIngredientCache<I>
-where
-    I: Ingredient,
-{
-    const UNINITIALIZED: u32 = u32::MAX;
-
-    /// Create a new cache
-    pub const fn new() -> Self {
-        Self {
-            ingredient_index: crate::sync::atomic::AtomicU32::new(Self::UNINITIALIZED),
-            phantom: PhantomData,
-        }
-    }
-
-    /// Get a reference to the ingredient in the database.
+    /// Caches an ingredient index.
     ///
-    /// If the ingredient index is not already in the cache, it will be loaded and cached.
-    #[inline(always)]
-    pub fn get_or_create<'db>(
-        &self,
-        zalsa: &'db Zalsa,
-        load_index: impl Fn() -> (IngredientIndex, &'db I),
-    ) -> &'db I {
-        const _: () = assert!(
-            mem::size_of::<(Nonce<StorageNonce>, IngredientIndex)>() == mem::size_of::<u64>()
-        );
-
-        let mut ingredient_index = self.ingredient_index.load(Ordering::Acquire);
-        if ingredient_index == Self::UNINITIALIZED {
-            ingredient_index = self.get_or_create_index_slow(load_index).as_u32();
-        };
-
-        zalsa
-            .lookup_ingredient(IngredientIndex::from_unchecked(ingredient_index))
-            .assert_type()
+    /// With manual registration, ingredient indices can vary across databases,
+    /// but we can retain most of the benefit by optimizing for the the case of
+    /// a single database.
+    pub struct IngredientCache<I>
+    where
+        I: Ingredient,
+    {
+        // A packed representation of `Option<(Nonce<StorageNonce>, IngredientIndex)>`.
+        //
+        // This allows us to replace a lock in favor of an atomic load. This works thanks to `Nonce`
+        // having a niche, which means the entire type can fit into an `AtomicU64`.
+        cached_data: AtomicU64,
+        phantom: PhantomData<fn() -> I>,
     }
 
-    #[cold]
-    #[inline(never)]
-    fn get_or_create_index_slow<'db>(
-        &self,
-        load_index: impl Fn() -> (IngredientIndex, &'db I),
-    ) -> IngredientIndex {
-        let (ingredient_index, _) = load_index();
-
-        // It doesn't matter if we overwrite any stores, as `create_index` should
-        // always return the same index when the `inventory` feature is enabled.
-        self.ingredient_index
-            .store(ingredient_index.as_u32(), Ordering::Release);
-
-        ingredient_index
-    }
-}
-
-/// Caches ingredient initialization in a specific database.
-///
-/// Optimized for the case of a single database.
-pub struct IngredientCache<I>
-where
-    I: Ingredient,
-{
-    // A packed representation of `Option<(Nonce<StorageNonce>, IngredientIndex)>`.
-    //
-    // This allows us to replace a lock in favor of an atomic load. This works thanks to `Nonce`
-    // having a niche, which means the entire type can fit into an `AtomicU64`.
-    cached_data: AtomicU64,
-    phantom: PhantomData<fn() -> I>,
-}
-
-impl<I> Default for IngredientCache<I>
-where
-    I: Ingredient,
-{
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<I> IngredientCache<I>
-where
-    I: Ingredient,
-{
-    const UNINITIALIZED: u64 = 0;
-
-    /// Create a new cache
-    pub const fn new() -> Self {
-        Self {
-            cached_data: AtomicU64::new(Self::UNINITIALIZED),
-            phantom: PhantomData,
+    impl<I> Default for IngredientCache<I>
+    where
+        I: Ingredient,
+    {
+        fn default() -> Self {
+            Self::new()
         }
     }
 
-    /// Get a reference to the ingredient in the database.
-    ///
-    /// If the ingredient is not already in the cache, it will be created.
-    #[inline(always)]
-    pub fn get_or_create<'db>(
-        &self,
-        zalsa: &'db Zalsa,
-        create_index: impl Fn() -> (IngredientIndex, &'db I),
-    ) -> &'db I {
-        const _: () = assert!(
-            mem::size_of::<(Nonce<StorageNonce>, IngredientIndex)>() == mem::size_of::<u64>()
-        );
+    impl<I> IngredientCache<I>
+    where
+        I: Ingredient,
+    {
+        const UNINITIALIZED: u64 = 0;
 
-        let cached_data = self.cached_data.load(Ordering::Acquire);
-        if cached_data == Self::UNINITIALIZED {
-            return self.get_or_create_index_slow(zalsa, create_index);
-        };
-
-        // Unpack our `u64` into the nonce and index.
-        let index = IngredientIndex::from_unchecked(cached_data as u32);
-
-        // SAFETY: We've checked against `UNINITIALIZED` (0) above and so the upper bits must be non-zero.
-        let nonce = Nonce::<StorageNonce>::from_u32(unsafe {
-            NonZeroU32::new_unchecked((cached_data >> u32::BITS) as u32)
-        });
-
-        // The data was cached for a different database, we have to ensure the ingredient was
-        // created in ours.
-        if zalsa.nonce() != nonce {
-            let (_, ingredient) = create_index();
-            return ingredient;
+        /// Create a new cache
+        pub const fn new() -> Self {
+            Self {
+                cached_data: AtomicU64::new(Self::UNINITIALIZED),
+                phantom: PhantomData,
+            }
         }
 
-        zalsa.lookup_ingredient(index).assert_type()
-    }
+        /// Get a reference to the ingredient in the database.
+        ///
+        /// If the ingredient is not already in the cache, it will be created.
+        #[inline(always)]
+        pub fn get_or_create<'db>(
+            &self,
+            zalsa: &'db Zalsa,
+            create_index: impl Fn() -> IngredientIndex,
+        ) -> &'db I {
+            let index = self.get_or_create_index(zalsa, create_index);
+            zalsa.lookup_ingredient(index).assert_type::<I>()
+        }
 
-    #[cold]
-    #[inline(never)]
-    fn get_or_create_index_slow<'db>(
-        &self,
-        zalsa: &'db Zalsa,
-        create_index: impl Fn() -> (IngredientIndex, &'db I),
-    ) -> &'db I {
-        let (index, ingredient) = create_index();
-        let nonce = zalsa.nonce().into_u32().get() as u64;
-        let packed = (nonce << u32::BITS) | (index.as_u32() as u64);
-        debug_assert_ne!(packed, IngredientCache::<I>::UNINITIALIZED);
+        pub fn get_or_create_index(
+            &self,
+            zalsa: &Zalsa,
+            create_index: impl Fn() -> IngredientIndex,
+        ) -> IngredientIndex {
+            const _: () = assert!(
+                mem::size_of::<(Nonce<StorageNonce>, IngredientIndex)>() == mem::size_of::<u64>()
+            );
 
-        // Discard the result, whether we won over the cache or not doesn't matter.
-        _ = self.cached_data.compare_exchange(
-            IngredientCache::<I>::UNINITIALIZED,
-            packed,
-            Ordering::Release,
-            Ordering::Relaxed,
-        );
+            let cached_data = self.cached_data.load(Ordering::Acquire);
+            if cached_data == Self::UNINITIALIZED {
+                return self.get_or_create_index_slow(zalsa, create_index);
+            };
 
-        // Use our locally computed index regardless of which one was cached.
-        ingredient
+            // Unpack our `u64` into the nonce and index.
+            let index = IngredientIndex::from_unchecked(cached_data as u32);
+
+            // SAFETY: We've checked against `UNINITIALIZED` (0) above and so the upper bits must be non-zero.
+            let nonce = crate::nonce::Nonce::<StorageNonce>::from_u32(unsafe {
+                std::num::NonZeroU32::new_unchecked((cached_data >> u32::BITS) as u32)
+            });
+
+            // The data was cached for a different database, we have to ensure the ingredient was
+            // created in ours.
+            if zalsa.nonce() != nonce {
+                return create_index();
+            }
+
+            index
+        }
+
+        #[cold]
+        #[inline(never)]
+        fn get_or_create_index_slow(
+            &self,
+            zalsa: &Zalsa,
+            create_index: impl Fn() -> IngredientIndex,
+        ) -> IngredientIndex {
+            let index = create_index();
+            let nonce = zalsa.nonce().into_u32().get() as u64;
+            let packed = (nonce << u32::BITS) | (index.as_u32() as u64);
+            debug_assert_ne!(packed, IngredientCache::<I>::UNINITIALIZED);
+
+            // Discard the result, whether we won over the cache or not doesn't matter.
+            _ = self.cached_data.compare_exchange(
+                IngredientCache::<I>::UNINITIALIZED,
+                packed,
+                Ordering::Release,
+                Ordering::Relaxed,
+            );
+
+            // Use our locally computed index regardless of which one was cached.
+            index
+        }
     }
 }

--- a/src/ingredient_cache.rs
+++ b/src/ingredient_cache.rs
@@ -26,7 +26,7 @@ pub struct GlobalIngredientCache<I>
 where
     I: Ingredient,
 {
-    ingredient_index: std::sync::atomic::AtomicU32,
+    ingredient_index: crate::sync::atomic::AtomicU32,
     phantom: PhantomData<fn() -> I>,
 }
 
@@ -50,7 +50,7 @@ where
     /// Create a new cache
     pub const fn new() -> Self {
         Self {
-            ingredient_index: std::sync::atomic::AtomicU32::new(Self::UNINITIALIZED),
+            ingredient_index: crate::sync::atomic::AtomicU32::new(Self::UNINITIALIZED),
             phantom: PhantomData,
         }
     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -56,9 +56,8 @@ impl<C: Configuration> Default for JarImpl<C> {
 
 impl<C: Configuration> Jar for JarImpl<C> {
     fn create_ingredients(
-        _zalsa: &Zalsa,
+        _zalsa: &mut Zalsa,
         struct_index: crate::zalsa::IngredientIndex,
-        _dependencies: crate::memo_ingredient_indices::IngredientIndices,
     ) -> Vec<Box<dyn Ingredient>> {
         let struct_ingredient: IngredientImpl<C> = IngredientImpl::new(struct_index);
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -116,7 +116,7 @@ impl<C: Configuration> IngredientImpl<C> {
                 fields,
                 revisions,
                 durabilities,
-                memos: Default::default(),
+                memos: MemoTable::new(self.memo_table_types()),
             })
         });
 
@@ -237,8 +237,12 @@ impl<C: Configuration> Ingredient for IngredientImpl<C> {
         C::DEBUG_NAME
     }
 
-    fn memo_table_types(&self) -> Arc<MemoTableTypes> {
-        self.memo_table_types.clone()
+    fn memo_table_types(&self) -> &Arc<MemoTableTypes> {
+        &self.memo_table_types
+    }
+
+    fn memo_table_types_mut(&mut self) -> &mut Arc<MemoTableTypes> {
+        &mut self.memo_table_types
     }
 
     /// Returns memory usage information about any inputs.

--- a/src/input/input_field.rs
+++ b/src/input/input_field.rs
@@ -76,7 +76,11 @@ where
         C::FIELD_DEBUG_NAMES[self.field_index]
     }
 
-    fn memo_table_types(&self) -> Arc<MemoTableTypes> {
+    fn memo_table_types(&self) -> &Arc<MemoTableTypes> {
+        unreachable!("input fields do not allocate pages")
+    }
+
+    fn memo_table_types_mut(&mut self) -> &mut Arc<MemoTableTypes> {
         unreachable!("input fields do not allocate pages")
     }
 }

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -15,7 +15,7 @@ use crate::durability::Durability;
 use crate::function::VerifyResult;
 use crate::id::{AsId, FromId};
 use crate::ingredient::Ingredient;
-use crate::plumbing::{IngredientIndices, Jar, ZalsaLocal};
+use crate::plumbing::{Jar, ZalsaLocal};
 use crate::revision::AtomicRevision;
 use crate::sync::{Arc, Mutex, OnceLock};
 use crate::table::memo::{MemoTable, MemoTableTypes, MemoTableWithTypesMut};
@@ -224,9 +224,8 @@ impl<C: Configuration> Default for JarImpl<C> {
 
 impl<C: Configuration> Jar for JarImpl<C> {
     fn create_ingredients(
-        _zalsa: &Zalsa,
+        _zalsa: &mut Zalsa,
         first_index: IngredientIndex,
-        _dependencies: IngredientIndices,
     ) -> Vec<Box<dyn Ingredient>> {
         vec![Box::new(IngredientImpl::<C>::new(first_index)) as _]
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,10 +102,13 @@ pub mod plumbing {
     pub use crate::tracked_struct::TrackedStructInDb;
     pub use crate::update::helper::{Dispatch as UpdateDispatch, Fallback as UpdateFallback};
     pub use crate::update::{always_update, Update};
+    pub use crate::views::DatabaseDownCaster;
     pub use crate::zalsa::{
-        transmute_data_ptr, views, IngredientCache, IngredientIndex, Zalsa, ZalsaDatabase,
+        transmute_data_ptr, views, ErasedJar, ErasedJarKind, IngredientCache, IngredientIndex,
+        Zalsa, ZalsaDatabase,
     };
     pub use crate::zalsa_local::ZalsaLocal;
+    pub use inventory::submit;
 
     pub mod accumulator {
         pub use crate::accumulator::{IngredientImpl, JarImpl};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod function;
 mod hash;
 mod id;
 mod ingredient;
+mod ingredient_cache;
 mod input;
 mod interned;
 mod key;
@@ -90,6 +91,7 @@ pub mod plumbing {
     pub use crate::durability::Durability;
     pub use crate::id::{AsId, FromId, FromIdWithDb, Id};
     pub use crate::ingredient::{Ingredient, Jar, Location};
+    pub use crate::ingredient_cache::{GlobalIngredientCache, IngredientCache};
     pub use crate::key::DatabaseKeyIndex;
     pub use crate::memo_ingredient_indices::{
         IngredientIndices, MemoIngredientIndices, MemoIngredientMap, MemoIngredientSingletonIndex,
@@ -104,11 +106,10 @@ pub mod plumbing {
     pub use crate::update::{always_update, Update};
     pub use crate::views::DatabaseDownCaster;
     pub use crate::zalsa::{
-        transmute_data_ptr, views, ErasedJar, ErasedJarKind, GlobalIngredientCache,
-        IngredientCache, IngredientIndex, Zalsa, ZalsaDatabase,
+        register_jar, transmute_data_ptr, views, ErasedJar, HasJar, IngredientIndex, JarKind,
+        Zalsa, ZalsaDatabase,
     };
     pub use crate::zalsa_local::ZalsaLocal;
-    pub use inventory::submit;
 
     pub mod accumulator {
         pub use crate::accumulator::{IngredientImpl, JarImpl};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,6 @@ mod input;
 mod interned;
 mod key;
 mod memo_ingredient_indices;
-mod nonce;
-#[cfg(feature = "rayon")]
-mod parallel;
 mod return_mode;
 mod revision;
 mod runtime;
@@ -34,6 +31,12 @@ mod update;
 mod views;
 mod zalsa;
 mod zalsa_local;
+
+#[cfg(not(feature = "inventory"))]
+mod nonce;
+
+#[cfg(feature = "rayon")]
+mod parallel;
 
 #[cfg(feature = "rayon")]
 pub use parallel::{join, par_map};
@@ -91,7 +94,7 @@ pub mod plumbing {
     pub use crate::durability::Durability;
     pub use crate::id::{AsId, FromId, FromIdWithDb, Id};
     pub use crate::ingredient::{Ingredient, Jar, Location};
-    pub use crate::ingredient_cache::{GlobalIngredientCache, IngredientCache};
+    pub use crate::ingredient_cache::IngredientCache;
     pub use crate::key::DatabaseKeyIndex;
     pub use crate::memo_ingredient_indices::{
         IngredientIndices, MemoIngredientIndices, MemoIngredientMap, MemoIngredientSingletonIndex,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,8 +104,8 @@ pub mod plumbing {
     pub use crate::update::{always_update, Update};
     pub use crate::views::DatabaseDownCaster;
     pub use crate::zalsa::{
-        transmute_data_ptr, views, ErasedJar, ErasedJarKind, IngredientCache, IngredientIndex,
-        Zalsa, ZalsaDatabase,
+        transmute_data_ptr, views, ErasedJar, ErasedJarKind, GlobalIngredientCache,
+        IngredientCache, IngredientIndex, Zalsa, ZalsaDatabase,
     };
     pub use crate::zalsa_local::ZalsaLocal;
     pub use inventory::submit;

--- a/src/memo_ingredient_indices.rs
+++ b/src/memo_ingredient_indices.rs
@@ -49,7 +49,7 @@ pub trait NewMemoIngredientIndices {
     ///
     /// The memo types must be correct.
     unsafe fn create(
-        zalsa: &Zalsa,
+        zalsa: &mut Zalsa,
         struct_indices: IngredientIndices,
         ingredient: IngredientIndex,
         memo_type: MemoEntryType,
@@ -62,7 +62,7 @@ impl NewMemoIngredientIndices for MemoIngredientIndices {
     ///
     /// The memo types must be correct.
     unsafe fn create(
-        zalsa: &Zalsa,
+        zalsa: &mut Zalsa,
         struct_indices: IngredientIndices,
         ingredient: IngredientIndex,
         memo_type: MemoEntryType,
@@ -146,7 +146,7 @@ impl MemoIngredientMap for MemoIngredientSingletonIndex {
 impl NewMemoIngredientIndices for MemoIngredientSingletonIndex {
     #[inline]
     unsafe fn create(
-        zalsa: &Zalsa,
+        zalsa: &mut Zalsa,
         indices: IngredientIndices,
         ingredient: IngredientIndex,
         memo_type: MemoEntryType,

--- a/src/salsa_struct.rs
+++ b/src/salsa_struct.rs
@@ -16,7 +16,7 @@ pub trait SalsaStructInDb: Sized {
     /// While implementors of this trait may call [`crate::zalsa::JarEntry::get_or_create`]
     /// to create the ingredient, they aren't required to. For example, supertypes recursively
     /// call [`crate::zalsa::JarEntry::get_or_create`] for their variants and combine them.
-    fn lookup_or_create_ingredient_index(zalsa: &Zalsa) -> IngredientIndices;
+    fn lookup_ingredient_index(zalsa: &Zalsa) -> IngredientIndices;
 
     /// Plumbing to support nested salsa supertypes.
     ///

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -23,24 +23,6 @@ pub mod shim {
         }
     }
 
-    /// A wrapper around shuttle's `RwLock` to mirror parking-lot's API.
-    #[derive(Default, Debug)]
-    pub struct RwLock<T>(shuttle::sync::RwLock<T>);
-
-    impl<T> RwLock<T> {
-        pub fn read(&self) -> RwLockReadGuard<'_, T> {
-            self.0.read().unwrap()
-        }
-
-        pub fn write(&self) -> RwLockWriteGuard<'_, T> {
-            self.0.write().unwrap()
-        }
-
-        pub fn get_mut(&mut self) -> &mut T {
-            self.0.get_mut().unwrap()
-        }
-    }
-
     /// A wrapper around shuttle's `Condvar` to mirror parking-lot's API.
     #[derive(Default, Debug)]
     pub struct Condvar(shuttle::sync::Condvar);
@@ -130,7 +112,7 @@ pub mod shim {
 
 #[cfg(not(feature = "shuttle"))]
 pub mod shim {
-    pub use parking_lot::{Mutex, MutexGuard, RwLock};
+    pub use parking_lot::{Mutex, MutexGuard};
     pub use std::sync::*;
     pub use std::{thread, thread_local};
 

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -3,19 +3,32 @@ use std::fmt::Debug;
 use std::mem;
 use std::ptr::{self, NonNull};
 
-use portable_atomic::hint::spin_loop;
-use thin_vec::ThinVec;
-
 use crate::sync::atomic::{AtomicPtr, Ordering};
-use crate::sync::{OnceLock, RwLock};
 use crate::{zalsa::MemoIngredientIndex, zalsa_local::QueryOriginRef};
 
 /// The "memo table" stores the memoized results of tracked function calls.
 /// Every tracked function must take a salsa struct as its first argument
 /// and memo tables are attached to those salsa structs as auxiliary data.
-#[derive(Default)]
 pub(crate) struct MemoTable {
-    memos: RwLock<ThinVec<MemoEntry>>,
+    memos: Box<[MemoEntry]>,
+}
+
+impl MemoTable {
+    /// Create a `MemoTable` with slots for memos from the provided `MemoTableTypes`.  
+    pub fn new(types: &MemoTableTypes) -> Self {
+        Self {
+            memos: (0..types.len()).map(|_| MemoEntry::default()).collect(),
+        }
+    }
+
+    /// Reset any memos in the table.
+    ///
+    /// Note that the memo entries should be freed manually before calling this function.
+    pub fn reset(&mut self) {
+        for memo in &mut self.memos {
+            *memo = MemoEntry::default();
+        }
+    }
 }
 
 pub trait Memo: Any + Send + Sync {
@@ -50,13 +63,8 @@ struct MemoEntry {
     atomic_memo: AtomicPtr<DummyMemo>,
 }
 
-#[derive(Default)]
-pub struct MemoEntryType {
-    data: OnceLock<MemoEntryTypeData>,
-}
-
 #[derive(Clone, Copy, Debug)]
-struct MemoEntryTypeData {
+pub struct MemoEntryType {
     /// The `type_id` of the erased memo type `M`
     type_id: TypeId,
 
@@ -89,16 +97,9 @@ impl MemoEntryType {
     #[inline]
     pub fn of<M: Memo>() -> Self {
         Self {
-            data: OnceLock::from(MemoEntryTypeData {
-                type_id: TypeId::of::<M>(),
-                to_dyn_fn: Self::to_dyn_fn::<M>(),
-            }),
+            type_id: TypeId::of::<M>(),
+            to_dyn_fn: Self::to_dyn_fn::<M>(),
         }
-    }
-
-    #[inline]
-    fn load(&self) -> Option<&MemoEntryTypeData> {
-        self.data.get()
     }
 }
 
@@ -127,43 +128,21 @@ impl Memo for DummyMemo {
 
 #[derive(Default)]
 pub struct MemoTableTypes {
-    types: boxcar::Vec<MemoEntryType>,
+    types: Vec<MemoEntryType>,
 }
 
 impl MemoTableTypes {
     pub(crate) fn set(
-        &self,
+        &mut self,
         memo_ingredient_index: MemoIngredientIndex,
-        memo_type: &MemoEntryType,
+        memo_type: MemoEntryType,
     ) {
-        let memo_ingredient_index = memo_ingredient_index.as_usize();
+        self.types
+            .insert(memo_ingredient_index.as_usize(), memo_type);
+    }
 
-        // Try to create our entry if it has not already been created.
-        if memo_ingredient_index >= self.types.count() {
-            while self.types.push(MemoEntryType::default()) < memo_ingredient_index {}
-        }
-
-        loop {
-            let Some(memo_entry_type) = self.types.get(memo_ingredient_index) else {
-                // It's possible that someone else began pushing to our index but has not
-                // completed the entry's initialization yet, as `boxcar` is lock-free. This
-                // is extremely unlikely given initialization is just a handful of instructions.
-                // Additionally, this function is generally only called on startup, so we can
-                // just spin here.
-                spin_loop();
-                continue;
-            };
-
-            memo_entry_type
-                .data
-                .set(
-                    *memo_type.data.get().expect(
-                        "cannot provide an empty `MemoEntryType` for `MemoEntryType::set()`",
-                    ),
-                )
-                .expect("memo type should only be set once");
-            break;
-        }
+    pub fn len(&self) -> usize {
+        self.types.len()
     }
 
     /// # Safety
@@ -204,59 +183,25 @@ impl MemoTableWithTypes<'_> {
         assert_eq!(
             self.types
                 .types
-                .get(memo_ingredient_index.as_usize())
-                .and_then(MemoEntryType::load)?
+                .get(memo_ingredient_index.as_usize())?
                 .type_id,
             TypeId::of::<M>(),
             "inconsistent type-id for `{memo_ingredient_index:?}`"
         );
 
-        // If the memo slot is already occupied, it must already have the
-        // right type info etc, and we only need the read-lock.
-        if let Some(MemoEntry { atomic_memo }) = self
+        // The memo table is pre-sized on creation based on the corresponding `MemoTableTypes`.
+        let MemoEntry { atomic_memo } = self
             .memos
             .memos
-            .read()
             .get(memo_ingredient_index.as_usize())
-        {
-            let old_memo =
-                atomic_memo.swap(MemoEntryType::to_dummy(memo).as_ptr(), Ordering::AcqRel);
+            .expect("accessed memo table with invalid index");
 
-            let old_memo = NonNull::new(old_memo);
+        let old_memo = atomic_memo.swap(MemoEntryType::to_dummy(memo).as_ptr(), Ordering::AcqRel);
 
-            // SAFETY: `type_id` check asserted above
-            return old_memo.map(|old_memo| unsafe { MemoEntryType::from_dummy(old_memo) });
-        }
+        let old_memo = NonNull::new(old_memo);
 
-        // Otherwise we need the write lock.
-        self.insert_cold(memo_ingredient_index, memo)
-    }
-
-    #[cold]
-    fn insert_cold<M: Memo>(
-        self,
-        memo_ingredient_index: MemoIngredientIndex,
-        memo: NonNull<M>,
-    ) -> Option<NonNull<M>> {
-        let memo_ingredient_index = memo_ingredient_index.as_usize();
-        let mut memos = self.memos.memos.write();
-
-        // Grow the table if needed.
-        if memos.len() <= memo_ingredient_index {
-            let additional_len = memo_ingredient_index - memos.len() + 1;
-            memos.reserve(additional_len);
-            while memos.len() <= memo_ingredient_index {
-                memos.push(MemoEntry::default());
-            }
-        }
-
-        let old_entry = mem::replace(
-            memos[memo_ingredient_index].atomic_memo.get_mut(),
-            MemoEntryType::to_dummy(memo).as_ptr(),
-        );
-
-        // SAFETY: The `TypeId` is asserted in `insert()`.
-        NonNull::new(old_entry).map(|memo| unsafe { MemoEntryType::from_dummy(memo) })
+        // SAFETY: `type_id` check asserted above
+        old_memo.map(|old_memo| unsafe { MemoEntryType::from_dummy(old_memo) })
     }
 
     #[inline]
@@ -264,13 +209,8 @@ impl MemoTableWithTypes<'_> {
         self,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> Option<NonNull<M>> {
-        let read = self.memos.memos.read();
-        let memo = read.get(memo_ingredient_index.as_usize())?;
-        let type_ = self
-            .types
-            .types
-            .get(memo_ingredient_index.as_usize())
-            .and_then(MemoEntryType::load)?;
+        let memo = self.memos.memos.get(memo_ingredient_index.as_usize())?;
+        let type_ = self.types.types.get(memo_ingredient_index.as_usize())?;
         assert_eq!(
             type_.type_id,
             TypeId::of::<M>(),
@@ -284,13 +224,12 @@ impl MemoTableWithTypes<'_> {
     #[cfg(feature = "salsa_unstable")]
     pub(crate) fn memory_usage(&self) -> Vec<crate::database::MemoInfo> {
         let mut memory_usage = Vec::new();
-        let memos = self.memos.memos.read();
-        for (index, memo) in memos.iter().enumerate() {
+        for (index, memo) in self.memos.memos.iter().enumerate() {
             let Some(memo) = NonNull::new(memo.atomic_memo.load(Ordering::Acquire)) else {
                 continue;
             };
 
-            let Some(type_) = self.types.types.get(index).and_then(MemoEntryType::load) else {
+            let Some(type_) = self.types.types.get(index) else {
                 continue;
             };
 
@@ -317,12 +256,7 @@ impl MemoTableWithTypesMut<'_> {
         memo_ingredient_index: MemoIngredientIndex,
         f: impl FnOnce(&mut M),
     ) {
-        let Some(type_) = self
-            .types
-            .types
-            .get(memo_ingredient_index.as_usize())
-            .and_then(MemoEntryType::load)
-        else {
+        let Some(type_) = self.types.types.get(memo_ingredient_index.as_usize()) else {
             return;
         };
         assert_eq!(
@@ -331,13 +265,13 @@ impl MemoTableWithTypesMut<'_> {
             "inconsistent type-id for `{memo_ingredient_index:?}`"
         );
 
-        // If the memo slot is already occupied, it must already have the
-        // right type info etc, and we only need the read-lock.
-        let memos = self.memos.memos.get_mut();
-        let Some(MemoEntry { atomic_memo }) = memos.get_mut(memo_ingredient_index.as_usize())
+        // The memo table is pre-sized on creation based on the corresponding `MemoTableTypes`.
+        let Some(MemoEntry { atomic_memo }) =
+            self.memos.memos.get_mut(memo_ingredient_index.as_usize())
         else {
             return;
         };
+
         let Some(memo) = NonNull::new(*atomic_memo.get_mut()) else {
             return;
         };
@@ -357,7 +291,7 @@ impl MemoTableWithTypesMut<'_> {
     #[inline]
     pub unsafe fn drop(&mut self) {
         let types = self.types.types.iter();
-        for ((_, type_), memo) in std::iter::zip(types, self.memos.memos.get_mut()) {
+        for (type_, memo) in std::iter::zip(types, &mut self.memos.memos) {
             // SAFETY: The types match as per our constructor invariant.
             unsafe { memo.take(type_) };
         }
@@ -371,12 +305,12 @@ impl MemoTableWithTypesMut<'_> {
         &mut self,
         mut f: impl FnMut(MemoIngredientIndex, Box<dyn Memo>),
     ) {
-        let memos = self.memos.memos.get_mut();
-        memos
+        self.memos
+            .memos
             .iter_mut()
             .zip(self.types.types.iter())
             .enumerate()
-            .filter_map(|(index, (memo, (_, type_)))| {
+            .filter_map(|(index, (memo, type_))| {
                 // SAFETY: The types match as per our constructor invariant.
                 let memo = unsafe { memo.take(type_)? };
                 Some((MemoIngredientIndex::from_usize(index), memo))
@@ -393,7 +327,6 @@ impl MemoEntry {
     unsafe fn take(&mut self, type_: &MemoEntryType) -> Option<Box<dyn Memo>> {
         let memo = mem::replace(self.atomic_memo.get_mut(), ptr::null_mut());
         let memo = NonNull::new(memo)?;
-        let type_ = type_.load()?;
         // SAFETY: Our preconditions.
         Some(unsafe { Box::from_raw((type_.to_dyn_fn)(memo).as_ptr()) })
     }

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -110,9 +110,8 @@ impl<C: Configuration> Default for JarImpl<C> {
 
 impl<C: Configuration> Jar for JarImpl<C> {
     fn create_ingredients(
-        _zalsa: &Zalsa,
+        _zalsa: &mut Zalsa,
         struct_index: crate::zalsa::IngredientIndex,
-        _dependencies: crate::memo_ingredient_indices::IngredientIndices,
     ) -> Vec<Box<dyn Ingredient>> {
         let struct_ingredient = <IngredientImpl<C>>::new(struct_index);
 

--- a/src/tracked_struct/tracked_field.rs
+++ b/src/tracked_struct/tracked_field.rs
@@ -82,7 +82,11 @@ where
         C::TRACKED_FIELD_NAMES[self.field_index]
     }
 
-    fn memo_table_types(&self) -> Arc<MemoTableTypes> {
+    fn memo_table_types(&self) -> &Arc<MemoTableTypes> {
+        unreachable!("tracked field does not allocate pages")
+    }
+
+    fn memo_table_types_mut(&mut self) -> &mut Arc<MemoTableTypes> {
         unreachable!("tracked field does not allocate pages")
     }
 }

--- a/src/views.rs
+++ b/src/views.rs
@@ -80,16 +80,16 @@ impl Views {
     }
 
     /// Add a new downcaster from `dyn Database` to `dyn DbView`.
-    pub fn add<DbView: ?Sized + Any>(&self, func: DatabaseDownCasterSig<DbView>) {
-        let target_type_id = TypeId::of::<DbView>();
-        if self
-            .view_casters
-            .iter()
-            .any(|(_, u)| u.target_type_id == target_type_id)
-        {
-            return;
+    pub fn add<DbView: ?Sized + Any>(
+        &self,
+        func: DatabaseDownCasterSig<DbView>,
+    ) -> DatabaseDownCaster<DbView> {
+        if let Some(view) = self.try_downcaster_for() {
+            return view;
         }
+
         self.view_casters.push(ViewCaster::new::<DbView>(func));
+        DatabaseDownCaster(self.source_type_id, func)
     }
 
     /// Retrieve an downcaster function from `dyn Database` to `dyn DbView`.
@@ -98,23 +98,31 @@ impl Views {
     ///
     /// If the underlying type of `db` is not the same as the database type this upcasts was created for.
     pub fn downcaster_for<DbView: ?Sized + Any>(&self) -> DatabaseDownCaster<DbView> {
+        self.try_downcaster_for().unwrap_or_else(|| {
+            panic!(
+                "No downcaster registered for type `{}` in `Views`",
+                std::any::type_name::<DbView>(),
+            )
+        })
+    }
+
+    /// Retrieve an downcaster function from `dyn Database` to `dyn DbView`, if it exists.
+    #[inline]
+    pub fn try_downcaster_for<DbView: ?Sized + Any>(&self) -> Option<DatabaseDownCaster<DbView>> {
         let view_type_id = TypeId::of::<DbView>();
-        for (_idx, view) in self.view_casters.iter() {
+        for (_, view) in self.view_casters.iter() {
             if view.target_type_id == view_type_id {
                 // SAFETY: We are unerasing the type erased function pointer having made sure the
-                // TypeId matches.
-                return DatabaseDownCaster(self.source_type_id, unsafe {
+                // `TypeId` matches.
+                return Some(DatabaseDownCaster(self.source_type_id, unsafe {
                     std::mem::transmute::<ErasedDatabaseDownCasterSig, DatabaseDownCasterSig<DbView>>(
                         view.cast,
                     )
-                });
+                }));
             }
         }
 
-        panic!(
-            "No downcaster registered for type `{}` in `Views`",
-            std::any::type_name::<DbView>(),
-        );
+        None
     }
 }
 

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -5,6 +5,7 @@ use std::mem;
 use std::num::NonZeroU32;
 use std::panic::RefUnwindSafe;
 
+use hashbrown::HashMap;
 use rustc_hash::FxHashMap;
 
 use crate::hash::TypeIdHasher;
@@ -12,7 +13,6 @@ use crate::ingredient::{Ingredient, Jar};
 use crate::nonce::{Nonce, NonceGenerator};
 use crate::runtime::Runtime;
 use crate::sync::atomic::{AtomicU64, Ordering};
-use crate::sync::{papaya, Mutex, RwLock};
 use crate::table::memo::MemoTableWithTypes;
 use crate::table::Table;
 use crate::views::Views;
@@ -62,7 +62,6 @@ pub unsafe trait ZalsaDatabase: Any {
 pub fn views<Db: ?Sized + Database>(db: &Db) -> &Views {
     db.zalsa().views()
 }
-
 /// Nonce type representing the underlying database storage.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct StorageNonce;
@@ -139,23 +138,20 @@ pub struct Zalsa {
     /// Map from the [`IngredientIndex::as_usize`][] of a salsa struct to a list of
     /// [ingredient-indices](`IngredientIndex`) for tracked functions that have this salsa struct
     /// as input.
-    memo_ingredient_indices: RwLock<Vec<Vec<IngredientIndex>>>,
+    memo_ingredient_indices: Vec<Vec<IngredientIndex>>,
 
     /// Map from the type-id of an `impl Jar` to the index of its first ingredient.
-    jar_map: papaya::HashMap<TypeId, IngredientIndex, BuildHasherDefault<TypeIdHasher>>,
-
-    /// The write-lock for `jar_map`.
-    jar_map_lock: Mutex<()>,
+    jar_map: HashMap<TypeId, IngredientIndex, BuildHasherDefault<TypeIdHasher>>,
 
     /// A map from the `IngredientIndex` to the `TypeId` of its ID struct.
     ///
     /// Notably this is not the reverse mapping of `jar_map`.
-    ingredient_to_id_struct_type_id_map: RwLock<FxHashMap<IngredientIndex, TypeId>>,
+    ingredient_to_id_struct_type_id_map: FxHashMap<IngredientIndex, TypeId>,
 
     /// Vector of ingredients.
     ///
     /// Immutable unless the mutex on `ingredients_map` is held.
-    ingredients_vec: boxcar::Vec<Box<dyn Ingredient>>,
+    ingredients_vec: Vec<Box<dyn Ingredient>>,
 
     /// Indices of ingredients that require reset when a new revision starts.
     ingredients_requiring_reset: boxcar::Vec<IngredientIndex>,
@@ -178,18 +174,29 @@ impl Zalsa {
     pub(crate) fn new<Db: Database>(
         event_callback: Option<Box<dyn Fn(crate::Event) + Send + Sync + 'static>>,
     ) -> Self {
-        Self {
+        let mut zalsa = Self {
             views_of: Views::new::<Db>(),
             nonce: NONCE.nonce(),
-            jar_map: papaya::HashMap::default(),
-            jar_map_lock: Mutex::default(),
+            jar_map: HashMap::default(),
             ingredient_to_id_struct_type_id_map: Default::default(),
-            ingredients_vec: boxcar::Vec::new(),
+            ingredients_vec: Vec::new(),
             ingredients_requiring_reset: boxcar::Vec::new(),
             runtime: Runtime::default(),
             memo_ingredient_indices: Default::default(),
             event_callback,
+        };
+
+        // Collect and initialize all registered ingredients.
+        let mut jars = inventory::iter::<ErasedJar>().collect::<Vec<_>>();
+
+        // Ensure structs are initialized before tracked functions.
+        jars.sort_by_key(|jar| jar.kind);
+
+        for jar in jars {
+            zalsa.insert_jar(jar);
         }
+
+        zalsa
     }
 
     pub(crate) fn nonce(&self) -> Nonce<StorageNonce> {
@@ -218,7 +225,7 @@ impl Zalsa {
     }
 
     #[inline]
-    pub(crate) fn lookup_ingredient(&self, index: IngredientIndex) -> &dyn Ingredient {
+    pub fn lookup_ingredient(&self, index: IngredientIndex) -> &dyn Ingredient {
         let index = index.as_u32() as usize;
         self.ingredients_vec
             .get(index)
@@ -231,7 +238,7 @@ impl Zalsa {
         struct_ingredient_index: IngredientIndex,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> IngredientIndex {
-        self.memo_ingredient_indices.read()[struct_ingredient_index.as_u32() as usize]
+        self.memo_ingredient_indices[struct_ingredient_index.as_u32() as usize]
             [memo_ingredient_index.as_usize()]
     }
 
@@ -239,7 +246,7 @@ impl Zalsa {
     pub(crate) fn ingredients(&self) -> impl Iterator<Item = &dyn Ingredient> {
         self.ingredients_vec
             .iter()
-            .map(|(_, ingredient)| ingredient.as_ref())
+            .map(|ingredient| ingredient.as_ref())
     }
 
     /// Starts unwinding the stack if the current revision is cancelled.
@@ -259,11 +266,11 @@ impl Zalsa {
     }
 
     pub(crate) fn next_memo_ingredient_index(
-        &self,
+        &mut self,
         struct_ingredient_index: IngredientIndex,
         ingredient_index: IngredientIndex,
     ) -> MemoIngredientIndex {
-        let mut memo_ingredients = self.memo_ingredient_indices.write();
+        let memo_ingredients = &mut self.memo_ingredient_indices;
         let idx = struct_ingredient_index.as_u32() as usize;
         let memo_ingredients = if let Some(memo_ingredients) = memo_ingredients.get_mut(idx) {
             memo_ingredients
@@ -278,6 +285,43 @@ impl Zalsa {
     }
 }
 
+/// A type-erased `Jar`.
+pub struct ErasedJar {
+    kind: ErasedJarKind,
+    type_id: fn() -> TypeId,
+    id_struct_type_id: fn() -> TypeId,
+    create_ingredients: fn(&mut Zalsa, IngredientIndex) -> Vec<Box<dyn Ingredient>>,
+}
+
+/// The kind of an `ErasedJar`.
+///
+/// Note that the ordering of the variants is important. Struct ingredients must be
+/// initialized before tracked functions, as tracked function ingredients depend on
+/// their input struct.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
+pub enum ErasedJarKind {
+    /// An input/tracked/interned struct.
+    Struct,
+
+    /// A tracked function.
+    TrackedFn,
+}
+
+impl ErasedJar {
+    /// Performs type-erasure of a given jar.
+    pub const fn erase<J: Jar>(kind: ErasedJarKind) -> Self {
+        Self {
+            kind,
+            type_id: TypeId::of::<J>,
+            create_ingredients: J::create_ingredients,
+            id_struct_type_id: J::id_struct_type_id,
+        }
+    }
+}
+
+// Jars are collected at compile-time to ensure all ingredients are registered statically.
+inventory::collect!(ErasedJar);
+
 /// Semver unstable APIs used by the macro expansions
 impl Zalsa {
     /// **NOT SEMVER STABLE**
@@ -291,7 +335,6 @@ impl Zalsa {
         let ingredient_index = self.ingredient_index(id);
         *self
             .ingredient_to_id_struct_type_id_map
-            .read()
             .get(&ingredient_index)
             .expect("should have the ingredient index available")
     }
@@ -299,44 +342,36 @@ impl Zalsa {
     /// **NOT SEMVER STABLE**
     #[doc(hidden)]
     #[inline]
-    pub fn lookup_jar_by_type<J: Jar>(&self) -> JarEntry<'_, J> {
+    pub fn lookup_jar_by_type<J: Jar>(&self) -> IngredientIndex {
         let jar_type_id = TypeId::of::<J>();
-        let guard = self.jar_map.guard();
 
-        match self.jar_map.get(&jar_type_id, &guard) {
-            Some(index) => JarEntry::Occupied(index),
-            None => JarEntry::Vacant {
-                guard,
-                zalsa: self,
-                _jar: PhantomData,
-            },
-        }
+        *self.jar_map.get(&jar_type_id).unwrap_or_else(|| {
+            panic!(
+                "ingredient `{}` was not registered",
+                std::any::type_name::<J>()
+            )
+        })
     }
 
-    #[cold]
-    #[inline(never)]
-    fn add_or_lookup_jar_by_type<J: Jar>(&self, guard: &papaya::LocalGuard<'_>) -> IngredientIndex {
-        let jar_type_id = TypeId::of::<J>();
-        let dependencies = J::create_dependencies(self);
+    fn insert_jar(&mut self, jar: &ErasedJar) {
+        let jar_type_id = (jar.type_id)();
 
-        let jar_map_lock = self.jar_map_lock.lock();
+        let index = IngredientIndex::from(self.ingredients_vec.len());
 
-        let index = IngredientIndex::from(self.ingredients_vec.count());
+        if self.jar_map.contains_key(&jar_type_id) {
+            return;
+        }
 
-        // Someone made it earlier than us.
-        if let Some(index) = self.jar_map.get(&jar_type_id, guard) {
-            return index;
-        };
-
-        let ingredients = J::create_ingredients(self, index, dependencies);
+        let ingredients = (jar.create_ingredients)(self, index);
         for ingredient in ingredients {
             let expected_index = ingredient.ingredient_index();
-
             if ingredient.requires_reset_for_new_revision() {
                 self.ingredients_requiring_reset.push(expected_index);
             }
 
-            let actual_index = self.ingredients_vec.push(ingredient);
+            self.ingredients_vec.push(ingredient);
+
+            let actual_index = self.ingredients_vec.len() - 1;
             assert_eq!(
                 expected_index.as_u32() as usize,
                 actual_index,
@@ -347,17 +382,10 @@ impl Zalsa {
             );
         }
 
-        // Insert the index after all ingredients are inserted to avoid exposing
-        // partially initialized jars to readers.
-        self.jar_map.insert(jar_type_id, index, guard);
-
-        drop(jar_map_lock);
+        self.jar_map.insert(jar_type_id, index);
 
         self.ingredient_to_id_struct_type_id_map
-            .write()
-            .insert(index, J::id_struct_type_id());
-
-        index
+            .insert(index, (jar.id_struct_type_id)());
     }
 
     /// **NOT SEMVER STABLE**
@@ -434,36 +462,6 @@ impl Zalsa {
     }
 }
 
-pub enum JarEntry<'a, J> {
-    Occupied(IngredientIndex),
-    Vacant {
-        zalsa: &'a Zalsa,
-        guard: papaya::LocalGuard<'a>,
-        _jar: PhantomData<J>,
-    },
-}
-
-impl<J> JarEntry<'_, J>
-where
-    J: Jar,
-{
-    #[inline]
-    pub fn get(&self) -> Option<IngredientIndex> {
-        match *self {
-            JarEntry::Occupied(index) => Some(index),
-            JarEntry::Vacant { .. } => None,
-        }
-    }
-
-    #[inline]
-    pub fn get_or_create(&self) -> IngredientIndex {
-        match self {
-            JarEntry::Occupied(index) => *index,
-            JarEntry::Vacant { zalsa, guard, _jar } => zalsa.add_or_lookup_jar_by_type::<J>(guard),
-        }
-    }
-}
-
 /// Caches a pointer to an ingredient in a database.
 /// Optimized for the case of a single database.
 pub struct IngredientCache<I>
@@ -502,68 +500,63 @@ where
     }
 
     /// Get a reference to the ingredient in the database.
+    ///
     /// If the ingredient is not already in the cache, it will be created.
     #[inline(always)]
     pub fn get_or_create<'db>(
         &self,
         zalsa: &'db Zalsa,
-        create_index: impl Fn() -> IngredientIndex,
+        create_index: impl Fn() -> (IngredientIndex, &'db I),
     ) -> &'db I {
-        let index = self.get_or_create_index(zalsa, create_index);
-        zalsa.lookup_ingredient(index).assert_type::<I>()
-    }
-
-    /// Get a reference to the ingredient in the database.
-    /// If the ingredient is not already in the cache, it will be created.
-    #[inline(always)]
-    pub fn get_or_create_index(
-        &self,
-        zalsa: &Zalsa,
-        create_index: impl Fn() -> IngredientIndex,
-    ) -> IngredientIndex {
         const _: () = assert!(
             mem::size_of::<(Nonce<StorageNonce>, IngredientIndex)>() == mem::size_of::<u64>()
         );
+
         let cached_data = self.cached_data.load(Ordering::Acquire);
         if cached_data == Self::UNINITIALIZED {
-            #[cold]
-            #[inline(never)]
-            fn get_or_create_index_slow<I: Ingredient>(
-                this: &IngredientCache<I>,
-                zalsa: &Zalsa,
-                create_index: impl Fn() -> IngredientIndex,
-            ) -> IngredientIndex {
-                let index = create_index();
-                let nonce = zalsa.nonce().into_u32().get() as u64;
-                let packed = (nonce << u32::BITS) | (index.as_u32() as u64);
-                debug_assert_ne!(packed, IngredientCache::<I>::UNINITIALIZED);
-
-                // Discard the result, whether we won over the cache or not does not matter
-                // we know that something has been cached now
-                _ = this.cached_data.compare_exchange(
-                    IngredientCache::<I>::UNINITIALIZED,
-                    packed,
-                    Ordering::Release,
-                    Ordering::Acquire,
-                );
-                // and we already have our index computed so we can just use that
-                index
-            }
-
-            return get_or_create_index_slow(self, zalsa, create_index);
+            return self.get_or_create_index_slow(zalsa, create_index);
         };
 
-        // unpack our u64
-        // SAFETY: We've checked against `UNINITIALIZED` (0) above and so the upper bits must be non-zero
+        // Unpack our `u64` into the nonce and index.
+        let index = IngredientIndex(cached_data as u32);
+
+        // SAFETY: We've checked against `UNINITIALIZED` (0) above and so the upper bits must be non-zero.
         let nonce = Nonce::<StorageNonce>::from_u32(unsafe {
             NonZeroU32::new_unchecked((cached_data >> u32::BITS) as u32)
         });
-        let mut index = IngredientIndex(cached_data as u32);
 
+        // The data was cached for a different database, we have to ensure the ingredient was
+        // created in ours.
         if zalsa.nonce() != nonce {
-            index = create_index();
+            let (_, ingredient) = create_index();
+            return ingredient;
         }
-        index
+
+        zalsa.lookup_ingredient(index).assert_type()
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn get_or_create_index_slow<'db>(
+        &self,
+        zalsa: &'db Zalsa,
+        create_index: impl Fn() -> (IngredientIndex, &'db I),
+    ) -> &'db I {
+        let (index, ingredient) = create_index();
+        let nonce = zalsa.nonce().into_u32().get() as u64;
+        let packed = (nonce << u32::BITS) | (index.as_u32() as u64);
+        debug_assert_ne!(packed, IngredientCache::<I>::UNINITIALIZED);
+
+        // Discard the result, whether we won over the cache or not doesn't matter.
+        _ = self.cached_data.compare_exchange(
+            IngredientCache::<I>::UNINITIALIZED,
+            packed,
+            Ordering::Release,
+            Ordering::Relaxed,
+        );
+
+        // Use our locally computed index regardless of which one was cached.
+        ingredient
     }
 }
 

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -151,8 +151,6 @@ pub struct Zalsa {
     ingredient_to_id_struct_type_id_map: FxHashMap<IngredientIndex, TypeId>,
 
     /// Vector of ingredients.
-    ///
-    /// Immutable unless the mutex on `ingredients_map` is held.
     ingredients_vec: Vec<Box<dyn Ingredient>>,
 
     /// Indices of ingredients that require reset when a new revision starts.

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -754,7 +754,7 @@ impl QueryOrigin {
             QueryOriginKind::Assigned => {
                 // SAFETY: `data.index` is initialized when the tag is `QueryOriginKind::Assigned`.
                 let index = unsafe { self.data.index };
-                let ingredient_index = IngredientIndex::from(self.metadata as usize);
+                let ingredient_index = IngredientIndex::from(self.metadata);
                 QueryOriginRef::Assigned(DatabaseKeyIndex::new(ingredient_index, index))
             }
 

--- a/tests/accumulate-chain.rs
+++ b/tests/accumulate-chain.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that when having nested tracked functions
 //! we don't drop any values when accumulating.
 

--- a/tests/accumulate-custom-debug.rs
+++ b/tests/accumulate-custom-debug.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 mod common;
 
 use expect_test::expect;

--- a/tests/accumulate-dag.rs
+++ b/tests/accumulate-dag.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 mod common;
 
 use expect_test::expect;

--- a/tests/accumulate-execution-order.rs
+++ b/tests/accumulate-execution-order.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Demonstrates that accumulation is done in the order
 //! in which things were originally executed.
 

--- a/tests/accumulate-from-tracked-fn.rs
+++ b/tests/accumulate-from-tracked-fn.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Accumulate values from within a tracked function.
 //! Then mutate the values so that the tracked function re-executes.
 //! Check that we accumulate the appropriate, new values.

--- a/tests/accumulate-no-duplicates.rs
+++ b/tests/accumulate-no-duplicates.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that we don't get duplicate accumulated values
 
 mod common;

--- a/tests/accumulate-reuse-workaround.rs
+++ b/tests/accumulate-reuse-workaround.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Demonstrates the workaround of wrapping calls to
 //! `accumulated` in a tracked function to get better
 //! reuse.

--- a/tests/accumulate-reuse.rs
+++ b/tests/accumulate-reuse.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Accumulator re-use test.
 //!
 //! Tests behavior when a query's only inputs

--- a/tests/accumulate.rs
+++ b/tests/accumulate.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 mod common;
 use common::{LogDatabase, LoggerDatabase};
 use expect_test::expect;

--- a/tests/accumulated_backdate.rs
+++ b/tests/accumulated_backdate.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Tests that accumulated values are correctly accounted for
 //! when backdating a value.
 

--- a/tests/backtrace.rs
+++ b/tests/backtrace.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 use expect_test::expect;
 use salsa::{Backtrace, Database, DatabaseImpl};
 use test_log::test;
@@ -71,15 +73,15 @@ fn backtrace_works() {
     expect![[r#"
         query stacktrace:
            0: query_e(Id(0))
-                     at tests/backtrace.rs:30
+                     at tests/backtrace.rs:32
            1: query_d(Id(0))
-                     at tests/backtrace.rs:25
+                     at tests/backtrace.rs:27
            2: query_c(Id(0))
-                     at tests/backtrace.rs:20
+                     at tests/backtrace.rs:22
            3: query_b(Id(0))
-                     at tests/backtrace.rs:15
+                     at tests/backtrace.rs:17
            4: query_a(Id(0))
-                     at tests/backtrace.rs:10
+                     at tests/backtrace.rs:12
     "#]]
     .assert_eq(&backtrace);
 
@@ -87,15 +89,15 @@ fn backtrace_works() {
     expect![[r#"
         query stacktrace:
            0: query_e(Id(1)) -> (R1, Durability::LOW)
-                     at tests/backtrace.rs:30
+                     at tests/backtrace.rs:32
            1: query_d(Id(1)) -> (R1, Durability::HIGH)
-                     at tests/backtrace.rs:25
+                     at tests/backtrace.rs:27
            2: query_c(Id(1)) -> (R1, Durability::HIGH)
-                     at tests/backtrace.rs:20
+                     at tests/backtrace.rs:22
            3: query_b(Id(1)) -> (R1, Durability::HIGH)
-                     at tests/backtrace.rs:15
+                     at tests/backtrace.rs:17
            4: query_a(Id(1)) -> (R1, Durability::HIGH)
-                     at tests/backtrace.rs:10
+                     at tests/backtrace.rs:12
     "#]]
     .assert_eq(&backtrace);
 
@@ -103,12 +105,12 @@ fn backtrace_works() {
     expect![[r#"
         query stacktrace:
            0: query_e(Id(2))
-                     at tests/backtrace.rs:30
+                     at tests/backtrace.rs:32
            1: query_cycle(Id(2))
-                     at tests/backtrace.rs:43
+                     at tests/backtrace.rs:45
                      cycle heads: query_cycle(Id(2)) -> IterationCount(0)
            2: query_f(Id(2))
-                     at tests/backtrace.rs:38
+                     at tests/backtrace.rs:40
     "#]]
     .assert_eq(&backtrace);
 
@@ -116,12 +118,12 @@ fn backtrace_works() {
     expect![[r#"
         query stacktrace:
            0: query_e(Id(3)) -> (R1, Durability::LOW)
-                     at tests/backtrace.rs:30
+                     at tests/backtrace.rs:32
            1: query_cycle(Id(3)) -> (R1, Durability::HIGH, iteration = IterationCount(0))
-                     at tests/backtrace.rs:43
+                     at tests/backtrace.rs:45
                      cycle heads: query_cycle(Id(3)) -> IterationCount(0)
            2: query_f(Id(3)) -> (R1, Durability::HIGH)
-                     at tests/backtrace.rs:38
+                     at tests/backtrace.rs:40
     "#]]
     .assert_eq(&backtrace);
 }

--- a/tests/check_auto_traits.rs
+++ b/tests/check_auto_traits.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that auto trait impls exist as expected.
 
 use std::panic::UnwindSafe;

--- a/tests/compile_fail.rs
+++ b/tests/compile_fail.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 #[rustversion::all(stable, since(1.84))]
 #[test]
 fn compile_fail() {

--- a/tests/cycle.rs
+++ b/tests/cycle.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test cases for fixpoint iteration cycle resolution.
 //!
 //! These test cases use a generic query setup that allows constructing arbitrary dependency

--- a/tests/cycle_accumulate.rs
+++ b/tests/cycle_accumulate.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 use std::collections::HashSet;
 
 mod common;

--- a/tests/cycle_fallback_immediate.rs
+++ b/tests/cycle_fallback_immediate.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! It is possible to omit the `cycle_fn`, only specifying `cycle_result` in which case
 //! an immediate fallback value is used as the cycle handling opposed to doing a fixpoint resolution.
 

--- a/tests/cycle_initial_call_back_into_cycle.rs
+++ b/tests/cycle_initial_call_back_into_cycle.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Calling back into the same cycle from your cycle initial function will trigger another cycle.
 
 #[salsa::tracked]

--- a/tests/cycle_initial_call_query.rs
+++ b/tests/cycle_initial_call_query.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! It's possible to call a Salsa query from within a cycle initial fn.
 
 #[salsa::tracked]

--- a/tests/cycle_maybe_changed_after.rs
+++ b/tests/cycle_maybe_changed_after.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Tests for incremental validation for queries involved in a cycle.
 mod common;
 

--- a/tests/cycle_output.rs
+++ b/tests/cycle_output.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test tracked struct output from a query in a cycle.
 mod common;
 use common::{HasLogger, LogDatabase, Logger};

--- a/tests/cycle_recovery_call_back_into_cycle.rs
+++ b/tests/cycle_recovery_call_back_into_cycle.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Calling back into the same cycle from your cycle recovery function _can_ work out, as long as
 //! the overall cycle still converges.
 

--- a/tests/cycle_recovery_call_query.rs
+++ b/tests/cycle_recovery_call_query.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! It's possible to call a Salsa query from within a cycle recovery fn.
 
 #[salsa::tracked]

--- a/tests/cycle_regression_455.rs
+++ b/tests/cycle_regression_455.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 use salsa::{Database, Setter};
 
 #[salsa::tracked]

--- a/tests/cycle_result_dependencies.rs
+++ b/tests/cycle_result_dependencies.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 use salsa::{Database, Setter};
 
 #[salsa::input]

--- a/tests/cycle_tracked.rs
+++ b/tests/cycle_tracked.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Tests for cycles where the cycle head is stored on a tracked struct
 //! and that tracked struct is freed in a later revision.
 

--- a/tests/cycle_tracked_own_input.rs
+++ b/tests/cycle_tracked_own_input.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test for cycle handling where a tracked struct created in the first revision
 //! is stored in the final value of the cycle but isn't recreated in the second
 //! iteration of the creating query.

--- a/tests/dataflow.rs
+++ b/tests/dataflow.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test case for fixpoint iteration cycle resolution.
 //!
 //! This test case is intended to simulate a (very simplified) version of a real dataflow analysis

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that `DeriveWithDb` is correctly derived.
 
 use expect_test::expect;

--- a/tests/debug_db_contents.rs
+++ b/tests/debug_db_contents.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 #[salsa::interned(debug)]
 struct InternedStruct<'db> {
     name: String,

--- a/tests/deletion-cascade.rs
+++ b/tests/deletion-cascade.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Delete cascade:
 //!
 //! * when we delete memoized data, also delete outputs from that data

--- a/tests/deletion-drops.rs
+++ b/tests/deletion-drops.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Basic deletion test:
 //!
 //! * entities not created in a revision are deleted, as is any memoized data keyed on them.

--- a/tests/deletion.rs
+++ b/tests/deletion.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Basic deletion test:
 //!
 //! * entities not created in a revision are deleted, as is any memoized data keyed on them.

--- a/tests/derive_update.rs
+++ b/tests/derive_update.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that the `Update` derive works as expected
 
 #[derive(salsa::Update)]

--- a/tests/durability.rs
+++ b/tests/durability.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Tests that code using the builder's durability methods compiles.
 
 use salsa::{Database, Durability, Setter};

--- a/tests/elided-lifetime-in-tracked-fn.rs
+++ b/tests/elided-lifetime-in-tracked-fn.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that a `tracked` fn on a `salsa::input`
 //! compiles and executes successfully.
 

--- a/tests/expect_reuse_field_x_of_a_tracked_struct_changes_but_fn_depends_on_field_y.rs
+++ b/tests/expect_reuse_field_x_of_a_tracked_struct_changes_but_fn_depends_on_field_y.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that if field X of a tracked struct changes but not field Y,
 //! functions that depend on X re-execute, but those depending only on Y do not
 //! compiles and executes successfully.

--- a/tests/expect_reuse_field_x_of_an_input_changes_but_fn_depends_on_field_y.rs
+++ b/tests/expect_reuse_field_x_of_an_input_changes_but_fn_depends_on_field_y.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that if field X of an input changes but not field Y,
 //! functions that depend on X re-execute, but those depending only on Y do not
 //! compiles and executes successfully.

--- a/tests/hash_collision.rs
+++ b/tests/hash_collision.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 use std::hash::Hash;
 
 #[test]

--- a/tests/hello_world.rs
+++ b/tests/hello_world.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that a `tracked` fn on a `salsa::input`
 //! compiles and executes successfully.
 

--- a/tests/input_default.rs
+++ b/tests/input_default.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Tests that fields attributed with `#[default]` are initialized with `Default::default()`.
 
 use salsa::Durability;

--- a/tests/input_field_durability.rs
+++ b/tests/input_field_durability.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Tests that code using the builder's durability methods compiles.
 
 use salsa::Durability;

--- a/tests/input_setter_preserves_durability.rs
+++ b/tests/input_setter_preserves_durability.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 use salsa::plumbing::ZalsaDatabase;
 use salsa::{Durability, Setter};
 use test_log::test;

--- a/tests/intern_access_in_different_revision.rs
+++ b/tests/intern_access_in_different_revision.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 use salsa::{Durability, Setter};
 
 #[salsa::interned(no_lifetime)]

--- a/tests/interned-revisions.rs
+++ b/tests/interned-revisions.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that a `tracked` fn on a `salsa::input`
 //! compiles and executes successfully.
 

--- a/tests/interned-structs.rs
+++ b/tests/interned-structs.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that a `tracked` fn on a `salsa::input`
 //! compiles and executes successfully.
 

--- a/tests/interned-structs_self_ref.rs
+++ b/tests/interned-structs_self_ref.rs
@@ -36,6 +36,11 @@ const _: () = {
     use salsa::plumbing as zalsa_;
     use zalsa_::interned as zalsa_struct_;
     type Configuration_ = InternedString<'static>;
+
+    zalsa_::submit! {
+        zalsa_::ErasedJar::erase::<zalsa_struct_::JarImpl<Configuration_>>(zalsa_::ErasedJarKind::Struct)
+    }
+
     #[derive(Clone)]
     struct StructData<'db>(String, InternedString<'db>);
 
@@ -87,9 +92,9 @@ const _: () = {
 
             let zalsa = db.zalsa();
             CACHE.get_or_create(zalsa, || {
-                zalsa
-                    .lookup_jar_by_type::<zalsa_struct_::JarImpl<Configuration_>>()
-                    .get_or_create()
+                let index = zalsa.lookup_jar_by_type::<zalsa_struct_::JarImpl<Configuration_>>();
+                let ingredient = zalsa.lookup_ingredient(index).assert_type();
+                (index, ingredient)
             })
         }
     }
@@ -115,9 +120,8 @@ const _: () = {
     impl zalsa_::SalsaStructInDb for InternedString<'_> {
         type MemoIngredientMap = zalsa_::MemoIngredientSingletonIndex;
 
-        fn lookup_or_create_ingredient_index(aux: &Zalsa) -> salsa::plumbing::IngredientIndices {
+        fn lookup_ingredient_index(aux: &Zalsa) -> salsa::plumbing::IngredientIndices {
             aux.lookup_jar_by_type::<zalsa_struct_::JarImpl<Configuration_>>()
-                .get_or_create()
                 .into()
         }
 

--- a/tests/interned-structs_self_ref.rs
+++ b/tests/interned-structs_self_ref.rs
@@ -101,7 +101,8 @@ const _: () = {
 
             let zalsa = db.zalsa();
             CACHE.get_or_create(zalsa, || {
-                zalsa.lookup_jar_by_type::<zalsa_struct_::JarImpl<Configuration_>>()
+                let index = zalsa.lookup_jar_by_type::<zalsa_struct_::JarImpl<Configuration_>>();
+                (index, zalsa.lookup_ingredient(index).assert_type())
             })
         }
     }

--- a/tests/interned-structs_self_ref.rs
+++ b/tests/interned-structs_self_ref.rs
@@ -95,14 +95,12 @@ const _: () = {
         where
             Db: ?Sized + zalsa_::Database,
         {
-            static CACHE: zalsa_::GlobalIngredientCache<
-                zalsa_struct_::IngredientImpl<Configuration_>,
-            > = zalsa_::GlobalIngredientCache::new();
+            static CACHE: zalsa_::IngredientCache<zalsa_struct_::IngredientImpl<Configuration_>> =
+                zalsa_::IngredientCache::new();
 
             let zalsa = db.zalsa();
             CACHE.get_or_create(zalsa, || {
-                let index = zalsa.lookup_jar_by_type::<zalsa_struct_::JarImpl<Configuration_>>();
-                (index, zalsa.lookup_ingredient(index).assert_type())
+                zalsa.lookup_jar_by_type::<zalsa_struct_::JarImpl<Configuration_>>()
             })
         }
     }

--- a/tests/interned-structs_self_ref.rs
+++ b/tests/interned-structs_self_ref.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that a `tracked` fn on a `salsa::input`
 //! compiles and executes successfully.
 
@@ -35,10 +37,16 @@ struct InternedString<'db>(
 const _: () = {
     use salsa::plumbing as zalsa_;
     use zalsa_::interned as zalsa_struct_;
+
     type Configuration_ = InternedString<'static>;
 
-    zalsa_::submit! {
-        zalsa_::ErasedJar::erase::<zalsa_struct_::JarImpl<Configuration_>>(zalsa_::ErasedJarKind::Struct)
+    impl<'db> zalsa_::HasJar for InternedString<'db> {
+        type Jar = zalsa_struct_::JarImpl<Configuration_>;
+        const KIND: zalsa_::JarKind = zalsa_::JarKind::Struct;
+    }
+
+    zalsa_::register_jar! {
+        zalsa_::ErasedJar::erase::<InternedString<'static>>()
     }
 
     #[derive(Clone)]

--- a/tests/interned-structs_self_ref.rs
+++ b/tests/interned-structs_self_ref.rs
@@ -87,14 +87,13 @@ const _: () = {
         where
             Db: ?Sized + zalsa_::Database,
         {
-            static CACHE: zalsa_::IngredientCache<zalsa_struct_::IngredientImpl<Configuration_>> =
-                zalsa_::IngredientCache::new();
+            static CACHE: zalsa_::GlobalIngredientCache<
+                zalsa_struct_::IngredientImpl<Configuration_>,
+            > = zalsa_::GlobalIngredientCache::new();
 
             let zalsa = db.zalsa();
             CACHE.get_or_create(zalsa, || {
-                let index = zalsa.lookup_jar_by_type::<zalsa_struct_::JarImpl<Configuration_>>();
-                let ingredient = zalsa.lookup_ingredient(index).assert_type();
-                (index, ingredient)
+                zalsa.lookup_jar_by_type::<zalsa_struct_::JarImpl<Configuration_>>()
             })
         }
     }

--- a/tests/lru.rs
+++ b/tests/lru.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that a `tracked` fn with lru options
 //! compiles and executes successfully.
 

--- a/tests/manual_registration.rs
+++ b/tests/manual_registration.rs
@@ -17,19 +17,28 @@ mod ingredients {
     }
 
     #[salsa::tracked]
-    pub(super) fn track<'db>(db: &'db dyn salsa::Database, input: MyInput) -> MyInterned<'db> {
+    pub(super) fn intern<'db>(db: &'db dyn salsa::Database, input: MyInput) -> MyInterned<'db> {
         MyInterned::new(db, input.field(db))
     }
 
     #[salsa::tracked]
-    pub(super) fn intern<'db>(db: &'db dyn salsa::Database, input: MyInput) -> MyTracked<'db> {
+    pub(super) fn track<'db>(db: &'db dyn salsa::Database, input: MyInput) -> MyTracked<'db> {
         MyTracked::new(db, input.field(db))
     }
 }
 
+#[salsa::db]
+#[derive(Clone, Default)]
+pub struct DatabaseImpl {
+    storage: salsa::Storage<Self>,
+}
+
+#[salsa::db]
+impl salsa::Database for DatabaseImpl {}
+
 #[test]
-fn test() {
-    let db = salsa::DatabaseImpl {
+fn single_database() {
+    let db = DatabaseImpl {
         storage: salsa::Storage::builder()
             .ingredient::<ingredients::track>()
             .ingredient::<ingredients::intern>()
@@ -46,4 +55,38 @@ fn test() {
 
     assert_eq!(tracked.field(&db), 1);
     assert_eq!(interned.field(&db), 1);
+}
+
+#[test]
+fn multiple_databases() {
+    let db1 = DatabaseImpl {
+        storage: salsa::Storage::builder()
+            .ingredient::<ingredients::intern>()
+            .ingredient::<ingredients::MyInput>()
+            .ingredient::<ingredients::MyInterned<'_>>()
+            .build(),
+    };
+
+    let input = ingredients::MyInput::new(&db1, 1);
+    let interned = ingredients::intern(&db1, input);
+    assert_eq!(interned.field(&db1), 1);
+
+    // Create a second database with different ingredient indices.
+    let db2 = DatabaseImpl {
+        storage: salsa::Storage::builder()
+            .ingredient::<ingredients::track>()
+            .ingredient::<ingredients::intern>()
+            .ingredient::<ingredients::MyInput>()
+            .ingredient::<ingredients::MyTracked<'_>>()
+            .ingredient::<ingredients::MyInterned<'_>>()
+            .build(),
+    };
+
+    let input = ingredients::MyInput::new(&db2, 2);
+    let interned = ingredients::intern(&db2, input);
+    assert_eq!(interned.field(&db2), 2);
+
+    let input = ingredients::MyInput::new(&db2, 3);
+    let tracked = ingredients::track(&db2, input);
+    assert_eq!(tracked.field(&db2), 3);
 }

--- a/tests/manual_registration.rs
+++ b/tests/manual_registration.rs
@@ -1,0 +1,49 @@
+#![cfg(not(feature = "inventory"))]
+
+mod ingredients {
+    #[salsa::input]
+    pub(super) struct MyInput {
+        field: u32,
+    }
+
+    #[salsa::tracked]
+    pub(super) struct MyTracked<'db> {
+        pub(super) field: u32,
+    }
+
+    #[salsa::interned]
+    pub(super) struct MyInterned<'db> {
+        pub(super) field: u32,
+    }
+
+    #[salsa::tracked]
+    pub(super) fn track<'db>(db: &'db dyn salsa::Database, input: MyInput) -> MyInterned<'db> {
+        MyInterned::new(db, input.field(db))
+    }
+
+    #[salsa::tracked]
+    pub(super) fn intern<'db>(db: &'db dyn salsa::Database, input: MyInput) -> MyTracked<'db> {
+        MyTracked::new(db, input.field(db))
+    }
+}
+
+#[test]
+fn test() {
+    let db = salsa::DatabaseImpl {
+        storage: salsa::Storage::builder()
+            .ingredient::<ingredients::track>()
+            .ingredient::<ingredients::intern>()
+            .ingredient::<ingredients::MyInput>()
+            .ingredient::<ingredients::MyTracked<'_>>()
+            .ingredient::<ingredients::MyInterned<'_>>()
+            .build(),
+    };
+
+    let input = ingredients::MyInput::new(&db, 1);
+
+    let tracked = ingredients::track(&db, input);
+    let interned = ingredients::intern(&db, input);
+
+    assert_eq!(tracked.field(&db), 1);
+    assert_eq!(interned.field(&db), 1);
+}

--- a/tests/memory-usage.rs
+++ b/tests/memory-usage.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 use expect_test::expect;
 
 #[salsa::input]

--- a/tests/mutate_in_place.rs
+++ b/tests/mutate_in_place.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that a setting a field on a `#[salsa::input]`
 //! overwrites and returns the old value.
 

--- a/tests/override_new_get_set.rs
+++ b/tests/override_new_get_set.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that the `constructor` macro overrides
 //! the `new` method's name and `get` and `set`
 //! change the name of the getter and setter of the fields.

--- a/tests/panic-when-creating-tracked-struct-outside-of-tracked-fn.rs
+++ b/tests/panic-when-creating-tracked-struct-outside-of-tracked-fn.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that creating a tracked struct outside of a
 //! tracked function panics with an assert message.
 

--- a/tests/parallel/main.rs
+++ b/tests/parallel/main.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 mod setup;
 mod signal;
 

--- a/tests/preverify-struct-with-leaked-data-2.rs
+++ b/tests/preverify-struct-with-leaked-data-2.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that a `tracked` fn on a `salsa::input`
 //! compiles and executes successfully.
 

--- a/tests/preverify-struct-with-leaked-data.rs
+++ b/tests/preverify-struct-with-leaked-data.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that a `tracked` fn on a `salsa::input`
 //! compiles and executes successfully.
 

--- a/tests/return_mode.rs
+++ b/tests/return_mode.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 use salsa::Database;
 
 #[salsa::input]

--- a/tests/singleton.rs
+++ b/tests/singleton.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Basic Singleton struct test:
 //!
 //! Singleton structs are created only once. Subsequent `get`s and `new`s after creation return the same `Id`.

--- a/tests/specify-only-works-if-the-key-is-created-in-the-current-query.rs
+++ b/tests/specify-only-works-if-the-key-is-created-in-the-current-query.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that `specify` only works if the key is a tracked struct created in the current query.
 //! compilation succeeds but execution panics
 #![allow(warnings)]

--- a/tests/synthetic_write.rs
+++ b/tests/synthetic_write.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that a constant `tracked` fn (has no inputs)
 //! compiles and executes successfully.
 #![allow(warnings)]

--- a/tests/tracked-struct-id-field-bad-eq.rs
+++ b/tests/tracked-struct-id-field-bad-eq.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test an id field whose `PartialEq` impl is always true.
 
 use salsa::{Database, Setter};

--- a/tests/tracked-struct-id-field-bad-hash.rs
+++ b/tests/tracked-struct-id-field-bad-hash.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test for a tracked struct where an untracked field has a
 //! very poorly chosen hash impl (always returns 0).
 //!

--- a/tests/tracked-struct-unchanged-in-new-rev.rs
+++ b/tests/tracked-struct-unchanged-in-new-rev.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 use salsa::{Database as Db, Setter};
 use test_log::test;
 

--- a/tests/tracked-struct-value-field-bad-eq.rs
+++ b/tests/tracked-struct-value-field-bad-eq.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test a field whose `PartialEq` impl is always true.
 //! This can result in us getting different results than
 //! if we were to execute from scratch.

--- a/tests/tracked-struct-value-field-not-eq.rs
+++ b/tests/tracked-struct-value-field-not-eq.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test a field whose `PartialEq` impl is always true.
 //! This can our "last changed" data to be wrong
 //! but we *should* always reflect the final values.

--- a/tests/tracked_assoc_fn.rs
+++ b/tests/tracked_assoc_fn.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that a `tracked` fn on a `salsa::input`
 //! compiles and executes successfully.
 #![allow(warnings)]

--- a/tests/tracked_fn_constant.rs
+++ b/tests/tracked_fn_constant.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that a constant `tracked` fn (has no inputs)
 //! compiles and executes successfully.
 #![allow(warnings)]

--- a/tests/tracked_fn_high_durability_dependency.rs
+++ b/tests/tracked_fn_high_durability_dependency.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "inventory")]
 #![allow(warnings)]
 
 use salsa::plumbing::HasStorage;

--- a/tests/tracked_fn_interned_lifetime.rs
+++ b/tests/tracked_fn_interned_lifetime.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 #[salsa::interned]
 struct Interned<'db> {
     field: i32,

--- a/tests/tracked_fn_multiple_args.rs
+++ b/tests/tracked_fn_multiple_args.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that a `tracked` fn on multiple salsa struct args
 //! compiles and executes successfully.
 

--- a/tests/tracked_fn_no_eq.rs
+++ b/tests/tracked_fn_no_eq.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 mod common;
 
 use common::LogDatabase;

--- a/tests/tracked_fn_on_input.rs
+++ b/tests/tracked_fn_on_input.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that a `tracked` fn on a `salsa::input`
 //! compiles and executes successfully.
 #![allow(warnings)]

--- a/tests/tracked_fn_on_input_with_high_durability.rs
+++ b/tests/tracked_fn_on_input_with_high_durability.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "inventory")]
 #![allow(warnings)]
 
 use common::{EventLoggerDatabase, HasLogger, LogDatabase, Logger};

--- a/tests/tracked_fn_on_interned.rs
+++ b/tests/tracked_fn_on_interned.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that a `tracked` fn on a `salsa::interned`
 //! compiles and executes successfully.
 

--- a/tests/tracked_fn_on_interned_enum.rs
+++ b/tests/tracked_fn_on_interned_enum.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that a `tracked` fn on a `salsa::interned`
 //! compiles and executes successfully.
 

--- a/tests/tracked_fn_on_tracked.rs
+++ b/tests/tracked_fn_on_tracked.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that a `tracked` fn on a `salsa::input`
 //! compiles and executes successfully.
 

--- a/tests/tracked_fn_on_tracked_specify.rs
+++ b/tests/tracked_fn_on_tracked_specify.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that a `tracked` fn on a `salsa::input`
 //! compiles and executes successfully.
 #![allow(warnings)]

--- a/tests/tracked_fn_orphan_escape_hatch.rs
+++ b/tests/tracked_fn_orphan_escape_hatch.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that a `tracked` fn on a `salsa::input`
 //! compiles and executes successfully.
 #![allow(warnings)]

--- a/tests/tracked_fn_read_own_entity.rs
+++ b/tests/tracked_fn_read_own_entity.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that a `tracked` fn on a `salsa::input`
 //! compiles and executes successfully.
 

--- a/tests/tracked_fn_read_own_specify.rs
+++ b/tests/tracked_fn_read_own_specify.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 use expect_test::expect;
 mod common;
 use common::LogDatabase;

--- a/tests/tracked_fn_return_ref.rs
+++ b/tests/tracked_fn_return_ref.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 use salsa::Database;
 
 #[salsa::input]

--- a/tests/tracked_method.rs
+++ b/tests/tracked_method.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that a `tracked` fn on a `salsa::input`
 //! compiles and executes successfully.
 #![allow(warnings)]

--- a/tests/tracked_method_inherent_return_deref.rs
+++ b/tests/tracked_method_inherent_return_deref.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 use salsa::Database;
 
 #[salsa::input]

--- a/tests/tracked_method_inherent_return_ref.rs
+++ b/tests/tracked_method_inherent_return_ref.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 use salsa::Database;
 
 #[salsa::input]

--- a/tests/tracked_method_on_tracked_struct.rs
+++ b/tests/tracked_method_on_tracked_struct.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 use salsa::Database;
 
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/tests/tracked_method_trait_return_ref.rs
+++ b/tests/tracked_method_trait_return_ref.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 use salsa::Database;
 
 #[salsa::input]

--- a/tests/tracked_method_with_self_ty.rs
+++ b/tests/tracked_method_with_self_ty.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that a `tracked` fn with `Self` in its signature or body on a `salsa::input`
 //! compiles and executes successfully.
 #![allow(warnings)]

--- a/tests/tracked_struct.rs
+++ b/tests/tracked_struct.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 mod common;
 
 use salsa::{Database, Setter};

--- a/tests/tracked_struct_db1_lt.rs
+++ b/tests/tracked_struct_db1_lt.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that tracked structs with lifetimes not named `'db`
 //! compile successfully.
 

--- a/tests/tracked_struct_disambiguates.rs
+++ b/tests/tracked_struct_disambiguates.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that disambiguation works, that is when we have a revision where we track multiple structs
 //! that have the same hash, we can still differentiate between them.
 #![allow(warnings)]

--- a/tests/tracked_struct_durability.rs
+++ b/tests/tracked_struct_durability.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 /// Test that high durabilities can't cause "access tracked struct from previous revision" panic.
 ///
 /// The test models a situation where we have two File inputs (0, 1), where `File(0)` has LOW

--- a/tests/tracked_struct_manual_update.rs
+++ b/tests/tracked_struct_manual_update.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 mod common;
 
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/tests/tracked_struct_mixed_tracked_fields.rs
+++ b/tests/tracked_struct_mixed_tracked_fields.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 mod common;
 
 use salsa::{Database, Setter};

--- a/tests/tracked_struct_recreate_new_revision.rs
+++ b/tests/tracked_struct_recreate_new_revision.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that re-creating a `tracked` struct after it was deleted in a previous
 //! revision doesn't panic.
 #![allow(warnings)]

--- a/tests/tracked_struct_with_interned_query.rs
+++ b/tests/tracked_struct_with_interned_query.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 mod common;
 
 use salsa::Setter;

--- a/tests/tracked_with_intern.rs
+++ b/tests/tracked_with_intern.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that a setting a field on a `#[salsa::input]`
 //! overwrites and returns the old value.
 

--- a/tests/tracked_with_struct_db.rs
+++ b/tests/tracked_with_struct_db.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that a setting a field on a `#[salsa::input]`
 //! overwrites and returns the old value.
 

--- a/tests/tracked_with_struct_ord.rs
+++ b/tests/tracked_with_struct_ord.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "inventory")]
+
 //! Test that `PartialOrd` and `Ord` can be derived for tracked structs
 
 use salsa::{Database, DatabaseImpl};


### PR DESCRIPTION
Salsa currently registers ingredients dynamically the first time they are accessed, but persistent caching will require that all serializable ingredients are registered up-front. It's possible that we may switch to a static ingredient registration API, but as a first step, we can use `inventory` to ensure all ingredients have stable indices. This should enable persistent caching and also give us the same performance benefits of static ingredient registration without a large breaking API change.

Inventory has pretty good platform support, I believe it includes all the platforms we care about. There is [a caveat on WebAssembly](https://docs.rs/inventory/latest/inventory/#webassembly-and-constructors), but I don't think it's a dealbreaker.