### PR TITLE
Shrink `DatabaseKeyIndex` to 8 bytes to save memory

### DIFF
--- a/components/salsa-macro-rules/src/setup_tracked_struct.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_struct.rs
@@ -300,8 +300,8 @@ macro_rules! setup_tracked_struct {
             }
 
             impl $zalsa::TrackedStructInDb for $Struct<'_> {
-                fn database_key_index(zalsa: &$zalsa::Zalsa, id: $zalsa::Id) -> $zalsa::DatabaseKeyIndex {
-                    $Configuration::ingredient_(zalsa).database_key_index(id)
+                fn ingredient_index(zalsa: &$zalsa::Zalsa, id: $zalsa::Id) -> $zalsa::IngredientIndex {
+                    $Configuration::ingredient_(zalsa).ingredient_index()
                 }
             }
 

--- a/src/function/accumulated.rs
+++ b/src/function/accumulated.rs
@@ -51,7 +51,7 @@ where
                 continue;
             }
 
-            let ingredient = zalsa.lookup_ingredient(k.ingredient_index());
+            let ingredient = zalsa.lookup_ingredient(k.ingredient_index_with_zalsa(zalsa));
             // Extend `output` with any values accumulated by `k`.
             // SAFETY: `db` owns the `ingredient`
             let (accumulated_map, input) =

