### PR TITLE
Increment iteration count for all queries with cycle handling participating in a cycle

### DIFF
--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -509,35 +509,12 @@ where
                     head_iteration_count,
                     memo_iteration_count: current_iteration_count,
                     verified_at: head_verified_at,
-                    cycle_heads,
-                    database_key_index: head_database_key,
                 } => {
                     if head_verified_at != memo_verified_at {
                         return false;
                     }
 
                     if head_iteration_count != current_iteration_count {
-                        return false;
-                    }
-
-                    // Check if the memo is still a cycle head and hasn't changed
-                    // to a normal cycle participant. This is to force re-execution in
-                    // a scenario like this:
-                    //
-                    // * There's a nested cycle with the outermost query A
-                    // * B participates in the cycle and is a cycle head in the first few iterations
-                    // * B becomes a non-cycle head in a later iteration
-                    // * There's a query `C` that has `B` as its cycle head
-                    //
-                    // The crucial point is that `B` switches from being a cycle head to being a regular cycle participant.
-                    // The issue with that is that `A` doesn't update `B`'s `iteration_count `when the iteration completes
-                    // because it only does that for cycle heads (and collecting all queries participating in a query would be sort of expensive?).
-                    //
-                    // When we now pull `C` in a later iteration, `validate_same_iteration` iterates over all its cycle heads (`B`),
-                    // and check if the iteration count still matches. Which is the case because `A` didn't update `B`'s iteration count.
-                    //
-                    // That's why we also check if `B` is still a cycle head in the current iteration.
-                    if !cycle_heads.contains(&head_database_key) {
                         return false;
                     }
                 }

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -409,11 +409,9 @@ mod persistence {
 pub(super) enum TryClaimHeadsResult<'me> {
     /// Claiming the cycle head results in a cycle.
     Cycle {
-        database_key_index: DatabaseKeyIndex,
         head_iteration_count: IterationCount,
         memo_iteration_count: IterationCount,
         verified_at: Revision,
-        cycle_heads: &'me CycleHeads,
     },
 
     /// The cycle head is not finalized, but it can be claimed.
@@ -460,28 +458,24 @@ impl<'me> Iterator for TryClaimCycleHeadsIter<'me> {
                 let provisional_status = ingredient
                     .provisional_status(self.zalsa, head_key_index)
                     .expect("cycle head memo to exist");
-                let (current_iteration_count, verified_at, cycle_heads) = match provisional_status {
+                let (current_iteration_count, verified_at) = match provisional_status {
                     ProvisionalStatus::Provisional {
                         iteration,
                         verified_at,
-                        cycle_heads,
-                    } => (iteration, verified_at, cycle_heads),
+                        cycle_heads: _,
+                    } => (iteration, verified_at),
                     ProvisionalStatus::Final {
                         iteration,
                         verified_at,
-                    } => (iteration, verified_at, empty_cycle_heads()),
-                    ProvisionalStatus::FallbackImmediate => (
-                        IterationCount::initial(),
-                        self.zalsa.current_revision(),
-                        empty_cycle_heads(),
-                    ),
+                    } => (iteration, verified_at),
+                    ProvisionalStatus::FallbackImmediate => {
+                        (IterationCount::initial(), self.zalsa.current_revision())
+                    }
                 };
 
                 Some(TryClaimHeadsResult::Cycle {
-                    database_key_index: head_database_key,
                     memo_iteration_count: current_iteration_count,
                     head_iteration_count: head.iteration_count.load(),
-                    cycle_heads,
                     verified_at,
                 })
             }


### PR DESCRIPTION
This is an alternative, and I think a more footgun-proof fix for https://github.com/salsa-rs/salsa/pull/1014

Up to now, Salsa increments the iteration count for all *cycle heads* participating in a query before starting a new iteration. However, queries with cycle handling that aren't cycle heads never increment their iteration count. Instead, they always use zero (or the iteration count from the last iteration). 

However, we use the iteration count in multiple places (e.g. `validate_same_iteration`, `validate_provisional`) to assert whether the most recent memo for a given key is "the same" as when a query dependent on it. For this to work, it's essential that the iteration count uniquely identify a query execution, which isn't the case now. 

The way https://github.com/salsa-rs/salsa/pull/1014 works around this is by adding an extra check to `validate_same_iteration` that always skips if a query has become a non-cycle head. This works, but it always requires remembering to check both the iteration count and whether the query is still in the cycle heads. In fact, we currently don't perform this check within `validate_provisional` because we can't; the cycle heads of a finalized memo are often empty. I'm not sure if that's the cause of the flaky test failures but it might as well be. 


This PR ensures that salsa either:

* Increments the iteration count as part of the outer cycle if the query is a cycle head
* Increments the iteration count when a query with cycle handling completes (that doesn't depend on itself)


## Test plan
I tested that the regression test from https://github.com/salsa-rs/salsa/pull/1014 still passes and I ran the parallel tests with 10k iterations