### PR TITLE
Expose API to manually trigger cancellation

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -59,6 +59,14 @@ pub trait Database: Send + ZalsaDatabase + AsDynDatabase {
         zalsa_mut.runtime_mut().report_tracked_write(durability);
     }
 
+    /// This method triggers cancellation.
+    /// If you invoke it while a snapshot exists, it
+    /// will block until that snapshot is dropped -- if that snapshot
+    /// is owned by the current thread, this could trigger deadlock.
+    fn trigger_cancellation(&mut self) {
+        let _ = self.zalsa_mut();
+    }
+
     /// Reports that the query depends on some state unknown to salsa.
     ///
     /// Queries which report untracked reads will be re-executed in the next


### PR DESCRIPTION
We (ty) use the salsa database to enforce exclusive ownership 
of `Arc`s. These may or may not be stored in the salsa database (we'll do a regular `set_input` if they're stored in the db).
The way this is implemented is that we call `as_dyn_database_mut().zalsa_mut()` 
before unwrapping the `Arc`. This allows us to avoid copying potentially large data structures.

However, https://github.com/salsa-rs/salsa/commit/211bc158dfe432138cfa77c6e0a51b6a2bc82884#r163337827 removed
`as_dyn_database_mut`. 

Ideally, Salsa would have a dedicated feature for Arcs like this. For now, I suggest
Adding a method that triggers cancellation without bumping the revision.


Previous discussion https://salsa.zulipchat.com/#narrow/stream/333573-salsa-3.2E0/topic/Expose.20an.20API.20to.20cancel.20other.20queries
