### PR TITLE
Avoid dynamic dispatch to access memo tables

### DIFF
--- a/components/salsa-macro-rules/src/setup_input_struct.rs
+++ b/components/salsa-macro-rules/src/setup_input_struct.rs
@@ -170,6 +170,16 @@ macro_rules! setup_input_struct {
                         $zalsa::None
                     }
                 }
+
+                #[inline]
+                unsafe fn memo_table(
+                    zalsa: &$zalsa::Zalsa,
+                    id: $zalsa::Id,
+                    current_revision: $zalsa::Revision,
+                ) -> $zalsa::MemoTableWithTypes<'_> {
+                    // SAFETY: Guaranteed by caller.
+                    unsafe { zalsa.table().memos::<$zalsa_struct::Value<$Configuration>>(id, current_revision) }
+                }
             }
 
             impl $Struct {

--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -202,6 +202,16 @@ macro_rules! setup_interned_struct {
                         $zalsa::None
                     }
                 }
+
+                #[inline]
+                unsafe fn memo_table(
+                    zalsa: &$zalsa::Zalsa,
+                    id: $zalsa::Id,
+                    current_revision: $zalsa::Revision,
+                ) -> $zalsa::MemoTableWithTypes<'_> {
+                    // SAFETY: Guaranteed by caller.
+                    unsafe { zalsa.table().memos::<$zalsa_struct::Value<$Configuration>>(id, current_revision) }
+                }
             }
 
             unsafe impl< $($db_lt_arg)? > $zalsa::Update for $Struct< $($db_lt_arg)? > {

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -130,6 +130,16 @@ macro_rules! setup_tracked_fn {
                                 None
                             }
                         }
+
+                        #[inline]
+                        unsafe fn memo_table(
+                            zalsa: &$zalsa::Zalsa,
+                            id: $zalsa::Id,
+                            current_revision: $zalsa::Revision,
+                        ) -> $zalsa::MemoTableWithTypes<'_> {
+                            // SAFETY: Guaranteed by caller.
+                            unsafe { zalsa.table().memos::<$zalsa::interned::Value<$Configuration>>(id, current_revision) }
+                        }
                     }
 
                     impl $zalsa::AsId for $InternedData<'_> {

--- a/components/salsa-macro-rules/src/setup_tracked_struct.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_struct.rs
@@ -231,6 +231,16 @@ macro_rules! setup_tracked_struct {
                         $zalsa::None
                     }
                 }
+
+                #[inline]
+                unsafe fn memo_table(
+                    zalsa: &$zalsa::Zalsa,
+                    id: $zalsa::Id,
+                    current_revision: $zalsa::Revision,
+                ) -> $zalsa::MemoTableWithTypes<'_> {
+                    // SAFETY: Guaranteed by caller.
+                    unsafe { zalsa.table().memos::<$zalsa_struct::Value<$Configuration>>(id, current_revision) }
+                }
             }
 
             impl $zalsa::TrackedStructInDb for $Struct<'_> {

--- a/components/salsa-macros/src/supertype.rs
+++ b/components/salsa-macros/src/supertype.rs
@@ -89,6 +89,19 @@ fn enum_impl(enum_item: syn::ItemEnum) -> syn::Result<TokenStream> {
                     None
                 }
             }
