### PR TITLE
Merge `FallbackImmediate` and `Fixpoint` code paths

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   book:
     name: Book
+    if: github.repository == 'salsa-rs/salsa'
     runs-on: ubuntu-latest
     env:
       MDBOOK_VERSION: "0.4.40"

--- a/src/cycle.rs
+++ b/src/cycle.rs
@@ -505,7 +505,6 @@ pub enum ProvisionalStatus<'db> {
         iteration: IterationCount,
         verified_at: Revision,
     },
-    FallbackImmediate,
 }
 
 impl<'db> ProvisionalStatus<'db> {

--- a/src/function.rs
+++ b/src/function.rs
@@ -370,7 +370,7 @@ where
         }
     }
 
-    /// Returns `final` only if the memo has the `verified_final` flag set and the cycle recovery strategy is not `FallbackImmediate`.
+    /// Returns `final` if the memo has the `verified_final` flag set.
     ///
     /// Otherwise, the value is still provisional. For both final and provisional, it also
     /// returns the iteration in which this memo was created (always 0 except for cycle heads).
@@ -386,13 +386,9 @@ where
         let verified_final = memo.revisions.verified_final.load(Ordering::Relaxed);
 
         Some(if verified_final {
-            if C::CYCLE_STRATEGY == CycleRecoveryStrategy::FallbackImmediate {
-                ProvisionalStatus::FallbackImmediate
-            } else {
-                ProvisionalStatus::Final {
-                    iteration,
-                    verified_at: memo.verified_at.load(),
-                }
+            ProvisionalStatus::Final {
+                iteration,
+                verified_at: memo.verified_at.load(),
             }
         } else {
             ProvisionalStatus::Provisional {

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -65,14 +65,21 @@ where
                 );
                 (new_value, active_query.pop())
             }
-            CycleRecoveryStrategy::FallbackImmediate | CycleRecoveryStrategy::Fixpoint => self
-                .execute_maybe_iterate(
+            CycleRecoveryStrategy::FallbackImmediate | CycleRecoveryStrategy::Fixpoint => {
+                let zalsa_local = claim_guard.zalsa_local();
+                let was_disabled = zalsa_local.set_cancellation_disabled(true);
+
+                let res = self.execute_maybe_iterate(
                     db,
                     opt_old_memo,
                     &mut claim_guard,
-                    zalsa_local,
                     memo_ingredient_index,
-                ),
+                );
+
+                zalsa_local.set_cancellation_disabled(was_disabled);
+
+                res
+            }
         };
 
         if let Some(old_memo) = opt_old_memo {

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -220,7 +220,8 @@ where
                 };
 
                 // For FallbackImmediate, use the fallback value instead of the computed value
-                // for all cycle participants.
+                // for all cycle participants. This ensures that the results don't depend on the query call order, see
+                // https://github.com/salsa-rs/salsa/pull/798#issuecomment-2812855285.
                 let new_value = if C::CYCLE_STRATEGY == CycleRecoveryStrategy::FallbackImmediate {
                     C::cycle_initial(db, id, C::id_to_input(zalsa, id))
                 } else {

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -7,7 +7,6 @@ use crate::function::sync::ReleaseMode;
 use crate::function::{ClaimGuard, Configuration, IngredientImpl};
 use crate::ingredient::WaitForResult;
 use crate::plumbing::ZalsaLocal;
-use crate::sync::atomic::{AtomicBool, Ordering};
 use crate::sync::thread;
 use crate::tracked_struct::Identity;
 use crate::zalsa::{MemoIngredientIndex, Zalsa};
@@ -66,65 +65,14 @@ where
                 );
                 (new_value, active_query.pop())
             }
