### PR TITLE
Remove bounds and type checks from `IngredientCache`

### DIFF
--- a/components/salsa-macro-rules/src/setup_accumulator_impl.rs
+++ b/components/salsa-macro-rules/src/setup_accumulator_impl.rs
@@ -34,9 +34,13 @@ macro_rules! setup_accumulator_impl {
                 static $CACHE: $zalsa::IngredientCache<$zalsa_struct::IngredientImpl<$Struct>> =
                     $zalsa::IngredientCache::new();
 
-                $CACHE.get_or_create(zalsa, || {
-                    zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Struct>>()
-                })
+                // SAFETY: `lookup_jar_by_type` returns a valid ingredient index, and the only
+                // ingredient created by our jar is the struct ingredient.
+                unsafe {
+                    $CACHE.get_or_create(zalsa, || {
+                        zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Struct>>()
+                    })
+                }
             }
 
             impl $zalsa::Accumulator for $Struct {

--- a/components/salsa-macro-rules/src/setup_input_struct.rs
+++ b/components/salsa-macro-rules/src/setup_input_struct.rs
@@ -109,9 +109,13 @@ macro_rules! setup_input_struct {
                     static CACHE: $zalsa::IngredientCache<$zalsa_struct::IngredientImpl<$Configuration>> =
                         $zalsa::IngredientCache::new();
 
-                    CACHE.get_or_create(zalsa, || {
-                        zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>()
-                    })
+                    // SAFETY: `lookup_jar_by_type` returns a valid ingredient index, and the only
+                    // ingredient created by our jar is the struct ingredient.
+                    unsafe {
+                        CACHE.get_or_create(zalsa, || {
+                            zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>()
+                        })
+                    }
                 }
 
                 pub fn ingredient_mut(db: &mut dyn $zalsa::Database) -> (&mut $zalsa_struct::IngredientImpl<Self>, &mut $zalsa::Runtime) {

--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -157,9 +157,14 @@ macro_rules! setup_interned_struct {
                         $zalsa::IngredientCache::new();
 
                     let zalsa = db.zalsa();
-                    CACHE.get_or_create(zalsa, || {
-                        zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>()
-                    })
+
+                    // SAFETY: `lookup_jar_by_type` returns a valid ingredient index, and the only
+                    // ingredient created by our jar is the struct ingredient.
+                    unsafe {
+                        CACHE.get_or_create(zalsa, || {
+                            zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>()
+                        })
+                    }
                 }
             }
 

--- a/components/salsa-macro-rules/src/setup_tracked_struct.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_struct.rs
@@ -196,9 +196,13 @@ macro_rules! setup_tracked_struct {
                     static CACHE: $zalsa::IngredientCache<$zalsa_struct::IngredientImpl<$Configuration>> =
                         $zalsa::IngredientCache::new();
 
-                    CACHE.get_or_create(zalsa, || {
-                        zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>()
-                    })
+                    // SAFETY: `lookup_jar_by_type` returns a valid ingredient index, and the only
+                    // ingredient created by our jar is the struct ingredient.
+                    unsafe {
+                        CACHE.get_or_create(zalsa, || {
+                            zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>()
+                        })
+                    }
                 }
             }
 

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -177,7 +177,8 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
 }
 
 impl dyn Ingredient {
-    /// Equivalent to the `downcast` methods on `any`.
+    /// Equivalent to the `downcast` method on `Any`.
+    ///
     /// Because we do not have dyn-upcasting support, we need this workaround.
     pub fn assert_type<T: Any>(&self) -> &T {
         assert_eq!(
@@ -192,7 +193,27 @@ impl dyn Ingredient {
         unsafe { transmute_data_ptr(self) }
     }
 
-    /// Equivalent to the `downcast` methods on `any`.
+    /// Equivalent to the `downcast` methods on `Any`.
+    ///
+    /// Because we do not have dyn-upcasting support, we need this workaround.
+    ///
+    /// # Safety
+    ///
+    /// The contained value must be of type `T`.
+    pub unsafe fn assert_type_unchecked<T: Any>(&self) -> &T {
+        debug_assert_eq!(
+            self.type_id(),
+            TypeId::of::<T>(),
+            "ingredient `{self:?}` is not of type `{}`",
+            std::any::type_name::<T>()
+        );
+
+        // SAFETY: Guaranteed by caller.
+        unsafe { transmute_data_ptr(self) }
+    }
+
+    /// Equivalent to the `downcast` method on `Any`.
+    ///
     /// Because we do not have dyn-upcasting support, we need this workaround.
     pub fn assert_type_mut<T: Any>(&mut self) -> &mut T {
         assert_eq!(

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -976,19 +976,19 @@ mod tests {
         let mut d = DisambiguatorMap::default();
         // set up all 4 permutations of differing field values
         let h1 = IdentityHash {
-            ingredient_index: IngredientIndex::from(0),
+            ingredient_index: IngredientIndex::new(0),
             hash: 0,
         };
         let h2 = IdentityHash {
-            ingredient_index: IngredientIndex::from(1),
+            ingredient_index: IngredientIndex::new(1),
             hash: 0,
         };
         let h3 = IdentityHash {
-            ingredient_index: IngredientIndex::from(0),
+            ingredient_index: IngredientIndex::new(0),
             hash: 1,
         };
         let h4 = IdentityHash {
-            ingredient_index: IngredientIndex::from(1),
+            ingredient_index: IngredientIndex::new(1),
             hash: 1,
         };
         assert_eq!(d.disambiguate(h1), Disambiguator(0));
@@ -1006,42 +1006,42 @@ mod tests {
         let mut d = IdentityMap::default();
         // set up all 8 permutations of differing field values
         let i1 = Identity {
-            ingredient_index: IngredientIndex::from(0),
+            ingredient_index: IngredientIndex::new(0),
             hash: 0,
             disambiguator: Disambiguator(0),
         };
         let i2 = Identity {
-            ingredient_index: IngredientIndex::from(1),
+            ingredient_index: IngredientIndex::new(1),
             hash: 0,
             disambiguator: Disambiguator(0),
         };
         let i3 = Identity {
-            ingredient_index: IngredientIndex::from(0),
+            ingredient_index: IngredientIndex::new(0),
             hash: 1,
             disambiguator: Disambiguator(0),
         };
         let i4 = Identity {
-            ingredient_index: IngredientIndex::from(1),
+            ingredient_index: IngredientIndex::new(1),
             hash: 1,
             disambiguator: Disambiguator(0),
         };
         let i5 = Identity {
-            ingredient_index: IngredientIndex::from(0),
+            ingredient_index: IngredientIndex::new(0),
             hash: 0,
             disambiguator: Disambiguator(1),
         };
         let i6 = Identity {
-            ingredient_index: IngredientIndex::from(1),
+            ingredient_index: IngredientIndex::new(1),
             hash: 0,
             disambiguator: Disambiguator(1),
         };
         let i7 = Identity {
-            ingredient_index: IngredientIndex::from(0),
+            ingredient_index: IngredientIndex::new(0),
             hash: 1,
             disambiguator: Disambiguator(1),
         };
         let i8 = Identity {
-            ingredient_index: IngredientIndex::from(1),
+            ingredient_index: IngredientIndex::new(1),
             hash: 1,
             disambiguator: Disambiguator(1),
         };

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -754,7 +754,11 @@ impl QueryOrigin {
             QueryOriginKind::Assigned => {
                 // SAFETY: `data.index` is initialized when the tag is `QueryOriginKind::Assigned`.
                 let index = unsafe { self.data.index };
-                let ingredient_index = IngredientIndex::from(self.metadata);
+
+                // SAFETY: `metadata` is initialized from a valid `IngredientIndex` when the tag
+                // is `QueryOriginKind::Assigned`.
+                let ingredient_index = unsafe { IngredientIndex::new_unchecked(self.metadata) };
+
                 QueryOriginRef::Assigned(DatabaseKeyIndex::new(ingredient_index, index))
             }
 

--- a/tests/interned-structs_self_ref.rs
+++ b/tests/interned-structs_self_ref.rs
@@ -99,9 +99,14 @@ const _: () = {
                 zalsa_::IngredientCache::new();
 
             let zalsa = db.zalsa();
-            CACHE.get_or_create(zalsa, || {
-                zalsa.lookup_jar_by_type::<zalsa_struct_::JarImpl<Configuration_>>()
-            })
+
+            // SAFETY: `lookup_jar_by_type` returns a valid ingredient index, and the only
+            // ingredient created by our jar is the struct ingredient.
+            unsafe {
+                CACHE.get_or_create(zalsa, || {
+                    zalsa.lookup_jar_by_type::<zalsa_struct_::JarImpl<Configuration_>>()
+                })
+            }
         }
     }
     impl zalsa_::AsId for InternedString<'_> {


### PR DESCRIPTION
@Veykril might need to verify my logic here, but I think this is correct given either the `inventory` feature or the nonce checks, as `IngredientCache` always loads the index directly from the database.

The safety arguments for unchecked access are less clear for other uses of `lookup_ingredient`. The most notable one is in `DatabaseKeyIndex::maybe_changed_after`, where I think it's actually possible that a function records a dependency on an ingredient from a different database, in which case we should panic. It would be nice if we could guarantee that ingredient indices are stable even with manual registration, but that sort of defeats the purpose.