### PR TITLE
Expose the input query Id with `cycle_initial`

### DIFF
--- a/benches/dataflow.rs
+++ b/benches/dataflow.rs
@@ -70,7 +70,7 @@ fn infer_definition<'db>(db: &'db dyn Db, def: Definition) -> Type {
     }
 }
 
-fn def_cycle_initial(_db: &dyn Db, _def: Definition) -> Type {
+fn def_cycle_initial(_db: &dyn Db, _id: salsa::Id, _def: Definition) -> Type {
     Type::Bottom
 }
 
@@ -85,7 +85,7 @@ fn def_cycle_recover(
     cycle_recover(value, count)
 }
 
-fn use_cycle_initial(_db: &dyn Db, _use: Use) -> Type {
+fn use_cycle_initial(_db: &dyn Db, _id: salsa::Id, _use: Use) -> Type {
     Type::Bottom
 }
 

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -302,8 +302,8 @@ macro_rules! setup_tracked_fn {
                     $inner($db, $($input_id),*)
                 }
 
-                fn cycle_initial<$db_lt>(db: &$db_lt Self::DbView, ($($input_id),*): ($($interned_input_ty),*)) -> Self::Output<$db_lt> {
-                    $($cycle_recovery_initial)*(db, $($input_id),*)
+                fn cycle_initial<$db_lt>(db: &$db_lt Self::DbView, id: salsa::Id, ($($input_id),*): ($($interned_input_ty),*)) -> Self::Output<$db_lt> {
+                    $($cycle_recovery_initial)*(db, id, $($input_id),*)
                 }
 
                 fn recover_from_cycle<$db_lt>(

--- a/components/salsa-macro-rules/src/unexpected_cycle_recovery.rs
+++ b/components/salsa-macro-rules/src/unexpected_cycle_recovery.rs
@@ -12,7 +12,7 @@ macro_rules! unexpected_cycle_recovery {
 
 #[macro_export]
 macro_rules! unexpected_cycle_initial {
-    ($db:ident, $($other_inputs:ident),*) => {{
+    ($db:ident, $id:ident, $($other_inputs:ident),*) => {{
         std::mem::drop($db);
         std::mem::drop(($($other_inputs,)*));
         panic!("no cycle initial value")

--- a/src/function.rs
+++ b/src/function.rs
@@ -85,7 +85,11 @@ pub trait Configuration: Any {
     fn execute<'db>(db: &'db Self::DbView, input: Self::Input<'db>) -> Self::Output<'db>;
 
     /// Get the cycle recovery initial value.
-    fn cycle_initial<'db>(db: &'db Self::DbView, input: Self::Input<'db>) -> Self::Output<'db>;
+    fn cycle_initial<'db>(
+        db: &'db Self::DbView,
+        id: Id,
+        input: Self::Input<'db>,
+    ) -> Self::Output<'db>;
 
     /// Decide whether to iterate a cycle again or fallback. `value` is the provisional return
     /// value from the latest iteration of this cycle. `count` is the number of cycle iterations

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -94,7 +94,7 @@ where
                     let cycle_heads = std::mem::take(cycle_heads);
                     let active_query =
                         zalsa_local.push_query(database_key_index, IterationCount::initial());
-                    new_value = C::cycle_initial(db, C::id_to_input(zalsa, id));
+                    new_value = C::cycle_initial(db, id, C::id_to_input(zalsa, id));
                     completed_query = active_query.pop();
                     // We need to set `cycle_heads` and `verified_final` because it needs to propagate to the callers.
                     // When verifying this, we will see we have fallback and mark ourselves verified.

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -236,7 +236,7 @@ where
                     inserting and returning fixpoint initial value"
                 );
                 let revisions = QueryRevisions::fixpoint_initial(database_key_index);
-                let initial_value = C::cycle_initial(db, C::id_to_input(zalsa, id));
+                let initial_value = C::cycle_initial(db, id, C::id_to_input(zalsa, id));
                 self.insert_memo(
                     zalsa,
                     id,
@@ -250,7 +250,7 @@ where
                 );
                 let active_query =
                     zalsa_local.push_query(database_key_index, IterationCount::initial());
-                let fallback_value = C::cycle_initial(db, C::id_to_input(zalsa, id));
+                let fallback_value = C::cycle_initial(db, id, C::id_to_input(zalsa, id));
                 let mut completed_query = active_query.pop();
                 completed_query
                     .revisions

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -558,7 +558,11 @@ mod _memory_usage {
             unimplemented!()
         }
 
-        fn cycle_initial<'db>(_: &'db Self::DbView, _: Self::Input<'db>) -> Self::Output<'db> {
+        fn cycle_initial<'db>(
+            _: &'db Self::DbView,
+            _: Id,
+            _: Self::Input<'db>,
+        ) -> Self::Output<'db> {
             unimplemented!()
         }
 

--- a/tests/backtrace.rs
+++ b/tests/backtrace.rs
@@ -52,7 +52,7 @@ fn query_cycle(db: &dyn Database, thing: Thing) -> String {
     }
 }
 
-fn cycle_initial(_db: &dyn salsa::Database, _thing: Thing) -> String {
+fn cycle_initial(_db: &dyn salsa::Database, _id: salsa::Id, _thing: Thing) -> String {
     String::new()
 }
 

--- a/tests/cycle.rs
+++ b/tests/cycle.rs
@@ -173,7 +173,7 @@ fn min_iterate<'db>(db: &'db dyn Db, inputs: Inputs) -> Value {
     fold_values(inputs.values(db), u8::min)
 }
 
-fn min_initial(_db: &dyn Db, _inputs: Inputs) -> Value {
+fn min_initial(_db: &dyn Db, _id: salsa::Id, _inputs: Inputs) -> Value {
     Value::N(255)
 }
 
@@ -183,7 +183,7 @@ fn max_iterate<'db>(db: &'db dyn Db, inputs: Inputs) -> Value {
     fold_values(inputs.values(db), u8::max)
 }
 
-fn max_initial(_db: &dyn Db, _inputs: Inputs) -> Value {
+fn max_initial(_db: &dyn Db, _id: salsa::Id, _inputs: Inputs) -> Value {
     Value::N(0)
 }
 
@@ -1175,7 +1175,7 @@ fn repeat_query_participating_in_cycle() {
         a.min(2)
     }
 
-    fn initial(_db: &dyn Db, _input: Input) -> u32 {
+    fn initial(_db: &dyn Db, _id: salsa::Id, _input: Input) -> u32 {
         0
     }
 
@@ -1280,7 +1280,7 @@ fn repeat_query_participating_in_cycle2() {
         a.min(2)
     }
 
-    fn initial(_db: &dyn Db, _input: Input) -> u32 {
+    fn initial(_db: &dyn Db, _id: salsa::Id, _input: Input) -> u32 {
         0
     }
 

--- a/tests/cycle_accumulate.rs
+++ b/tests/cycle_accumulate.rs
@@ -44,7 +44,7 @@ fn check_file(db: &dyn LogDatabase, file: File) -> Vec<u32> {
     sorted_issues
 }
 
-fn cycle_initial(_db: &dyn LogDatabase, _file: File) -> Vec<u32> {
+fn cycle_initial(_db: &dyn LogDatabase, _id: salsa::Id, _file: File) -> Vec<u32> {
     vec![]
 }
 

--- a/tests/cycle_fallback_immediate.rs
+++ b/tests/cycle_fallback_immediate.rs
@@ -11,7 +11,7 @@ fn one_o_one(db: &dyn salsa::Database) -> u32 {
     val + 1
 }
 
-fn cycle_result(_db: &dyn salsa::Database) -> u32 {
+fn cycle_result(_db: &dyn salsa::Database, _id: salsa::Id) -> u32 {
     100
 }
 
@@ -38,7 +38,7 @@ fn two_queries2(db: &dyn salsa::Database) -> i32 {
     CALLS_COUNT.fetch_add(1, Ordering::Relaxed)
 }
 
-fn two_queries_cycle_result(_db: &dyn salsa::Database) -> i32 {
+fn two_queries_cycle_result(_db: &dyn salsa::Database, _id: salsa::Id) -> i32 {
     1
 }
 

--- a/tests/cycle_initial_call_back_into_cycle.rs
+++ b/tests/cycle_initial_call_back_into_cycle.rs
@@ -17,7 +17,7 @@ fn query(db: &dyn salsa::Database) -> u32 {
     }
 }
 
-fn cycle_initial(db: &dyn salsa::Database) -> u32 {
+fn cycle_initial(db: &dyn salsa::Database, _id: salsa::Id) -> u32 {
     initial_value(db)
 }
 

--- a/tests/cycle_initial_call_query.rs
+++ b/tests/cycle_initial_call_query.rs
@@ -17,7 +17,7 @@ fn query(db: &dyn salsa::Database) -> u32 {
     }
 }
 
-fn cycle_initial(db: &dyn salsa::Database) -> u32 {
+fn cycle_initial(db: &dyn salsa::Database, _id: salsa::Id) -> u32 {
     initial_value(db)
 }
 

--- a/tests/cycle_maybe_changed_after.rs
+++ b/tests/cycle_maybe_changed_after.rs
@@ -36,7 +36,7 @@ fn query_d<'db>(db: &'db dyn salsa::Database, input: Input) -> u32 {
     }
 }
 
-fn query_a_initial(_db: &dyn Database, _input: Input) -> u32 {
+fn query_a_initial(_db: &dyn Database, _id: salsa::Id, _input: Input) -> u32 {
     0
 }
 
@@ -128,7 +128,7 @@ fn nested_cycle_fewer_dependencies_in_first_iteration() {
         })
     }
 
-    fn head_initial(_db: &dyn Database, _input: Input) -> Option<ClassLiteral<'_>> {
+    fn head_initial(_db: &dyn Database, _id: salsa::Id, _input: Input) -> Option<ClassLiteral<'_>> {
         None
     }
 

--- a/tests/cycle_output.rs
+++ b/tests/cycle_output.rs
@@ -40,7 +40,7 @@ fn query_b(db: &dyn Db, input: InputValue) -> u32 {
     query_a(db, input)
 }
 
-fn cycle_initial(_db: &dyn Db, _input: InputValue) -> u32 {
+fn cycle_initial(_db: &dyn Db, _id: salsa::Id, _input: InputValue) -> u32 {
     0
 }
 

--- a/tests/cycle_recovery_call_back_into_cycle.rs
+++ b/tests/cycle_recovery_call_back_into_cycle.rs
@@ -21,7 +21,7 @@ fn query(db: &dyn ValueDatabase) -> u32 {
     }
 }
 
-fn cycle_initial(_db: &dyn ValueDatabase) -> u32 {
+fn cycle_initial(_db: &dyn ValueDatabase, _id: salsa::Id) -> u32 {
     0
 }
 

--- a/tests/cycle_recovery_call_query.rs
+++ b/tests/cycle_recovery_call_query.rs
@@ -17,7 +17,7 @@ fn query(db: &dyn salsa::Database) -> u32 {
     }
 }
 
-fn cycle_initial(_db: &dyn salsa::Database) -> u32 {
+fn cycle_initial(_db: &dyn salsa::Database, _id: salsa::Id) -> u32 {
     0
 }
 

--- a/tests/cycle_regression_455.rs
+++ b/tests/cycle_regression_455.rs
@@ -12,7 +12,7 @@ fn memoized_a<'db>(db: &'db dyn Database, tracked: MyTracked<'db>) -> u32 {
     MyTracked::new(db, 0);
     memoized_b(db, tracked)
 }
-fn cycle_initial(_db: &dyn Database, _input: MyTracked) -> u32 {
+fn cycle_initial(_db: &dyn Database, _id: salsa::Id, _input: MyTracked) -> u32 {
     0
 }
 

--- a/tests/cycle_result_dependencies.rs
+++ b/tests/cycle_result_dependencies.rs
@@ -12,7 +12,7 @@ fn has_cycle(db: &dyn Database, input: Input) -> i32 {
     has_cycle(db, input)
 }
 
-fn cycle_result(db: &dyn Database, input: Input) -> i32 {
+fn cycle_result(db: &dyn Database, _id: salsa::Id, input: Input) -> i32 {
     input.value(db)
 }
 

--- a/tests/cycle_tracked.rs
+++ b/tests/cycle_tracked.rs
@@ -110,7 +110,7 @@ fn cost_to_start<'db>(db: &'db dyn Database, node: Node<'db>) -> usize {
     min_cost
 }
 
-fn max_initial(_db: &dyn Database, _node: Node) -> usize {
+fn max_initial(_db: &dyn Database, _id: salsa::Id, _node: Node) -> usize {
     usize::MAX
 }
 
@@ -246,7 +246,11 @@ fn create_tracked_in_cycle<'db>(
     }
 }
 
-fn initial_with_structs(_db: &dyn Database, _input: GraphInput) -> Vec<IterationNode<'_>> {
+fn initial_with_structs(
+    _db: &dyn Database,
+    _id: salsa::Id,
+    _input: GraphInput,
+) -> Vec<IterationNode<'_>> {
     vec![]
 }
 

--- a/tests/cycle_tracked_own_input.rs
+++ b/tests/cycle_tracked_own_input.rs
@@ -81,7 +81,7 @@ fn infer_type_param<'db>(db: &'db dyn salsa::Database, node: TypeParamNode) -> T
     }
 }
 
-fn infer_class_initial(_db: &'_ dyn Database, _node: ClassNode) -> Type<'_> {
+fn infer_class_initial(_db: &'_ dyn Database, _id: salsa::Id, _node: ClassNode) -> Type<'_> {
     Type::Unknown
 }
 

--- a/tests/dataflow.rs
+++ b/tests/dataflow.rs
@@ -71,7 +71,7 @@ fn infer_definition<'db>(db: &'db dyn Db, def: Definition) -> Type {
     }
 }
 
-fn def_cycle_initial(_db: &dyn Db, _def: Definition) -> Type {
+fn def_cycle_initial(_db: &dyn Db, _id: salsa::Id, _def: Definition) -> Type {
     Type::Bottom
 }
 
@@ -86,7 +86,7 @@ fn def_cycle_recover(
     cycle_recover(value, count)
 }
 
-fn use_cycle_initial(_db: &dyn Db, _use: Use) -> Type {
+fn use_cycle_initial(_db: &dyn Db, _id: salsa::Id, _use: Use) -> Type {
     Type::Bottom
 }
 

--- a/tests/parallel/cycle_a_t1_b_t2.rs
+++ b/tests/parallel/cycle_a_t1_b_t2.rs
@@ -45,7 +45,7 @@ fn query_b(db: &dyn KnobsDatabase) -> CycleValue {
     CycleValue(a_value.0 + 1).min(MAX)
 }
 
-fn initial(_db: &dyn KnobsDatabase) -> CycleValue {
+fn initial(_db: &dyn KnobsDatabase, _id: salsa::Id) -> CycleValue {
     MIN
 }
 

--- a/tests/parallel/cycle_a_t1_b_t2_fallback.rs
+++ b/tests/parallel/cycle_a_t1_b_t2_fallback.rs
@@ -41,11 +41,11 @@ fn query_b(db: &dyn KnobsDatabase) -> u32 {
     query_a(db) | OFFSET_B
 }
 
-fn cycle_result_a(_db: &dyn KnobsDatabase) -> u32 {
+fn cycle_result_a(_db: &dyn KnobsDatabase, _id: salsa::Id) -> u32 {
     FALLBACK_A
 }
 
-fn cycle_result_b(_db: &dyn KnobsDatabase) -> u32 {
+fn cycle_result_b(_db: &dyn KnobsDatabase, _id: salsa::Id) -> u32 {
     FALLBACK_B
 }
 

--- a/tests/parallel/cycle_ab_peeping_c.rs
+++ b/tests/parallel/cycle_ab_peeping_c.rs
@@ -30,7 +30,7 @@ fn query_a(db: &dyn KnobsDatabase) -> CycleValue {
     b_value
 }
 
-fn cycle_initial(_db: &dyn KnobsDatabase) -> CycleValue {
+fn cycle_initial(_db: &dyn KnobsDatabase, _id: salsa::Id) -> CycleValue {
     MIN
 }
 

--- a/tests/parallel/cycle_iteration_mismatch.rs
+++ b/tests/parallel/cycle_iteration_mismatch.rs
@@ -62,7 +62,7 @@ fn query_f(db: &dyn KnobsDatabase) -> CycleValue {
     CycleValue(b.0.max(e.0))
 }
 
-fn initial(_db: &dyn KnobsDatabase) -> CycleValue {
+fn initial(_db: &dyn KnobsDatabase, _id: salsa::Id) -> CycleValue {
     MIN
 }
 

--- a/tests/parallel/cycle_nested_deep.rs
+++ b/tests/parallel/cycle_nested_deep.rs
@@ -46,7 +46,7 @@ fn query_e(db: &dyn KnobsDatabase) -> CycleValue {
     query_c(db)
 }
 
-fn initial(_db: &dyn KnobsDatabase) -> CycleValue {
+fn initial(_db: &dyn KnobsDatabase, _id: salsa::Id) -> CycleValue {
     MIN
 }
 

--- a/tests/parallel/cycle_nested_deep_conditional.rs
+++ b/tests/parallel/cycle_nested_deep_conditional.rs
@@ -55,7 +55,7 @@ fn query_e(db: &dyn KnobsDatabase) -> CycleValue {
     query_c(db)
 }
 
-fn initial(_db: &dyn KnobsDatabase) -> CycleValue {
+fn initial(_db: &dyn KnobsDatabase, _id: salsa::Id) -> CycleValue {
     MIN
 }
 

--- a/tests/parallel/cycle_nested_deep_conditional_changed.rs
+++ b/tests/parallel/cycle_nested_deep_conditional_changed.rs
@@ -61,7 +61,7 @@ fn query_e(db: &dyn salsa::Database, input: Input) -> CycleValue {
     query_c(db, input)
 }
 
-fn initial(_db: &dyn salsa::Database, _input: Input) -> CycleValue {
+fn initial(_db: &dyn salsa::Database, _id: salsa::Id, _input: Input) -> CycleValue {
     MIN
 }
 

--- a/tests/parallel/cycle_nested_deep_panic.rs
+++ b/tests/parallel/cycle_nested_deep_panic.rs
@@ -49,7 +49,7 @@ fn query_e(db: &dyn KnobsDatabase) -> CycleValue {
     query_c(db)
 }
 
-fn initial(_db: &dyn KnobsDatabase) -> CycleValue {
+fn initial(_db: &dyn KnobsDatabase, _id: salsa::Id) -> CycleValue {
     MIN
 }
 

--- a/tests/parallel/cycle_nested_three_threads.rs
+++ b/tests/parallel/cycle_nested_three_threads.rs
@@ -55,7 +55,7 @@ fn query_c(db: &dyn KnobsDatabase) -> CycleValue {
     CycleValue(a_value.0.max(b_value.0))
 }
 
-fn initial(_db: &dyn KnobsDatabase) -> CycleValue {
+fn initial(_db: &dyn KnobsDatabase, _id: salsa::Id) -> CycleValue {
     MIN
 }
 

--- a/tests/parallel/cycle_nested_three_threads_changed.rs
+++ b/tests/parallel/cycle_nested_three_threads_changed.rs
@@ -54,7 +54,7 @@ fn query_c(db: &dyn salsa::Database, input: Input) -> CycleValue {
     CycleValue(a_value.0.max(b_value.0))
 }
 
-fn initial(_db: &dyn salsa::Database, _input: Input) -> CycleValue {
+fn initial(_db: &dyn salsa::Database, _id: salsa::Id, _input: Input) -> CycleValue {
     MIN
 }
 

--- a/tests/parallel/cycle_panic.rs
+++ b/tests/parallel/cycle_panic.rs
@@ -28,7 +28,7 @@ fn cycle_fn(
     panic!("cancel!")
 }
 
-fn initial(_db: &dyn KnobsDatabase) -> u32 {
+fn initial(_db: &dyn KnobsDatabase, _id: salsa::Id) -> u32 {
     0
 }
 

--- a/tests/parallel/cycle_provisional_depending_on_itself.rs
+++ b/tests/parallel/cycle_provisional_depending_on_itself.rs
@@ -67,7 +67,7 @@ fn query_c(db: &dyn KnobsDatabase) -> CycleValue {
     b
 }
 
-fn cycle_initial(_db: &dyn KnobsDatabase) -> CycleValue {
+fn cycle_initial(_db: &dyn KnobsDatabase, _id: salsa::Id) -> CycleValue {
     MIN
 }
 


### PR DESCRIPTION
The `cycle_fn` function receives a `salsa::Id` (from #1012), but in this PR we'll make it so that the `cycle_initial` function can also receive it.
This PR contains breaking API changes.

For context on this PR, see https://github.com/astral-sh/ruff/pull/20566#issuecomment-3449992521.
