### PR TITLE
Detect overlapping supertype variants via leaf type IDs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ rustc-hash = "2"
 smallvec = { version = "1", features = ["const_new"] }
 thin-vec = { version = "0.2.14" }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
+typeid = "1.0"
 
 # Automatic ingredient registration.
 inventory = { version = "0.3.20", optional = true }

--- a/components/salsa-macro-rules/src/setup_input_struct.rs
+++ b/components/salsa-macro-rules/src/setup_input_struct.rs
@@ -207,6 +207,7 @@ macro_rules! setup_input_struct {
 
             impl $zalsa::SalsaStructInDb for $Struct {
                 type MemoIngredientMap = $zalsa::MemoIngredientSingletonIndex;
+                const LEAF_TYPE_IDS: &'static [$zalsa::ConstTypeId] = &[$zalsa::ConstTypeId::of::<$Struct>()];
 
                 fn lookup_ingredient_index(aux: &$zalsa::Zalsa) -> $zalsa::IngredientIndices {
                     aux.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>().into()

--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -237,6 +237,7 @@ macro_rules! setup_interned_struct {
 
             impl< $($db_lt_arg)? > $zalsa::SalsaStructInDb for $Struct< $($db_lt_arg)? > {
                 type MemoIngredientMap = $zalsa::MemoIngredientSingletonIndex;
+                const LEAF_TYPE_IDS: &'static [$zalsa::ConstTypeId] = &[$zalsa::ConstTypeId::of::<$Struct>()];
 
                 fn lookup_ingredient_index(aux: &$zalsa::Zalsa) -> $zalsa::IngredientIndices {
                     aux.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>().into()

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -123,6 +123,7 @@ macro_rules! setup_tracked_fn {
 
                     impl $zalsa::SalsaStructInDb for $InternedData<'_> {
                         type MemoIngredientMap = $zalsa::MemoIngredientSingletonIndex;
+                        const LEAF_TYPE_IDS: &'static [$zalsa::ConstTypeId] = &[$zalsa::ConstTypeId::of::<$InternedData>()];
 
                         fn lookup_ingredient_index(aux: &$zalsa::Zalsa) -> $zalsa::IngredientIndices {
                             $zalsa::IngredientIndices::empty()

--- a/components/salsa-macro-rules/src/setup_tracked_struct.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_struct.rs
@@ -254,6 +254,7 @@ macro_rules! setup_tracked_struct {
 
             impl $zalsa::SalsaStructInDb for $Struct<'_> {
                 type MemoIngredientMap = $zalsa::MemoIngredientSingletonIndex;
+                const LEAF_TYPE_IDS: &'static [$zalsa::ConstTypeId] = &[$zalsa::ConstTypeId::of::<$Struct<'static>>()];
 
                 fn lookup_ingredient_index(aux: &$zalsa::Zalsa) -> $zalsa::IngredientIndices {
                     aux.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>().into()

--- a/components/salsa-macros/src/supertype.rs
+++ b/components/salsa-macros/src/supertype.rs
@@ -1,4 +1,5 @@
 use proc_macro2::TokenStream;
+use syn::visit_mut::VisitMut;
 
 use crate::token_stream_with_error;
 
@@ -66,13 +67,68 @@ fn enum_impl(enum_item: syn::ItemEnum) -> syn::Result<TokenStream> {
         }
     };
 
+    // Build variant types with all enum lifetime params replaced by 'static,
+    // for use in const context (where generic lifetime params are not available).
+    let enum_lifetimes: Vec<syn::Lifetime> = enum_item
+        .generics
+        .lifetimes()
+        .map(|lt| lt.lifetime.clone())
+        .collect();
+    let variant_types_static: Vec<syn::Type> = variant_types
+        .iter()
+        .map(|ty| replace_lifetimes_with_static(ty, &enum_lifetimes))
+        .collect();
+
+    // Generate variant index identifiers for the const concatenation
+    let variant_indices: Vec<syn::Ident> = variant_names
+        .iter()
+        .enumerate()
+        .map(|(i, _)| quote::format_ident!("__VARIANT_{}", i))
+        .collect();
+
     let salsa_struct_in_db = quote! {
         impl #impl_generics zalsa::SalsaStructInDb for #enum_name #type_generics
         #where_clause {
             type MemoIngredientMap = zalsa::MemoIngredientIndices;
 
+            const LEAF_TYPE_IDS: &'static [zalsa::ConstTypeId] = {
+                // Get each variant's leaf type IDs as consts.
+                // We use the 'static version of variant types since consts
+                // cannot reference generic lifetime parameters.
+                #(
+                    const #variant_indices: &[zalsa::ConstTypeId] =
+                        <#variant_types_static as zalsa::SalsaStructInDb>::LEAF_TYPE_IDS;
+                )*
+
+                // Total number of leaf type IDs across all variants
+                const __N: usize = #( #variant_indices.len() + )* 0;
+
+                // Build concatenated array
+                const __IDS: [zalsa::ConstTypeId; __N] = {
+                    let mut __result = [zalsa::ConstTypeId::of::<()>(); __N];
+                    let mut __dst: usize = 0;
+                    #(
+                        {
+                            let mut __i: usize = 0;
+                            while __i < #variant_indices.len() {
+                                __result[__dst] = #variant_indices[__i];
+                                __dst += 1;
+                                __i += 1;
+                            }
+                        }
+                    )*
+                    __result
+                };
+                &__IDS
+            };
+
             #[inline]
             fn lookup_ingredient_index(__zalsa: &zalsa::Zalsa) -> zalsa::IngredientIndices {
+                zalsa::assert_supertype_no_overlap(
+                    stringify!(#enum_name),
+                    &[#( <#variant_types_static as zalsa::SalsaStructInDb>::LEAF_TYPE_IDS ),*],
+                    &[#( stringify!(#variant_names) ),*],
+                );
                 zalsa::IngredientIndices::merge([ #( <#variant_types as zalsa::SalsaStructInDb>::lookup_ingredient_index(__zalsa) ),* ])
             }
 
@@ -122,4 +178,24 @@ fn enum_impl(enum_item: syn::ItemEnum) -> syn::Result<TokenStream> {
         };
     };
     Ok(all_impls)
+}
+
+/// Replace all occurrences of the given lifetime parameters with `'static`.
+///
+/// This is needed because associated consts cannot reference generic lifetime
+/// parameters from the enclosing impl block.
+fn replace_lifetimes_with_static(ty: &syn::Type, lifetimes: &[syn::Lifetime]) -> syn::Type {
+    struct LifetimeReplacer<'a>(&'a [syn::Lifetime]);
+
+    impl VisitMut for LifetimeReplacer<'_> {
+        fn visit_lifetime_mut(&mut self, lt: &mut syn::Lifetime) {
+            if self.0.iter().any(|param_lt| param_lt.ident == lt.ident) {
+                *lt = syn::Lifetime::new("'static", lt.apostrophe);
+            }
+        }
+    }
+
+    let mut ty = ty.clone();
+    LifetimeReplacer(lifetimes).visit_type_mut(&mut ty);
+    ty
 }

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -452,6 +452,7 @@ mod _memory_usage {
 
     impl SalsaStructInDb for DummyStruct {
         type MemoIngredientMap = MemoIngredientSingletonIndex;
+        const LEAF_TYPE_IDS: &'static [typeid::ConstTypeId] = &[];
 
         fn lookup_ingredient_index(_: &Zalsa) -> IngredientIndices {
             unimplemented!()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@ pub mod prelude {
 pub mod plumbing {
     pub use std::any::TypeId;
     pub use std::option::Option::{self, None, Some};
+    pub use typeid::ConstTypeId;
 
     #[cfg(feature = "accumulator")]
     pub use salsa_macro_rules::setup_accumulator_impl;
@@ -109,7 +110,7 @@ pub mod plumbing {
     };
     pub use crate::revision::{AtomicRevision, Revision};
     pub use crate::runtime::{Runtime, Stamp, stamp};
-    pub use crate::salsa_struct::SalsaStructInDb;
+    pub use crate::salsa_struct::{SalsaStructInDb, assert_supertype_no_overlap};
     pub use crate::storage::{HasStorage, Storage};
     pub use crate::table::memo::MemoTableWithTypes;
     pub use crate::tracked_struct::TrackedStructInDb;

--- a/src/salsa_struct.rs
+++ b/src/salsa_struct.rs
@@ -8,6 +8,15 @@ use crate::{DatabaseKeyIndex, Id, Revision};
 pub trait SalsaStructInDb: Sized {
     type MemoIngredientMap: MemoIngredientMap;
 
+    /// The type IDs of all concrete (leaf) salsa struct types that this type can contain.
+    ///
+    /// For concrete salsa structs (input/tracked/interned), this is a single-element slice
+    /// containing the struct's own type ID.
+    ///
+    /// For supertype enums, this is the concatenation of all variants' leaf type IDs,
+    /// enabling transitive overlap detection.
+    const LEAF_TYPE_IDS: &'static [typeid::ConstTypeId];
+
     /// Lookup or create ingredient indices.
     ///
     /// Note that this method does *not* create the ingredients themselves, this is handled by
@@ -78,4 +87,28 @@ pub trait SalsaStructInDb: Sized {
         id: Id,
         current_revision: Revision,
     ) -> MemoTableWithTypes<'_>;
+}
+
+/// Asserts that no two variants of a supertype enum transitively contain the same concrete
+/// salsa type. Called once at runtime from the generated `lookup_ingredient_index`.
+pub fn assert_supertype_no_overlap(
+    enum_name: &str,
+    variant_leaves: &[&[typeid::ConstTypeId]],
+    variant_names: &[&str],
+) {
+    for i in 0..variant_leaves.len() {
+        for j in (i + 1)..variant_leaves.len() {
+            for a in variant_leaves[i] {
+                for b in variant_leaves[j] {
+                    assert!(
+                        a != b,
+                        "supertype enum `{enum_name}` has overlapping variants: \
+                         `{}` and `{}` (transitively) contain the same concrete salsa type",
+                        variant_names[i],
+                        variant_names[j],
+                    );
+                }
+            }
+        }
+    }
 }

--- a/tests/interned-structs_self_ref.rs
+++ b/tests/interned-structs_self_ref.rs
@@ -142,6 +142,9 @@ const _: () = {
     impl zalsa_::SalsaStructInDb for InternedString<'_> {
         type MemoIngredientMap = zalsa_::MemoIngredientSingletonIndex;
 
+        const LEAF_TYPE_IDS: &'static [salsa::plumbing::ConstTypeId] =
+            &[salsa::plumbing::ConstTypeId::of::<InternedString>()];
+
         fn lookup_ingredient_index(aux: &Zalsa) -> salsa::plumbing::IngredientIndices {
             aux.lookup_jar_by_type::<zalsa_struct_::JarImpl<Configuration_>>()
                 .into()

--- a/tests/supertype_overlap.rs
+++ b/tests/supertype_overlap.rs
@@ -1,0 +1,99 @@
+//! Tests that overlapping variant types in supertype enums are detected.
+#![cfg(feature = "inventory")]
+
+use salsa::plumbing::ZalsaDatabase;
+
+#[salsa::interned(no_lifetime, debug)]
+struct Name {
+    text: String,
+}
+
+#[salsa::interned(no_lifetime, debug)]
+struct Age {
+    value: u32,
+}
+
+#[salsa::input(debug)]
+struct Input {
+    data: u32,
+}
+
+// ---- Test: direct overlap (same type in two variants) ----
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Supertype)]
+enum DirectOverlap {
+    First(Name),
+    Second(Name), // same type as First
+}
+
+#[test]
+#[should_panic(expected = "overlapping variants")]
+fn direct_overlap_detected() {
+    let db = salsa::DatabaseImpl::new();
+    let _name = Name::new(&db, "hello".to_string());
+    let _ =
+        <DirectOverlap as salsa::plumbing::SalsaStructInDb>::lookup_ingredient_index(db.zalsa());
+}
+
+// ---- Test: transitive overlap (nested supertype contains same type) ----
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Supertype)]
+enum Inner {
+    Name(Name),
+    Age(Age),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Supertype)]
+enum TransitiveOverlap {
+    Inner(Inner), // transitively contains Name and Age
+    Name(Name),   // overlaps with Inner's Name variant
+}
+
+#[test]
+#[should_panic(expected = "overlapping variants")]
+fn transitive_overlap_detected() {
+    let db = salsa::DatabaseImpl::new();
+    let _name = Name::new(&db, "hello".to_string());
+    let _ = <TransitiveOverlap as salsa::plumbing::SalsaStructInDb>::lookup_ingredient_index(
+        db.zalsa(),
+    );
+}
+
+// ---- Test: no overlap (disjoint types) ----
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Supertype)]
+enum NoOverlap {
+    Name(Name),
+    Age(Age),
+}
+
+#[test]
+fn no_overlap_is_fine() {
+    let db = salsa::DatabaseImpl::new();
+    let _name = Name::new(&db, "hello".to_string());
+    // This should NOT panic
+    let _ = <NoOverlap as salsa::plumbing::SalsaStructInDb>::lookup_ingredient_index(db.zalsa());
+}
+
+// ---- Test: no overlap with nesting (disjoint nested supertypes) ----
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Supertype)]
+enum DisjointInner {
+    Name(Name),
+    Age(Age),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::Supertype)]
+enum DisjointOuter {
+    Inner(DisjointInner),
+    Input(Input), // Input is not in DisjointInner, so no overlap
+}
+
+#[test]
+fn disjoint_nesting_is_fine() {
+    let db = salsa::DatabaseImpl::new();
+    let _name = Name::new(&db, "hello".to_string());
+    // This should NOT panic
+    let _ =
+        <DisjointOuter as salsa::plumbing::SalsaStructInDb>::lookup_ingredient_index(db.zalsa());
+}


### PR DESCRIPTION
This can cause hard to debug issues and is never useful so we should recognize this. Ideally at compile time but comparing type ids at compile time is not yet possible