### PR TITLE
refactor: Use `CycleHeadKeys` in `maybe_changed_after`

### DIFF
--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -7,7 +7,7 @@ use std::panic::UnwindSafe;
 
 use accumulated::{Accumulated, AnyAccumulated};
 
-use crate::cycle::CycleHeads;
+use crate::cycle::CycleHeadKeys;
 use crate::function::VerifyResult;
 use crate::ingredient::{Ingredient, Jar};
 use crate::plumbing::ZalsaLocal;
@@ -106,7 +106,7 @@ impl<A: Accumulator> Ingredient for IngredientImpl<A> {
         _db: crate::database::RawDatabase<'_>,
         _input: Id,
         _revision: Revision,
-        _cycle_heads: &mut CycleHeads,
+        _cycle_heads: &mut CycleHeadKeys,
     ) -> VerifyResult {
         panic!("nothing should ever depend on an accumulator directly")
     }

--- a/src/function.rs
+++ b/src/function.rs
@@ -7,7 +7,8 @@ use std::sync::OnceLock;
 pub(crate) use sync::SyncGuard;
 
 use crate::cycle::{
-    empty_cycle_heads, CycleHeads, CycleRecoveryAction, CycleRecoveryStrategy, ProvisionalStatus,
+    empty_cycle_heads, CycleHeadKeys, CycleHeads, CycleRecoveryAction, CycleRecoveryStrategy,
+    ProvisionalStatus,
 };
 use crate::database::RawDatabase;
 use crate::function::delete::DeletedEntries;
@@ -265,7 +266,7 @@ where
         db: RawDatabase<'_>,
         input: Id,
         revision: Revision,
