### PR TITLE
Call `cycle_fn` for every iteration

### DIFF
--- a/benches/dataflow.rs
+++ b/benches/dataflow.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeSet;
 use std::iter::IntoIterator;
 
 use codspeed_criterion_compat::{criterion_group, criterion_main, BatchSize, Criterion};
-use salsa::{CycleRecoveryAction, Database as Db, Setter};
+use salsa::{Database as Db, Setter};
 
 /// A Use of a symbol.
 #[salsa::input]
@@ -78,10 +78,10 @@ fn def_cycle_recover(
     _db: &dyn Db,
     _id: salsa::Id,
     _last_provisional_value: &Type,
-    value: &Type,
+    value: Type,
     count: u32,
     _def: Definition,
-) -> CycleRecoveryAction<Type> {
+) -> Type {
     cycle_recover(value, count)
 }
 
@@ -93,24 +93,24 @@ fn use_cycle_recover(
     _db: &dyn Db,
     _id: salsa::Id,
     _last_provisional_value: &Type,
-    value: &Type,
+    value: Type,
     count: u32,
     _use: Use,
-) -> CycleRecoveryAction<Type> {
+) -> Type {
     cycle_recover(value, count)
 }
 
-fn cycle_recover(value: &Type, count: u32) -> CycleRecoveryAction<Type> {
-    match value {
-        Type::Bottom => CycleRecoveryAction::Iterate,
+fn cycle_recover(value: Type, count: u32) -> Type {
+    match &value {
+        Type::Bottom => value,
         Type::Values(_) => {
             if count > 4 {
-                CycleRecoveryAction::Fallback(Type::Top)
+                Type::Top
             } else {
-                CycleRecoveryAction::Iterate
+                value
             }
         }
-        Type::Top => CycleRecoveryAction::Iterate,
+        Type::Top => value,
     }
 }
 

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -310,10 +310,10 @@ macro_rules! setup_tracked_fn {
                     db: &$db_lt dyn $Db,
                     id: salsa::Id,
                     last_provisional_value: &Self::Output<$db_lt>,
-                    value: &Self::Output<$db_lt>,
+                    value: Self::Output<$db_lt>,
                     iteration_count: u32,
                     ($($input_id),*): ($($interned_input_ty),*)
-                ) -> $zalsa::CycleRecoveryAction<Self::Output<$db_lt>> {
+                ) -> Self::Output<$db_lt> {
                     $($cycle_recovery_fn)*(db, id, last_provisional_value, value, iteration_count, $($input_id),*)
                 }
 

--- a/components/salsa-macro-rules/src/unexpected_cycle_recovery.rs
+++ b/components/salsa-macro-rules/src/unexpected_cycle_recovery.rs
@@ -4,9 +4,9 @@
 #[macro_export]
 macro_rules! unexpected_cycle_recovery {
     ($db:ident, $id:ident, $last_provisional_value:ident, $new_value:ident, $count:ident, $($other_inputs:ident),*) => {{
-        let (_db, _id, _last_provisional_value, _new_value, _count) = ($db, $id, $last_provisional_value, $new_value, $count);
+        let (_db, _id, _last_provisional_value, _count) = ($db, $id, $last_provisional_value, $count);
         std::mem::drop(($($other_inputs,)*));
-        salsa::CycleRecoveryAction::Iterate
+        $new_value
     }};
 }
 

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -372,28 +372,20 @@ where
             };
 
             // We are in a cycle that hasn't converged; ask the user's
-            // cycle-recovery function what to do:
-            match C::recover_from_cycle(
+            // cycle-recovery function what to do (it may return the same value or a different one):
+            new_value = C::recover_from_cycle(
                 db,
                 id,
                 last_provisional_value,
-                &new_value,
+                new_value,
                 iteration_count.as_u32(),
                 C::id_to_input(zalsa, id),
-            ) {
-                crate::CycleRecoveryAction::Iterate => {}
-                crate::CycleRecoveryAction::Fallback(fallback_value) => {
-                    tracing::debug!(
-                        "{database_key_index:?}: execute: user cycle_fn says to fall back"
-                    );
-                    new_value = fallback_value;
-                }
+            );
 
-                let new_cycle_heads = active_query.take_cycle_heads();
-                for head in new_cycle_heads {
-                    if !cycle_heads.contains(&head.database_key_index) {
-                        panic!("Cycle recovery function for {database_key_index:?} introduced a cycle, depending on {:?}. This is not allowed.", head.database_key_index);
-                    }
+            let new_cycle_heads = active_query.take_cycle_heads();
+            for head in new_cycle_heads {
+                if !cycle_heads.contains(&head.database_key_index) {
+                    panic!("Cycle recovery function for {database_key_index:?} introduced a cycle, depending on {:?}. This is not allowed.", head.database_key_index);
                 }
             }
 

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -496,7 +496,7 @@ mod _memory_usage {
     use crate::plumbing::{self, IngredientIndices, MemoIngredientSingletonIndex, SalsaStructInDb};
     use crate::table::memo::MemoTableWithTypes;
     use crate::zalsa::Zalsa;
-    use crate::{CycleRecoveryAction, Database, Id, Revision};
+    use crate::{Database, Id, Revision};
 
     use std::any::TypeId;
     use std::num::NonZeroUsize;
@@ -564,11 +564,11 @@ mod _memory_usage {
             _: &'db Self::DbView,
             _: Id,
             _: &Self::Output<'db>,
-            _: &Self::Output<'db>,
+            value: Self::Output<'db>,
             _: u32,
             _: Self::Input<'db>,
-        ) -> CycleRecoveryAction<Self::Output<'db>> {
-            unimplemented!()
+        ) -> Self::Output<'db> {
+            value
         }
 
         fn serialize<S>(_: &Self::Output<'_>, _: S) -> Result<S::Ok, S::Error>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ pub use self::database::IngredientInfo;
 pub use self::accumulator::Accumulator;
 pub use self::active_query::Backtrace;
 pub use self::cancelled::Cancelled;
-pub use self::cycle::CycleRecoveryAction;
+
 pub use self::database::Database;
 pub use self::database_impl::DatabaseImpl;
 pub use self::durability::Durability;
@@ -92,7 +92,7 @@ pub mod plumbing {
     #[cfg(feature = "accumulator")]
     pub use crate::accumulator::Accumulator;
     pub use crate::attach::{attach, with_attached_database};
-    pub use crate::cycle::{CycleRecoveryAction, CycleRecoveryStrategy};
+    pub use crate::cycle::CycleRecoveryStrategy;
     pub use crate::database::{current_revision, Database};
     pub use crate::durability::Durability;
     pub use crate::id::{AsId, FromId, FromIdWithDb, Id};

--- a/tests/cycle_accumulate.rs
+++ b/tests/cycle_accumulate.rs
@@ -52,11 +52,11 @@ fn cycle_fn(
     _db: &dyn LogDatabase,
     _id: salsa::Id,
     _last_provisional_value: &[u32],
-    _value: &[u32],
+    value: Vec<u32>,
     _count: u32,
     _file: File,
-) -> salsa::CycleRecoveryAction<Vec<u32>> {
-    salsa::CycleRecoveryAction::Iterate
+) -> Vec<u32> {
+    value
 }
 
 #[test]

--- a/tests/cycle_recovery_call_back_into_cycle.rs
+++ b/tests/cycle_recovery_call_back_into_cycle.rs
@@ -29,13 +29,13 @@ fn cycle_fn(
     db: &dyn ValueDatabase,
     _id: salsa::Id,
     last_provisional_value: &u32,
-    value: &u32,
+    value: u32,
     _count: u32,
-) -> salsa::CycleRecoveryAction<u32> {
-    if value == last_provisional_value {
-        salsa::CycleRecoveryAction::Iterate
+) -> u32 {
+    if &value == last_provisional_value {
+        value
     } else {
-        salsa::CycleRecoveryAction::Fallback(fallback_value(db))
+        fallback_value(db)
     }
 }
 

--- a/tests/cycle_recovery_call_query.rs
+++ b/tests/cycle_recovery_call_query.rs
@@ -25,10 +25,10 @@ fn cycle_fn(
     db: &dyn salsa::Database,
     _id: salsa::Id,
     _last_provisional_value: &u32,
-    _value: &u32,
+    _value: u32,
     _count: u32,
-) -> salsa::CycleRecoveryAction<u32> {
-    salsa::CycleRecoveryAction::Fallback(fallback_value(db))
+) -> u32 {
+    fallback_value(db)
 }
 
 #[test_log::test]

--- a/tests/cycle_recovery_dependencies.rs
+++ b/tests/cycle_recovery_dependencies.rs
@@ -39,12 +39,12 @@ fn cycle_fn(
     db: &dyn salsa::Database,
     _id: salsa::Id,
     _last_provisional_value: &u32,
-    _value: &u32,
+    value: u32,
     _count: u32,
     input: Input,
-) -> salsa::CycleRecoveryAction<u32> {
+) -> u32 {
     let _input = input.value(db);
-    salsa::CycleRecoveryAction::Iterate
+    value
 }
 
 #[test_log::test]

--- a/tests/dataflow.rs
+++ b/tests/dataflow.rs
@@ -7,7 +7,7 @@
 use std::collections::BTreeSet;
 use std::iter::IntoIterator;
 
-use salsa::{CycleRecoveryAction, Database as Db, Setter};
+use salsa::{Database as Db, Setter};
 
 /// A Use of a symbol.
 #[salsa::input]
@@ -79,12 +79,12 @@ fn def_cycle_recover(
     _db: &dyn Db,
     _id: salsa::Id,
     last_provisional_value: &Type,
-    value: &Type,
+    value: Type,
     count: u32,
     _def: Definition,
-) -> CycleRecoveryAction<Type> {
-    if value == last_provisional_value {
-        CycleRecoveryAction::Iterate
+) -> Type {
+    if &value == last_provisional_value {
+        value
     } else {
         cycle_recover(value, count)
     }
@@ -98,28 +98,28 @@ fn use_cycle_recover(
     _db: &dyn Db,
     _id: salsa::Id,
     last_provisional_value: &Type,
-    value: &Type,
+    value: Type,
     count: u32,
     _use: Use,
-) -> CycleRecoveryAction<Type> {
-    if value != last_provisional_value {
-        cycle_recover(value, count)
+) -> Type {
+    if &value == last_provisional_value {
+        value
     } else {
-        CycleRecoveryAction::Iterate
+        cycle_recover(value, count)
     }
 }
 
-fn cycle_recover(value: &Type, count: u32) -> CycleRecoveryAction<Type> {
-    match value {
-        Type::Bottom => CycleRecoveryAction::Iterate,
+fn cycle_recover(value: Type, count: u32) -> Type {
+    match &value {
+        Type::Bottom => value,
         Type::Values(_) => {
             if count > 4 {
-                CycleRecoveryAction::Fallback(Type::Top)
+                Type::Top
             } else {
-                CycleRecoveryAction::Iterate
+                value
             }
         }
-        Type::Top => CycleRecoveryAction::Iterate,
+        Type::Top => value,
     }
 }
 

--- a/tests/parallel/cycle_panic.rs
+++ b/tests/parallel/cycle_panic.rs
@@ -22,9 +22,9 @@ fn cycle_fn(
     _db: &dyn KnobsDatabase,
     _id: salsa::Id,
     _last_provisional_value: &u32,
-    _value: &u32,
+    _value: u32,
     _count: u32,
-) -> salsa::CycleRecoveryAction<u32> {
+) -> u32 {
     panic!("cancel!")
 }
 


### PR DESCRIPTION
This PR changes when salsa calls `cycle_fn`. 

Before: Salsa only called `cycle_fn` when the last provisional and current value were different (this cycle head hasn't converged)

Now: Salsa will call `cycle_fn` for every iteration

This feels more consistent for a cycle with nested cycles because, before, a query could have converged but kept being executed
because one of the other heads in this cycle hasn't converged yet. 

Always calling the `cycle_fn` also has the benefit that users can use it to finalize the query result. 


This also makes `CycleRecoveryAction` redundant because there's no real difference between `Iterate` and `Fallback`. That's why this PR changes the `cycle_fn` signature to take an owned `value` and return `Self::Output`.