+
+            #[inline]
+            unsafe fn memo_table(
+                zalsa: &zalsa::Zalsa,
+                id: zalsa::Id,
+                current_revision: zalsa::Revision,
+            ) -> zalsa::MemoTableWithTypes<'_> {
+                // Note that we need to use `dyn_memos` here, as the `Id` could map to any variant
+                // of the supertype enum.
+                //
+                // SAFETY: Guaranteed by caller.
+                unsafe { zalsa.table().dyn_memos(id, current_revision) }
+            }
         }
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,7 @@ pub mod plumbing {
     pub use crate::runtime::{stamp, Runtime, Stamp};
     pub use crate::salsa_struct::SalsaStructInDb;
     pub use crate::storage::{HasStorage, Storage};
+    pub use crate::table::memo::MemoTableWithTypes;
     pub use crate::tracked_struct::TrackedStructInDb;
     pub use crate::update::helper::{Dispatch as UpdateDispatch, Fallback as UpdateFallback};
     pub use crate::update::{always_update, Update};

--- a/src/salsa_struct.rs
+++ b/src/salsa_struct.rs
@@ -1,8 +1,9 @@
 use std::any::TypeId;
 
 use crate::memo_ingredient_indices::{IngredientIndices, MemoIngredientMap};
+use crate::table::memo::MemoTableWithTypes;
 use crate::zalsa::Zalsa;
-use crate::Id;
+use crate::{Id, Revision};
 
 pub trait SalsaStructInDb: Sized {
     type MemoIngredientMap: MemoIngredientMap;
@@ -62,4 +63,16 @@ pub trait SalsaStructInDb: Sized {
     /// Why `TypeId` and not `IngredientIndex`? Because it's cheaper and easier: the `TypeId` is readily
     /// available at compile time, while the `IngredientIndex` requires a runtime lookup.
     fn cast(id: Id, type_id: TypeId) -> Option<Self>;
+
+    /// Return the memo table associated with `id`.
+    ///
+    /// # Safety
+    ///
+    /// The parameter `current_revision` must be the current revision of the owner of database
+    /// owning this table.
+    unsafe fn memo_table(
+        zalsa: &Zalsa,
+        id: Id,
+        current_revision: Revision,
+    ) -> MemoTableWithTypes<'_>;
 }

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -9,7 +9,7 @@ use crate::{zalsa::MemoIngredientIndex, zalsa_local::QueryOriginRef};
 /// The "memo table" stores the memoized results of tracked function calls.
 /// Every tracked function must take a salsa struct as its first argument
 /// and memo tables are attached to those salsa structs as auxiliary data.
-pub(crate) struct MemoTable {
+pub struct MemoTable {
     memos: Box<[MemoEntry]>,
 }
 
@@ -168,7 +168,7 @@ impl MemoTableTypes {
     }
 }
 
-pub(crate) struct MemoTableWithTypes<'a> {
+pub struct MemoTableWithTypes<'a> {
     types: &'a MemoTableTypes,
     memos: &'a MemoTable,
 }

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -954,9 +954,8 @@ where
 {
     #[inline(always)]
     unsafe fn memos(&self, current_revision: Revision) -> &crate::table::memo::MemoTable {
-        // Acquiring the read lock here with the current revision
-        // ensures that there is no danger of a race
-        // when deleting a tracked struct.
+        // Acquiring the read lock here with the current revision to ensure that there
+        // is no danger of a race when deleting a tracked struct.
         self.read_lock(current_revision);
         &self.memos
     }

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -7,6 +7,7 @@ use rustc_hash::FxHashMap;
 
 use crate::hash::TypeIdHasher;
 use crate::ingredient::{Ingredient, Jar};
+use crate::plumbing::SalsaStructInDb;
 use crate::runtime::Runtime;
 use crate::table::memo::MemoTableWithTypes;
 use crate::table::Table;
@@ -225,15 +226,14 @@ impl Zalsa {
 
     /// Returns the [`Table`] used to store the value of salsa structs
     #[inline]
-    pub(crate) fn table(&self) -> &Table {
+    pub fn table(&self) -> &Table {
         self.runtime.table()
     }
 
     /// Returns the [`MemoTable`][] for the salsa struct with the given id
-    pub(crate) fn memo_table_for(&self, id: Id) -> MemoTableWithTypes<'_> {
-        let table = self.table();
-        // SAFETY: We are supplying the correct current revision
-        unsafe { table.memos(id, self.current_revision()) }
+    pub(crate) fn memo_table_for<T: SalsaStructInDb>(&self, id: Id) -> MemoTableWithTypes<'_> {
+        // SAFETY: We are supplying the correct current revision.
+        unsafe { T::memo_table(self, id, self.current_revision()) }
     }
 
     #[inline]

--- a/tests/interned-structs_self_ref.rs
+++ b/tests/interned-structs_self_ref.rs
@@ -139,6 +139,20 @@ const _: () = {
                 None
             }
         }
+
+        #[inline]
+        unsafe fn memo_table(
+            zalsa: &zalsa_::Zalsa,
+            id: zalsa_::Id,
+            current_revision: zalsa_::Revision,
+        ) -> zalsa_::MemoTableWithTypes<'_> {
+            // SAFETY: Guaranteed by caller.
+            unsafe {
+                zalsa
+                    .table()
+                    .memos::<zalsa_struct_::Value<Configuration_>>(id, current_revision)
+            }
+        }
     }
 
     unsafe impl zalsa_::Update for InternedString<'_> {


### PR DESCRIPTION
We know the concrete type of the input `Id`, so we shouldn't need dynamic dispatch unless it is a supertype.