--- a/src/function/diff_outputs.rs
+++ b/src/function/diff_outputs.rs
@@ -38,7 +38,7 @@ fn diff_outputs_on_revision(
     // Note that tracked structs are not stored as direct query outputs, but they are still outputs
     // that need to be reported as stale.
     for (identity, id) in &completed_query.stale_tracked_structs {
-        let output = DatabaseKeyIndex::new(identity.ingredient_index(), *id);
+        let output = DatabaseKeyIndex::new_non_interned(identity.ingredient_index(), *id);
         report_stale_output(zalsa, key, output);
     }
 

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -631,7 +631,11 @@ fn validate_provisional(
     for cycle_head in cycle_heads {
         // Test if our cycle heads (with the same revision) are now finalized.
         let Some(kind) = zalsa
-            .lookup_ingredient(cycle_head.database_key_index.ingredient_index())
+            .lookup_ingredient(
+                cycle_head
+                    .database_key_index
+                    .ingredient_index_with_zalsa(zalsa),
+            )
             .provisional_status(zalsa, cycle_head.database_key_index.key_index())
         else {
             return false;

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -260,7 +260,7 @@ where
         }
 
         for (identity, id) in self.revisions.tracked_struct_ids() {
-            let key = DatabaseKeyIndex::new(identity.ingredient_index(), *id);
+            let key = DatabaseKeyIndex::new_non_interned(identity.ingredient_index(), *id);
             key.remove_stale_output(zalsa, executor);
         }
     }
@@ -447,7 +447,7 @@ impl<'me> Iterator for TryClaimCycleHeadsIter<'me> {
         let head_key_index = head_database_key.key_index();
         let ingredient = self
             .zalsa
-            .lookup_ingredient(head_database_key.ingredient_index());
+            .lookup_ingredient(head_database_key.ingredient_index_with_zalsa(self.zalsa));
 
         match ingredient.wait_for(self.zalsa, head_key_index) {
             WaitForResult::Cycle { .. } => {

--- a/src/input.rs
+++ b/src/input.rs
@@ -140,7 +140,7 @@ impl<C: Configuration> IngredientImpl<C> {
     }
 
     pub fn database_key_index(&self, id: Id) -> DatabaseKeyIndex {
-        DatabaseKeyIndex::new(self.ingredient_index, id)
+        DatabaseKeyIndex::new_non_interned(self.ingredient_index, id)
     }
 
     pub fn new_input(
@@ -230,7 +230,7 @@ impl<C: Configuration> IngredientImpl<C> {
         let durability = value.durabilities[field_index];
         let revision = value.revisions[field_index];
         zalsa_local.report_tracked_read_simple(
-            DatabaseKeyIndex::new(field_ingredient_index, id),
+            DatabaseKeyIndex::new_non_interned(field_ingredient_index, id),
             durability,
             revision,
         );

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -712,7 +712,7 @@ where
                 let ingredient_index =
                     zalsa.ingredient_index_for_memo(self.ingredient_index, memo_ingredient_index);
 
-                let executor = DatabaseKeyIndex::new(ingredient_index, id);
+                let executor = DatabaseKeyIndex::new_non_interned(ingredient_index, id);
 
                 zalsa.event(&|| Event::new(EventKind::DidDiscard { key: executor }));
 
@@ -766,7 +766,7 @@ where
     /// Returns the database key index for an interned value with the given id.
     #[inline]
     pub fn database_key_index(&self, id: Id) -> DatabaseKeyIndex {
-        DatabaseKeyIndex::new(self.ingredient_index, id)
+        DatabaseKeyIndex::new_interned(self.ingredient_index, id)
     }
 
     /// Lookup the data for an interned value based on its ID.

--- a/src/key.rs
+++ b/src/key.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::num::NonZeroU32;
 
 use crate::function::{VerifyCycleHeads, VerifyResult};
+use crate::id::GenerationlessId;
 use crate::zalsa::{IngredientIndex, Zalsa};
 use crate::{Database, Id};
 
@@ -40,6 +41,18 @@ impl DatabaseKeyIndex {
 
     #[inline]
     pub(crate) const fn new_non_interned(ingredient_index: IngredientIndex, key_index: Id) -> Self {
+        Self {
+            index: key_index.index_nonzero(),
+            generation_or_ingredient_index: ingredient_index.as_u32()
+                << Self::INGREDIENT_INDEX_SHIFT,
+        }
+    }
+
+    #[inline]
+    pub(crate) const fn new_non_interned_generationless(
+        ingredient_index: IngredientIndex,
+        key_index: GenerationlessId,
+    ) -> Self {
         Self {
             index: key_index.index_nonzero(),
             generation_or_ingredient_index: ingredient_index.as_u32()

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,8 +1,9 @@
 use std::fmt;
+use std::num::NonZeroU32;
 
 use crate::function::{VerifyCycleHeads, VerifyResult};
 use crate::zalsa::{IngredientIndex, Zalsa};
-use crate::Id;
+use crate::{Database, Id};
 
 // ANCHOR: DatabaseKeyIndex
 /// An integer that uniquely identifies a particular query instance within the
@@ -11,26 +12,95 @@ use crate::Id;
 /// only for inserting into maps and the like.
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct DatabaseKeyIndex {
-    key_index: Id,
-    ingredient_index: IngredientIndex,
+    index: NonZeroU32,
+    /// `DatabaseKeyIndex` is stored *a lot*, as every query dependency stores one. Therefore
+    /// we want to make it compact.
+    ///
+    /// The ingredient index is technically needed only for tracked fns - other things can
+    /// grab it from the page, whose index is stored in `index`. On the other hand,
+    /// only interned structs need a generation - for GC. So we store like the following:
+    ///
+    /// If this is an interned, this stores the generation (left-shifted by a bit and ORed with 0b1,
+    /// as every generation is). If not, the LSB is 0, and the rest of the bits store the
+    /// `IngredientIndex` shifted left by 1 bit.
+    generation_or_ingredient_index: u32,
 }
 // ANCHOR_END: DatabaseKeyIndex
 
 impl DatabaseKeyIndex {
+    const INGREDIENT_INDEX_SHIFT: u32 = 2;
+
     #[inline]
-    pub(crate) const fn new(ingredient_index: IngredientIndex, key_index: Id) -> Self {
+    pub(crate) const fn new_interned(_ingredient_index: IngredientIndex, key_index: Id) -> Self {
         Self {
-            key_index,
-            ingredient_index,
+            index: key_index.index_nonzero(),
+            generation_or_ingredient_index: key_index.generation(),
         }
     }
 
-    pub const fn ingredient_index(self) -> IngredientIndex {
-        self.ingredient_index
+    #[inline]
+    pub(crate) const fn new_non_interned(ingredient_index: IngredientIndex, key_index: Id) -> Self {
+        Self {
+            index: key_index.index_nonzero(),
+            generation_or_ingredient_index: ingredient_index.as_u32()
+                << Self::INGREDIENT_INDEX_SHIFT,
+        }
     }
 
-    pub const fn key_index(self) -> Id {
-        self.key_index
+    #[inline]
+    pub(crate) fn new_non_interned_with_tag(
+        ingredient_index: IngredientIndex,
+        key_index: Id,
+    ) -> Self {
+        let mut result = Self::new_non_interned(ingredient_index, key_index);
+        result.generation_or_ingredient_index |= 0b10;
+        result
+    }
+
+    #[inline]
+    pub(crate) fn has_tag(self) -> bool {
+        // The LSB is 0, meaning a non-interned, and the second LSB is 1, meaning the tag is on.
+        (self.generation_or_ingredient_index & 0b11) == 0b10
+    }
+
+    #[inline]
+    pub(crate) fn ingredient_index_with_zalsa(self, zalsa: &Zalsa) -> IngredientIndex {
+        if self.is_interned() {
+            zalsa.ingredient_index(self.key_index())
+        } else {
+            IngredientIndex::new(
+                self.generation_or_ingredient_index >> Self::INGREDIENT_INDEX_SHIFT,
+            )
+        }
+    }
+
+    #[inline]
+    pub fn ingredient_index(self, db: &dyn Database) -> IngredientIndex {
+        self.ingredient_index_with_zalsa(db.zalsa())
+    }
+
+    #[track_caller]
+    #[cfg(feature = "persistence")]
+    pub(crate) fn ingredient_index_assert_non_interned(self) -> IngredientIndex {
+        assert!(!self.is_interned());
+        IngredientIndex::new(self.generation_or_ingredient_index >> Self::INGREDIENT_INDEX_SHIFT)
+    }
+
+    /// **Warning:** For tracked fns on interned structs, the generation is *permanently lost* once stored
+    /// in a `DatabaseKeyIndex`. Usually it is not a problem to bring an accurate [`Id`] from a different place,
+    /// and where it is hard, it is not needed. However you need to be careful when handling this.
+    pub fn key_index(self) -> Id {
+        let generation = if self.is_interned() {
+            self.generation_or_ingredient_index
+        } else {
+            1
+        };
+        Id::from_raw_parts(self.index, generation)
+    }
+
+    #[inline]
+    fn is_interned(self) -> bool {
+        (self.generation_or_ingredient_index & 0b1) == 0b1
     }
 
     pub(crate) fn maybe_changed_after(
@@ -45,14 +115,14 @@ impl DatabaseKeyIndex {
             // here, `db` has to be either the correct type already, or a subtype (as far as trait
             // hierarchy is concerned)
             zalsa
-                .lookup_ingredient(self.ingredient_index())
+                .lookup_ingredient(self.ingredient_index_with_zalsa(zalsa))
                 .maybe_changed_after(zalsa, db, self.key_index(), last_verified_at, cycle_heads)
         }
     }
 
     pub(crate) fn remove_stale_output(&self, zalsa: &Zalsa, executor: DatabaseKeyIndex) {
         zalsa
-            .lookup_ingredient(self.ingredient_index())
+            .lookup_ingredient(self.ingredient_index_with_zalsa(zalsa))
             .remove_stale_output(zalsa, executor, self.key_index())
     }
 
@@ -62,7 +132,7 @@ impl DatabaseKeyIndex {
         database_key_index: DatabaseKeyIndex,
     ) {
         zalsa
-            .lookup_ingredient(self.ingredient_index())
+            .lookup_ingredient(self.ingredient_index_with_zalsa(zalsa))
             .mark_validated_output(zalsa, database_key_index, self.key_index())
     }
 }
@@ -73,7 +143,10 @@ impl serde::Serialize for DatabaseKeyIndex {
     where
         S: serde::Serializer,
     {
-        serde::Serialize::serialize(&(self.key_index, self.ingredient_index), serializer)
+        serde::Serialize::serialize(
+            &(self.index, self.generation_or_ingredient_index),
+            serializer,
+        )
     }
 }
 
@@ -83,11 +156,12 @@ impl<'de> serde::Deserialize<'de> for DatabaseKeyIndex {
     where
         D: serde::Deserializer<'de>,
     {
-        let (key_index, ingredient_index) = serde::Deserialize::deserialize(deserializer)?;
+        let (index, generation_or_ingredient_index) =
+            serde::Deserialize::deserialize(deserializer)?;
 
         Ok(DatabaseKeyIndex {
-            key_index,
-            ingredient_index,
+            index,
+            generation_or_ingredient_index,
         })
     }
 }
@@ -95,13 +169,14 @@ impl<'de> serde::Deserialize<'de> for DatabaseKeyIndex {
 impl fmt::Debug for DatabaseKeyIndex {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         crate::attach::with_attached_database(|db| {
-            let ingredient = db.zalsa().lookup_ingredient(self.ingredient_index());
+            let zalsa = db.zalsa();
+            let ingredient = zalsa.lookup_ingredient(self.ingredient_index_with_zalsa(zalsa));
             ingredient.fmt_index(self.key_index(), f)
         })
         .unwrap_or_else(|| {
             f.debug_tuple("DatabaseKeyIndex")
-                .field(&self.ingredient_index())
-                .field(&self.key_index())
+                .field(&self.index)
+                .field(&self.generation_or_ingredient_index)
                 .finish()
         })
     }

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -74,9 +74,7 @@ pub struct IngredientIndex(u32);
 
 impl IngredientIndex {
     /// The maximum supported ingredient index.
-    ///
-    /// This reserves one bit for an optional tag.
-    const MAX_INDEX: u32 = 0x7FFF_FFFF;
+    const MAX_INDEX: u32 = 0x3FFF_FFFF;
 
     /// Create an ingredient index from a `u32`.
     pub(crate) fn new(v: u32) -> Self {
@@ -95,24 +93,12 @@ impl IngredientIndex {
     }
 
     /// Convert the ingredient index back into a `u32`.
-    pub(crate) fn as_u32(self) -> u32 {
+    pub(crate) const fn as_u32(self) -> u32 {
         self.0
     }
 
     pub fn successor(self, index: usize) -> Self {
         IngredientIndex(self.0 + 1 + index as u32)
-    }
-
-    /// Returns a new `IngredientIndex` with the tag bit set to the provided value.
-    pub(crate) fn with_tag(mut self, tag: bool) -> IngredientIndex {
-        self.0 &= Self::MAX_INDEX;
-        self.0 |= (tag as u32) << 31;
-        self
-    }
-
-    /// Returns the value of the tag bit.
-    pub(crate) fn tag(self) -> bool {
-        self.0 & !Self::MAX_INDEX != 0
     }
 }
 

--- a/tests/cycle_output.rs
+++ b/tests/cycle_output.rs
@@ -188,12 +188,12 @@ fn revalidate_with_change_after_output_read() {
             "salsa_event(DidDiscard { key: read_value(Id(403)) })",
             "salsa_event(WillIterateCycle { database_key: query_b(Id(0)), iteration_count: IterationCount(1) })",
             "salsa_event(WillExecute { database_key: query_a(Id(0)) })",
-            "salsa_event(WillExecute { database_key: read_value(Id(401g1)) })",
+            "salsa_event(WillExecute { database_key: read_value(Id(401)) })",
             "salsa_event(WillIterateCycle { database_key: query_b(Id(0)), iteration_count: IterationCount(2) })",
             "salsa_event(WillExecute { database_key: query_a(Id(0)) })",
-            "salsa_event(WillExecute { database_key: read_value(Id(402g1)) })",
+            "salsa_event(WillExecute { database_key: read_value(Id(402)) })",
             "salsa_event(WillIterateCycle { database_key: query_b(Id(0)), iteration_count: IterationCount(3) })",
             "salsa_event(WillExecute { database_key: query_a(Id(0)) })",
-            "salsa_event(WillExecute { database_key: read_value(Id(403g1)) })",
+            "salsa_event(WillExecute { database_key: read_value(Id(403)) })",
         ]"#]]);
 }

--- a/tests/interned-revisions.rs
+++ b/tests/interned-revisions.rs
@@ -160,7 +160,7 @@ fn test_immortal() {
         input.set_field1(&mut db).to(i);
         let result = function(&db, input);
         assert_eq!(result.field1(&db).0, i);
-        assert_eq!(salsa::plumbing::AsId::as_id(&result).generation(), 0);
+        assert_eq!(salsa::plumbing::AsId::as_id(&result).generation(), 1);
     }
 }
 

--- a/tests/memory-usage.rs
+++ b/tests/memory-usage.rs
@@ -136,7 +136,7 @@ fn test() {
                 IngredientInfo {
                     debug_name: "memory_usage::MyInterned<'_>",
                     count: 3,
-                    size_of_metadata: 192,
+                    size_of_metadata: 168,
                     size_of_fields: 24,
                     heap_size_of_fields: None,
                 },
@@ -168,7 +168,7 @@ fn test() {
                 IngredientInfo {
                     debug_name: "memory_usage::MyTracked<'_>",
                     count: 2,
-                    size_of_metadata: 168,
+                    size_of_metadata: 160,
                     size_of_fields: 16,
                     heap_size_of_fields: None,
                 },
@@ -178,7 +178,7 @@ fn test() {
                 IngredientInfo {
                     debug_name: "(memory_usage::MyTracked<'_>, memory_usage::MyTracked<'_>)",
                     count: 1,
-                    size_of_metadata: 108,
+                    size_of_metadata: 104,
                     size_of_fields: 16,
                     heap_size_of_fields: None,
                 },

--- a/tests/persistence.rs
+++ b/tests/persistence.rs
@@ -63,7 +63,7 @@ fn everything() {
           },
           "ingredients": {
             "0": {
-              "1": {
+              "4294967297": {
                 "durabilities": [
                   0
                 ],
@@ -74,7 +74,7 @@ fn everything() {
                   1
                 ]
               },
-              "2": {
+              "4294967298": {
                 "durabilities": [
                   0
                 ],
@@ -113,7 +113,7 @@ fn everything() {
           },
           "ingredients": {
             "0": {
-              "1": {
+              "4294967297": {
                 "durabilities": [
                   0
                 ],
@@ -124,7 +124,7 @@ fn everything() {
                   1
                 ]
               },
-              "2": {
+              "4294967298": {
                 "durabilities": [
                   0
                 ],
@@ -135,7 +135,7 @@ fn everything() {
                   2
                 ]
               },
-              "3": {
+              "4294967299": {
                 "durabilities": [
                   0
                 ],
@@ -146,7 +146,7 @@ fn everything() {
                   1
                 ]
               },
-              "4": {
+              "4294967300": {
                 "durabilities": [
                   0
                 ],
@@ -159,7 +159,7 @@ fn everything() {
               }
             },
             "2": {
-              "1025": {
+              "4294968321": {
                 "durabilities": [
                   0
                 ],
@@ -172,7 +172,7 @@ fn everything() {
               }
             },
             "4": {
-              "3073": {
+              "4294970369": {
                 "durability": 2,
                 "last_interned_at": 1,
                 "fields": [
@@ -181,7 +181,7 @@ fn everything() {
               }
             },
             "5": {
-              "4097": {
+              "4294971393": {
                 "durability": 0,
                 "updated_at": 1,
                 "revisions": [],
@@ -191,24 +191,24 @@ fn everything() {
               }
             },
             "7": {
-              "5121": {
+              "4294972417": {
                 "durability": 2,
                 "last_interned_at": 18446744073709551615,
                 "fields": [
-                  3,
-                  4
+                  4294967299,
+                  4294967300
                 ]
               }
             },
             "19": {
-              "2049": {
+              "4294969345": {
                 "durability": 2,
                 "last_interned_at": 18446744073709551615,
                 "fields": null
               }
             },
             "6": {
-              "7:5121": {
+              "7:4294972417": {
                 "value": "aaa",
                 "verified_at": 1,
                 "revisions": {
@@ -218,11 +218,11 @@ fn everything() {
                     "Derived": [
                       [
                         3,
-                        1
+                        4
                       ],
                       [
                         4,
-                        1
+                        4
                       ]
                     ]
                   },
@@ -232,8 +232,8 @@ fn everything() {
               }
             },
             "8": {
-              "0:3": {
-                "value": 4097,
+              "0:4294967299": {
+                "value": 4294971393,
                 "verified_at": 1,
                 "revisions": {
                   "changed_at": 1,
@@ -242,7 +242,7 @@ fn everything() {
                     "Derived": [
                       [
                         3,
-                        1
+                        4
                       ]
                     ]
                   },
@@ -255,7 +255,7 @@ fn everything() {
                           "hash": 6073466998405137972,
                           "disambiguator": 0
                         },
-                        4097
+                        4294971393
                       ]
                     ],
                     "cycle_heads": [],
@@ -265,8 +265,8 @@ fn everything() {
               }
             },
             "18": {
-              "19:2049": {
-                "value": 3073,
+              "19:4294969345": {
+                "value": 4294970369,
                 "verified_at": 1,
                 "revisions": {
                   "changed_at": 1,
@@ -275,7 +275,7 @@ fn everything() {
                     "Derived": [
                       [
                         3073,
-                        4
+                        1
                       ]
                     ]
                   },
@@ -347,7 +347,7 @@ fn partial_query() {
           },
           "ingredients": {
             "0": {
-              "1": {
+              "4294967297": {
                 "durabilities": [
                   0
                 ],
@@ -360,7 +360,7 @@ fn partial_query() {
               }
             },
             "13": {
-              "0:1": {
+              "0:4294967297": {
                 "value": 1,
                 "verified_at": 1,
                 "revisions": {
@@ -370,7 +370,7 @@ fn partial_query() {
                     "Derived": [
                       [
                         1,
-                        1
+                        4
                       ]
                     ]
                   },
@@ -462,7 +462,7 @@ fn partial_query_interned() {
           },
           "ingredients": {
             "0": {
-              "1": {
+              "4294967297": {
                 "durabilities": [
                   0
                 ],
@@ -475,7 +475,7 @@ fn partial_query_interned() {
               }
             },
             "4": {
-              "3073": {
+              "4294970369": {
                 "durability": 0,
                 "last_interned_at": 1,
                 "fields": [
@@ -484,18 +484,18 @@ fn partial_query_interned() {
               }
             },
             "17": {
-              "1025": {
+              "4294968321": {
                 "durability": 2,
                 "last_interned_at": 18446744073709551615,
                 "fields": [
-                  1,
+                  4294967297,
                   0
                 ]
               }
             },
             "16": {
-              "17:1025": {
-                "value": 3073,
+              "17:4294968321": {
+                "value": 4294970369,
                 "verified_at": 1,
                 "revisions": {
                   "changed_at": 1,
@@ -504,11 +504,11 @@ fn partial_query_interned() {
                     "Derived": [
                       [
                         1,
-                        1
+                        4
                       ],
                       [
                         3073,
-                        4
+                        1
                       ]
                     ]
                   },


### PR DESCRIPTION
Via the observation that:

 - The `IngredientIndex` can be retrieved from the page, except for tracked fns
 - The generation is useless, except for interneds

And since they don't overlap, we can store only what needed for each.

For rust-analyzer, this saves 55mb on itself and 200mb on a large codebase (omicron).