### PR TITLE
Use visitor to extract memory usage information

### DIFF
--- a/components/salsa-macro-rules/src/setup_input_struct.rs
+++ b/components/salsa-macro-rules/src/setup_input_struct.rs
@@ -103,8 +103,8 @@ macro_rules! setup_input_struct {
                 type Durabilities = [$zalsa::Durability; $N];
 
                 $(
-                    fn heap_size(value: &Self::Fields) -> Option<usize> {
-                        Some($heap_size_fn(value))
+                    fn heap_size(value: &Self::Fields, visitor: &mut dyn salsa::MemoryUsageVisitor) -> Option<usize> {
+                        Some($heap_size_fn(value, visitor))
                     }
                 )?
             }

--- a/components/salsa-macro-rules/src/setup_input_struct.rs
+++ b/components/salsa-macro-rules/src/setup_input_struct.rs
@@ -103,8 +103,8 @@ macro_rules! setup_input_struct {
                 type Durabilities = [$zalsa::Durability; $N];
 
                 $(
-                    fn heap_size(value: &Self::Fields, _panic_if_missing: $zalsa::PanicIfHeapSizeMissing) -> usize {
-                        $heap_size_fn(value)
+                    fn heap_size(value: &Self::Fields) -> Option<usize> {
+                        Some($heap_size_fn(value))
                     }
                 )?
             }

--- a/components/salsa-macro-rules/src/setup_input_struct.rs
+++ b/components/salsa-macro-rules/src/setup_input_struct.rs
@@ -50,6 +50,9 @@ macro_rules! setup_input_struct {
         // If true, generate a debug impl.
         generate_debug_impl: $generate_debug_impl:tt,
 
+        // The function used to implement `C::heap_size`.
+        heap_size_fn: $($heap_size_fn:path)?,
+
         // Annoyingly macro-rules hygiene does not extend to items defined in the macro.
         // We have the procedural macro generate names for those items that are
         // not used elsewhere in the user's code.
@@ -98,6 +101,12 @@ macro_rules! setup_input_struct {
 
                 type Revisions = [$zalsa::Revision; $N];
                 type Durabilities = [$zalsa::Durability; $N];
+
+                $(
+                    fn heap_size(value: &Self::Fields, _panic_if_missing: $zalsa::PanicIfHeapSizeMissing) -> usize {
+                        $heap_size_fn(value)
+                    }
+                )?
             }
 
             impl $Configuration {

--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -151,8 +151,8 @@ macro_rules! setup_interned_struct {
                 type Struct<'db> = $Struct< $($db_lt_arg)? >;
 
                 $(
-                    fn heap_size(value: &Self::Fields<'_>) -> Option<usize> {
-                        Some($heap_size_fn(value))
+                    fn heap_size(value: &Self::Fields<'_>, visitor: &mut dyn salsa::MemoryUsageVisitor) -> Option<usize> {
+                        Some($heap_size_fn(value, visitor))
                     }
                 )?
             }

--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -66,6 +66,9 @@ macro_rules! setup_interned_struct {
         // If true, generate a debug impl.
         generate_debug_impl: $generate_debug_impl:tt,
 
+        // The function used to implement `C::heap_size`.
+        heap_size_fn: $($heap_size_fn:path)?,
+
         // Annoyingly macro-rules hygiene does not extend to items defined in the macro.
         // We have the procedural macro generate names for those items that are
         // not used elsewhere in the user's code.
@@ -146,6 +149,12 @@ macro_rules! setup_interned_struct {
                 )?
                 type Fields<'a> = $StructDataIdent<'a>;
                 type Struct<'db> = $Struct< $($db_lt_arg)? >;
+
+                $(
+                    fn heap_size(value: &Self::Fields<'_>, _panic_if_missing: $zalsa::PanicIfHeapSizeMissing) -> usize {
+                        $heap_size_fn(value)
+                    }
+                )?
             }
 
             impl $Configuration {

--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -151,8 +151,8 @@ macro_rules! setup_interned_struct {
                 type Struct<'db> = $Struct< $($db_lt_arg)? >;
 
                 $(
-                    fn heap_size(value: &Self::Fields<'_>, _panic_if_missing: $zalsa::PanicIfHeapSizeMissing) -> usize {
-                        $heap_size_fn(value)
+                    fn heap_size(value: &Self::Fields<'_>) -> Option<usize> {
+                        Some($heap_size_fn(value))
                     }
                 )?
             }

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -231,7 +231,7 @@ macro_rules! setup_tracked_fn {
                 $($values_equal)+
 
                 $(
-                    fn heap_size(value: &Self::Output<'_>) -> usize {
+                    fn heap_size(value: &Self::Output<'_>, _panic_if_missing: $zalsa::PanicIfHeapSizeMissing) -> usize {
                         $heap_size_fn(value)
                     }
                 )?

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -231,8 +231,8 @@ macro_rules! setup_tracked_fn {
                 $($values_equal)+
 
                 $(
-                    fn heap_size(value: &Self::Output<'_>) -> Option<usize> {
-                        Some($heap_size_fn(value))
+                    fn heap_size(value: &Self::Output<'_>, visitor: &mut dyn salsa::MemoryUsageVisitor) -> Option<usize> {
+                        Some($heap_size_fn(value, visitor))
                     }
                 )?
 

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -231,8 +231,8 @@ macro_rules! setup_tracked_fn {
                 $($values_equal)+
 
                 $(
-                    fn heap_size(value: &Self::Output<'_>, _panic_if_missing: $zalsa::PanicIfHeapSizeMissing) -> usize {
-                        $heap_size_fn(value)
+                    fn heap_size(value: &Self::Output<'_>) -> Option<usize> {
+                        Some($heap_size_fn(value))
                     }
                 )?
 

--- a/components/salsa-macro-rules/src/setup_tracked_struct.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_struct.rs
@@ -88,6 +88,9 @@ macro_rules! setup_tracked_struct {
         // If true, generate a debug impl.
         generate_debug_impl: $generate_debug_impl:tt,
 
+        // The function used to implement `C::heap_size`.
+        heap_size_fn: $($heap_size_fn:path)?,
+
         // Annoyingly macro-rules hygiene does not extend to items defined in the macro.
         // We have the procedural macro generate names for those items that are
         // not used elsewhere in the user's code.
@@ -185,6 +188,12 @@ macro_rules! setup_tracked_struct {
                         )* false
                     }
                 }
+
+                $(
+                    fn heap_size(value: &Self::Fields<'_>, _panic_if_missing: $zalsa::PanicIfHeapSizeMissing) -> usize {
+                        $heap_size_fn(value)
+                    }
+                )?
             }
 
             impl $Configuration {

--- a/components/salsa-macro-rules/src/setup_tracked_struct.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_struct.rs
@@ -190,8 +190,8 @@ macro_rules! setup_tracked_struct {
                 }
 
                 $(
-                    fn heap_size(value: &Self::Fields<'_>) -> Option<usize> {
-                        Some($heap_size_fn(value))
+                    fn heap_size(value: &Self::Fields<'_>, visitor: &mut dyn salsa::MemoryUsageVisitor) -> Option<usize> {
+                        Some($heap_size_fn(value, visitor))
                     }
                 )?
             }

--- a/components/salsa-macro-rules/src/setup_tracked_struct.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_struct.rs
@@ -190,8 +190,8 @@ macro_rules! setup_tracked_struct {
                 }
 
                 $(
-                    fn heap_size(value: &Self::Fields<'_>, _panic_if_missing: $zalsa::PanicIfHeapSizeMissing) -> usize {
-                        $heap_size_fn(value)
+                    fn heap_size(value: &Self::Fields<'_>) -> Option<usize> {
+                        Some($heap_size_fn(value))
                     }
                 )?
             }

--- a/components/salsa-macros/src/input.rs
+++ b/components/salsa-macros/src/input.rs
@@ -65,7 +65,7 @@ impl crate::options::AllowedOptions for InputStruct {
 
     const REVISIONS: bool = false;
 
-    const HEAP_SIZE: bool = false;
+    const HEAP_SIZE: bool = true;
 
     const SELF_TY: bool = false;
 }
@@ -112,6 +112,7 @@ impl Macro {
         let field_attrs = salsa_struct.field_attrs();
         let is_singleton = self.args.singleton.is_some();
         let generate_debug_impl = salsa_struct.generate_debug_impl();
+        let heap_size_fn = self.args.heap_size_fn.iter();
 
         let zalsa = self.hygiene.ident("zalsa");
         let zalsa_struct = self.hygiene.ident("zalsa_struct");
@@ -140,6 +141,7 @@ impl Macro {
                     num_fields: #num_fields,
                     is_singleton: #is_singleton,
                     generate_debug_impl: #generate_debug_impl,
+                    heap_size_fn: #(#heap_size_fn)*,
                     unused_names: [
                         #zalsa,
                         #zalsa_struct,

--- a/components/salsa-macros/src/interned.rs
+++ b/components/salsa-macros/src/interned.rs
@@ -65,7 +65,7 @@ impl crate::options::AllowedOptions for InternedStruct {
 
     const REVISIONS: bool = true;
 
-    const HEAP_SIZE: bool = false;
+    const HEAP_SIZE: bool = true;
 
     const SELF_TY: bool = false;
 }
@@ -131,6 +131,8 @@ impl Macro {
             (None, quote!(#struct_ident), static_lifetime)
         };
 
+        let heap_size_fn = self.args.heap_size_fn.iter();
+
         let zalsa = self.hygiene.ident("zalsa");
         let zalsa_struct = self.hygiene.ident("zalsa_struct");
         let Configuration = self.hygiene.ident("Configuration");
@@ -161,6 +163,7 @@ impl Macro {
                     field_attrs: [#([#(#field_unused_attrs),*]),*],
                     num_fields: #num_fields,
                     generate_debug_impl: #generate_debug_impl,
+                    heap_size_fn: #(#heap_size_fn)*,
                     unused_names: [
                         #zalsa,
                         #zalsa_struct,

--- a/components/salsa-macros/src/tracked_struct.rs
+++ b/components/salsa-macros/src/tracked_struct.rs
@@ -61,7 +61,7 @@ impl crate::options::AllowedOptions for TrackedStruct {
 
     const REVISIONS: bool = false;
 
-    const HEAP_SIZE: bool = false;
+    const HEAP_SIZE: bool = true;
 
     const SELF_TY: bool = false;
 }
@@ -141,6 +141,8 @@ impl Macro {
             }
         });
 
+        let heap_size_fn = self.args.heap_size_fn.iter();
+
         let num_tracked_fields = salsa_struct.num_tracked_fields();
         let generate_debug_impl = salsa_struct.generate_debug_impl();
 
@@ -188,6 +190,9 @@ impl Macro {
 
                     num_tracked_fields: #num_tracked_fields,
                     generate_debug_impl: #generate_debug_impl,
+
+                    heap_size_fn: #(#heap_size_fn)*,
+
                     unused_names: [
                         #zalsa,
                         #zalsa_struct,

--- a/src/database.rs
+++ b/src/database.rs
@@ -143,14 +143,27 @@ pub use memory_usage::IngredientInfo;
 #[cfg(feature = "salsa_unstable")]
 pub(crate) use memory_usage::{MemoInfo, SlotInfo};
 
+/// Whether to panic on the default `heap_size()`, to ensure the user has provided a custom one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PanicIfHeapSizeMissing {
+    Yes,
+    No,
+}
+
 #[cfg(feature = "salsa_unstable")]
 mod memory_usage {
-    use crate::Database;
+    use crate::{Database, PanicIfHeapSizeMissing};
     use hashbrown::HashMap;
 
     impl dyn Database {
         /// Returns information about any Salsa structs.
-        pub fn structs_info(&self) -> Vec<IngredientInfo> {
+        ///
+        /// If `panic_is_missing` is [`PanicIfHeapSizeMissing::Yes`], and there is an ingredient with no `heap_size()` function,
+        /// this function will panic. This can be used to ensure coverage.
+        pub fn structs_info(
+            &self,
+            panic_if_missing: PanicIfHeapSizeMissing,
+        ) -> Vec<IngredientInfo> {
             self.zalsa()
                 .ingredients()
                 .filter_map(|ingredient| {
@@ -158,7 +171,7 @@ mod memory_usage {
                     let mut size_of_metadata = 0;
                     let mut instances = 0;
 
-                    for slot in ingredient.memory_usage(self)? {
+                    for slot in ingredient.memory_usage(self, panic_if_missing)? {
                         instances += 1;
                         size_of_fields += slot.size_of_fields;
                         size_of_metadata += slot.size_of_metadata;
@@ -178,11 +191,17 @@ mod memory_usage {
         ///
         /// The returned map holds memory usage information for memoized values of a given query, keyed
         /// by the query function name.
-        pub fn queries_info(&self) -> HashMap<&'static str, IngredientInfo> {
+        ///
+        /// If `panic_is_missing` is [`PanicIfHeapSizeMissing::Yes`], and there is an ingredient with no `heap_size()` function,
+        /// this function will panic. This can be used to ensure coverage.
+        pub fn queries_info(
+            &self,
+            panic_if_missing: PanicIfHeapSizeMissing,
+        ) -> HashMap<&'static str, IngredientInfo> {
             let mut queries = HashMap::new();
 
             for input_ingredient in self.zalsa().ingredients() {
-                let Some(input_info) = input_ingredient.memory_usage(self) else {
+                let Some(input_info) = input_ingredient.memory_usage(self, panic_if_missing) else {
                     continue;
                 };
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -150,9 +150,6 @@ mod memory_usage {
 
     impl dyn Database {
         /// Returns information about any Salsa structs.
-        ///
-        /// If `panic_is_missing` is [`PanicIfHeapSizeMissing::Yes`], and there is an ingredient with no `heap_size()` function,
-        /// this function will panic. This can be used to ensure coverage.
         pub fn structs_info(&self) -> Vec<IngredientInfo> {
             self.zalsa()
                 .ingredients()
@@ -188,9 +185,6 @@ mod memory_usage {
         ///
         /// The returned map holds memory usage information for memoized values of a given query, keyed
         /// by the query function name.
-        ///
-        /// If `panic_is_missing` is [`PanicIfHeapSizeMissing::Yes`], and there is an ingredient with no `heap_size()` function,
-        /// this function will panic. This can be used to ensure coverage.
         pub fn queries_info(&self) -> HashMap<&'static str, IngredientInfo> {
             let mut queries = HashMap::new();
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -138,95 +138,95 @@ impl dyn Database {
 }
 
 #[cfg(feature = "salsa_unstable")]
-pub use memory_usage::IngredientInfo;
-
-#[cfg(feature = "salsa_unstable")]
-pub(crate) use memory_usage::{MemoInfo, SlotInfo};
+pub use memory_usage::{MemoMemoryInfo, MemoryUsageVisitor, StructMemoryInfo};
 
 #[cfg(feature = "salsa_unstable")]
 mod memory_usage {
     use crate::Database;
-    use hashbrown::HashMap;
+
+    pub trait MemoryUsageVisitor: std::any::Any {
+        fn visit_tracked_struct(&mut self, info: StructMemoryInfo) {
+            self.visit_struct(info);
+        }
+
+        fn visit_memo(&mut self, info: MemoMemoryInfo) {
+            let _ = info;
+        }
+
+        fn visit_input_struct(&mut self, info: StructMemoryInfo) {
+            self.visit_struct(info);
+        }
+
+        fn visit_interned_struct(&mut self, info: StructMemoryInfo) {
+            self.visit_struct(info);
+        }
+
+        fn visit_struct(&mut self, info: StructMemoryInfo) {
+            let _ = info;
+        }
+
+        fn add_detail(&mut self, name: &'static str, size: usize) {
+            let (_, _) = (name, size);
+        }
+    }
 
     impl dyn Database {
-        /// Returns information about any Salsa structs.
-        pub fn structs_info(&self) -> Vec<IngredientInfo> {
-            self.zalsa()
-                .ingredients()
-                .filter_map(|ingredient| {
-                    let mut size_of_fields = 0;
-                    let mut size_of_metadata = 0;
-                    let mut instances = 0;
-                    let mut heap_size_of_fields = None;
-
-                    for slot in ingredient.memory_usage(self)? {
-                        instances += 1;
-                        size_of_fields += slot.size_of_fields;
-                        size_of_metadata += slot.size_of_metadata;
-
-                        if let Some(slot_heap_size) = slot.heap_size_of_fields {
-                            heap_size_of_fields =
-                                Some(heap_size_of_fields.unwrap_or_default() + slot_heap_size);
-                        }
-                    }
-
-                    Some(IngredientInfo {
-                        count: instances,
-                        size_of_fields,
-                        size_of_metadata,
-                        heap_size_of_fields,
-                        debug_name: ingredient.debug_name(),
-                    })
-                })
-                .collect()
-        }
-
-        /// Returns information about any memoized Salsa queries.
-        ///
-        /// The returned map holds memory usage information for memoized values of a given query, keyed
-        /// by the query function name.
-        pub fn queries_info(&self) -> HashMap<&'static str, IngredientInfo> {
-            let mut queries = HashMap::new();
-
-            for input_ingredient in self.zalsa().ingredients() {
-                let Some(input_info) = input_ingredient.memory_usage(self) else {
-                    continue;
-                };
-
-                for input in input_info {
-                    for memo in input.memos {
-                        let info = queries.entry(memo.debug_name).or_insert(IngredientInfo {
-                            debug_name: memo.output.debug_name,
-                            ..Default::default()
-                        });
-
-                        info.count += 1;
-                        info.size_of_fields += memo.output.size_of_fields;
-                        info.size_of_metadata += memo.output.size_of_metadata;
-
-                        if let Some(memo_heap_size) = memo.output.heap_size_of_fields {
-                            info.heap_size_of_fields =
-                                Some(info.heap_size_of_fields.unwrap_or_default() + memo_heap_size);
-                        }
-                    }
-                }
+        /// Collects information about the memory usage of salsa structs and query functions.
+        pub fn memory_usage(&self, visitor: &mut dyn MemoryUsageVisitor) {
+            for ingredient in self.zalsa().ingredients() {
+                ingredient.memory_usage(self, visitor);
             }
-
-            queries
         }
     }
 
-    /// Information about instances of a particular Salsa ingredient.
-    #[derive(Default, Debug, PartialEq, Eq, PartialOrd, Ord)]
-    pub struct IngredientInfo {
-        debug_name: &'static str,
-        count: usize,
-        size_of_metadata: usize,
-        size_of_fields: usize,
-        heap_size_of_fields: Option<usize>,
+    /// Memory usage information about a particular instance of struct, input, output, or memo.
+    #[derive(Debug, PartialEq, Eq)]
+    pub struct MemoMemoryInfo {
+        pub(crate) query_debug_name: &'static str,
+        pub(crate) result_debug_name: &'static str,
+        pub(crate) size_of_metadata: usize,
+        pub(crate) size_of_fields: usize,
+        pub(crate) heap_size_of_fields: Option<usize>,
     }
 
-    impl IngredientInfo {
+    impl MemoMemoryInfo {
+        /// Returns the debug name of the ingredient.
+        pub fn query_debug_name(&self) -> &'static str {
+            self.query_debug_name
+        }
+
+        /// Returns the debug name of the ingredient.
+        pub fn result_debug_name(&self) -> &'static str {
+            self.result_debug_name
+        }
+
+        /// Returns the total stack size of the fields of any instances of this ingredient, in bytes.
+        pub fn size_of_fields(&self) -> usize {
+            self.size_of_fields
+        }
+
+        /// Returns the total heap size of the fields of any instances of this ingredient, in bytes.
+        ///
+        /// Returns `None` if the ingredient doesn't specify a `heap_size` function.
+        pub fn heap_size_of_fields(&self) -> Option<usize> {
+            self.heap_size_of_fields
+        }
+
+        /// Returns the total size of Salsa metadata of any instances of this ingredient, in bytes.
+        pub fn size_of_metadata(&self) -> usize {
+            self.size_of_metadata
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    pub struct StructMemoryInfo {
+        pub(crate) debug_name: &'static str,
+        pub(crate) size_of_metadata: usize,
+        pub(crate) size_of_fields: usize,
+        pub(crate) heap_size_of_fields: Option<usize>,
+    }
+
+    impl StructMemoryInfo {
         /// Returns the debug name of the ingredient.
         pub fn debug_name(&self) -> &'static str {
             self.debug_name
@@ -248,25 +248,5 @@ mod memory_usage {
         pub fn size_of_metadata(&self) -> usize {
             self.size_of_metadata
         }
-
-        /// Returns the number of instances of this ingredient.
-        pub fn count(&self) -> usize {
-            self.count
-        }
-    }
-
-    /// Memory usage information about a particular instance of struct, input or output.
-    pub struct SlotInfo {
-        pub(crate) debug_name: &'static str,
-        pub(crate) size_of_metadata: usize,
-        pub(crate) size_of_fields: usize,
-        pub(crate) heap_size_of_fields: Option<usize>,
-        pub(crate) memos: Vec<MemoInfo>,
-    }
-
-    /// Memory usage information about a particular memo.
-    pub struct MemoInfo {
-        pub(crate) debug_name: &'static str,
-        pub(crate) output: SlotInfo,
     }
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -74,7 +74,18 @@ pub trait Configuration: Any {
     fn id_to_input(db: &Self::DbView, key: Id) -> Self::Input<'_>;
 
     /// Returns the size of any heap allocations in the output value, in bytes.
-    fn heap_size(_value: &Self::Output<'_>) -> usize {
+    fn heap_size(
+        _value: &Self::Output<'_>,
+        panic_if_missing: crate::PanicIfHeapSizeMissing,
+    ) -> usize {
+        if panic_if_missing == crate::PanicIfHeapSizeMissing::Yes {
+            panic!(
+                "tried to estimate sizes but `size_of()` was not defined.\n\
+                ingredient: {}\ntype: {}",
+                Self::DEBUG_NAME,
+                std::any::type_name::<Self::Output<'_>>()
+            );
+        }
         0
     }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -74,19 +74,8 @@ pub trait Configuration: Any {
     fn id_to_input(db: &Self::DbView, key: Id) -> Self::Input<'_>;
 
     /// Returns the size of any heap allocations in the output value, in bytes.
-    fn heap_size(
-        _value: &Self::Output<'_>,
-        panic_if_missing: crate::PanicIfHeapSizeMissing,
-    ) -> usize {
-        if panic_if_missing == crate::PanicIfHeapSizeMissing::Yes {
-            panic!(
-                "tried to estimate sizes but `size_of()` was not defined.\n\
-                ingredient: {}\ntype: {}",
-                Self::DEBUG_NAME,
-                std::any::type_name::<Self::Output<'_>>()
-            );
-        }
-        0
+    fn heap_size(_value: &Self::Output<'_>) -> Option<usize> {
+        None
     }
 
     /// Invoked when we need to compute the value for the given key, either because we've never

--- a/src/function.rs
+++ b/src/function.rs
@@ -74,7 +74,10 @@ pub trait Configuration: Any {
     fn id_to_input(db: &Self::DbView, key: Id) -> Self::Input<'_>;
 
     /// Returns the size of any heap allocations in the output value, in bytes.
-    fn heap_size(_value: &Self::Output<'_>) -> Option<usize> {
+    fn heap_size(
+        _value: &Self::Output<'_>,
+        _visitor: &mut dyn crate::MemoryUsageVisitor,
+    ) -> Option<usize> {
         None
     }
 

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -316,23 +316,21 @@ where
     }
 
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(
-        &self,
-        panic_if_missing: crate::PanicIfHeapSizeMissing,
-    ) -> crate::database::MemoInfo {
+    fn memory_usage(&self) -> crate::database::MemoInfo {
         let size_of = std::mem::size_of::<Memo<C>>() + self.revisions.allocation_size();
-        let heap_size = self
-            .value
-            .as_ref()
-            .map(|value| C::heap_size(value, panic_if_missing))
-            .unwrap_or(0);
+        let heap_size = if let Some(value) = self.value.as_ref() {
+            C::heap_size(value)
+        } else {
+            Some(0)
+        };
 
         crate::database::MemoInfo {
             debug_name: C::DEBUG_NAME,
             output: crate::database::SlotInfo {
                 size_of_metadata: size_of - std::mem::size_of::<C::Output<'static>>(),
                 debug_name: std::any::type_name::<C::Output<'static>>(),
-                size_of_fields: std::mem::size_of::<C::Output<'static>>() + heap_size,
+                size_of_fields: std::mem::size_of::<C::Output<'static>>(),
+                heap_size_of_fields: heap_size,
                 memos: Vec::new(),
             },
         }

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -316,9 +316,16 @@ where
     }
 
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(&self) -> crate::database::MemoInfo {
+    fn memory_usage(
+        &self,
+        panic_if_missing: crate::PanicIfHeapSizeMissing,
+    ) -> crate::database::MemoInfo {
         let size_of = std::mem::size_of::<Memo<C>>() + self.revisions.allocation_size();
-        let heap_size = self.value.as_ref().map(C::heap_size).unwrap_or(0);
+        let heap_size = self
+            .value
+            .as_ref()
+            .map(|value| C::heap_size(value, panic_if_missing))
+            .unwrap_or(0);
 
         crate::database::MemoInfo {
             debug_name: C::DEBUG_NAME,

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -171,7 +171,11 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
     /// Returns memory usage information about any instances of the ingredient,
     /// if applicable.
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(&self, _db: &dyn Database) -> Option<Vec<crate::database::SlotInfo>> {
+    fn memory_usage(
+        &self,
+        _db: &dyn Database,
+        _panic_if_missing: crate::PanicIfHeapSizeMissing,
+    ) -> Option<Vec<crate::database::SlotInfo>> {
         None
     }
 }

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -171,11 +171,7 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
     /// Returns memory usage information about any instances of the ingredient,
     /// if applicable.
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(
-        &self,
-        _db: &dyn Database,
-        _panic_if_missing: crate::PanicIfHeapSizeMissing,
-    ) -> Option<Vec<crate::database::SlotInfo>> {
+    fn memory_usage(&self, _db: &dyn Database) -> Option<Vec<crate::database::SlotInfo>> {
         None
     }
 }

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -12,6 +12,8 @@ use crate::table::memo::MemoTableTypes;
 use crate::table::Table;
 use crate::zalsa::{transmute_data_mut_ptr, transmute_data_ptr, IngredientIndex, Zalsa};
 use crate::zalsa_local::QueryOriginRef;
+#[cfg(feature = "salsa_unstable")]
+use crate::MemoryUsageVisitor;
 use crate::{Database, DatabaseKeyIndex, Id, Revision};
 
 /// A "jar" is a group of ingredients that are added atomically.
@@ -171,8 +173,8 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
     /// Returns memory usage information about any instances of the ingredient,
     /// if applicable.
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(&self, _db: &dyn Database) -> Option<Vec<crate::database::SlotInfo>> {
-        None
+    fn memory_usage(&self, db: &dyn Database, visitor: &mut dyn MemoryUsageVisitor) {
+        let _ = (db, visitor);
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -19,6 +19,8 @@ use crate::sync::Arc;
 use crate::table::memo::{MemoTable, MemoTableTypes};
 use crate::table::{Slot, Table};
 use crate::zalsa::{IngredientIndex, Zalsa};
+#[cfg(feature = "salsa_unstable")]
+use crate::MemoryUsageVisitor;
 use crate::{Database, Durability, Id, Revision, Runtime};
 
 pub trait Configuration: Any {
@@ -42,7 +44,10 @@ pub trait Configuration: Any {
     type Durabilities: Send + Sync + fmt::Debug + IndexMut<usize, Output = Durability>;
 
     /// Returns the size of any heap allocations in the output value, in bytes.
-    fn heap_size(_value: &Self::Fields) -> Option<usize> {
+    fn heap_size(
+        _value: &Self::Fields,
+        _visitor: &mut dyn crate::MemoryUsageVisitor,
+    ) -> Option<usize> {
         None
     }
 }
@@ -252,14 +257,12 @@ impl<C: Configuration> Ingredient for IngredientImpl<C> {
 
     /// Returns memory usage information about any inputs.
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(&self, db: &dyn Database) -> Option<Vec<crate::database::SlotInfo>> {
-        let memory_usage = self
-            .entries(db)
+    fn memory_usage(&self, db: &dyn Database, visitor: &mut dyn MemoryUsageVisitor) {
+        for value in self.entries(db) {
             // SAFETY: The memo table belongs to a value that we allocated, so it
             // has the correct type.
-            .map(|value| unsafe { value.memory_usage(&self.memo_table_types) })
-            .collect();
-        Some(memory_usage)
+            unsafe { value.memory_usage(&self.memo_table_types, visitor) }
+        }
     }
 }
 
@@ -311,18 +314,23 @@ where
     ///
     /// The `MemoTable` must belong to a `Value` of the correct type.
     #[cfg(feature = "salsa_unstable")]
-    unsafe fn memory_usage(&self, memo_table_types: &MemoTableTypes) -> crate::database::SlotInfo {
-        let heap_size = C::heap_size(&self.fields);
+    unsafe fn memory_usage(
+        &self,
+        memo_table_types: &MemoTableTypes,
+        visitor: &mut dyn MemoryUsageVisitor,
+    ) {
+        let heap_size = C::heap_size(&self.fields, visitor);
         // SAFETY: The caller guarantees this is the correct types table.
         let memos = unsafe { memo_table_types.attach_memos(&self.memos) };
 
-        crate::database::SlotInfo {
+        visitor.visit_input_struct(crate::database::StructMemoryInfo {
             debug_name: C::DEBUG_NAME,
             size_of_metadata: std::mem::size_of::<Self>() - std::mem::size_of::<C::Fields>(),
             size_of_fields: std::mem::size_of::<C::Fields>(),
             heap_size_of_fields: heap_size,
-            memos: memos.memory_usage(),
-        }
+        });
+
+        memos.memory_usage(visitor);
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -42,16 +42,8 @@ pub trait Configuration: Any {
     type Durabilities: Send + Sync + fmt::Debug + IndexMut<usize, Output = Durability>;
 
     /// Returns the size of any heap allocations in the output value, in bytes.
-    fn heap_size(_value: &Self::Fields, panic_if_missing: crate::PanicIfHeapSizeMissing) -> usize {
-        if panic_if_missing == crate::PanicIfHeapSizeMissing::Yes {
-            panic!(
-                "tried to estimate sizes but `heap_size()` was not defined.\n\
-                ingredient: {}\ntype: {}",
-                Self::DEBUG_NAME,
-                std::any::type_name::<Self::Fields>()
-            );
-        }
-        0
+    fn heap_size(_value: &Self::Fields) -> Option<usize> {
+        None
     }
 }
 
@@ -260,16 +252,12 @@ impl<C: Configuration> Ingredient for IngredientImpl<C> {
 
     /// Returns memory usage information about any inputs.
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(
-        &self,
-        db: &dyn Database,
-        panic_if_missing: crate::PanicIfHeapSizeMissing,
-    ) -> Option<Vec<crate::database::SlotInfo>> {
+    fn memory_usage(&self, db: &dyn Database) -> Option<Vec<crate::database::SlotInfo>> {
         let memory_usage = self
             .entries(db)
             // SAFETY: The memo table belongs to a value that we allocated, so it
             // has the correct type.
-            .map(|value| unsafe { value.memory_usage(&self.memo_table_types, panic_if_missing) })
+            .map(|value| unsafe { value.memory_usage(&self.memo_table_types) })
             .collect();
         Some(memory_usage)
     }
@@ -323,20 +311,17 @@ where
     ///
     /// The `MemoTable` must belong to a `Value` of the correct type.
     #[cfg(feature = "salsa_unstable")]
-    unsafe fn memory_usage(
-        &self,
-        memo_table_types: &MemoTableTypes,
-        panic_if_missing: crate::PanicIfHeapSizeMissing,
-    ) -> crate::database::SlotInfo {
-        let heap_size = C::heap_size(&self.fields, panic_if_missing);
+    unsafe fn memory_usage(&self, memo_table_types: &MemoTableTypes) -> crate::database::SlotInfo {
+        let heap_size = C::heap_size(&self.fields);
         // SAFETY: The caller guarantees this is the correct types table.
         let memos = unsafe { memo_table_types.attach_memos(&self.memos) };
 
         crate::database::SlotInfo {
             debug_name: C::DEBUG_NAME,
             size_of_metadata: std::mem::size_of::<Self>() - std::mem::size_of::<C::Fields>(),
-            size_of_fields: std::mem::size_of::<C::Fields>() + heap_size,
-            memos: memos.memory_usage(panic_if_missing),
+            size_of_fields: std::mem::size_of::<C::Fields>(),
+            heap_size_of_fields: heap_size,
+            memos: memos.memory_usage(),
         }
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -40,6 +40,19 @@ pub trait Configuration: Any {
 
     /// A array of [`Durability`], one per each of the value fields.
     type Durabilities: Send + Sync + fmt::Debug + IndexMut<usize, Output = Durability>;
+
+    /// Returns the size of any heap allocations in the output value, in bytes.
+    fn heap_size(_value: &Self::Fields, panic_if_missing: crate::PanicIfHeapSizeMissing) -> usize {
+        if panic_if_missing == crate::PanicIfHeapSizeMissing::Yes {
+            panic!(
+                "tried to estimate sizes but `heap_size()` was not defined.\n\
+                ingredient: {}\ntype: {}",
+                Self::DEBUG_NAME,
+                std::any::type_name::<Self::Fields>()
+            );
+        }
+        0
+    }
 }
 
 pub struct JarImpl<C: Configuration> {
@@ -247,12 +260,16 @@ impl<C: Configuration> Ingredient for IngredientImpl<C> {
 
     /// Returns memory usage information about any inputs.
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(&self, db: &dyn Database) -> Option<Vec<crate::database::SlotInfo>> {
+    fn memory_usage(
+        &self,
+        db: &dyn Database,
+        panic_if_missing: crate::PanicIfHeapSizeMissing,
+    ) -> Option<Vec<crate::database::SlotInfo>> {
         let memory_usage = self
             .entries(db)
             // SAFETY: The memo table belongs to a value that we allocated, so it
             // has the correct type.
-            .map(|value| unsafe { value.memory_usage(&self.memo_table_types) })
+            .map(|value| unsafe { value.memory_usage(&self.memo_table_types, panic_if_missing) })
             .collect();
         Some(memory_usage)
     }
@@ -306,15 +323,20 @@ where
     ///
     /// The `MemoTable` must belong to a `Value` of the correct type.
     #[cfg(feature = "salsa_unstable")]
-    unsafe fn memory_usage(&self, memo_table_types: &MemoTableTypes) -> crate::database::SlotInfo {
+    unsafe fn memory_usage(
+        &self,
+        memo_table_types: &MemoTableTypes,
+        panic_if_missing: crate::PanicIfHeapSizeMissing,
+    ) -> crate::database::SlotInfo {
+        let heap_size = C::heap_size(&self.fields, panic_if_missing);
         // SAFETY: The caller guarantees this is the correct types table.
         let memos = unsafe { memo_table_types.attach_memos(&self.memos) };
 
         crate::database::SlotInfo {
             debug_name: C::DEBUG_NAME,
             size_of_metadata: std::mem::size_of::<Self>() - std::mem::size_of::<C::Fields>(),
-            size_of_fields: std::mem::size_of::<C::Fields>(),
-            memos: memos.memory_usage(),
+            size_of_fields: std::mem::size_of::<C::Fields>() + heap_size,
+            memos: memos.memory_usage(panic_if_missing),
         }
     }
 }

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -46,19 +46,8 @@ pub trait Configuration: Sized + 'static {
     type Struct<'db>: Copy + FromId + AsId;
 
     /// Returns the size of any heap allocations in the output value, in bytes.
-    fn heap_size(
-        _value: &Self::Fields<'_>,
-        panic_if_missing: crate::PanicIfHeapSizeMissing,
-    ) -> usize {
-        if panic_if_missing == crate::PanicIfHeapSizeMissing::Yes {
-            panic!(
-                "tried to estimate sizes but `heap_size()` was not defined.\n\
-                ingredient: {}\ntype: {}",
-                Self::DEBUG_NAME,
-                std::any::type_name::<Self::Struct<'_>>()
-            );
-        }
-        0
+    fn heap_size(_value: &Self::Fields<'_>) -> Option<usize> {
+        None
     }
 }
 
@@ -214,12 +203,8 @@ where
     /// The `MemoTable` must belong to a `Value` of the correct type. Additionally, the
     /// lock must be held for the shard containing the value.
     #[cfg(all(not(feature = "shuttle"), feature = "salsa_unstable"))]
-    unsafe fn memory_usage(
-        &self,
-        memo_table_types: &MemoTableTypes,
-        panic_if_missing: crate::PanicIfHeapSizeMissing,
-    ) -> crate::database::SlotInfo {
-        let heap_size = C::heap_size(self.fields(), panic_if_missing);
+    unsafe fn memory_usage(&self, memo_table_types: &MemoTableTypes) -> crate::database::SlotInfo {
+        let heap_size = C::heap_size(self.fields());
         // SAFETY: The caller guarantees we hold the lock for the shard containing the value, so we
         // have at-least read-only access to the value's memos.
         let memos = unsafe { &*self.memos.get() };
@@ -229,8 +214,9 @@ where
         crate::database::SlotInfo {
             debug_name: C::DEBUG_NAME,
             size_of_metadata: std::mem::size_of::<Self>() - std::mem::size_of::<C::Fields<'_>>(),
-            size_of_fields: std::mem::size_of::<C::Fields<'_>>() + heap_size,
-            memos: memos.memory_usage(panic_if_missing),
+            size_of_fields: std::mem::size_of::<C::Fields<'_>>(),
+            heap_size_of_fields: heap_size,
+            memos: memos.memory_usage(),
         }
     }
 }
@@ -871,11 +857,7 @@ where
 
     /// Returns memory usage information about any interned values.
     #[cfg(all(not(feature = "shuttle"), feature = "salsa_unstable"))]
-    fn memory_usage(
-        &self,
-        db: &dyn Database,
-        panic_if_missing: crate::PanicIfHeapSizeMissing,
-    ) -> Option<Vec<crate::database::SlotInfo>> {
+    fn memory_usage(&self, db: &dyn Database) -> Option<Vec<crate::database::SlotInfo>> {
         use parking_lot::lock_api::RawMutex;
 
         for shard in self.shards.iter() {
@@ -887,7 +869,7 @@ where
             .entries(db)
             // SAFETY: The memo table belongs to a value that we allocated, so it
             // has the correct type. Additionally, we are holding the locks for all shards.
-            .map(|value| unsafe { value.memory_usage(&self.memo_table_types, panic_if_missing) })
+            .map(|value| unsafe { value.memory_usage(&self.memo_table_types) })
             .collect();
 
         for shard in self.shards.iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub use parallel::{join, par_map};
 pub use salsa_macros::{accumulator, db, input, interned, tracked, Supertype, Update};
 
 #[cfg(feature = "salsa_unstable")]
-pub use self::database::IngredientInfo;
+pub use self::database::{MemoMemoryInfo, MemoryUsageVisitor, StructMemoryInfo};
 
 pub use self::accumulator::Accumulator;
 pub use self::active_query::Backtrace;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ pub use self::accumulator::Accumulator;
 pub use self::active_query::Backtrace;
 pub use self::cancelled::Cancelled;
 pub use self::cycle::CycleRecoveryAction;
-pub use self::database::{AsDynDatabase, Database};
+pub use self::database::{AsDynDatabase, Database, PanicIfHeapSizeMissing};
 pub use self::database_impl::DatabaseImpl;
 pub use self::durability::Durability;
 pub use self::event::{Event, EventKind};
@@ -90,7 +90,7 @@ pub mod plumbing {
     pub use crate::accumulator::Accumulator;
     pub use crate::attach::{attach, with_attached_database};
     pub use crate::cycle::{CycleRecoveryAction, CycleRecoveryStrategy};
-    pub use crate::database::{current_revision, Database};
+    pub use crate::database::{current_revision, Database, PanicIfHeapSizeMissing};
     pub use crate::durability::Durability;
     pub use crate::id::{AsId, FromId, FromIdWithDb, Id};
     pub use crate::ingredient::{Ingredient, Jar, Location};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ pub use self::accumulator::Accumulator;
 pub use self::active_query::Backtrace;
 pub use self::cancelled::Cancelled;
 pub use self::cycle::CycleRecoveryAction;
-pub use self::database::{AsDynDatabase, Database, PanicIfHeapSizeMissing};
+pub use self::database::{AsDynDatabase, Database};
 pub use self::database_impl::DatabaseImpl;
 pub use self::durability::Durability;
 pub use self::event::{Event, EventKind};
@@ -90,7 +90,7 @@ pub mod plumbing {
     pub use crate::accumulator::Accumulator;
     pub use crate::attach::{attach, with_attached_database};
     pub use crate::cycle::{CycleRecoveryAction, CycleRecoveryStrategy};
-    pub use crate::database::{current_revision, Database, PanicIfHeapSizeMissing};
+    pub use crate::database::{current_revision, Database};
     pub use crate::durability::Durability;
     pub use crate::id::{AsId, FromId, FromIdWithDb, Id};
     pub use crate::ingredient::{Ingredient, Jar, Location};

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -37,7 +37,10 @@ pub trait Memo: Any + Send + Sync {
 
     /// Returns memory usage information about the memoized value.
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(&self) -> crate::database::MemoInfo;
+    fn memory_usage(
+        &self,
+        panic_if_missing: crate::PanicIfHeapSizeMissing,
+    ) -> crate::database::MemoInfo;
 }
 
 /// Data for a memoized entry.
@@ -113,7 +116,10 @@ impl Memo for DummyMemo {
     }
 
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(&self) -> crate::database::MemoInfo {
+    fn memory_usage(
+        &self,
+        _panic_if_missing: crate::PanicIfHeapSizeMissing,
+    ) -> crate::database::MemoInfo {
         crate::database::MemoInfo {
             debug_name: "dummy",
             output: crate::database::SlotInfo {
@@ -222,7 +228,10 @@ impl MemoTableWithTypes<'_> {
     }
 
     #[cfg(feature = "salsa_unstable")]
-    pub(crate) fn memory_usage(&self) -> Vec<crate::database::MemoInfo> {
+    pub(crate) fn memory_usage(
+        &self,
+        panic_if_missing: crate::PanicIfHeapSizeMissing,
+    ) -> Vec<crate::database::MemoInfo> {
         let mut memory_usage = Vec::new();
         for (index, memo) in self.memos.memos.iter().enumerate() {
             let Some(memo) = NonNull::new(memo.atomic_memo.load(Ordering::Acquire)) else {
@@ -235,7 +244,7 @@ impl MemoTableWithTypes<'_> {
 
             // SAFETY: The `TypeId` is asserted in `insert()`.
             let dyn_memo: &dyn Memo = unsafe { (type_.to_dyn_fn)(memo).as_ref() };
-            memory_usage.push(dyn_memo.memory_usage());
+            memory_usage.push(dyn_memo.memory_usage(panic_if_missing));
         }
 
         memory_usage

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -14,7 +14,7 @@ pub struct MemoTable {
 }
 
 impl MemoTable {
-    /// Create a `MemoTable` with slots for memos from the provided `MemoTableTypes`.  
+    /// Create a `MemoTable` with slots for memos from the provided `MemoTableTypes`.
     pub fn new(types: &MemoTableTypes) -> Self {
         Self {
             memos: (0..types.len()).map(|_| MemoEntry::default()).collect(),
@@ -37,10 +37,7 @@ pub trait Memo: Any + Send + Sync {
 
     /// Returns memory usage information about the memoized value.
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(
-        &self,
-        panic_if_missing: crate::PanicIfHeapSizeMissing,
-    ) -> crate::database::MemoInfo;
+    fn memory_usage(&self) -> crate::database::MemoInfo;
 }
 
 /// Data for a memoized entry.
@@ -116,16 +113,14 @@ impl Memo for DummyMemo {
     }
 
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(
-        &self,
-        _panic_if_missing: crate::PanicIfHeapSizeMissing,
-    ) -> crate::database::MemoInfo {
+    fn memory_usage(&self) -> crate::database::MemoInfo {
         crate::database::MemoInfo {
             debug_name: "dummy",
             output: crate::database::SlotInfo {
                 debug_name: "dummy",
                 size_of_metadata: 0,
                 size_of_fields: 0,
+                heap_size_of_fields: None,
                 memos: Vec::new(),
             },
         }
@@ -228,10 +223,7 @@ impl MemoTableWithTypes<'_> {
     }
 
     #[cfg(feature = "salsa_unstable")]
-    pub(crate) fn memory_usage(
-        &self,
-        panic_if_missing: crate::PanicIfHeapSizeMissing,
-    ) -> Vec<crate::database::MemoInfo> {
+    pub(crate) fn memory_usage(&self) -> Vec<crate::database::MemoInfo> {
         let mut memory_usage = Vec::new();
         for (index, memo) in self.memos.memos.iter().enumerate() {
             let Some(memo) = NonNull::new(memo.atomic_memo.load(Ordering::Acquire)) else {
@@ -244,7 +236,7 @@ impl MemoTableWithTypes<'_> {
 
             // SAFETY: The `TypeId` is asserted in `insert()`.
             let dyn_memo: &dyn Memo = unsafe { (type_.to_dyn_fn)(memo).as_ref() };
-            memory_usage.push(dyn_memo.memory_usage(panic_if_missing));
+            memory_usage.push(dyn_memo.memory_usage());
         }
 
         memory_usage

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -92,19 +92,8 @@ pub trait Configuration: Sized + 'static {
     ) -> bool;
 
     /// Returns the size of any heap allocations in the output value, in bytes.
-    fn heap_size(
-        _value: &Self::Fields<'_>,
-        panic_if_missing: crate::PanicIfHeapSizeMissing,
-    ) -> usize {
-        if panic_if_missing == crate::PanicIfHeapSizeMissing::Yes {
-            panic!(
-                "tried to estimate sizes but `heap_size()` was not defined.\n\
-                ingredient: {}\ntype: {}",
-                Self::DEBUG_NAME,
-                std::any::type_name::<Self::Struct<'_>>()
-            );
-        }
-        0
+    fn heap_size(_value: &Self::Fields<'_>) -> Option<usize> {
+        None
     }
 }
 // ANCHOR_END: Configuration
@@ -877,16 +866,12 @@ where
 
     /// Returns memory usage information about any tracked structs.
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(
-        &self,
-        db: &dyn Database,
-        panic_if_missing: crate::PanicIfHeapSizeMissing,
-    ) -> Option<Vec<crate::database::SlotInfo>> {
+    fn memory_usage(&self, db: &dyn Database) -> Option<Vec<crate::database::SlotInfo>> {
         let memory_usage = self
             .entries(db)
             // SAFETY: The memo table belongs to a value that we allocated, so it
             // has the correct type.
-            .map(|value| unsafe { value.memory_usage(&self.memo_table_types, panic_if_missing) })
+            .map(|value| unsafe { value.memory_usage(&self.memo_table_types) })
             .collect();
         Some(memory_usage)
     }
@@ -954,20 +939,17 @@ where
     ///
     /// The `MemoTable` must belong to a `Value` of the correct type.
     #[cfg(feature = "salsa_unstable")]
-    unsafe fn memory_usage(
-        &self,
-        memo_table_types: &MemoTableTypes,
-        panic_if_missing: crate::PanicIfHeapSizeMissing,
-    ) -> crate::database::SlotInfo {
-        let heap_size = C::heap_size(self.fields(), panic_if_missing);
+    unsafe fn memory_usage(&self, memo_table_types: &MemoTableTypes) -> crate::database::SlotInfo {
+        let heap_size = C::heap_size(self.fields());
         // SAFETY: The caller guarantees this is the correct types table.
         let memos = unsafe { memo_table_types.attach_memos(&self.memos) };
 
         crate::database::SlotInfo {
             debug_name: C::DEBUG_NAME,
             size_of_metadata: mem::size_of::<Self>() - mem::size_of::<C::Fields<'_>>(),
-            size_of_fields: mem::size_of::<C::Fields<'_>>() + heap_size,
-            memos: memos.memory_usage(panic_if_missing),
+            size_of_fields: mem::size_of::<C::Fields<'_>>(),
+            heap_size_of_fields: heap_size,
+            memos: memos.memory_usage(),
         }
     }
 }

--- a/tests/compile-fail/input_struct_incompatibles.rs
+++ b/tests/compile-fail/input_struct_incompatibles.rs
@@ -25,7 +25,4 @@ struct InputWithTrackedField {
     field: u32,
 }
 
-#[salsa::input(heap_size = size)]
-struct InputWithHeapSize(u32);
-
 fn main() {}

--- a/tests/compile-fail/input_struct_incompatibles.stderr
+++ b/tests/compile-fail/input_struct_incompatibles.stderr
@@ -47,12 +47,6 @@ error: `#[tracked]` cannot be used with `#[salsa::input]`
 25 | |     field: u32,
    | |______________^
 
-error: `heap_size` option not allowed here
-  --> tests/compile-fail/input_struct_incompatibles.rs:28:16
-   |
-28 | #[salsa::input(heap_size = size)]
-   |                ^^^^^^^^^
-
 error: cannot find attribute `tracked` in this scope
   --> tests/compile-fail/input_struct_incompatibles.rs:24:7
    |

--- a/tests/compile-fail/interned_struct_incompatibles.rs
+++ b/tests/compile-fail/interned_struct_incompatibles.rs
@@ -39,9 +39,4 @@ struct InternedWithZeroRevisions {
     field: u32,
 }
 
-#[salsa::interned(heap_size = size)]
-struct AccWithHeapSize {
-    field: u32,
-}
-
 fn main() {}

--- a/tests/compile-fail/interned_struct_incompatibles.stderr
+++ b/tests/compile-fail/interned_struct_incompatibles.stderr
@@ -41,12 +41,6 @@ error: `#[tracked]` cannot be used with `#[salsa::interned]`
 34 | |     field: u32,
    | |______________^
 
-error: `heap_size` option not allowed here
-  --> tests/compile-fail/interned_struct_incompatibles.rs:42:19
-   |
-42 | #[salsa::interned(heap_size = size)]
-   |                   ^^^^^^^^^
-
 error: cannot find attribute `tracked` in this scope
   --> tests/compile-fail/interned_struct_incompatibles.rs:33:7
    |

--- a/tests/compile-fail/tracked_struct_incompatibles.rs
+++ b/tests/compile-fail/tracked_struct_incompatibles.rs
@@ -33,9 +33,4 @@ struct TrackedStructWithRevisions {
     field: u32,
 }
 
-#[salsa::tracked(heap_size = size)]
-struct TrackedStructWithHeapSize {
-    field: u32,
-}
-
 fn main() {}

--- a/tests/compile-fail/tracked_struct_incompatibles.stderr
+++ b/tests/compile-fail/tracked_struct_incompatibles.stderr
@@ -39,9 +39,3 @@ error: `revisions` option not allowed here
    |
 31 | #[salsa::tracked(revisions = 12)]
    |                  ^^^^^^^^^
-
-error: `heap_size` option not allowed here
-  --> tests/compile-fail/tracked_struct_incompatibles.rs:36:18
-   |
-36 | #[salsa::tracked(heap_size = size)]
-   |                  ^^^^^^^^^


### PR DESCRIPTION
I'm not sure this is the right approach. It does require a fair amount of boilerplate code by any application that wants to extract memory usage information. However, it does allow applications to report detailed reports (e.g., aggregate by struct in addition to by memo) or even call custom aggregation functionality. 

It also avoids the double visiting of the current implementation

I'm curious for your feedback
