### PR TITLE
Provide a method to attach a database even if it's different from the current attached one

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub use self::runtime::Runtime;
 pub use self::storage::{Storage, StorageHandle};
 pub use self::update::Update;
 pub use self::zalsa::IngredientIndex;
-pub use crate::attach::{attach, with_attached_database};
+pub use crate::attach::{attach, attach_allow_change, with_attached_database};
 
 pub mod prelude {
     #[cfg(feature = "accumulator")]


### PR DESCRIPTION
rust-analyzer needs this.