### PR TITLE
Exclude the book from published crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 description = "A generic framework for on-demand, incrementalized computation (experimental)"
+exclude = [
+    "book/",
+]
 
 [dependencies]
 salsa-macro-rules = { version = "0.26.1", path = "components/salsa-macro-rules" }


### PR DESCRIPTION
This has a couple of advantages.

Most obviously, this greatly reduces the sizes of the published crates, and doing so comes at no cost since nothing else in the crate references the contents of `book/`. Before this PR:

```
$ cargo publish --dry-run
[…]
    Packaged 347 files, 2.6MiB (696.8KiB compressed)
[…]
```

After this PR:
```
    Packaged 286 files, 1.2MiB (251.9KiB compressed)
```

Less obviously, the presence of `book/mermaid.css` and `book/mermaid.min.js` complicates the source license situation of the published crates. These files aren’t compiled into libraries or executables, but merely having them in the source means that people like me (working on a `rust-salsa` package for Fedora) *do* have to worry about whether their licenses are properly documented, properly attributed, and [allowable](https://docs.fedoraproject.org/en-US/legal/all-allowed/), including both `mermaid` itself and any NPM dependencies bundled into `mermaid.min.js`. Excluding these unnecessary sources from the crate makes all of these annoyances disappear.