-        cycle_heads: &mut CycleHeads,
+        cycle_heads: &mut CycleHeadKeys,
     ) -> VerifyResult {
         // SAFETY: The `db` belongs to the ingredient as per caller invariant
         let db = unsafe { self.view_caster().downcast_unchecked(db) };

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -1,4 +1,4 @@
-use crate::cycle::{CycleHeads, CycleRecoveryStrategy, IterationCount};
+use crate::cycle::{CycleHeadKeys, CycleHeads, CycleRecoveryStrategy, IterationCount};
 use crate::function::memo::Memo;
 use crate::function::sync::ClaimResult;
 use crate::function::{Configuration, IngredientImpl, VerifyResult};
@@ -222,7 +222,7 @@ where
 
         if let Some(old_memo) = opt_old_memo {
             if old_memo.value.is_some() {
-                let mut cycle_heads = CycleHeads::default();
+                let mut cycle_heads = CycleHeadKeys::new();
                 if let VerifyResult::Unchanged { .. } =
                     self.deep_verify_memo(db, zalsa, old_memo, database_key_index, &mut cycle_heads)
                 {

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -2,7 +2,8 @@ use std::any::{Any, TypeId};
 use std::fmt;
 
 use crate::cycle::{
-    empty_cycle_heads, CycleHeads, CycleRecoveryStrategy, IterationCount, ProvisionalStatus,
+    empty_cycle_heads, CycleHeadKeys, CycleHeads, CycleRecoveryStrategy, IterationCount,
+    ProvisionalStatus,
 };
 use crate::database::RawDatabase;
 use crate::function::VerifyResult;
@@ -51,7 +52,7 @@ pub trait Ingredient: Any + std::fmt::Debug + Send + Sync {
         db: crate::database::RawDatabase<'_>,
         input: Id,
         revision: Revision,
-        cycle_heads: &mut CycleHeads,
+        cycle_heads: &mut CycleHeadKeys,
     ) -> VerifyResult;
 
     /// Returns information about the current provisional status of `input`.

--- a/src/input.rs
+++ b/src/input.rs
@@ -8,7 +8,7 @@ pub mod singleton;
 
 use input_field::FieldIngredientImpl;
 
-use crate::cycle::CycleHeads;
+use crate::cycle::CycleHeadKeys;
 use crate::function::VerifyResult;
 use crate::id::{AsId, FromId, FromIdWithDb};
 use crate::ingredient::Ingredient;
@@ -226,7 +226,7 @@ impl<C: Configuration> Ingredient for IngredientImpl<C> {
         _db: crate::database::RawDatabase<'_>,
         _input: Id,
         _revision: Revision,
-        _cycle_heads: &mut CycleHeads,
+        _cycle_heads: &mut CycleHeadKeys,
     ) -> VerifyResult {
         // Input ingredients are just a counter, they store no data, they are immortal.
         // Their *fields* are stored in function ingredients elsewhere.

--- a/src/input/input_field.rs
+++ b/src/input/input_field.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::marker::PhantomData;
 
-use crate::cycle::CycleHeads;
+use crate::cycle::CycleHeadKeys;
 use crate::function::VerifyResult;
 use crate::ingredient::Ingredient;
 use crate::input::{Configuration, IngredientImpl, Value};
@@ -56,7 +56,7 @@ where
         _db: crate::database::RawDatabase<'_>,
         input: Id,
         revision: Revision,
-        _cycle_heads: &mut CycleHeads,
+        _cycle_heads: &mut CycleHeadKeys,
     ) -> VerifyResult {
         let value = <IngredientImpl<C>>::data(zalsa, input);
         VerifyResult::changed_if(value.revisions[self.field_index] > revision)

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -10,7 +10,7 @@ use crossbeam_utils::CachePadded;
 use intrusive_collections::{intrusive_adapter, LinkedList, LinkedListLink, UnsafeRef};
 use rustc_hash::FxBuildHasher;
 
-use crate::cycle::CycleHeads;
+use crate::cycle::CycleHeadKeys;
 use crate::durability::Durability;
 use crate::function::VerifyResult;
 use crate::id::{AsId, FromId};
@@ -797,7 +797,7 @@ where
         _db: crate::database::RawDatabase<'_>,
         input: Id,
         _revision: Revision,
-        _cycle_heads: &mut CycleHeads,
+        _cycle_heads: &mut CycleHeadKeys,
     ) -> VerifyResult {
         // Record the current revision as active.
         let current_revision = zalsa.current_revision();

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use crate::cycle::CycleHeads;
+use crate::cycle::CycleHeadKeys;
 use crate::function::VerifyResult;
 use crate::zalsa::{IngredientIndex, Zalsa};
 use crate::Id;
@@ -39,7 +39,7 @@ impl DatabaseKeyIndex {
         db: crate::database::RawDatabase<'_>,
         zalsa: &Zalsa,
         last_verified_at: crate::Revision,
-        cycle_heads: &mut CycleHeads,
+        cycle_heads: &mut CycleHeadKeys,
     ) -> VerifyResult {
         // SAFETY: The `db` belongs to the ingredient
         unsafe {

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -10,7 +10,7 @@ use crossbeam_queue::SegQueue;
 use thin_vec::ThinVec;
 use tracked_field::FieldIngredientImpl;
 
-use crate::cycle::CycleHeads;
+use crate::cycle::CycleHeadKeys;
 use crate::function::VerifyResult;
 use crate::id::{AsId, FromId};
 use crate::ingredient::{Ingredient, Jar};
@@ -817,7 +817,7 @@ where
         _db: crate::database::RawDatabase<'_>,
         _input: Id,
         _revision: Revision,
-        _cycle_heads: &mut CycleHeads,
+        _cycle_heads: &mut CycleHeadKeys,
     ) -> VerifyResult {
         // Any change to a tracked struct results in a new ID generation.
         VerifyResult::unchanged()

--- a/src/tracked_struct/tracked_field.rs
+++ b/src/tracked_struct/tracked_field.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use crate::cycle::CycleHeads;
+use crate::cycle::CycleHeadKeys;
 use crate::function::VerifyResult;
 use crate::ingredient::Ingredient;
 use crate::sync::Arc;
@@ -61,7 +61,7 @@ where
         _db: crate::database::RawDatabase<'_>,
         input: Id,
         revision: crate::Revision,
-        _cycle_heads: &mut CycleHeads,
+        _cycle_heads: &mut CycleHeadKeys,
     ) -> VerifyResult {
         let data = <super::IngredientImpl<C>>::data(zalsa.table(), input);
         let field_changed_at = data.revisions[self.field_index];


### PR DESCRIPTION
I'm debugging a run-away issue with fixpoint iteration and cycle heads and
was confused why it is okay to push `IterationCount::initial` in `maybe_changed_after` if
The memo we're verifying is from a later iteration. 

It turns out, this is fine because the `iteration_count` is never used in `maybe_update_after`. 

This PR introduces a `CycleHeadKeys` that only tracks the heads without iteration 
to clarify that the iteration is irrelevant in this part of the code.
