### PR TITLE
Remove extra bounds checks from memo table hot-paths

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -116,7 +116,9 @@ impl<C: Configuration> IngredientImpl<C> {
                 fields,
                 revisions,
                 durabilities,
-                memos: MemoTable::new(self.memo_table_types()),
+                // SAFETY: We only ever access the memos of a value that we allocated through
+                // our `MemoTableTypes`.
+                memos: unsafe { MemoTable::new(self.memo_table_types()) },
             })
         });
 

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -586,7 +586,9 @@ where
         let id = zalsa_local.allocate(zalsa, self.ingredient_index, |id| Value::<C> {
             shard: shard_index as u16,
             link: LinkedListLink::new(),
-            memos: UnsafeCell::new(MemoTable::new(self.memo_table_types())),
+            // SAFETY: We only ever access the memos of a value that we allocated through
+            // our `MemoTableTypes`.
+            memos: UnsafeCell::new(unsafe { MemoTable::new(self.memo_table_types()) }),
             // SAFETY: We call `from_internal_data` to restore the correct lifetime before access.
             fields: UnsafeCell::new(unsafe { self.to_internal_data(assemble(id, key)) }),
             shared: UnsafeCell::new(ValueShared {

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -443,7 +443,9 @@ where
             // lifetime erase for storage
             fields: unsafe { mem::transmute::<C::Fields<'db>, C::Fields<'static>>(fields) },
             revisions: C::new_revisions(current_deps.changed_at),
-            memos: MemoTable::new(self.memo_table_types()),
+            // SAFETY: We only ever access the memos of a value that we allocated through
+            // our `MemoTableTypes`.
+            memos: unsafe { MemoTable::new(self.memo_table_types()) },
         };
 
         while let Some(id) = self.free_list.pop() {


### PR DESCRIPTION
This is just a small optimization that takes advantage of the fact that an index being valid for a `MemoTable` guarantees that it is valid for the corresponding `MemoTableTypes`, so we can avoid the duplicate bounds checks here.

It would be nice if we could remove the bounds and type checks here completely, but I don't think that's possible because we sometimes compute the `MemoIngredientIndex` from a salsa supertype `Id`, which could be smuggled across databases. 