### PR TITLE
Require interned structs' fields to be `Update`

### DIFF
--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -78,6 +78,8 @@ macro_rules! setup_interned_struct {
         // The path to the `serialize` function for the value's fields.
         deserialize_fn: $($deserialize_fn:path)?,
 
+        assert_types_are_update: {$($assert_types_are_update:tt)*},
+
         // Annoyingly macro-rules hygiene does not extend to items defined in the macro.
         // We have the procedural macro generate names for those items that are
         // not used elsewhere in the user's code.
@@ -291,6 +293,8 @@ macro_rules! setup_interned_struct {
 
             unsafe impl< $($db_lt_arg)? > $zalsa::Update for $Struct< $($db_lt_arg)? > {
                 unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
+                    $($assert_types_are_update)*
+
                     if unsafe { *old_pointer } != new_value {
                         unsafe { *old_pointer = new_value };
                         true

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -67,7 +67,7 @@ macro_rules! setup_tracked_fn {
         // If true, the input and output values implement `serde::{Serialize, Deserialize}`.
         persist: $persist:tt,
 
-        assert_return_type_is_update: {$($assert_return_type_is_update:tt)*},
+        assert_types_are_update: {$($assert_types_are_update:tt)*},
 
         $(self_ty: $self_ty:ty,)?
 
@@ -295,7 +295,7 @@ macro_rules! setup_tracked_fn {
                 )?
 
                 fn execute<$db_lt>($db: &$db_lt Self::DbView, ($($input_id),*): ($($interned_input_ty),*)) -> Self::Output<$db_lt> {
-                    $($assert_return_type_is_update)*
+                    $($assert_types_are_update)*
 
                     $($inner_fn)*
 

--- a/components/salsa-macros/src/accumulator.rs
+++ b/components/salsa-macros/src/accumulator.rs
@@ -33,7 +33,7 @@ impl AllowedOptions for Accumulator {
     const SPECIFY: bool = false;
     const NO_EQ: bool = false;
     const DEBUG: bool = false;
-    const NON_UPDATE_RETURN_TYPE: bool = false;
+    const NON_UPDATE_TYPES: bool = false;
     const NO_LIFETIME: bool = false;
     const SINGLETON: bool = false;
     const DATA: bool = false;

--- a/components/salsa-macros/src/input.rs
+++ b/components/salsa-macros/src/input.rs
@@ -43,7 +43,7 @@ impl AllowedOptions for InputStruct {
 
     const NO_LIFETIME: bool = false;
 
-    const NON_UPDATE_RETURN_TYPE: bool = false;
+    const NON_UPDATE_TYPES: bool = false;
 
     const SINGLETON: bool = true;
 

--- a/components/salsa-macros/src/interned.rs
+++ b/components/salsa-macros/src/interned.rs
@@ -43,7 +43,7 @@ impl AllowedOptions for InternedStruct {
 
     const NO_LIFETIME: bool = true;
 
-    const NON_UPDATE_RETURN_TYPE: bool = false;
+    const NON_UPDATE_TYPES: bool = false;
 
     const SINGLETON: bool = true;
 
@@ -145,6 +145,12 @@ impl Macro {
         let CACHE = self.hygiene.ident("CACHE");
         let Db = self.hygiene.ident("Db");
 
+        let assert_types_are_update = if self.args.non_update_types.is_none() {
+            crate::update::assert_update(&db_lt, &zalsa, field_tys.iter().map(|ty| (**ty).clone()))
+        } else {
+            quote! {}
+        };
+
         Ok(crate::debug::dump_tokens(
             struct_ident,
             quote! {
@@ -173,6 +179,7 @@ impl Macro {
                     persist: #persist,
                     serialize_fn: #(#serialize_fn)*,
                     deserialize_fn: #(#deserialize_fn)*,
+                    assert_types_are_update: { #assert_types_are_update },
                     unused_names: [
                         #zalsa,
                         #zalsa_struct,

--- a/components/salsa-macros/src/tracked_struct.rs
+++ b/components/salsa-macros/src/tracked_struct.rs
@@ -39,7 +39,7 @@ impl AllowedOptions for TrackedStruct {
 
     const NO_LIFETIME: bool = false;
 
-    const NON_UPDATE_RETURN_TYPE: bool = false;
+    const NON_UPDATE_TYPES: bool = false;
 
     const SINGLETON: bool = true;
 

--- a/tests/compile-fail/interned_not_update.rs
+++ b/tests/compile-fail/interned_not_update.rs
@@ -1,0 +1,14 @@
+use salsa::Database as Db;
+
+#[salsa::input]
+struct MyInput {}
+
+#[salsa::tracked]
+fn tracked_fn<'db>(_db: &'db dyn Db, _: (), _: &'db str) {}
+
+#[salsa::interned]
+struct Interned<'db> {
+    _field: &'db str,
+}
+
+fn main() {}

--- a/tests/compile-fail/interned_not_update.stderr
+++ b/tests/compile-fail/interned_not_update.stderr
@@ -1,0 +1,13 @@
+error: lifetime may not live long enough
+ --> tests/compile-fail/interned_not_update.rs:7:48
+  |
+7 | fn tracked_fn<'db>(_db: &'db dyn Db, _: (), _: &'db str) {}
+  |               --- lifetime `'db` defined here  ^ requires that `'db` must outlive `'static`
+
+error: lifetime may not live long enough
+  --> tests/compile-fail/interned_not_update.rs:11:13
+   |
+10 | struct Interned<'db> {
+   |                 --- lifetime `'db` defined here
+11 |     _field: &'db str,
+   |             ^ requires that `'db` must outlive `'static`


### PR DESCRIPTION
To fix an unsoundness - #985.

There are two breaking changes here:

 1. Interned fields and interned function fields are required to be `Update` (or `'static`)
 2. `unsafe(non_update_return_types)` in tracked fn options was renamed to `unsafe(non_update_types)` (and includes interned parameters as well now).

Fixes #985.