### PR TITLE
feat: Improve unstable size analysis support

### DIFF
--- a/components/salsa-macro-rules/src/setup_input_struct.rs
+++ b/components/salsa-macro-rules/src/setup_input_struct.rs
@@ -50,6 +50,9 @@ macro_rules! setup_input_struct {
         // If true, generate a debug impl.
         generate_debug_impl: $generate_debug_impl:tt,
 
+        // The function used to implement `C::heap_size`.
+        heap_size_fn: $($heap_size_fn:path)?,
+
         // Annoyingly macro-rules hygiene does not extend to items defined in the macro.
         // We have the procedural macro generate names for those items that are
         // not used elsewhere in the user's code.
@@ -89,6 +92,12 @@ macro_rules! setup_input_struct {
 
                 type Revisions = [$zalsa::Revision; $N];
                 type Durabilities = [$zalsa::Durability; $N];
+
+                $(
+                    fn heap_size(value: &Self::Fields, _panic_if_missing: $zalsa::PanicIfHeapSizeMissing) -> usize {
+                        $heap_size_fn(value)
+                    }
+                )?
             }
 
             impl $Configuration {

--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -66,6 +66,9 @@ macro_rules! setup_interned_struct {
         // If true, generate a debug impl.
         generate_debug_impl: $generate_debug_impl:tt,
 
+        // The function used to implement `C::heap_size`.
+        heap_size_fn: $($heap_size_fn:path)?,
+
         // Annoyingly macro-rules hygiene does not extend to items defined in the macro.
         // We have the procedural macro generate names for those items that are
         // not used elsewhere in the user's code.
@@ -137,6 +140,12 @@ macro_rules! setup_interned_struct {
                 )?
                 type Fields<'a> = $StructDataIdent<'a>;
                 type Struct<'db> = $Struct< $($db_lt_arg)? >;
+
+                $(
+                    fn heap_size(value: &Self::Fields<'_>, _panic_if_missing: $zalsa::PanicIfHeapSizeMissing) -> usize {
+                        $heap_size_fn(value)
+                    }
+                )?
             }
 
             impl $Configuration {

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -211,7 +211,7 @@ macro_rules! setup_tracked_fn {
                 $($values_equal)+
 
                 $(
-                    fn heap_size(value: &Self::Output<'_>) -> usize {
+                    fn heap_size(value: &Self::Output<'_>, _panic_if_missing: $zalsa::PanicIfHeapSizeMissing) -> usize {
                         $heap_size_fn(value)
                     }
                 )?

--- a/components/salsa-macro-rules/src/setup_tracked_struct.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_struct.rs
@@ -88,6 +88,9 @@ macro_rules! setup_tracked_struct {
         // If true, generate a debug impl.
         generate_debug_impl: $generate_debug_impl:tt,
 
+        // The function used to implement `C::heap_size`.
+        heap_size_fn: $($heap_size_fn:path)?,
+
         // Annoyingly macro-rules hygiene does not extend to items defined in the macro.
         // We have the procedural macro generate names for those items that are
         // not used elsewhere in the user's code.
@@ -176,6 +179,12 @@ macro_rules! setup_tracked_struct {
                         )* false
                     }
                 }
+
+                $(
+                    fn heap_size(value: &Self::Fields<'_>, _panic_if_missing: $zalsa::PanicIfHeapSizeMissing) -> usize {
+                        $heap_size_fn(value)
+                    }
+                )?
             }
 
             impl $Configuration {

--- a/components/salsa-macros/src/input.rs
+++ b/components/salsa-macros/src/input.rs
@@ -65,7 +65,7 @@ impl crate::options::AllowedOptions for InputStruct {
 
     const REVISIONS: bool = false;
 
-    const HEAP_SIZE: bool = false;
+    const HEAP_SIZE: bool = true;
 
     const SELF_TY: bool = false;
 }
@@ -112,6 +112,7 @@ impl Macro {
         let field_attrs = salsa_struct.field_attrs();
         let is_singleton = self.args.singleton.is_some();
         let generate_debug_impl = salsa_struct.generate_debug_impl();
+        let heap_size_fn = self.args.heap_size_fn.iter();
 
         let zalsa = self.hygiene.ident("zalsa");
         let zalsa_struct = self.hygiene.ident("zalsa_struct");
@@ -140,6 +141,7 @@ impl Macro {
                     num_fields: #num_fields,
                     is_singleton: #is_singleton,
                     generate_debug_impl: #generate_debug_impl,
+                    heap_size_fn: #(#heap_size_fn)*,
                     unused_names: [
                         #zalsa,
                         #zalsa_struct,

--- a/components/salsa-macros/src/interned.rs
+++ b/components/salsa-macros/src/interned.rs
@@ -65,7 +65,7 @@ impl crate::options::AllowedOptions for InternedStruct {
 
     const REVISIONS: bool = true;
 
-    const HEAP_SIZE: bool = false;
+    const HEAP_SIZE: bool = true;
 
     const SELF_TY: bool = false;
 }
@@ -131,6 +131,8 @@ impl Macro {
             (None, quote!(#struct_ident), static_lifetime)
         };
 
+        let heap_size_fn = self.args.heap_size_fn.iter();
+
         let zalsa = self.hygiene.ident("zalsa");
         let zalsa_struct = self.hygiene.ident("zalsa_struct");
         let Configuration = self.hygiene.ident("Configuration");
@@ -161,6 +163,7 @@ impl Macro {
                     field_attrs: [#([#(#field_unused_attrs),*]),*],
                     num_fields: #num_fields,
                     generate_debug_impl: #generate_debug_impl,
+                    heap_size_fn: #(#heap_size_fn)*,
                     unused_names: [
                         #zalsa,
                         #zalsa_struct,

--- a/components/salsa-macros/src/tracked_struct.rs
+++ b/components/salsa-macros/src/tracked_struct.rs
@@ -61,7 +61,7 @@ impl crate::options::AllowedOptions for TrackedStruct {
 
     const REVISIONS: bool = false;
 
-    const HEAP_SIZE: bool = false;
+    const HEAP_SIZE: bool = true;
 
     const SELF_TY: bool = false;
 }
@@ -141,6 +141,8 @@ impl Macro {
             }
         });
 
+        let heap_size_fn = self.args.heap_size_fn.iter();
+
         let num_tracked_fields = salsa_struct.num_tracked_fields();
         let generate_debug_impl = salsa_struct.generate_debug_impl();
 
@@ -188,6 +190,9 @@ impl Macro {
 
                     num_tracked_fields: #num_tracked_fields,
                     generate_debug_impl: #generate_debug_impl,
+
+                    heap_size_fn: #(#heap_size_fn)*,
+
                     unused_names: [
                         #zalsa,
                         #zalsa_struct,

--- a/src/function.rs
+++ b/src/function.rs
@@ -73,7 +73,18 @@ pub trait Configuration: Any {
     fn id_to_input(db: &Self::DbView, key: Id) -> Self::Input<'_>;
 
     /// Returns the size of any heap allocations in the output value, in bytes.
-    fn heap_size(_value: &Self::Output<'_>) -> usize {
+    fn heap_size(
+        _value: &Self::Output<'_>,
+        panic_if_missing: crate::PanicIfHeapSizeMissing,
+    ) -> usize {
+        if panic_if_missing == crate::PanicIfHeapSizeMissing::Yes {
+            panic!(
+                "tried to estimate sizes but `size_of()` was not defined.\n\
+                ingredient: {}\ntype: {}",
+                Self::DEBUG_NAME,
+                std::any::type_name::<Self::Output<'_>>()
+            );
+        }
         0
     }
 

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -314,9 +314,16 @@ where
     }
 
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(&self) -> crate::database::MemoInfo {
+    fn memory_usage(
+        &self,
+        panic_if_missing: crate::PanicIfHeapSizeMissing,
+    ) -> crate::database::MemoInfo {
         let size_of = std::mem::size_of::<Memo<C>>() + self.revisions.allocation_size();
-        let heap_size = self.value.as_ref().map(C::heap_size).unwrap_or(0);
+        let heap_size = self
+            .value
+            .as_ref()
+            .map(|value| C::heap_size(value, panic_if_missing))
+            .unwrap_or(0);
 
         crate::database::MemoInfo {
             debug_name: C::DEBUG_NAME,

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -185,7 +185,11 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
     /// Returns memory usage information about any instances of the ingredient,
     /// if applicable.
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(&self, _db: &dyn Database) -> Option<Vec<crate::database::SlotInfo>> {
+    fn memory_usage(
+        &self,
+        _db: &dyn Database,
+        _panic_if_missing: crate::PanicIfHeapSizeMissing,
+    ) -> Option<Vec<crate::database::SlotInfo>> {
         None
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -40,6 +40,19 @@ pub trait Configuration: Any {
 
     /// A array of [`Durability`], one per each of the value fields.
     type Durabilities: Send + Sync + fmt::Debug + IndexMut<usize, Output = Durability>;
+
+    /// Returns the size of any heap allocations in the output value, in bytes.
+    fn heap_size(_value: &Self::Fields, panic_if_missing: crate::PanicIfHeapSizeMissing) -> usize {
+        if panic_if_missing == crate::PanicIfHeapSizeMissing::Yes {
+            panic!(
+                "tried to estimate sizes but `heap_size()` was not defined.\n\
+                ingredient: {}\ntype: {}",
+                Self::DEBUG_NAME,
+                std::any::type_name::<Self::Fields>()
+            );
+        }
+        0
+    }
 }
 
 pub struct JarImpl<C: Configuration> {
@@ -244,12 +257,16 @@ impl<C: Configuration> Ingredient for IngredientImpl<C> {
 
     /// Returns memory usage information about any inputs.
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(&self, db: &dyn Database) -> Option<Vec<crate::database::SlotInfo>> {
+    fn memory_usage(
+        &self,
+        db: &dyn Database,
+        panic_if_missing: crate::PanicIfHeapSizeMissing,
+    ) -> Option<Vec<crate::database::SlotInfo>> {
         let memory_usage = self
             .entries(db)
             // SAFETY: The memo table belongs to a value that we allocated, so it
             // has the correct type.
-            .map(|value| unsafe { value.memory_usage(&self.memo_table_types) })
+            .map(|value| unsafe { value.memory_usage(&self.memo_table_types, panic_if_missing) })
             .collect();
         Some(memory_usage)
     }
@@ -303,15 +320,20 @@ where
     ///
     /// The `MemoTable` must belong to a `Value` of the correct type.
     #[cfg(feature = "salsa_unstable")]
-    unsafe fn memory_usage(&self, memo_table_types: &MemoTableTypes) -> crate::database::SlotInfo {
+    unsafe fn memory_usage(
+        &self,
+        memo_table_types: &MemoTableTypes,
+        panic_if_missing: crate::PanicIfHeapSizeMissing,
+    ) -> crate::database::SlotInfo {
+        let heap_size = C::heap_size(&self.fields, panic_if_missing);
         // SAFETY: The caller guarantees this is the correct types table.
         let memos = unsafe { memo_table_types.attach_memos(&self.memos) };
 
         crate::database::SlotInfo {
             debug_name: C::DEBUG_NAME,
             size_of_metadata: std::mem::size_of::<Self>() - std::mem::size_of::<C::Fields>(),
-            size_of_fields: std::mem::size_of::<C::Fields>(),
-            memos: memos.memory_usage(),
+            size_of_fields: std::mem::size_of::<C::Fields>() + heap_size,
+            memos: memos.memory_usage(panic_if_missing),
         }
     }
 }

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -44,6 +44,22 @@ pub trait Configuration: Sized + 'static {
 
     /// The end user struct
     type Struct<'db>: Copy + FromId + AsId;
+
+    /// Returns the size of any heap allocations in the output value, in bytes.
+    fn heap_size(
+        _value: &Self::Fields<'_>,
+        panic_if_missing: crate::PanicIfHeapSizeMissing,
+    ) -> usize {
+        if panic_if_missing == crate::PanicIfHeapSizeMissing::Yes {
+            panic!(
+                "tried to estimate sizes but `heap_size()` was not defined.\n\
+                ingredient: {}\ntype: {}",
+                Self::DEBUG_NAME,
+                std::any::type_name::<Self::Struct<'_>>()
+            );
+        }
+        0
+    }
 }
 
 pub trait InternedData: Sized + Eq + Hash + Clone + Sync + Send {}
@@ -198,7 +214,12 @@ where
     /// The `MemoTable` must belong to a `Value` of the correct type. Additionally, the
     /// lock must be held for the shard containing the value.
     #[cfg(all(not(feature = "shuttle"), feature = "salsa_unstable"))]
-    unsafe fn memory_usage(&self, memo_table_types: &MemoTableTypes) -> crate::database::SlotInfo {
+    unsafe fn memory_usage(
+        &self,
+        memo_table_types: &MemoTableTypes,
+        panic_if_missing: crate::PanicIfHeapSizeMissing,
+    ) -> crate::database::SlotInfo {
+        let heap_size = C::heap_size(self.fields(), panic_if_missing);
         // SAFETY: The caller guarantees we hold the lock for the shard containing the value, so we
         // have at-least read-only access to the value's memos.
         let memos = unsafe { &*self.memos.get() };
@@ -208,8 +229,8 @@ where
         crate::database::SlotInfo {
             debug_name: C::DEBUG_NAME,
             size_of_metadata: std::mem::size_of::<Self>() - std::mem::size_of::<C::Fields<'_>>(),
-            size_of_fields: std::mem::size_of::<C::Fields<'_>>(),
-            memos: memos.memory_usage(),
+            size_of_fields: std::mem::size_of::<C::Fields<'_>>() + heap_size,
+            memos: memos.memory_usage(panic_if_missing),
         }
     }
 }
@@ -855,7 +876,11 @@ where
 
     /// Returns memory usage information about any interned values.
     #[cfg(all(not(feature = "shuttle"), feature = "salsa_unstable"))]
-    fn memory_usage(&self, db: &dyn Database) -> Option<Vec<crate::database::SlotInfo>> {
+    fn memory_usage(
+        &self,
+        db: &dyn Database,
+        panic_if_missing: crate::PanicIfHeapSizeMissing,
+    ) -> Option<Vec<crate::database::SlotInfo>> {
         use parking_lot::lock_api::RawMutex;
 
         for shard in self.shards.iter() {
@@ -867,7 +892,7 @@ where
             .entries(db)
             // SAFETY: The memo table belongs to a value that we allocated, so it
             // has the correct type. Additionally, we are holding the locks for all shards.
-            .map(|value| unsafe { value.memory_usage(&self.memo_table_types) })
+            .map(|value| unsafe { value.memory_usage(&self.memo_table_types, panic_if_missing) })
             .collect();
 
         for shard in self.shards.iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub use self::accumulator::Accumulator;
 pub use self::active_query::Backtrace;
 pub use self::cancelled::Cancelled;
 pub use self::cycle::CycleRecoveryAction;
-pub use self::database::{AsDynDatabase, Database};
+pub use self::database::{AsDynDatabase, Database, PanicIfHeapSizeMissing};
 pub use self::database_impl::DatabaseImpl;
 pub use self::durability::Durability;
 pub use self::event::{Event, EventKind};
@@ -86,7 +86,7 @@ pub mod plumbing {
     pub use crate::accumulator::Accumulator;
     pub use crate::attach::{attach, with_attached_database};
     pub use crate::cycle::{CycleRecoveryAction, CycleRecoveryStrategy};
-    pub use crate::database::{current_revision, Database};
+    pub use crate::database::{current_revision, Database, PanicIfHeapSizeMissing};
     pub use crate::durability::Durability;
     pub use crate::id::{AsId, FromId, FromIdWithDb, Id};
     pub use crate::ingredient::{Ingredient, Jar, Location};

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -90,6 +90,22 @@ pub trait Configuration: Sized + 'static {
         old_fields: *mut Self::Fields<'db>,
         new_fields: Self::Fields<'db>,
     ) -> bool;
+
+    /// Returns the size of any heap allocations in the output value, in bytes.
+    fn heap_size(
+        _value: &Self::Fields<'_>,
+        panic_if_missing: crate::PanicIfHeapSizeMissing,
+    ) -> usize {
+        if panic_if_missing == crate::PanicIfHeapSizeMissing::Yes {
+            panic!(
+                "tried to estimate sizes but `heap_size()` was not defined.\n\
+                ingredient: {}\ntype: {}",
+                Self::DEBUG_NAME,
+                std::any::type_name::<Self::Struct<'_>>()
+            );
+        }
+        0
+    }
 }
 // ANCHOR_END: Configuration
 
@@ -855,12 +871,16 @@ where
 
     /// Returns memory usage information about any tracked structs.
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(&self, db: &dyn Database) -> Option<Vec<crate::database::SlotInfo>> {
+    fn memory_usage(
+        &self,
+        db: &dyn Database,
+        panic_if_missing: crate::PanicIfHeapSizeMissing,
+    ) -> Option<Vec<crate::database::SlotInfo>> {
         let memory_usage = self
             .entries(db)
             // SAFETY: The memo table belongs to a value that we allocated, so it
             // has the correct type.
-            .map(|value| unsafe { value.memory_usage(&self.memo_table_types) })
+            .map(|value| unsafe { value.memory_usage(&self.memo_table_types, panic_if_missing) })
             .collect();
         Some(memory_usage)
     }
@@ -929,15 +949,20 @@ where
     ///
     /// The `MemoTable` must belong to a `Value` of the correct type.
     #[cfg(feature = "salsa_unstable")]
-    unsafe fn memory_usage(&self, memo_table_types: &MemoTableTypes) -> crate::database::SlotInfo {
+    unsafe fn memory_usage(
+        &self,
+        memo_table_types: &MemoTableTypes,
+        panic_if_missing: crate::PanicIfHeapSizeMissing,
+    ) -> crate::database::SlotInfo {
+        let heap_size = C::heap_size(self.fields(), panic_if_missing);
         // SAFETY: The caller guarantees this is the correct types table.
         let memos = unsafe { memo_table_types.attach_memos(&self.memos) };
 
         crate::database::SlotInfo {
             debug_name: C::DEBUG_NAME,
             size_of_metadata: mem::size_of::<Self>() - mem::size_of::<C::Fields<'_>>(),
-            size_of_fields: mem::size_of::<C::Fields<'_>>(),
-            memos: memos.memory_usage(),
+            size_of_fields: mem::size_of::<C::Fields<'_>>() + heap_size,
+            memos: memos.memory_usage(panic_if_missing),
         }
     }
 }

--- a/tests/compile-fail/input_struct_incompatibles.rs
+++ b/tests/compile-fail/input_struct_incompatibles.rs
@@ -25,7 +25,4 @@ struct InputWithTrackedField {
     field: u32,
 }
 
-#[salsa::input(heap_size = size)]
-struct InputWithHeapSize(u32);
-
 fn main() {}

--- a/tests/compile-fail/input_struct_incompatibles.stderr
+++ b/tests/compile-fail/input_struct_incompatibles.stderr
@@ -47,12 +47,6 @@ error: `#[tracked]` cannot be used with `#[salsa::input]`
 25 | |     field: u32,
    | |______________^
 
-error: `heap_size` option not allowed here
-  --> tests/compile-fail/input_struct_incompatibles.rs:28:16
-   |
-28 | #[salsa::input(heap_size = size)]
-   |                ^^^^^^^^^
-
 error: cannot find attribute `tracked` in this scope
   --> tests/compile-fail/input_struct_incompatibles.rs:24:7
    |

--- a/tests/compile-fail/interned_struct_incompatibles.rs
+++ b/tests/compile-fail/interned_struct_incompatibles.rs
@@ -39,9 +39,4 @@ struct InternedWithZeroRevisions {
     field: u32,
 }
 
-#[salsa::interned(heap_size = size)]
-struct AccWithHeapSize {
-    field: u32,
-}
-
 fn main() {}

--- a/tests/compile-fail/interned_struct_incompatibles.stderr
+++ b/tests/compile-fail/interned_struct_incompatibles.stderr
@@ -41,12 +41,6 @@ error: `#[tracked]` cannot be used with `#[salsa::interned]`
 34 | |     field: u32,
    | |______________^
 
-error: `heap_size` option not allowed here
-  --> tests/compile-fail/interned_struct_incompatibles.rs:42:19
-   |
-42 | #[salsa::interned(heap_size = size)]
-   |                   ^^^^^^^^^
-
 error: cannot find attribute `tracked` in this scope
   --> tests/compile-fail/interned_struct_incompatibles.rs:33:7
    |

--- a/tests/compile-fail/tracked_struct_incompatibles.rs
+++ b/tests/compile-fail/tracked_struct_incompatibles.rs
@@ -33,9 +33,4 @@ struct TrackedStructWithRevisions {
     field: u32,
 }
 
-#[salsa::tracked(heap_size = size)]
-struct TrackedStructWithHeapSize {
-    field: u32,
-}
-
 fn main() {}

--- a/tests/compile-fail/tracked_struct_incompatibles.stderr
+++ b/tests/compile-fail/tracked_struct_incompatibles.stderr
@@ -39,9 +39,3 @@ error: `revisions` option not allowed here
    |
 31 | #[salsa::tracked(revisions = 12)]
    |                  ^^^^^^^^^
-
-error: `heap_size` option not allowed here
-  --> tests/compile-fail/tracked_struct_incompatibles.rs:36:18
-   |
-36 | #[salsa::tracked(heap_size = size)]
-   |                  ^^^^^^^^^

--- a/tests/memory-usage.rs
+++ b/tests/memory-usage.rs
@@ -1,18 +1,18 @@
 use expect_test::expect;
 
-#[salsa::input]
+#[salsa::input(heap_size = string_tuple_size_of)]
 struct MyInput {
-    field: u32,
+    field: String,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(heap_size = string_tuple_size_of)]
 struct MyTracked<'db> {
-    field: u32,
+    field: String,
 }
 
-#[salsa::interned]
+#[salsa::interned(heap_size = string_tuple_size_of)]
 struct MyInterned<'db> {
-    field: u32,
+    field: String,
 }
 
 #[salsa::tracked]
@@ -30,12 +30,16 @@ fn input_to_string<'db>(_db: &'db dyn salsa::Database) -> String {
     "a".repeat(1000)
 }
 
-#[salsa::tracked(heap_size = string_heap_size)]
+#[salsa::tracked(heap_size = string_size_of)]
 fn input_to_string_get_size<'db>(_db: &'db dyn salsa::Database) -> String {
     "a".repeat(1000)
 }
 
-fn string_heap_size(x: &String) -> usize {
+fn string_size_of(x: &String) -> usize {
+    x.capacity()
+}
+
+fn string_tuple_size_of((x,): &(String,)) -> usize {
     x.capacity()
 }
 
@@ -54,9 +58,9 @@ fn input_to_tracked_tuple<'db>(
 fn test() {
     let db = salsa::DatabaseImpl::new();
 
-    let input1 = MyInput::new(&db, 1);
-    let input2 = MyInput::new(&db, 2);
-    let input3 = MyInput::new(&db, 3);
+    let input1 = MyInput::new(&db, "a".repeat(50));
+    let input2 = MyInput::new(&db, "a".repeat(150));
+    let input3 = MyInput::new(&db, "a".repeat(250));
 
     let _tracked1 = input_to_tracked(&db, input1);
     let _tracked2 = input_to_tracked(&db, input2);
@@ -70,27 +74,27 @@ fn test() {
     let _string1 = input_to_string(&db);
     let _string2 = input_to_string_get_size(&db);
 
-    let structs_info = <dyn salsa::Database>::structs_info(&db);
+    let structs_info = <dyn salsa::Database>::structs_info(&db, salsa::PanicIfHeapSizeMissing::No);
 
     let expected = expect![[r#"
         [
             IngredientInfo {
                 debug_name: "MyInput",
                 count: 3,
-                size_of_metadata: 84,
-                size_of_fields: 12,
+                size_of_metadata: 96,
+                size_of_fields: 522,
             },
             IngredientInfo {
                 debug_name: "MyTracked",
                 count: 4,
-                size_of_metadata: 112,
-                size_of_fields: 16,
+                size_of_metadata: 128,
+                size_of_fields: 396,
             },
             IngredientInfo {
                 debug_name: "MyInterned",
                 count: 3,
-                size_of_metadata: 156,
-                size_of_fields: 12,
+                size_of_metadata: 168,
+                size_of_fields: 522,
             },
             IngredientInfo {
                 debug_name: "input_to_string::interned_arguments",
@@ -108,9 +112,10 @@ fn test() {
 
     expected.assert_eq(&format!("{structs_info:#?}"));
 
-    let mut queries_info = <dyn salsa::Database>::queries_info(&db)
-        .into_iter()
-        .collect::<Vec<_>>();
+    let mut queries_info =
+        <dyn salsa::Database>::queries_info(&db, salsa::PanicIfHeapSizeMissing::No)
+            .into_iter()
+            .collect::<Vec<_>>();
     queries_info.sort();
 
     let expected = expect![[r#"
@@ -163,4 +168,16 @@ fn test() {
         ]"#]];
 
     expected.assert_eq(&format!("{queries_info:#?}"));
+}
+
+#[test]
+#[should_panic = "tried to estimate sizes but `heap_size()` was not defined.\ningredient: MyInput"]
+fn missing_coverage() {
+    #[salsa::input]
+    struct MyInput {}
+
+    let db = salsa::DatabaseImpl::default();
+    let _input = MyInput::new(&db);
+
+    <dyn salsa::Database>::structs_info(&db, salsa::PanicIfHeapSizeMissing::Yes);
 }


### PR DESCRIPTION
 1. Include an option `panic_if_missing` that will panic if there is an ingredient with no `heap_size()` defined, to ensure coverage.
 2. Add `heap_size()` to tracked structs, interneds an inputs.