### PR TITLE
Fix book build with newer mdbook versions

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -1,6 +1,5 @@
 [book]
 authors = ["Salsa Contributors"]
-multilingual = false
 src = "src"
 title = "Salsa"
 


### PR DESCRIPTION
As of mdbook 0.5.0, multilingual is no longer accepted as a configuration item in book.toml. Since this configuration value never had any effect, we can just remove it.

https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md#config-changes