### PR TITLE
Deduplicate tracked struct IDs on memos

### DIFF
--- a/examples/calc/db.rs
+++ b/examples/calc/db.rs
@@ -48,6 +48,7 @@ impl CalcDatabaseImpl {
     }
 
     #[cfg(test)]
+    #[allow(dead_code)]
     pub fn take_logs(&self) -> Vec<String> {
         let mut logs = self.logs.lock().unwrap();
         if let Some(logs) = &mut *logs {

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -193,12 +193,14 @@ where
                         revisions.set_cycle_heads(CycleHeads::initial(database_key_index));
                         // We need this for `cycle_heads()` to work. We will unset this in the outer `execute()`.
                         *revisions.verified_final.get_mut() = false;
-                        Some(self.insert_memo(
-                            zalsa,
-                            id,
-                            Memo::new(Some(fallback_value), zalsa.current_revision(), revisions),
-                            memo_ingredient_index,
-                        ))
+
+                        let memo = Memo::new(
+                            Some(fallback_value),
+                            zalsa.current_revision(),
+                            // TODO: Why is this correct?
+                            revisions.drop_tracked_outputs(),
+                        );
+                        Some(self.insert_memo(zalsa, id, memo, memo_ingredient_index))
                     }
                 };
             }

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -274,7 +274,7 @@ impl<'db, C: Configuration> Memo<'db, C> {
         zalsa: &Zalsa,
         database_key_index: DatabaseKeyIndex,
     ) {
-        for output in self.revisions.origin.as_ref().outputs() {
+        for output in self.revisions.outputs() {
             output.mark_validated_output(zalsa, database_key_index);
         }
     }
@@ -309,8 +309,8 @@ impl<C: Configuration> crate::table::memo::Memo for Memo<'static, C>
 where
     C::Output<'static>: Send + Sync + Any,
 {
-    fn origin(&self) -> QueryOriginRef<'_> {
-        self.revisions.origin.as_ref()
+    fn revisions(&self) -> &QueryRevisions {
+        &self.revisions
     }
 
     #[cfg(feature = "salsa_unstable")]

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -689,7 +689,7 @@ where
 
                 zalsa.event(&|| Event::new(EventKind::DidDiscard { key: executor }));
 
-                for stale_output in memo.origin().outputs() {
+                for stale_output in memo.revisions().outputs() {
                     stale_output.remove_stale_output(zalsa, executor);
                 }
             })

--- a/src/key.rs
+++ b/src/key.rs
@@ -10,7 +10,7 @@ use crate::{Database, Id};
 /// database. Used to track input and output dependencies between queries. Fully
 /// ordered and equatable but those orderings are arbitrary, and meant to be used
 /// only for inserting into maps and the like.
-#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct DatabaseKeyIndex {
     key_index: Id,
     ingredient_index: IngredientIndex,

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -8,7 +8,8 @@ use thin_vec::ThinVec;
 
 use crate::sync::atomic::{AtomicPtr, Ordering};
 use crate::sync::{OnceLock, RwLock};
-use crate::{zalsa::MemoIngredientIndex, zalsa_local::QueryOriginRef};
+use crate::zalsa::MemoIngredientIndex;
+use crate::zalsa_local::QueryRevisions;
 
 /// The "memo table" stores the memoized results of tracked function calls.
 /// Every tracked function must take a salsa struct as its first argument
@@ -19,8 +20,8 @@ pub(crate) struct MemoTable {
 }
 
 pub trait Memo: Any + Send + Sync {
-    /// Returns the `origin` of this memo
-    fn origin(&self) -> QueryOriginRef<'_>;
+    /// Returns the `revision` of this memo
+    fn revisions(&self) -> &QueryRevisions;
 
     /// Returns memory usage information about the memoized value.
     #[cfg(feature = "salsa_unstable")]
@@ -107,7 +108,7 @@ impl MemoEntryType {
 struct DummyMemo;
 
 impl Memo for DummyMemo {
-    fn origin(&self) -> QueryOriginRef<'_> {
+    fn revisions(&self) -> &QueryRevisions {
         unreachable!("should not get here")
     }
 

--- a/tests/memory-usage.rs
+++ b/tests/memory-usage.rs
@@ -147,7 +147,7 @@ fn test() {
                 IngredientInfo {
                     debug_name: "memory_usage::MyTracked",
                     count: 2,
-                    size_of_metadata: 192,
+                    size_of_metadata: 168,
                     size_of_fields: 16,
                 },
             ),
@@ -156,7 +156,7 @@ fn test() {
                 IngredientInfo {
                     debug_name: "(memory_usage::MyTracked, memory_usage::MyTracked)",
                     count: 1,
-                    size_of_metadata: 132,
+                    size_of_metadata: 108,
                     size_of_fields: 16,
                 },
             ),


### PR DESCRIPTION
This is a pretty minor memory usage saving as most queries don't create tracked structs anyways (at least in ty), but still seemed worth doing.