### PR TITLE
Fix missing license files in published macros/macro-rules crates

### DIFF
--- a/components/salsa-macro-rules/LICENSE-APACHE
+++ b/components/salsa-macro-rules/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/components/salsa-macro-rules/LICENSE-MIT
+++ b/components/salsa-macro-rules/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/components/salsa-macros/LICENSE-APACHE
+++ b/components/salsa-macros/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/components/salsa-macros/LICENSE-MIT
+++ b/components/salsa-macros/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT


### PR DESCRIPTION
Both the MIT and Apache-2.0 licenses require the license texts to be included in copies. Fix missing license files in published `salsa-macros` and `salsa-macro-rules` crates by adding symbolic links to the top-level license files.

Before this PR:

```
~/src/forks/salsa/components/salsa-macros$ cargo publish --dry-run
~/src/forks/salsa/components/salsa-macros$ tar -tzf ../../target/package/salsa-macros-0.24.0.crate 
salsa-macros-0.24.0/.cargo_vcs_info.json
salsa-macros-0.24.0/CHANGELOG.md
salsa-macros-0.24.0/Cargo.lock
salsa-macros-0.24.0/Cargo.toml
salsa-macros-0.24.0/Cargo.toml.orig
salsa-macros-0.24.0/src/accumulator.rs
salsa-macros-0.24.0/src/db.rs
salsa-macros-0.24.0/src/db_lifetime.rs
salsa-macros-0.24.0/src/debug.rs
salsa-macros-0.24.0/src/fn_util.rs
salsa-macros-0.24.0/src/hygiene.rs
salsa-macros-0.24.0/src/input.rs
salsa-macros-0.24.0/src/interned.rs
salsa-macros-0.24.0/src/lib.rs
salsa-macros-0.24.0/src/options.rs
salsa-macros-0.24.0/src/salsa_struct.rs
salsa-macros-0.24.0/src/supertype.rs
salsa-macros-0.24.0/src/tracked.rs
salsa-macros-0.24.0/src/tracked_fn.rs
salsa-macros-0.24.0/src/tracked_impl.rs
salsa-macros-0.24.0/src/tracked_struct.rs
salsa-macros-0.24.0/src/update.rs
salsa-macros-0.24.0/src/xform.rs
```

After this PR:

```
~/src/forks/salsa/components/salsa-macros$ cargo publish --dry-run
~/src/forks/salsa/components/salsa-macros$ tar -tzf ../../target/package/salsa-macros-0.24.0.crate 
salsa-macros-0.24.0/.cargo_vcs_info.json
salsa-macros-0.24.0/CHANGELOG.md
salsa-macros-0.24.0/Cargo.lock
salsa-macros-0.24.0/Cargo.toml
salsa-macros-0.24.0/Cargo.toml.orig
salsa-macros-0.24.0/LICENSE-APACHE
salsa-macros-0.24.0/LICENSE-MIT
salsa-macros-0.24.0/src/accumulator.rs
salsa-macros-0.24.0/src/db.rs
salsa-macros-0.24.0/src/db_lifetime.rs
salsa-macros-0.24.0/src/debug.rs
salsa-macros-0.24.0/src/fn_util.rs
salsa-macros-0.24.0/src/hygiene.rs
salsa-macros-0.24.0/src/input.rs
salsa-macros-0.24.0/src/interned.rs
salsa-macros-0.24.0/src/lib.rs
salsa-macros-0.24.0/src/options.rs
salsa-macros-0.24.0/src/salsa_struct.rs
salsa-macros-0.24.0/src/supertype.rs
salsa-macros-0.24.0/src/tracked.rs
salsa-macros-0.24.0/src/tracked_fn.rs
salsa-macros-0.24.0/src/tracked_impl.rs
salsa-macros-0.24.0/src/tracked_struct.rs
salsa-macros-0.24.0/src/update.rs
salsa-macros-0.24.0/src/xform.rs
```