### PR TITLE
Remove `QueryOriginKind::FixpointInitial`

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -685,9 +685,6 @@ mod persistence {
 
                             QueryOrigin::assigned(key)
                         }
-                        QueryOriginRef::FixpointInitial => unreachable!(
-                            "`should_serialize` returns `false` for provisional queries"
-                        ),
                     };
 
                     let memo = memo.with_origin(flattened_origin);

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -440,14 +440,6 @@ where
                 // in rev 1 but not in rev 2.
                 VerifyResult::changed()
             }
-            // Return `Unchanged` similar to the initial value that we insert
-            // when we hit the cycle. Any dependencies accessed when creating the fixpoint initial
-            // are tracked by the outer query. Nothing should have changed assuming that the
-            // fixpoint initial function is deterministic.
-            QueryOriginRef::FixpointInitial => {
-                cycle_heads.insert_head(database_key_index);
-                VerifyResult::unchanged()
-            }
             QueryOriginRef::DerivedUntracked(_) => {
                 // Untracked inputs? Have to assume that it changed.
                 VerifyResult::changed()

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -58,7 +58,7 @@ impl<C: Configuration> IngredientImpl<C> {
     }
 
     /// Evicts the existing memo for the given key, replacing it
-    /// with an equivalent memo that has no value. If the memo is untracked, FixpointInitial,
+    /// with an equivalent memo that has no value. If the memo is untracked
     /// or has values assigned as output of another query, this has no effect.
     pub(super) fn evict_value_from_memo_for(
         table: MemoTableWithTypesMut<'_>,
@@ -66,9 +66,7 @@ impl<C: Configuration> IngredientImpl<C> {
     ) {
         let map = |memo: &mut Memo<'static, C>| {
             match memo.revisions.origin.as_ref() {
-                QueryOriginRef::Assigned(_)
-                | QueryOriginRef::DerivedUntracked(_)
-                | QueryOriginRef::FixpointInitial => {
+                QueryOriginRef::Assigned(_) | QueryOriginRef::DerivedUntracked(_) => {
                     // Careful: Cannot evict memos whose values were
                     // assigned as output of another query
                     // or those with untracked inputs


### PR DESCRIPTION
Using a `derived` with no inputs should give us the same behavior (because `deep_verify_memo` for no dependencies always returns `Unchanged`).

The only part that I don't feel a 100% sure about is the eviction, which was disabled for fixpoint initial values. 
However, it's not clear to me why we wouldn't be able to re-create a fixpoint initial value? Can't we just re-run the query
and it will either create a new fixpiont initial or compute the final result.
