### PR TITLE
refactor: Replace unsafe unwrap with `expect` call

### DIFF
--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -183,8 +183,10 @@ where
                     debug_assert!(memo.may_be_provisional());
                     memo.value.as_ref()
                 };
-                // SAFETY: The `LRU` does not run mid-execution, so the value remains filled
-                let last_provisional_value = unsafe { last_provisional_value.unwrap_unchecked() };
+
+                let last_provisional_value = last_provisional_value.expect(
+                    "`fetch_cold_cycle` should have inserted a provisional memo with Cycle::initial",
+                );
                 crate::tracing::debug!(
                     "{database_key_index:?}: execute: \
                         I am a cycle head, comparing last provisional value with new value"


### PR DESCRIPTION
The cost of the `unwrap` is marginal compared to re-running all queries in a cycle. Using `unsafe` here only makes it unnecessarily hard to debug when the invariant is broken.