-            CycleRecoveryStrategy::FallbackImmediate => {
-                let (mut new_value, active_query) = Self::execute_query(
-                    db,
-                    zalsa,
-                    claim_guard
-                        .zalsa_local()
-                        .push_query(database_key_index, IterationCount::initial()),
-                    opt_old_memo,
-                );
-
-                let mut completed_query = active_query.pop();
-
-                if let Some(cycle_heads) = completed_query.revisions.cycle_heads_mut() {
-                    // Did the new result we got depend on our own provisional value, in a cycle?
-                    if cycle_heads.contains(&database_key_index) {
-                        // Ignore the computed value, leave the fallback value there.
-                        let memo = self
-                            .get_memo_from_table_for(zalsa, id, memo_ingredient_index)
-                            .unwrap_or_else(|| {
-                                unreachable!(
-                                    "{database_key_index:#?} is a `FallbackImmediate` cycle head, \
-                                        but no memo found"
-                                )
-                            });
-                        // We need to mark the memo as finalized so other cycle participants that have fallbacks
-                        // will be verified (participants that don't have fallbacks will not be verified).
-                        memo.revisions.verified_final.store(true, Ordering::Release);
-                        return Some(memo);
-                    }
-
-                    // If we're in the middle of a cycle and we have a fallback, use it instead.
-                    // Cycle participants that don't have a fallback will be discarded in
-                    // `validate_provisional()`.
-                    let cycle_heads = std::mem::take(cycle_heads);
-                    let active_query = claim_guard
-                        .zalsa_local()
-                        .push_query(database_key_index, IterationCount::initial());
-                    new_value = C::cycle_initial(db, id, C::id_to_input(zalsa, id));
-                    completed_query = active_query.pop();
-                    // We need to set `cycle_heads` and `verified_final` because it needs to propagate to the callers.
-                    // When verifying this, we will see we have fallback and mark ourselves verified.
-                    completed_query.revisions.set_cycle_heads(cycle_heads);
-                    completed_query.revisions.verified_final = AtomicBool::new(false);
-                }
-
-                (new_value, completed_query)
-            }
-            CycleRecoveryStrategy::Fixpoint => {
-                let zalsa_local = claim_guard.zalsa_local();
-                let was_disabled = zalsa_local.set_cancellation_disabled(true);
-                let res = self.execute_maybe_iterate(
+            CycleRecoveryStrategy::FallbackImmediate | CycleRecoveryStrategy::Fixpoint => self
+                .execute_maybe_iterate(
                     db,
                     opt_old_memo,
                     &mut claim_guard,
+                    zalsa_local,
                     memo_ingredient_index,
-                );
-                zalsa_local.set_cancellation_disabled(was_disabled);
-                res
-            }
+                ),
         };
 
         if let Some(old_memo) = opt_old_memo {
@@ -271,6 +219,14 @@ where
                     panic!("cycle participant with non-empty cycle heads and that doesn't depend on itself must have an outer cycle responsible to finalize the query later (query: {database_key_index:?}, cycle heads: {cycle_heads:?}).");
                 };
 
+                // For FallbackImmediate, use the fallback value instead of the computed value
+                // for all cycle participants.
+                let new_value = if C::CYCLE_STRATEGY == CycleRecoveryStrategy::FallbackImmediate {
+                    C::cycle_initial(db, id, C::id_to_input(zalsa, id))
+                } else {
+                    new_value
+                };
+
                 let completed_query = complete_cycle_participant(
                     active_query,
                     claim_guard,
@@ -325,25 +281,34 @@ where
                 iteration_count
             };
 
