### PR TITLE
Fix cycle head durability

### DIFF
--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -934,6 +934,10 @@ impl QueryOrigin {
         }
     }
 
+    pub fn is_derived_untracked(&self) -> bool {
+        matches!(self.kind, QueryOriginKind::DerivedUntracked)
+    }
+
     /// Create a query origin of type `QueryOriginKind::Derived`, with the given edges.
     pub fn derived(input_outputs: Box<[QueryEdge]>) -> QueryOrigin {
         // Exceeding `u32::MAX` query edges should never happen in real-world usage.

--- a/tests/cycle_input_different_cycle_head.rs
+++ b/tests/cycle_input_different_cycle_head.rs
@@ -1,0 +1,72 @@
+#![cfg(feature = "inventory")]
+
+//! Tests that the durability correctly propagates
+//! to all cycle heads.
+
+use salsa::Setter as _;
+
+#[test_log::test]
+fn low_durability_cycle_enter_from_different_head() {
+    let mut db = MyDbImpl::default();
+    // Start with 0, the same as returned by cycle initial
+    let input = Input::builder(0).new(&db);
+    db.input = Some(input);
+
+    assert_eq!(query_a(&db), 0); // Prime the Db
+
+    input.set_value(&mut db).to(10);
+
+    assert_eq!(query_b(&db), 10);
+}
+
+#[salsa::input]
+struct Input {
+    value: u32,
+}
+
+#[salsa::db]
+trait MyDb: salsa::Database {
+    fn input(&self) -> Input;
+}
+
+#[salsa::db]
+#[derive(Clone, Default)]
+struct MyDbImpl {
+    storage: salsa::Storage<Self>,
+    input: Option<Input>,
+}
+
+#[salsa::db]
+impl salsa::Database for MyDbImpl {}
+
+#[salsa::db]
+impl MyDb for MyDbImpl {
+    fn input(&self) -> Input {
+        self.input.unwrap()
+    }
+}
+
+#[salsa::tracked(cycle_initial=cycle_initial)]
+fn query_a(db: &dyn MyDb) -> u32 {
+    query_b(db);
+    db.input().value(db)
+}
+
+fn cycle_initial(_db: &dyn MyDb, _id: salsa::Id) -> u32 {
+    0
+}
+
+#[salsa::interned]
+struct Interned {
+    value: u32,
+}
+
+#[salsa::tracked(cycle_initial=cycle_initial)]
+fn query_b<'db>(db: &'db dyn MyDb) -> u32 {
+    query_c(db)
+}
+
+#[salsa::tracked]
+fn query_c(db: &dyn MyDb) -> u32 {
+    query_a(db)
+}


### PR DESCRIPTION
This PR fixes a bug in Salsa's fixpoint handling where 
the durability wasn't correctly propagated to nested cycle heads. 

I noticed this bug when trying to write a test for another bug. I don't think
this is very common but we have to fix it because it's unsound.

We need to force an extra iteration when the cycle heads metadata like its `durability`, `changed_at` or whether it has untracked reads
change. This is necessary to propagate the change to all other cycle heads so that, when calling `other_head.maybe_changed_after`, Salsa doesn't
short circuit (e.g. because the `durability` incorrecty is `HIGH`). 


The way I reprocue this in the added test is by having a cycle that converges after the first iteration
because the `cycle_initial` and the first iteration both return the same value. However, the initial value has
the `durability` `HIGH` whereas the value after the first iteration is `LOW` (the query read an input).


While the added test is specific to a case where the cycle converges immediately because it produces the same value as the cycle initial function, the problem isn't specific to inital functions. 

Note: I also considered changing the `durability` of the initial memo to low. However, this is incorrect too because it "poisons" all queries participating in the cycle and they all end up with durability LOW even if they don't read any inputs.


