### PR TITLE
Skip `provisional_retry` for non-cycle-heads

### DIFF
--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -122,12 +122,19 @@ where
         // our no-longer-provisional memo.
         // That is only correct for fixpoint cycles, though: `FallbackImmediate` cycles
         // never have provisional entries.
-        if C::CYCLE_STRATEGY == CycleRecoveryStrategy::FallbackImmediate
-            || !memo.provisional_retry(zalsa, zalsa_local, self.database_key_index(id), retry_count)
-        {
-            Some(memo)
-        } else {
-            None
+        match C::CYCLE_STRATEGY {
+            CycleRecoveryStrategy::FallbackImmediate | CycleRecoveryStrategy::Panic => Some(memo),
+            CycleRecoveryStrategy::Fixpoint => {
+                if !memo.provisional_retry(
+                    zalsa,
+                    zalsa_local,
+                    self.database_key_index(id),
+                    retry_count,
+                ) {
+                    return Some(memo);
+                }
+                None
+            }
         }
     }
 


### PR DESCRIPTION
Skip `provisional_retry` for queries that aren't cycle heads.

`provisional_retry` ensures that no stale memo "escapes" when multiple threads participate in the same cycle. 
However, we only need to ensure this for queries that are potential cycle heads because all non-cycle queries can't 
be an entry point into a multi-threaded cycle.