-            let cycle = Cycle {
-                head_ids: cycle_heads.ids(),
-                id,
-                iteration: iteration_count.as_u32(),
+            // For FallbackImmediate, the value always converges immediately (we use the
+            // fallback directly). We still iterate if metadata hasn't converged.
+            // For Fixpoint, ask the recovery function what value to use and check convergence.
+            let value_converged = if C::CYCLE_STRATEGY == CycleRecoveryStrategy::FallbackImmediate {
+                // Use the fallback value instead of the computed value.
+                new_value = C::cycle_initial(db, id, C::id_to_input(zalsa, id));
+                true
+            } else {
+                let cycle = Cycle {
+                    head_ids: cycle_heads.ids(),
+                    id,
+                    iteration: iteration_count.as_u32(),
+                };
+                // We are in a cycle that hasn't converged; ask the user's
+                // cycle-recovery function what to do (it may return the same value or a different one):
+                new_value = C::recover_from_cycle(
+                    db,
+                    &cycle,
+                    last_provisional_value,
+                    new_value,
+                    C::id_to_input(zalsa, id),
+                );
+
+                C::values_equal(&new_value, last_provisional_value)
             };
-            // We are in a cycle that hasn't converged; ask the user's
-            // cycle-recovery function what to do (it may return the same value or a different one):
-            new_value = C::recover_from_cycle(
-                db,
-                &cycle,
-                last_provisional_value,
-                new_value,
-                C::id_to_input(zalsa, id),
-            );
 
             let new_cycle_heads = active_query.take_cycle_heads();
             assert_no_new_cycle_heads(&cycle_heads, new_cycle_heads, database_key_index);
-
-            let value_converged = C::values_equal(&new_value, last_provisional_value);
 
             let completed_query = match try_complete_cycle_head(
                 active_query,

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -1,6 +1,6 @@
 use rustc_hash::FxHashMap;
 
-use crate::cycle::{CycleHeads, CycleRecoveryStrategy, IterationCount};
+use crate::cycle::{CycleRecoveryStrategy, IterationCount};
 use crate::function::eviction::EvictionPolicy;
 use crate::function::maybe_changed_after::VerifyCycleHeads;
 use crate::function::memo::Memo;
@@ -112,20 +112,7 @@ where
         {
             ClaimResult::Claimed(guard) => guard,
             ClaimResult::Running(blocked_on) => {
-                if !blocked_on.block_on(zalsa) {
-                    return None;
-                }
-
-                if C::CYCLE_STRATEGY == CycleRecoveryStrategy::FallbackImmediate {
-                    let memo = self.get_memo_from_table_for(zalsa, id, memo_ingredient_index);
-
-                    if let Some(memo) = memo {
-                        if memo.value.is_some() {
-                            memo.block_on_heads(zalsa);
-                        }
-                    }
-                }
-
+                blocked_on.block_on(zalsa);
                 return None;
             }
             ClaimResult::Cycle { .. } => {
@@ -196,35 +183,6 @@ where
         database_key_index: DatabaseKeyIndex,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> &'db Memo<'db, C> {
-        // check if there's a provisional value for this query
-        // Note we don't `validate_may_be_provisional` the memo here as we want to reuse an
-        // existing provisional memo if it exists
-        let memo_guard = self.get_memo_from_table_for(zalsa, id, memo_ingredient_index);
-        if let Some(memo) = memo_guard {
-            // Ideally, we'd use the last provisional memo even if it wasn't a cycle head in the last iteration
-            // but that would require inserting itself as a cycle head, which either requires clone
-            // on the value OR a concurrent `Vec` for cycle heads.
-            if memo.verified_at.load() == zalsa.current_revision()
-                && memo.value.is_some()
-                && memo.revisions.cycle_heads().contains(&database_key_index)
-            {
-                if C::CYCLE_STRATEGY == CycleRecoveryStrategy::Fixpoint {
-                    memo.revisions
-                        .cycle_heads()
-                        .remove_all_except(database_key_index);
-                }
-
-                crate::tracing::debug!(
-                    "hit cycle at {database_key_index:#?}, \
-                        returning last provisional value: {:#?}",
-                    memo.revisions
-                );
-
-                // SAFETY: memo is present in memo_map.
-                return unsafe { self.extend_memo_lifetime(memo) };
-            }
-        }
-
         // no provisional value; create/insert/return initial provisional value
         match C::CYCLE_STRATEGY {
             // SAFETY: We do not access the query stack reentrantly.
@@ -237,7 +195,34 @@ where
                     );
                 })
             },
-            CycleRecoveryStrategy::Fixpoint => {
+            CycleRecoveryStrategy::Fixpoint | CycleRecoveryStrategy::FallbackImmediate => {
+                // check if there's a provisional value for this query
+                // Note we don't `validate_may_be_provisional` the memo here as we want to reuse an
+                // existing provisional memo if it exists
+                let memo_guard = self.get_memo_from_table_for(zalsa, id, memo_ingredient_index);
+                if let Some(memo) = &memo_guard {
+                    // Ideally, we'd use the last provisional memo even if it wasn't a cycle head in the last iteration
+                    // but that would require inserting itself as a cycle head, which either requires clone
+                    // on the value OR a concurrent `Vec` for cycle heads.
+                    if memo.verified_at.load() == zalsa.current_revision()
+                        && memo.value.is_some()
+                        && memo.revisions.cycle_heads().contains(&database_key_index)
+                    {
+                        memo.revisions
+                            .cycle_heads()
+                            .remove_all_except(database_key_index);
+
+                        crate::tracing::debug!(
+                            "hit cycle at {database_key_index:#?}, \
+                                returning last provisional value: {:#?}",
+                            memo.revisions
+                        );
+
+                        // SAFETY: memo is present in memo_map.
+                        return unsafe { self.extend_memo_lifetime(memo) };
+                    }
+                }
+
                 crate::tracing::debug!(
                     "hit cycle at {database_key_index:#?}, \
                     inserting and returning fixpoint initial value"
@@ -261,33 +246,6 @@ where
                     zalsa,
                     id,
                     Memo::new(Some(initial_value), zalsa.current_revision(), revisions),
-                    memo_ingredient_index,
-                )
-            }
-            CycleRecoveryStrategy::FallbackImmediate => {
-                crate::tracing::debug!(
-                    "hit a `FallbackImmediate` cycle at {database_key_index:#?}"
-                );
-                let active_query =
-                    zalsa_local.push_query(database_key_index, IterationCount::initial());
-                let fallback_value = C::cycle_initial(db, id, C::id_to_input(zalsa, id));
-                let mut completed_query = active_query.pop();
-                completed_query
-                    .revisions
-                    .set_cycle_heads(CycleHeads::initial(
-                        database_key_index,
-                        IterationCount::initial(),
-                    ));
-                // We need this for `cycle_heads()` to work. We will unset this in the outer `execute()`.
-                *completed_query.revisions.verified_final.get_mut() = false;
-                self.insert_memo(
-                    zalsa,
-                    id,
-                    Memo::new(
-                        Some(fallback_value),
-                        zalsa.current_revision(),
-                        completed_query.revisions,
-                    ),
                     memo_ingredient_index,
                 )
             }

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -112,7 +112,7 @@ where
         {
             ClaimResult::Claimed(guard) => guard,
             ClaimResult::Running(blocked_on) => {
-                blocked_on.block_on(zalsa);
+                let _ = blocked_on.block_on(zalsa);
                 return None;
             }
             ClaimResult::Cycle { .. } => {

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -360,7 +360,6 @@ where
             &memo.revisions,
             verified_at,
             cycle_heads,
-            C::CYCLE_STRATEGY,
         ) || validate_same_iteration(
             zalsa,
             zalsa_local,
@@ -617,7 +616,6 @@ fn validate_provisional(
     memo_revisions: &QueryRevisions,
     memo_verified_at: Revision,
     cycle_heads: &CycleHeads,
-    cycle_recovery_strategy: CycleRecoveryStrategy,
 ) -> bool {
     crate::tracing::trace!("{database_key_index:?}: validate_provisional({database_key_index:?})",);
 
@@ -651,24 +649,7 @@ fn validate_provisional(
                 if iteration != cycle_head.iteration_count.load() {
                     return false;
                 }
-
-                // FIXME: We can ignore this, I just don't have a use-case for this.
-                if cycle_recovery_strategy == CycleRecoveryStrategy::FallbackImmediate {
-                    panic!("cannot mix `cycle_fn` and `cycle_result` in cycles")
-                }
             }
-            ProvisionalStatus::FallbackImmediate => match cycle_recovery_strategy {
-                CycleRecoveryStrategy::Panic => {
-                    // Queries without fallback are not considered when inside a cycle.
-                    return false;
-                }
-                // FIXME: We can do the same as with `CycleRecoveryStrategy::Panic` here, I just don't have
-                // a use-case for this.
-                CycleRecoveryStrategy::Fixpoint => {
-                    panic!("cannot mix `cycle_fn` and `cycle_result` in cycles")
-                }
-                CycleRecoveryStrategy::FallbackImmediate => {}
-            },
         }
     }
     // Relaxed is sufficient here because there are no other writes we need to ensure have

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -10,7 +10,7 @@ use crate::function::{Configuration, IngredientImpl};
 use crate::ingredient::WaitForResult;
 use crate::key::DatabaseKeyIndex;
 use crate::revision::AtomicRevision;
-use crate::runtime::Running;
+
 use crate::sync::atomic::Ordering;
 use crate::table::memo::MemoTableWithTypesMut;
 use crate::zalsa::{MemoIngredientIndex, Zalsa};
@@ -128,70 +128,6 @@ impl<'db, C: Configuration> Memo<'db, C> {
         // ever `false` is purely an optimization; if we read an out-of-date `false`, it just means
         // we might go validate it again unnecessarily.
         !self.revisions.verified_final.load(Ordering::Relaxed)
-    }
-
-    /// Blocks on all cycle heads (recursively) that this memo depends on.
-    ///
-    /// Returns `true` if awaiting all cycle heads results in a cycle. This means, they're all waiting
-    /// for us to make progress.
-    #[inline(always)]
-    pub(super) fn block_on_heads(&self, zalsa: &Zalsa) -> bool {
-        // IMPORTANT: If you make changes to this function, make sure to run `cycle_nested_deep` with
-        // shuttle with at least 10k iterations.
-
-        let cycle_heads = self.cycle_heads();
-        if cycle_heads.is_empty() {
-            return true;
-        }
-
-        return block_on_heads_cold(zalsa, cycle_heads);
-
-        #[inline(never)]
-        fn block_on_heads_cold(zalsa: &Zalsa, heads: &CycleHeads) -> bool {
-            let _entered = crate::tracing::debug_span!("block_on_heads").entered();
-            let cycle_heads = TryClaimCycleHeadsIter::new(zalsa, heads);
-            let mut all_cycles = true;
-
-            for claim_result in cycle_heads {
-                match claim_result {
-                    TryClaimHeadsResult::Cycle {
-                        memo_iteration_count: current_iteration_count,
-                        head_iteration_count,
-                        ..
-                    } => {
-                        // We need to refetch if the head now has a new iteration count.
-                        // This is to avoid a race between thread A and B:
-                        // * thread A is in `blocks_on` (`retry_provisional`) for the memo `c`. It owns the lock for `e`
-                        // * thread B owns `d` and calls `c`. `c` didn't depend on `e` in the first iteration.
-                        //   Thread B completes the first iteration (which bumps the iteration count on `c`).
-                        //   `c` now depends on E in the second iteration, introducing a new cycle head.
-                        //   Thread B transfers ownership of `c` to thread A (which awakes A).
-                        // * Thread A now continues, there are no other cycle heads, so all queries result in a cycle.
-                        //   However, `d` has now a new iteration count, so it's important that we refetch `c`.
-
-                        if current_iteration_count != head_iteration_count {
-                            all_cycles = false;
-                        }
-                    }
-                    TryClaimHeadsResult::Available => {
-                        all_cycles = false;
-                    }
-                    TryClaimHeadsResult::Running(running) => {
-                        all_cycles = false;
-                        if !running.block_on(zalsa) {
-                            // We cannot really handle local cancellations reliably here
-                            // so we treat it as a general cancellation / panic.
-                            //
-                            // We shouldn't hit this though as we disable local cancellation
-                            // in cycles.
-                            crate::Cancelled::PropagatedPanic.throw();
-                        }
-                    }
-                }
-            }
-
-            all_cycles
-        }
     }
 
     /// Cycle heads that should be propagated to dependent queries.
@@ -411,7 +347,7 @@ mod persistence {
 }
 
 #[derive(Debug)]
-pub(super) enum TryClaimHeadsResult<'me> {
+pub(super) enum TryClaimHeadsResult {
     /// Claiming the cycle head results in a cycle.
     Cycle {
         head_iteration_count: IterationCount,
@@ -423,7 +359,7 @@ pub(super) enum TryClaimHeadsResult<'me> {
     Available,
 
     /// The cycle head is currently executed on another thread.
-    Running(Running<'me>),
+    Running,
 }
 
 /// Iterator to try claiming the transitive cycle heads of a memo.
@@ -443,8 +379,8 @@ impl<'a> TryClaimCycleHeadsIter<'a> {
     }
 }
 
-impl<'me> Iterator for TryClaimCycleHeadsIter<'me> {
-    type Item = TryClaimHeadsResult<'me>;
+impl Iterator for TryClaimCycleHeadsIter<'_> {
+    type Item = TryClaimHeadsResult;
 
     fn next(&mut self) -> Option<Self::Item> {
         let head = self.cycle_heads.next()?;
@@ -473,9 +409,6 @@ impl<'me> Iterator for TryClaimCycleHeadsIter<'me> {
                         iteration,
                         verified_at,
                     } => (iteration, verified_at),
-                    ProvisionalStatus::FallbackImmediate => {
-                        (IterationCount::initial(), self.zalsa.current_revision())
-                    }
                 };
 
                 Some(TryClaimHeadsResult::Cycle {
@@ -487,7 +420,7 @@ impl<'me> Iterator for TryClaimCycleHeadsIter<'me> {
             WaitForResult::Running(running) => {
                 crate::tracing::trace!("Ingredient {head_database_key:?} is running: {running:?}");
 
-                Some(TryClaimHeadsResult::Running(running))
+                Some(TryClaimHeadsResult::Running)
             }
             WaitForResult::Available => Some(TryClaimHeadsResult::Available),
         }

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -725,15 +725,6 @@ impl QueryRevisions {
         }
     }
 
-    /// Returns a mutable reference to the `CycleHeads` for this query, or `None` if the list is empty.
-    pub(crate) fn cycle_heads_mut(&mut self) -> Option<&mut CycleHeads> {
-        self.extra
-            .0
-            .as_mut()
-            .map(|extra| &mut extra.cycle_heads)
-            .filter(|cycle_heads| !cycle_heads.is_empty())
-    }
-
     /// Sets the `CycleHeads` for this query.
     pub(crate) fn set_cycle_heads(&mut self, cycle_heads: CycleHeads) {
         match &mut self.extra.0 {

--- a/tests/cycle_fallback_immediate.rs
+++ b/tests/cycle_fallback_immediate.rs
@@ -3,8 +3,6 @@
 //! It is possible to omit the `cycle_fn`, only specifying `cycle_result` in which case
 //! an immediate fallback value is used as the cycle handling opposed to doing a fixpoint resolution.
 
-use std::sync::atomic::{AtomicI32, Ordering};
-
 #[salsa::tracked(cycle_result=cycle_result)]
 fn one_o_one(db: &dyn salsa::Database) -> u32 {
     let val = one_o_one(db);
@@ -24,18 +22,12 @@ fn simple() {
 
 #[salsa::tracked(cycle_result=two_queries_cycle_result)]
 fn two_queries1(db: &dyn salsa::Database) -> i32 {
-    two_queries2(db);
-    0
+    two_queries2(db) + 1
 }
 
-#[salsa::tracked]
+#[salsa::tracked(cycle_result=two_queries_cycle_result)]
 fn two_queries2(db: &dyn salsa::Database) -> i32 {
-    two_queries1(db);
-    // This is horribly against Salsa's rules, but we want to test that
-    // the value from within the cycle is not considered, and this is
-    // the only way I found.
-    static CALLS_COUNT: AtomicI32 = AtomicI32::new(0);
-    CALLS_COUNT.fetch_add(1, Ordering::Relaxed)
+    two_queries1(db)
 }
 
 fn two_queries_cycle_result(_db: &dyn salsa::Database, _id: salsa::Id) -> i32 {


### PR DESCRIPTION
## Summary

Spinned out of https://github.com/salsa-rs/salsa/pull/1059#discussion_r2678737797

This PR removes most special casing of `FallbackImmediate` and, instead, integrates it into the normal `Fixpoint` code. Not only should this fix the caching issues that `FallbackImmediate` has today, it also reduces overall complexity and makes it easier to make changes to how we handle cycles in Salsa (no need to update two completely different implementations).


This PR preserves the existing `FallbackImmediate` behavior where all heads participating in a query use their fallback value (and not just the cycle heads). I now believe that this behavior is essential for deterministic outputs, as pointed out by Carl in https://github.com/salsa-rs/salsa/pull/798#issuecomment-2812855285

See https://github.com/salsa-rs/salsa/blob/b6398ecdfb41de7250d21bb91183a9f8bfdc5827/src/function/execute.rs#L96-L107

This PR is based on top of https://github.com/salsa-rs/salsa/pull/1062


One difference worth mentioning is that we now overapproximate the dependencies for queries with `cycle_result`, keeping all dependencies rather than just those up to the initial cycle. This is fine as it is, and I'm not aware of an easy way to remember when we hit the cycle and which dependencies we've seen up to this point.