### PR TITLE
Support a new `Durability::NEVER_CHANGE`

### DIFF
--- a/components/salsa-macro-rules/src/setup_input_struct.rs
+++ b/components/salsa-macro-rules/src/setup_input_struct.rs
@@ -392,7 +392,7 @@ macro_rules! setup_input_struct {
                 pub(super) fn new_builder($($field_id: $field_ty),*) -> $Builder {
                     $Builder {
                         fields: ($($field_id,)*),
-                        durabilities: [::salsa::Durability::default(); $N],
+                        durabilities: [::salsa::Durability::MIN; $N],
                     }
                 }
 

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -67,6 +67,8 @@ macro_rules! setup_tracked_fn {
         // If true, the input and output values implement `serde::{Serialize, Deserialize}`.
         persist: $persist:tt,
 
+        force_durability: $force_durability:expr,
+
         assert_return_type_is_update: {$($assert_return_type_is_update:tt)*},
 
         $(self_ty: $self_ty:ty,)?
@@ -285,6 +287,8 @@ macro_rules! setup_tracked_fn {
                 type Output<$db_lt> = $output_ty;
 
                 const CYCLE_STRATEGY: $zalsa::CycleRecoveryStrategy = $zalsa::CycleRecoveryStrategy::$cycle_recovery_strategy;
+
+                const FORCE_DURABILITY: Option<$zalsa::Durability> = $force_durability;
 
                 $($values_equal)+
 

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -391,7 +391,7 @@ macro_rules! setup_tracked_fn {
                             zalsa,
                             struct_index,
                             first_index,
-                            $zalsa::function::MemoEntryType::of::<$zalsa::function::Memo<$Configuration>>(),
+                            $zalsa::function::MemoEntryType::of::<$zalsa::function::AmbiguousMemo<$Configuration>>(),
                             intern_ingredient_memo_types,
                         )
                     };

--- a/components/salsa-macros/src/accumulator.rs
+++ b/components/salsa-macros/src/accumulator.rs
@@ -49,6 +49,7 @@ impl AllowedOptions for Accumulator {
     const SELF_TY: bool = false;
     // TODO: Support serializing accumulators.
     const PERSIST: AllowedPersistOptions = AllowedPersistOptions::Invalid;
+    const FORCE_DURABILITY: bool = false;
 }
 
 struct StructMacro {

--- a/components/salsa-macros/src/input.rs
+++ b/components/salsa-macros/src/input.rs
@@ -70,6 +70,8 @@ impl AllowedOptions for InputStruct {
     const SELF_TY: bool = false;
 
     const PERSIST: AllowedPersistOptions = AllowedPersistOptions::AllowedValue;
+
+    const FORCE_DURABILITY: bool = false;
 }
 
 impl SalsaStructAllowedOptions for InputStruct {

--- a/components/salsa-macros/src/interned.rs
+++ b/components/salsa-macros/src/interned.rs
@@ -70,6 +70,8 @@ impl AllowedOptions for InternedStruct {
     const SELF_TY: bool = false;
 
     const PERSIST: AllowedPersistOptions = AllowedPersistOptions::AllowedValue;
+
+    const FORCE_DURABILITY: bool = false;
 }
 
 impl SalsaStructAllowedOptions for InternedStruct {

--- a/components/salsa-macros/src/tracked_fn.rs
+++ b/components/salsa-macros/src/tracked_fn.rs
@@ -63,6 +63,8 @@ impl AllowedOptions for TrackedFn {
     const SELF_TY: bool = true;
 
     const PERSIST: AllowedPersistOptions = AllowedPersistOptions::AllowedIdent;
+
+    const FORCE_DURABILITY: bool = true;
 }
 
 struct Macro {
@@ -209,6 +211,10 @@ impl Macro {
             Some(ty) => quote! { self_ty: #ty, },
             None => quote! {},
         };
+        let force_durability = match &self.args.force_durability {
+            Some(durability) => quote!(Some(#durability)),
+            None => quote!(None),
+        };
 
         Ok(crate::debug::dump_tokens(
             fn_name,
@@ -234,6 +240,7 @@ impl Macro {
                 lru: #lru,
                 return_mode: #return_mode,
                 persist: #persist,
+                force_durability: #force_durability,
                 assert_return_type_is_update: { #assert_return_type_is_update },
                 #self_ty
                 unused_names: [

--- a/components/salsa-macros/src/tracked_struct.rs
+++ b/components/salsa-macros/src/tracked_struct.rs
@@ -66,6 +66,8 @@ impl AllowedOptions for TrackedStruct {
     const SELF_TY: bool = false;
 
     const PERSIST: AllowedPersistOptions = AllowedPersistOptions::AllowedValue;
+
+    const FORCE_DURABILITY: bool = false;
 }
 
 impl SalsaStructAllowedOptions for TrackedStruct {

--- a/src/accumulator/accumulated_map.rs
+++ b/src/accumulator/accumulated_map.rs
@@ -21,6 +21,10 @@ impl std::fmt::Debug for AccumulatedMap {
 }
 
 impl AccumulatedMap {
+    pub(crate) const EMPTY: AccumulatedMap = AccumulatedMap {
+        map: hashbrown::HashMap::with_hasher(FxBuildHasher),
+    };
+
     pub fn accumulate<A: Accumulator>(&mut self, index: IngredientIndex, value: A) {
         self.map
             .entry(index)

--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -106,7 +106,6 @@ impl ActiveQuery {
     ) {
         self.durability = self.durability.min(durability);
         self.changed_at = self.changed_at.max(changed_at);
-        self.input_outputs.insert(QueryEdge::input(input));
         self.cycle_heads.extend(cycle_heads);
         #[cfg(feature = "accumulator")]
         {
@@ -114,6 +113,10 @@ impl ActiveQuery {
                 true => InputAccumulatedValues::Any,
                 false => accumulated_inputs.load(),
             });
+        }
+        if !cycle_heads.is_empty() || durability != Durability::NEVER_CHANGE {
+            // During cycles we need to record dependencies.
+            self.input_outputs.insert(QueryEdge::input(input));
         }
     }
 
@@ -125,7 +128,9 @@ impl ActiveQuery {
     ) {
         self.durability = self.durability.min(durability);
         self.changed_at = self.changed_at.max(revision);
-        self.input_outputs.insert(QueryEdge::input(input));
+        if durability != Durability::NEVER_CHANGE {
+            self.input_outputs.insert(QueryEdge::input(input));
+        }
     }
 
     pub(super) fn add_untracked_read(&mut self, changed_at: Revision) {
@@ -147,7 +152,9 @@ impl ActiveQuery {
 
     /// Adds a key to our list of outputs.
     pub(super) fn add_output(&mut self, key: DatabaseKeyIndex) {
-        self.input_outputs.insert(QueryEdge::output(key));
+        if self.durability != Durability::NEVER_CHANGE {
+            self.input_outputs.insert(QueryEdge::output(key));
+        }
     }
 
     /// True if the given key was output by this query.

--- a/src/cycle.rs
+++ b/src/cycle.rs
@@ -217,6 +217,7 @@ impl<'de> serde::Deserialize<'de> for AtomicIterationCount {
 pub struct CycleHeads(ThinVec<CycleHead>);
 
 impl CycleHeads {
+    #[inline]
     pub(crate) fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
@@ -505,6 +506,7 @@ pub enum ProvisionalStatus<'db> {
         iteration: IterationCount,
         verified_at: Revision,
     },
+    FinalNeverChange,
     FallbackImmediate,
 }
 

--- a/src/durability.rs
+++ b/src/durability.rs
@@ -46,6 +46,7 @@ impl std::fmt::Debug for Durability {
                 DurabilityVal::Low => f.write_str("Durability::LOW"),
                 DurabilityVal::Medium => f.write_str("Durability::MEDIUM"),
                 DurabilityVal::High => f.write_str("Durability::HIGH"),
+                DurabilityVal::NeverChange => f.write_str("Durability::NEVER_CHANGE"),
             }
         } else {
             f.debug_tuple("Durability")
@@ -61,14 +62,17 @@ enum DurabilityVal {
     Low = 0,
     Medium = 1,
     High = 2,
+    NeverChange = 3,
 }
 
 impl From<u8> for DurabilityVal {
+    #[inline]
     fn from(value: u8) -> Self {
         match value {
             0 => DurabilityVal::Low,
             1 => DurabilityVal::Medium,
             2 => DurabilityVal::High,
+            3 => DurabilityVal::NeverChange,
             _ => panic!("invalid durability"),
         }
     }
@@ -87,23 +91,28 @@ impl Durability {
 
     /// High durability: things that are not expected to change under
     /// common usage.
-    ///
-    /// Example: the standard library or something from crates.io
     pub const HIGH: Durability = Durability(DurabilityVal::High);
+
+    /// The input is guaranteed to never change. Queries calling it won't have
+    /// it as a dependency.
+    ///
+    /// Example: the standard library or something from crates.io.
+    pub const NEVER_CHANGE: Durability = Durability(DurabilityVal::NeverChange);
 
     /// The minimum possible durability; equivalent to LOW but
     /// "conceptually" distinct (i.e., if we add more durability
     /// levels, this could change).
-    pub(crate) const MIN: Durability = Self::LOW;
+    pub const MIN: Durability = Self::LOW;
 
-    /// The maximum possible durability; equivalent to HIGH but
+    /// The maximum possible durability; equivalent to NEVER_CHANGE but
     /// "conceptually" distinct (i.e., if we add more durability
     /// levels, this could change).
-    pub(crate) const MAX: Durability = Self::HIGH;
+    pub(crate) const MAX: Durability = Self::NEVER_CHANGE;
 
     /// Number of durability levels.
-    pub(crate) const LEN: usize = Self::HIGH.0 as usize + 1;
+    pub(crate) const LEN: usize = Self::MAX.0 as usize + 1;
 
+    #[inline]
     pub(crate) fn index(self) -> usize {
         self.0 as usize
     }

--- a/src/function.rs
+++ b/src/function.rs
@@ -16,12 +16,14 @@ use crate::key::DatabaseKeyIndex;
 use crate::plumbing::{self, MemoIngredientMap};
 use crate::salsa_struct::SalsaStructInDb;
 use crate::sync::Arc;
-use crate::table::memo::MemoTableTypes;
+use crate::table::memo::{Either, MemoTableTypes};
 use crate::table::Table;
 use crate::views::DatabaseDownCaster;
 use crate::zalsa::{IngredientIndex, JarKind, MemoIngredientIndex, Zalsa};
 use crate::zalsa_local::{QueryEdge, QueryOriginRef};
 use crate::{Cycle, Durability, Id, Revision};
+
+pub use crate::function::memo::AmbiguousMemo;
 
 #[cfg(feature = "accumulator")]
 mod accumulated;
@@ -37,7 +39,9 @@ mod memo;
 mod specify;
 mod sync;
 
-pub type Memo<C> = memo::Memo<'static, C>;
+type EitherMemoNonNull<'db, C> =
+    Either<NonNull<memo::Memo<'db, C>>, NonNull<memo::NeverChangeMemo<'db, C>>>;
+type EitherMemoRef<'a, 'db, C> = Either<&'a memo::Memo<'db, C>, &'a memo::NeverChangeMemo<'db, C>>;
 
 pub trait Configuration: Any {
     const DEBUG_NAME: &'static str;
@@ -246,10 +250,20 @@ where
     /// when this function is called and (b) ensuring that any entries
     /// removed from the memo-map are added to `deleted_entries`, which is
     /// only cleared with `&mut self`.
+    #[inline]
     unsafe fn extend_memo_lifetime<'this>(
         &'this self,
         memo: &memo::Memo<'this, C>,
     ) -> &'this memo::Memo<'this, C> {
+        // SAFETY: the caller must guarantee that the memo will not be released before `&self`
+        unsafe { std::mem::transmute(memo) }
+    }
+
+    #[inline]
+    unsafe fn extend_either_memo_lifetime<'this>(
+        &'this self,
+        memo: EitherMemoRef<'_, 'this, C>,
+    ) -> EitherMemoRef<'this, 'this, C> {
         // SAFETY: the caller must guarantee that the memo will not be released before `&self`
         unsafe { std::mem::transmute(memo) }
     }
@@ -282,6 +296,39 @@ where
         }
         // SAFETY: memo has been inserted into the table
         unsafe { self.extend_memo_lifetime(memo.as_ref()) }
+    }
+
+    fn insert_never_change_memo<'db>(
+        &'db self,
+        zalsa: &'db Zalsa,
+        id: Id,
+        memo: memo::NeverChangeMemo<'db, C>,
+        memo_ingredient_index: MemoIngredientIndex,
+    ) -> EitherMemoRef<'db, 'db, C> {
+        // We convert to a `NonNull` here as soon as possible because we are going to alias
+        // into the `Box`, which is a `noalias` type.
+        // SAFETY: memo is not null
+        let memo = unsafe { NonNull::new_unchecked(Box::into_raw(Box::new(memo))) };
+
+        // SAFETY: memo must be in the map (it's not yet, but it will be by the time this
+        // value is returned) and anything removed from map is added to deleted entries (ensured elsewhere).
+        let db_memo = unsafe { self.extend_either_memo_lifetime(Either::Right(memo.as_ref())) };
+
+        if let Some(old_value) =
+            // SAFETY: We delay the drop of `old_value` until a new revision starts which ensures no
+            // references will exist for the memo contents.
+            unsafe {
+                self.insert_never_change_memo_into_table_for(zalsa, id, memo, memo_ingredient_index)
+            }
+        {
+            // In case there is a reference to the old memo out there, we have to store it
+            // in the deleted entries. This will get cleared when a new revision starts.
+            //
+            // SAFETY: Once the revision starts, there will be no outstanding borrows to the
+            // memo contents, and so it will be safe to free.
+            unsafe { self.deleted_entries.push(old_value) };
+        }
+        db_memo
     }
 
     #[inline]
@@ -335,6 +382,7 @@ where
         else {
             return;
         };
+        let Either::Left(memo) = memo else { todo!() };
 
         let origin = memo.revisions.origin.as_ref();
 
@@ -371,8 +419,11 @@ where
         zalsa: &'db Zalsa,
         input: Id,
     ) -> Option<ProvisionalStatus<'db>> {
-        let memo =
-            self.get_memo_from_table_for(zalsa, input, self.memo_ingredient_index(zalsa, input))?;
+        let Either::Left(memo) =
+            self.get_memo_from_table_for(zalsa, input, self.memo_ingredient_index(zalsa, input))?
+        else {
+            return Some(ProvisionalStatus::FinalNeverChange);
+        };
 
         let iteration = memo.revisions.iteration();
         let verified_final = memo.revisions.verified_final.load(Ordering::Relaxed);
@@ -396,7 +447,7 @@ where
     }
 
     fn set_cycle_iteration_count(&self, zalsa: &Zalsa, input: Id, iteration_count: IterationCount) {
-        let Some(memo) =
+        let Some(Either::Left(memo)) =
             self.get_memo_from_table_for(zalsa, input, self.memo_ingredient_index(zalsa, input))
         else {
             return;
@@ -407,7 +458,7 @@ where
     }
 
     fn finalize_cycle_head(&self, zalsa: &Zalsa, input: Id) {
-        let Some(memo) =
+        let Some(Either::Left(memo)) =
             self.get_memo_from_table_for(zalsa, input, self.memo_ingredient_index(zalsa, input))
         else {
             return;
@@ -417,7 +468,7 @@ where
     }
 
     fn cycle_converged(&self, zalsa: &Zalsa, input: Id) -> bool {
-        let Some(memo) =
+        let Some(Either::Left(memo)) =
             self.get_memo_from_table_for(zalsa, input, self.memo_ingredient_index(zalsa, input))
         else {
             return true;
@@ -534,7 +585,12 @@ where
             let memo =
                 self.get_memo_from_table_for(zalsa, entry.key_index(), memo_ingredient_index);
 
-            if memo.is_some_and(|memo| memo.should_serialize()) {
+            let should_serialize = match memo {
+                Some(Either::Left(memo)) => memo.should_serialize(),
+                Some(Either::Right(memo)) => memo.should_serialize(),
+                None => false,
+            };
+            if should_serialize {
                 return true;
             }
         }

--- a/src/function.rs
+++ b/src/function.rs
@@ -21,7 +21,7 @@ use crate::table::Table;
 use crate::views::DatabaseDownCaster;
 use crate::zalsa::{IngredientIndex, JarKind, MemoIngredientIndex, Zalsa};
 use crate::zalsa_local::{QueryEdge, QueryOriginRef};
-use crate::{Cycle, Id, Revision};
+use crate::{Cycle, Durability, Id, Revision};
 
 #[cfg(feature = "accumulator")]
 mod accumulated;
@@ -61,6 +61,8 @@ pub trait Configuration: Any {
     /// Determines whether this function can recover from being a participant in a cycle
     /// (and, if so, how).
     const CYCLE_STRATEGY: CycleRecoveryStrategy;
+
+    const FORCE_DURABILITY: Option<Durability>;
 
     /// Invokes after a new result `new_value` has been computed for which an older memoized value
     /// existed `old_value`, or in fixpoint iteration. Returns true if the new value is equal to

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -63,7 +63,7 @@ where
                     zalsa_local.push_query(database_key_index, IterationCount::initial()),
                     opt_old_memo,
                 );
-                (new_value, active_query.pop())
+                (new_value, active_query.pop(C::FORCE_DURABILITY))
             }
             CycleRecoveryStrategy::FallbackImmediate => {
                 let (mut new_value, active_query) = Self::execute_query(
@@ -73,7 +73,7 @@ where
                     opt_old_memo,
                 );
 
-                let mut completed_query = active_query.pop();
+                let mut completed_query = active_query.pop(C::FORCE_DURABILITY);
 
                 if let Some(cycle_heads) = completed_query.revisions.cycle_heads_mut() {
                     // Did the new result we got depend on our own provisional value, in a cycle?
@@ -100,7 +100,7 @@ where
                     let active_query =
                         zalsa_local.push_query(database_key_index, IterationCount::initial());
                     new_value = C::cycle_initial(db, id, C::id_to_input(zalsa, id));
-                    completed_query = active_query.pop();
+                    completed_query = active_query.pop(C::FORCE_DURABILITY);
                     // We need to set `cycle_heads` and `verified_final` because it needs to propagate to the callers.
                     // When verifying this, we will see we have fallback and mark ourselves verified.
                     completed_query.revisions.set_cycle_heads(cycle_heads);
@@ -232,7 +232,7 @@ where
                     panic!("{database_key_index:?}: execute: too many cycle iterations")
                 });
 
-                let mut completed_query = active_query.pop();
+                let mut completed_query = active_query.pop(C::FORCE_DURABILITY);
                 completed_query
                     .revisions
                     .update_iteration_count_mut(database_key_index, iteration_count);
@@ -312,7 +312,7 @@ where
                     claim_guard.set_release_mode(ReleaseMode::SelfOnly);
                 }
 
-                let mut completed_query = active_query.pop();
+                let mut completed_query = active_query.pop(C::FORCE_DURABILITY);
                 *completed_query.revisions.verified_final.get_mut() = false;
                 completed_query.revisions.set_cycle_heads(cycle_heads);
 
@@ -392,7 +392,7 @@ where
                 }
             }
 
-            let mut completed_query = active_query.pop();
+            let mut completed_query = active_query.pop(C::FORCE_DURABILITY);
 
             let value_converged = C::values_equal(&new_value, last_provisional_value);
 

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -265,7 +265,7 @@ where
                 let active_query =
                     zalsa_local.push_query(database_key_index, IterationCount::initial());
                 let fallback_value = C::cycle_initial(db, id, C::id_to_input(zalsa, id));
-                let mut completed_query = active_query.pop();
+                let mut completed_query = active_query.pop(C::FORCE_DURABILITY);
                 completed_query
                     .revisions
                     .set_cycle_heads(CycleHeads::initial(

--- a/src/function/inputs.rs
+++ b/src/function/inputs.rs
@@ -1,4 +1,5 @@
 use crate::function::{Configuration, IngredientImpl};
+use crate::table::memo::Either;
 use crate::zalsa::Zalsa;
 use crate::zalsa_local::QueryOriginRef;
 use crate::Id;
@@ -10,6 +11,9 @@ where
     pub(super) fn origin<'db>(&self, zalsa: &'db Zalsa, key: Id) -> Option<QueryOriginRef<'db>> {
         let memo_ingredient_index = self.memo_ingredient_index(zalsa, key);
         self.get_memo_from_table_for(zalsa, key, memo_ingredient_index)
-            .map(|m| m.revisions.origin.as_ref())
+            .map(|m| match m {
+                Either::Left(m) => m.revisions.origin.as_ref(),
+                Either::Right(_) => QueryOriginRef::Derived(&[]),
+            })
     }
 }

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -534,6 +534,7 @@ mod _memory_usage {
         const LOCATION: Location = Location { file: "", line: 0 };
         const PERSIST: bool = false;
         const CYCLE_STRATEGY: CycleRecoveryStrategy = CycleRecoveryStrategy::Panic;
+        const FORCE_DURABILITY: Option<crate::Durability> = None;
 
         type DbView = dyn Database;
         type SalsaStruct<'db> = DummyStruct;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,9 +157,9 @@ pub mod plumbing {
     }
 
     pub mod function {
+        pub use crate::function::AmbiguousMemo;
         pub use crate::function::Configuration;
         pub use crate::function::IngredientImpl;
-        pub use crate::function::Memo;
         pub use crate::table::memo::MemoEntryType;
     }
 

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -309,13 +309,15 @@ impl ZalsaLocal {
             changed_at
         );
 
-        // SAFETY: We do not access the query stack reentrantly.
-        unsafe {
-            self.with_query_stack_unchecked_mut(|stack| {
-                if let Some(top_query) = stack.last_mut() {
-                    top_query.add_read_simple(input, durability, changed_at);
-                }
-            })
+        if durability < Durability::NEVER_CHANGE {
+            // SAFETY: We do not access the query stack reentrantly.
+            unsafe {
+                self.with_query_stack_unchecked_mut(|stack| {
+                    if let Some(top_query) = stack.last_mut() {
+                        top_query.add_read_simple(input, durability, changed_at);
+                    }
+                })
+            }
         }
     }
 

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -1249,8 +1249,12 @@ impl ActiveQueryGuard<'_> {
     /// which summarizes the other queries that were accessed during this
     /// query's execution.
     #[inline]
-    pub(crate) fn pop(self) -> CompletedQuery {
-        self.complete()
+    pub(crate) fn pop(self, force_durability: Option<Durability>) -> CompletedQuery {
+        let mut result = self.complete();
+        if let Some(durability) = force_durability {
+            result.revisions.durability = durability;
+        }
+        result
     }
 }
 

--- a/tests/accumulate-chain.rs
+++ b/tests/accumulate-chain.rs
@@ -13,38 +13,50 @@ use test_log::test;
 #[derive(Debug)]
 struct Log(#[allow(dead_code)] String);
 
-#[salsa::tracked]
-fn push_logs(db: &dyn Database) {
-    push_a_logs(db);
+// We need a dummy input, otherwise our query will have a `NEVER_CHANGE` durability,
+// and queries with this durability don't accumulate.
+#[salsa::input]
+struct Input {
+    dummy: (),
 }
 
 #[salsa::tracked]
-fn push_a_logs(db: &dyn Database) {
+fn push_logs(db: &dyn Database, input: Input) {
+    _ = input.dummy(db);
+    push_a_logs(db, input);
+}
+
+#[salsa::tracked]
+fn push_a_logs(db: &dyn Database, input: Input) {
+    _ = input.dummy(db);
     Log("log a".to_string()).accumulate(db);
-    push_b_logs(db);
+    push_b_logs(db, input);
 }
 
 #[salsa::tracked]
-fn push_b_logs(db: &dyn Database) {
+fn push_b_logs(db: &dyn Database, input: Input) {
+    _ = input.dummy(db);
     // No logs
-    push_c_logs(db);
+    push_c_logs(db, input);
 }
 
 #[salsa::tracked]
-fn push_c_logs(db: &dyn Database) {
+fn push_c_logs(db: &dyn Database, input: Input) {
+    _ = input.dummy(db);
     // No logs
-    push_d_logs(db);
+    push_d_logs(db, input);
 }
 
 #[salsa::tracked]
-fn push_d_logs(db: &dyn Database) {
+fn push_d_logs(db: &dyn Database, input: Input) {
+    _ = input.dummy(db);
     Log("log d".to_string()).accumulate(db);
 }
 
 #[test]
 fn accumulate_chain() {
     DatabaseImpl::new().attach(|db| {
-        let logs = push_logs::accumulated::<Log>(db);
+        let logs = push_logs::accumulated::<Log>(db, Input::new(db, ()));
         // Check that we get all the logs.
         expect![[r#"
             [

--- a/tests/accumulate-no-duplicates.rs
+++ b/tests/accumulate-no-duplicates.rs
@@ -41,36 +41,40 @@ fn push_logs(db: &dyn Database) {
 fn push_a_logs(db: &dyn Database, input: MyInput) {
     Log("log a".to_string()).accumulate(db);
     if input.n(db) == 1 {
-        push_b_logs(db);
-        push_b_logs(db);
-        push_c_logs(db);
-        push_b_logs(db);
+        push_b_logs(db, input);
+        push_b_logs(db, input);
+        push_c_logs(db, input);
+        push_b_logs(db, input);
     } else {
-        push_b_logs(db);
+        push_b_logs(db, input);
     }
 }
 
 #[salsa::tracked]
-fn push_b_logs(db: &dyn Database) {
+fn push_b_logs(db: &dyn Database, input: MyInput) {
+    _ = input.n(db);
     Log("log b".to_string()).accumulate(db);
 }
 
 #[salsa::tracked]
-fn push_c_logs(db: &dyn Database) {
+fn push_c_logs(db: &dyn Database, input: MyInput) {
+    _ = input.n(db);
     Log("log c".to_string()).accumulate(db);
-    push_d_logs(db);
-    push_e_logs(db);
+    push_d_logs(db, input);
+    push_e_logs(db, input);
 }
 
 // Note this isn't tracked
-fn push_d_logs(db: &dyn Database) {
+fn push_d_logs(db: &dyn Database, input: MyInput) {
+    _ = input.n(db);
     Log("log d".to_string()).accumulate(db);
     push_a_logs(db, MyInput::new(db, 2));
-    push_b_logs(db);
+    push_b_logs(db, input);
 }
 
 #[salsa::tracked]
-fn push_e_logs(db: &dyn Database) {
+fn push_e_logs(db: &dyn Database, input: MyInput) {
+    _ = input.n(db);
     Log("log e".to_string()).accumulate(db);
 }
 
@@ -97,6 +101,9 @@ fn accumulate_no_duplicates() {
                 ),
                 Log(
                     "log a",
+                ),
+                Log(
+                    "log b",
                 ),
                 Log(
                     "log e",

--- a/tests/backtrace.rs
+++ b/tests/backtrace.rs
@@ -81,13 +81,13 @@ fn backtrace_works() {
         query stacktrace:
            0: query_e(Id(1)) -> (R1, Durability::LOW)
                      at tests/backtrace.rs:32
-           1: query_d(Id(1)) -> (R1, Durability::HIGH)
+           1: query_d(Id(1)) -> (R1, Durability::NEVER_CHANGE)
                      at tests/backtrace.rs:27
-           2: query_c(Id(1)) -> (R1, Durability::HIGH)
+           2: query_c(Id(1)) -> (R1, Durability::NEVER_CHANGE)
                      at tests/backtrace.rs:22
-           3: query_b(Id(1)) -> (R1, Durability::HIGH)
+           3: query_b(Id(1)) -> (R1, Durability::NEVER_CHANGE)
                      at tests/backtrace.rs:17
-           4: query_a(Id(1)) -> (R1, Durability::HIGH)
+           4: query_a(Id(1)) -> (R1, Durability::NEVER_CHANGE)
                      at tests/backtrace.rs:12
     "#]]
     .assert_eq(&backtrace);
@@ -110,10 +110,10 @@ fn backtrace_works() {
         query stacktrace:
            0: query_e(Id(3)) -> (R1, Durability::LOW)
                      at tests/backtrace.rs:32
-           1: query_cycle(Id(3)) -> (R1, Durability::HIGH, iteration = 0)
+           1: query_cycle(Id(3)) -> (R1, Durability::NEVER_CHANGE, iteration = 0)
                      at tests/backtrace.rs:45
                      cycle heads: query_cycle(Id(3)) -> iteration = 0
-           2: query_f(Id(3)) -> (R1, Durability::HIGH)
+           2: query_f(Id(3)) -> (R1, Durability::NEVER_CHANGE)
                      at tests/backtrace.rs:40
     "#]]
     .assert_eq(&backtrace);

--- a/tests/cycle_output.rs
+++ b/tests/cycle_output.rs
@@ -14,6 +14,7 @@ struct Output<'db> {
 #[salsa::input]
 struct InputValue {
     value: u32,
+    dummy: (),
 }
 
 #[salsa::tracked]
@@ -23,6 +24,8 @@ fn read_value<'db>(db: &'db dyn Db, output: Output<'db>) -> u32 {
 
 #[salsa::tracked]
 fn query_a(db: &dyn Db, input: InputValue) -> u32 {
+    // Dummy read so that the durability is not `NEVER_CHANGE`.
+    _ = input.dummy(db);
     let val = query_b(db, input);
     let output = Output::new(db, val);
     let read = read_value(db, output);
@@ -37,6 +40,8 @@ fn query_a(db: &dyn Db, input: InputValue) -> u32 {
 
 #[salsa::tracked(cycle_initial=cycle_initial)]
 fn query_b(db: &dyn Db, input: InputValue) -> u32 {
+    // Dummy read so that the durability is not `NEVER_CHANGE`.
+    _ = input.dummy(db);
     query_a(db, input)
 }
 
@@ -118,7 +123,7 @@ impl Db for Database {}
 #[test_log::test]
 fn single_revision() {
     let db = Database::default();
-    let input = InputValue::new(&db, 1);
+    let input = InputValue::new(&db, 1, ());
 
     assert_eq!(query_b(&db, input), 3);
 }
@@ -127,8 +132,8 @@ fn single_revision() {
 fn revalidate_no_changes() {
     let mut db = Database::default();
 
-    let ab_input = InputValue::new(&db, 1);
-    let c_input = InputValue::new(&db, 10);
+    let ab_input = InputValue::new(&db, 1, ());
+    let c_input = InputValue::new(&db, 10, ());
     assert_eq!(query_c(&db, c_input), 10);
     assert_eq!(query_b(&db, ab_input), 3);
 
@@ -156,8 +161,8 @@ fn revalidate_no_changes() {
 fn revalidate_with_change_after_output_read() {
     let mut db = Database::default();
 
-    let ab_input = InputValue::new(&db, 1);
-    let d_input = InputValue::new(&db, 10);
+    let ab_input = InputValue::new(&db, 1, ());
+    let d_input = InputValue::new(&db, 10, ());
     db.set_input(d_input);
 
     assert_eq!(query_b(&db, ab_input), 3);


### PR DESCRIPTION
Inputs with this durability are assumed to never change. This allows us to optimize their storage a lot and not store any data about them except for the value. That makes them very compact.

This is done by bit-tagging the memo and using it as one of two types.

The overhead of handling the possibility of a second type will be seen in synthetic benchmarks; in practice, if using this durability (for example, for library code), speed will increase, not decrease (in addition to improved memory usage), because we don't need to validate query dependencies if they are assumed to never change.

Values participating in cycles cannot have `Durability::NEVER_CHANGE`: while it is possible to support this (and in fact, an early revision of the code did) it introduces a lot of complications to the code, as we need to replace the type of a memo after it has been inserted.

The two commits are completely separated and can be sent as different PRs if wanted.

The code is correct and ready to review, but I still need to review the failing tests: many now use this durability unintentionally because they do not read inputs, causing them to fail.