### PR TITLE
refactor: Push active query in execute

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,7 +152,8 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
+            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-benchmark
+            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}
             ${{ runner.os }}-cargo-
 
       - name: "Build benchmarks"

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -5,7 +5,7 @@ use crate::function::{Configuration, IngredientImpl};
 use crate::plumbing::ZalsaLocal;
 use crate::sync::atomic::{AtomicBool, Ordering};
 use crate::tracked_struct::Identity;
-use crate::zalsa::{MemoIngredientIndex, Zalsa, ZalsaDatabase};
+use crate::zalsa::{MemoIngredientIndex, Zalsa};
 use crate::zalsa_local::{ActiveQueryGuard, QueryRevisions};
 use crate::{DatabaseKeyIndex, Event, EventKind, Id};
 
@@ -26,13 +26,14 @@ where
     pub(super) fn execute<'db>(
         &'db self,
         db: &'db C::DbView,
+        zalsa: &'db Zalsa,
+        zalsa_local: &'db ZalsaLocal,
         database_key_index: DatabaseKeyIndex,
         opt_old_memo: Option<&Memo<'db, C>>,
     ) -> &'db Memo<'db, C> {
         let id = database_key_index.key_index();
 
         crate::tracing::info!("{:?}: executing query", database_key_index);
-        let (zalsa, zalsa_local) = db.zalsas();
 
         zalsa.event(&|| {
             Event::new(EventKind::WillExecute {

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -130,7 +130,6 @@ where
         )
     }
 
-    #[inline]
     fn execute_maybe_iterate<'db>(
         &'db self,
         db: &'db C::DbView,

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -232,7 +232,7 @@ where
             }
         }
 
-        let memo = self.execute(db, database_key_index, opt_old_memo);
+        let memo = self.execute(db, zalsa, zalsa_local, database_key_index, opt_old_memo);
 
         Some(memo)
     }

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -232,11 +232,7 @@ where
             }
         }
 
-        let memo = self.execute(
-            db,
-            zalsa_local.push_query(database_key_index, IterationCount::initial()),
-            opt_old_memo,
-        );
+        let memo = self.execute(db, database_key_index, opt_old_memo);
 
         Some(memo)
     }

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -227,7 +227,7 @@ where
         // `in_cycle` tracks if the enclosing query is in a cycle. `deep_verify.cycle_heads` tracks
         // if **this query** encountered a cycle (which means there's some provisional value somewhere floating around).
         if old_memo.value.is_some() && !cycle_heads.has_any() {
-            let memo = self.execute(db, database_key_index, Some(old_memo));
+            let memo = self.execute(db, zalsa, zalsa_local, database_key_index, Some(old_memo));
             let changed_at = memo.revisions.changed_at;
 
             // Always assume that a provisional value has changed.

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -2,7 +2,7 @@ use rustc_hash::FxHashMap;
 
 #[cfg(feature = "accumulator")]
 use crate::accumulator::accumulated_map::InputAccumulatedValues;
-use crate::cycle::{CycleRecoveryStrategy, IterationCount, ProvisionalStatus};
+use crate::cycle::{CycleRecoveryStrategy, ProvisionalStatus};
 use crate::function::memo::Memo;
 use crate::function::sync::ClaimResult;
 use crate::function::{Configuration, IngredientImpl};
@@ -227,9 +227,7 @@ where
         // `in_cycle` tracks if the enclosing query is in a cycle. `deep_verify.cycle_heads` tracks
         // if **this query** encountered a cycle (which means there's some provisional value somewhere floating around).
         if old_memo.value.is_some() && !cycle_heads.has_any() {
-            let active_query =
-                zalsa_local.push_query(database_key_index, IterationCount::initial());
-            let memo = self.execute(db, active_query, Some(old_memo));
+            let memo = self.execute(db, database_key_index, Some(old_memo));
             let changed_at = memo.revisions.changed_at;
 
             // Always assume that a provisional value has changed.

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -131,7 +131,6 @@ impl ZalsaLocal {
         }
     }
 
-    #[inline]
     pub(crate) fn push_query(
         &self,
         database_key_index: DatabaseKeyIndex,

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -131,6 +131,7 @@ impl ZalsaLocal {
         }
     }
 
+    #[inline]
     pub(crate) fn push_query(
         &self,
         database_key_index: DatabaseKeyIndex,


### PR DESCRIPTION
Splitting this out of https://github.com/salsa-rs/salsa/pull/995 to get a better sense for what's causing the perf regression. 

https://github.com/salsa-rs/salsa/pull/995 needs to control the `iteration_count` (there are cases where it doesn't start from 0). That's why pushing the new query needs to be moved into `execute_maybe_iterate` (and `execute` for non cyclic queries)