### PR TITLE
perf: Add `SyncTable::peek_claim` fast path for `function::Ingredient::wait_for`

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -428,11 +428,11 @@ where
     fn wait_for<'me>(&'me self, zalsa: &'me Zalsa, key_index: Id) -> WaitForResult<'me> {
         match self
             .sync_table
-            .try_claim(zalsa, key_index, Reentrancy::Deny)
+            .peek_claim(zalsa, key_index, Reentrancy::Deny)
         {
             ClaimResult::Running(blocked_on) => WaitForResult::Running(blocked_on),
             ClaimResult::Cycle { inner } => WaitForResult::Cycle { inner },
-            ClaimResult::Claimed(_) => WaitForResult::Available,
+            ClaimResult::Claimed(()) => WaitForResult::Available,
         }
     }
 


### PR DESCRIPTION

Pulled out of https://github.com/salsa-rs/salsa/pull/958 as that PR wants to split these functions for an added `zalsa_local` parameter anways