### PR TITLE
Optimize `Id::hash`

### DIFF
--- a/src/id.rs
+++ b/src/id.rs
@@ -1,5 +1,5 @@
 use std::fmt::Debug;
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 use std::num::NonZeroU32;
 
 use crate::zalsa::Zalsa;
@@ -17,7 +17,7 @@ use crate::zalsa::Zalsa;
 ///
 /// As an end-user of `Salsa` you will generally not use `Id` directly,
 /// it is wrapped in new types.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "persistence", derive(serde::Serialize, serde::Deserialize))]
 pub struct Id {
     index: NonZeroU32,
@@ -123,6 +123,13 @@ impl Id {
     #[inline]
     pub const fn generation(self) -> u32 {
         self.generation
+    }
+}
+
+impl Hash for Id {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Convert to a `u64` to avoid dispatching multiple calls to `H::write`.
+        state.write_u64(self.as_bits());
     }
 }
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,4 +1,4 @@
-use core::fmt;
+use std::fmt;
 
 use crate::function::{VerifyCycleHeads, VerifyResult};
 use crate::zalsa::{IngredientIndex, Zalsa};


### PR DESCRIPTION
This improves codegen, but not sure it'll have a measurable impact:
```diff
- hash_one_id:
- 	mov eax, dword ptr [rdi]
- 	mov ecx, dword ptr [rdi + 4]
- 	movabs rdx, -1065810590584100411
- 	imul rax, rdx
- 	add rax, rcx
- 	imul rax, rdx
- 	rol rax, 26
-   ret

+ hash_one_id:
+ 	movabs rax, -1065810590584100411
+ 	imul rax, qword ptr [rdi]
+ 	rol rax, 26
+   ret
```