### PR TITLE
Add `salsa::Update` trait bounds to generics when deriving `salsa::Update`

### DIFF
--- a/tests/interned-structs.rs
+++ b/tests/interned-structs.rs
@@ -78,6 +78,14 @@ struct InternedStringWithCustomIdAndNoLifetime<'db> {
     data: String,
 }
 
+#[derive(salsa::Update, Clone, Eq, PartialEq, Hash, Debug)]
+struct Generic<T>(T);
+
+#[salsa::interned(debug)]
+struct InternedOverGeneric {
+    value: Generic<String>,
+}
+
 #[salsa::tracked]
 fn intern_stuff(db: &dyn salsa::Database) -> String {
     let s1 = InternedString::new(db, "Hello, ".to_string());
@@ -215,5 +223,14 @@ fn interning_reference() {
 
     let s1 = InternedFoo::new(&db, Foo);
     let s2 = InternedFoo::new(&db, &Foo);
+    assert_eq!(s1, s2);
+}
+
+#[test]
+fn interned_generic() {
+    let db = salsa::DatabaseImpl::new();
+
+    let s1 = InternedOverGeneric::new(&db, Generic("test".to_string()));
+    let s2 = InternedOverGeneric::new(&db, Generic("test".to_string()));
     assert_eq!(s1, s2);
 }


### PR DESCRIPTION
Support deriving `salsa::Update` for generic types. 

We have a few generic types in ty that are used within interned values, for which deriving `salsa::Update` currently doesn't work because the derived `salsa::Update` doesn't work for all `T`s, only `T`s that implement `salsa::Update`. 

This PR adds a generic constraint to the `salsa::Update` implementation to every generic type.