### PR TITLE
Lower `FallbackImmediate` to `Fixpoint` 

### DIFF
--- a/components/salsa-macro-rules/src/unexpected_cycle_recovery.rs
+++ b/components/salsa-macro-rules/src/unexpected_cycle_recovery.rs
@@ -18,3 +18,16 @@ macro_rules! unexpected_cycle_initial {
         panic!("no cycle initial value")
     }};
 }
+
+// Macro that generates the body of the cycle recovery function
+// for `cycle_result` where we always return the previous (fallback) value.
+// This makes the cycle converge immediately after one iteration.
+#[macro_export]
+macro_rules! cycle_recovery_return_previous {
+    ($db:ident, $cycle:ident, $last_provisional_value:ident, $new_value:ident, $($other_inputs:ident),*) => {{
+        let (_db, _cycle) = ($db, $cycle);
+        std::mem::drop($new_value);
+        std::mem::drop(($($other_inputs,)*));
+        ::std::clone::Clone::clone($last_provisional_value)
+    }};
+}

--- a/components/salsa-macros/src/tracked_fn.rs
+++ b/components/salsa-macros/src/tracked_fn.rs
@@ -291,9 +291,11 @@ impl Macro {
                 quote!(Fixpoint),
             )),
             (None, None, Some(cycle_result)) => Ok((
-                quote!((salsa::plumbing::unexpected_cycle_recovery!)),
+                // Recovery function that always returns the previous (fallback) value.
+                // This makes the cycle converge immediately after one iteration.
+                quote!((salsa::plumbing::cycle_recovery_return_previous!)),
                 quote!(((#cycle_result))),
-                quote!(FallbackImmediate),
+                quote!(Fixpoint),
             )),
             (_, _, Some(_)) => Err(syn::Error::new_spanned(
                 self.args.cycle_initial.as_ref().unwrap(),

--- a/src/cycle.rs
+++ b/src/cycle.rs
@@ -72,11 +72,6 @@ pub enum CycleRecoveryStrategy {
     /// This choice is computed by the query's `cycle_recovery`
     /// function and initial value.
     Fixpoint,
-
-    /// Recovers from cycles by inserting a fallback value for all
-    /// queries that have a fallback, and ignoring any other query
-    /// in the cycle (as if they were not computed).
-    FallbackImmediate,
 }
 
 /// A "cycle head" is the query at which we encounter a cycle; that is, if A -> B -> C -> A, then A
@@ -505,7 +500,6 @@ pub enum ProvisionalStatus<'db> {
         iteration: IterationCount,
         verified_at: Revision,
     },
-    FallbackImmediate,
 }
 
 impl<'db> ProvisionalStatus<'db> {

--- a/src/function.rs
+++ b/src/function.rs
@@ -370,7 +370,7 @@ where
         }
     }
 
-    /// Returns `final` only if the memo has the `verified_final` flag set and the cycle recovery strategy is not `FallbackImmediate`.
+    /// Returns `final` only if the memo has the `verified_final` flag set.
     ///
     /// Otherwise, the value is still provisional. For both final and provisional, it also
     /// returns the iteration in which this memo was created (always 0 except for cycle heads).
@@ -386,13 +386,9 @@ where
         let verified_final = memo.revisions.verified_final.load(Ordering::Relaxed);
 
         Some(if verified_final {
-            if C::CYCLE_STRATEGY == CycleRecoveryStrategy::FallbackImmediate {
-                ProvisionalStatus::FallbackImmediate
-            } else {
-                ProvisionalStatus::Final {
-                    iteration,
-                    verified_at: memo.verified_at.load(),
-                }
+            ProvisionalStatus::Final {
+                iteration,
+                verified_at: memo.verified_at.load(),
             }
         } else {
             ProvisionalStatus::Provisional {

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -1,6 +1,6 @@
 use rustc_hash::FxHashMap;
 
-use crate::cycle::{CycleHeads, CycleRecoveryStrategy, IterationCount};
+use crate::cycle::{CycleRecoveryStrategy, IterationCount};
 use crate::function::eviction::EvictionPolicy;
 use crate::function::maybe_changed_after::VerifyCycleHeads;
 use crate::function::memo::Memo;
@@ -110,17 +110,6 @@ where
             ClaimResult::Claimed(guard) => guard,
             ClaimResult::Running(blocked_on) => {
                 blocked_on.block_on(zalsa);
-
-                if C::CYCLE_STRATEGY == CycleRecoveryStrategy::FallbackImmediate {
-                    let memo = self.get_memo_from_table_for(zalsa, id, memo_ingredient_index);
-
-                    if let Some(memo) = memo {
-                        if memo.value.is_some() {
-                            memo.block_on_heads(zalsa);
-                        }
-                    }
-                }
-
                 return None;
             }
             ClaimResult::Cycle { .. } => {
@@ -191,35 +180,6 @@ where
         database_key_index: DatabaseKeyIndex,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> &'db Memo<'db, C> {
-        // check if there's a provisional value for this query
-        // Note we don't `validate_may_be_provisional` the memo here as we want to reuse an
-        // existing provisional memo if it exists
-        let memo_guard = self.get_memo_from_table_for(zalsa, id, memo_ingredient_index);
-        if let Some(memo) = memo_guard {
-            // Ideally, we'd use the last provisional memo even if it wasn't a cycle head in the last iteration
-            // but that would require inserting itself as a cycle head, which either requires clone
-            // on the value OR a concurrent `Vec` for cycle heads.
-            if memo.verified_at.load() == zalsa.current_revision()
-                && memo.value.is_some()
-                && memo.revisions.cycle_heads().contains(&database_key_index)
-            {
-                if C::CYCLE_STRATEGY == CycleRecoveryStrategy::Fixpoint {
-                    memo.revisions
-                        .cycle_heads()
-                        .remove_all_except(database_key_index);
-                }
-
-                crate::tracing::debug!(
-                    "hit cycle at {database_key_index:#?}, \
-                        returning last provisional value: {:#?}",
-                    memo.revisions
-                );
-
-                // SAFETY: memo is present in memo_map.
-                return unsafe { self.extend_memo_lifetime(memo) };
-            }
-        }
-
         // no provisional value; create/insert/return initial provisional value
         match C::CYCLE_STRATEGY {
             // SAFETY: We do not access the query stack reentrantly.
@@ -233,6 +193,35 @@ where
                 })
             },
             CycleRecoveryStrategy::Fixpoint => {
+                // check if there's a provisional value for this query
+                // Note we don't `validate_may_be_provisional` the memo here as we want to reuse an
+                // existing provisional memo if it exists
+                let memo_guard = self.get_memo_from_table_for(zalsa, id, memo_ingredient_index);
+                if let Some(memo) = memo_guard {
+                    // Ideally, we'd use the last provisional memo even if it wasn't a cycle head in the last iteration
+                    // but that would require inserting itself as a cycle head, which either requires clone
+                    // on the value OR a concurrent `Vec` for cycle heads.
+                    if memo.verified_at.load() == zalsa.current_revision()
+                        && memo.value.is_some()
+                        && memo.revisions.cycle_heads().contains(&database_key_index)
+                    {
+                        if C::CYCLE_STRATEGY == CycleRecoveryStrategy::Fixpoint {
+                            memo.revisions
+                                .cycle_heads()
+                                .remove_all_except(database_key_index);
+                        }
+
+                        crate::tracing::debug!(
+                            "hit cycle at {database_key_index:#?}, \
+                                returning last provisional value: {:#?}",
+                            memo.revisions
+                        );
+
+                        // SAFETY: memo is present in memo_map.
+                        return unsafe { self.extend_memo_lifetime(memo) };
+                    }
+                }
+
                 crate::tracing::debug!(
                     "hit cycle at {database_key_index:#?}, \
                     inserting and returning fixpoint initial value"
@@ -256,33 +245,6 @@ where
                     zalsa,
                     id,
                     Memo::new(Some(initial_value), zalsa.current_revision(), revisions),
-                    memo_ingredient_index,
-                )
-            }
-            CycleRecoveryStrategy::FallbackImmediate => {
-                crate::tracing::debug!(
-                    "hit a `FallbackImmediate` cycle at {database_key_index:#?}"
-                );
-                let active_query =
-                    zalsa_local.push_query(database_key_index, IterationCount::initial());
-                let fallback_value = C::cycle_initial(db, id, C::id_to_input(zalsa, id));
-                let mut completed_query = active_query.pop();
-                completed_query
-                    .revisions
-                    .set_cycle_heads(CycleHeads::initial(
-                        database_key_index,
-                        IterationCount::initial(),
-                    ));
-                // We need this for `cycle_heads()` to work. We will unset this in the outer `execute()`.
-                *completed_query.revisions.verified_final.get_mut() = false;
-                self.insert_memo(
-                    zalsa,
-                    id,
-                    Memo::new(
-                        Some(fallback_value),
-                        zalsa.current_revision(),
-                        completed_query.revisions,
-                    ),
                     memo_ingredient_index,
                 )
             }

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -359,7 +359,6 @@ where
             &memo.revisions,
             verified_at,
             cycle_heads,
-            C::CYCLE_STRATEGY,
         ) || validate_same_iteration(
             zalsa,
             zalsa_local,
@@ -465,7 +464,6 @@ fn maybe_changed_after_cold_cycle(
                 );
             })
         },
-        CycleRecoveryStrategy::FallbackImmediate => VerifyResult::unchanged(),
         CycleRecoveryStrategy::Fixpoint => {
             crate::tracing::debug!(
                     "hit cycle at {database_key_index:?} in `maybe_changed_after`,  returning fixpoint initial value",
@@ -616,7 +614,6 @@ fn validate_provisional(
     memo_revisions: &QueryRevisions,
     memo_verified_at: Revision,
     cycle_heads: &CycleHeads,
-    cycle_recovery_strategy: CycleRecoveryStrategy,
 ) -> bool {
     crate::tracing::trace!("{database_key_index:?}: validate_provisional({database_key_index:?})",);
 
@@ -635,7 +632,7 @@ fn validate_provisional(
                 iteration,
                 verified_at,
             } => {
-                // Only consider the cycle head if it is from the same revision as the memo
+                // Only consider the cycle head if it is from the same revision as the memo.
                 if verified_at != memo_verified_at {
                     return false;
                 }
@@ -650,24 +647,7 @@ fn validate_provisional(
                 if iteration != cycle_head.iteration_count.load() {
                     return false;
                 }
-
-                // FIXME: We can ignore this, I just don't have a use-case for this.
-                if cycle_recovery_strategy == CycleRecoveryStrategy::FallbackImmediate {
-                    panic!("cannot mix `cycle_fn` and `cycle_result` in cycles")
-                }
             }
-            ProvisionalStatus::FallbackImmediate => match cycle_recovery_strategy {
-                CycleRecoveryStrategy::Panic => {
-                    // Queries without fallback are not considered when inside a cycle.
-                    return false;
-                }
-                // FIXME: We can do the same as with `CycleRecoveryStrategy::Panic` here, I just don't have
-                // a use-case for this.
-                CycleRecoveryStrategy::Fixpoint => {
-                    panic!("cannot mix `cycle_fn` and `cycle_result` in cycles")
-                }
-                CycleRecoveryStrategy::FallbackImmediate => {}
-            },
         }
     }
     // Relaxed is sufficient here because there are no other writes we need to ensure have

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,10 +85,11 @@ pub mod plumbing {
     #[cfg(feature = "accumulator")]
     pub use salsa_macro_rules::setup_accumulator_impl;
     pub use salsa_macro_rules::{
-        gate_accumulated, macro_if, maybe_backdate, maybe_default, maybe_default_tt,
-        return_mode_expression, return_mode_ty, setup_input_struct, setup_interned_struct,
-        setup_tracked_assoc_fn_body, setup_tracked_fn, setup_tracked_method_body,
-        setup_tracked_struct, unexpected_cycle_initial, unexpected_cycle_recovery,
+        cycle_recovery_return_previous, gate_accumulated, macro_if, maybe_backdate, maybe_default,
+        maybe_default_tt, return_mode_expression, return_mode_ty, setup_input_struct,
+        setup_interned_struct, setup_tracked_assoc_fn_body, setup_tracked_fn,
+        setup_tracked_method_body, setup_tracked_struct, unexpected_cycle_initial,
+        unexpected_cycle_recovery,
     };
 
     #[cfg(feature = "accumulator")]

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -660,15 +660,6 @@ impl QueryRevisions {
         }
     }
 
-    /// Returns a mutable reference to the `CycleHeads` for this query, or `None` if the list is empty.
-    pub(crate) fn cycle_heads_mut(&mut self) -> Option<&mut CycleHeads> {
-        self.extra
-            .0
-            .as_mut()
-            .map(|extra| &mut extra.cycle_heads)
-            .filter(|cycle_heads| !cycle_heads.is_empty())
-    }
-
     /// Sets the `CycleHeads` for this query.
     pub(crate) fn set_cycle_heads(&mut self, cycle_heads: CycleHeads) {
         match &mut self.extra.0 {

--- a/tests/cycle_fallback_immediate.rs
+++ b/tests/cycle_fallback_immediate.rs
@@ -3,8 +3,6 @@
 //! It is possible to omit the `cycle_fn`, only specifying `cycle_result` in which case
 //! an immediate fallback value is used as the cycle handling opposed to doing a fixpoint resolution.
 
-use std::sync::atomic::{AtomicI32, Ordering};
-
 #[salsa::tracked(cycle_result=cycle_result)]
 fn one_o_one(db: &dyn salsa::Database) -> u32 {
     let val = one_o_one(db);
@@ -24,18 +22,12 @@ fn simple() {
 
 #[salsa::tracked(cycle_result=two_queries_cycle_result)]
 fn two_queries1(db: &dyn salsa::Database) -> i32 {
-    two_queries2(db);
-    0
+    two_queries2(db) + 1
 }
 
 #[salsa::tracked]
 fn two_queries2(db: &dyn salsa::Database) -> i32 {
-    two_queries1(db);
-    // This is horribly against Salsa's rules, but we want to test that
-    // the value from within the cycle is not considered, and this is
-    // the only way I found.
-    static CALLS_COUNT: AtomicI32 = AtomicI32::new(0);
-    CALLS_COUNT.fetch_add(1, Ordering::Relaxed)
+    two_queries1(db)
 }
 
 fn two_queries_cycle_result(_db: &dyn salsa::Database, _id: salsa::Id) -> i32 {


### PR DESCRIPTION
## Summary

Alternative to https://github.com/salsa-rs/salsa/pull/1063

This PR implements `FallbackImmediate` on top of `Fixpoint` with a recovery function
that always returns `previous_value.clone()`. 

Unlike #1063, this PR doesn't preserve the behavior that all heads participating in 
the cycle return the fallback value. 

Now that I write this summary, preserving that behavior that all cycle heads 
return the fallback value is important for determinism or the results
start depending on the query execution order (it now suddenly matters for a query `a -> b` and `b -> a` whether you call `a` or `b` first). Which is the behavior that @carljm pointed out in https://github.com/salsa-rs/salsa/pull/798#issuecomment-2812855285



For context, see https://github.com/salsa-rs/salsa/pull/1059#discussion_r2678737797
