### PR TITLE
Bump hashbrown to 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ salsa-macros = { version = "0.25.2", path = "components/salsa-macros", optional 
 boxcar = "0.2.13"
 crossbeam-queue = "0.3.12"
 crossbeam-utils = "0.8.21"
-hashbrown = "0.15"
+hashbrown = "0.17"
 hashlink = "0.10"
 indexmap = "2"
 intrusive-collections = "0.9.7"


### PR DESCRIPTION
Updates hashbrown to 0.17 to avoid that downstream consumers have to pull
in multiple hashbrown versions
