### PR TITLE
Do not use `#[allow(non_local_definitions)]`

### DIFF
--- a/benches/accumulator.rs
+++ b/benches/accumulator.rs
@@ -19,7 +19,7 @@ struct Expression<'db> {
 
 #[salsa::tracked]
 #[inline(never)]
-fn root<'db>(db: &'db dyn salsa::Database, input: Input) -> Vec<usize> {
+fn root(db: &dyn salsa::Database, input: Input) -> Vec<usize> {
     (0..input.expressions(db))
         .map(|i| infer_expression(db, Expression::new(db, i)))
         .collect()

--- a/benches/dataflow.rs
+++ b/benches/dataflow.rs
@@ -50,7 +50,7 @@ impl Type {
 }
 
 #[salsa::tracked(cycle_fn=use_cycle_recover, cycle_initial=use_cycle_initial)]
-fn infer_use<'db>(db: &'db dyn Db, u: Use) -> Type {
+fn infer_use(db: &dyn Db, u: Use) -> Type {
     let defs = u.reaching_definitions(db);
     match defs[..] {
         [] => Type::Bottom,
@@ -60,7 +60,7 @@ fn infer_use<'db>(db: &'db dyn Db, u: Use) -> Type {
 }
 
 #[salsa::tracked(cycle_fn=def_cycle_recover, cycle_initial=def_cycle_initial)]
-fn infer_definition<'db>(db: &'db dyn Db, def: Definition) -> Type {
+fn infer_definition(db: &dyn Db, def: Definition) -> Type {
     let increment_ty = Type::Values(Box::from([def.increment(db)]));
     if let Some(base) = def.base(db) {
         let base_ty = infer_use(db, base);

--- a/benches/incremental.rs
+++ b/benches/incremental.rs
@@ -15,7 +15,7 @@ struct Tracked<'db> {
 
 #[salsa::tracked(returns(ref))]
 #[inline(never)]
-fn index<'db>(db: &'db dyn salsa::Database, input: Input) -> Vec<Tracked<'db>> {
+fn index(db: &dyn salsa::Database, input: Input) -> Vec<Tracked<'_>> {
     (0..input.field(db)).map(|i| Tracked::new(db, i)).collect()
 }
 

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -95,13 +95,43 @@ macro_rules! setup_tracked_fn {
         ) -> ::salsa::plumbing::return_mode_ty!(($return_mode, __), $db_lt, $output_ty) {
             use ::salsa::plumbing as $zalsa;
 
+            $zalsa::attach($db, || {
+                let (zalsa, zalsa_local) = $db.zalsas();
+                let result = $zalsa::macro_if! {
+                    if $needs_interner {
+                        {
+                            let key = $fn_name::intern_ingredient_(zalsa).intern_id(zalsa, zalsa_local, ($($input_id),*), |_, data| data);
+                            $fn_name::fn_ingredient_($db, zalsa).fetch($db, zalsa, zalsa_local, key)
+                        }
+                    } else {
+                        {
+                            $fn_name::fn_ingredient_($db, zalsa).fetch($db, zalsa, zalsa_local, $zalsa::AsId::as_id(&($($input_id),*)))
+                        }
+                    }
+                };
+
+                $zalsa::return_mode_expression!(($return_mode, __), $output_ty, result,)
+            })
+        }
+
+        // The module needs be last in the macro expansion in order to make the tracked
+        // function's ident be identified as a function, not a struct, during semantic highlighting.
+        // for more details, see https://github.com/salsa-rs/salsa/pull/612.
+        #[doc(hidden)]
+        #[allow(non_camel_case_types)]
+        $vis struct $fn_name {
+            _priv: ::std::convert::Infallible,
+        }
+
+        const _: () = {
+            use ::salsa::plumbing as $zalsa;
+
             struct $Configuration;
 
             $zalsa::register_jar! {
                 $zalsa::ErasedJar::erase::<$fn_name>()
             }
 
-            #[allow(non_local_definitions)]
             impl $zalsa::HasJar for $fn_name {
                 type Jar = $fn_name;
                 const KIND: $zalsa::JarKind = $zalsa::JarKind::TrackedFn;
@@ -357,7 +387,6 @@ macro_rules! setup_tracked_fn {
                 }
             }
 
-            #[allow(non_local_definitions)]
             impl $zalsa::Jar for $fn_name {
                 fn create_ingredients(
                     zalsa: &mut $zalsa::Zalsa,
@@ -421,7 +450,6 @@ macro_rules! setup_tracked_fn {
                 }
             }
 
-            #[allow(non_local_definitions)]
             impl $fn_name {
                 $zalsa::gate_accumulated! {
                     pub fn accumulated<$db_lt, A: ::salsa::Accumulator>(
@@ -466,34 +494,21 @@ macro_rules! setup_tracked_fn {
                 fn set_lru_capacity(db: &mut dyn $Db, value: usize) where for<'trivial_bounds> $Eviction: $zalsa::function::HasCapacity {
                     $Configuration::fn_ingredient_mut(db).set_capacity(value);
                 }
-            }
 
-            $zalsa::attach($db, || {
-                let (zalsa, zalsa_local) = $db.zalsas();
-                let result = $zalsa::macro_if! {
-                    if $needs_interner {
-                        {
-                            let key = $Configuration::intern_ingredient_(zalsa).intern_id(zalsa, zalsa_local, ($($input_id),*), |_, data| data);
-                            $Configuration::fn_ingredient_($db, zalsa).fetch($db, zalsa, zalsa_local, key)
-                        }
-                    } else {
-                        {
-                            $Configuration::fn_ingredient_($db, zalsa).fetch($db, zalsa, zalsa_local, $zalsa::AsId::as_id(&($($input_id),*)))
-                        }
+                $zalsa::macro_if! { $needs_interner =>
+                    #[inline]
+                    fn intern_ingredient_(
+                        zalsa: &$zalsa::Zalsa,
+                    ) -> &$zalsa::interned::IngredientImpl<$Configuration> {
+                        $Configuration::intern_ingredient_(zalsa)
                     }
-                };
+                }
 
-                $zalsa::return_mode_expression!(($return_mode, __), $output_ty, result,)
-            })
-        }
-
-        // The struct needs be last in the macro expansion in order to make the tracked
-        // function's ident be identified as a function, not a struct, during semantic highlighting.
-        // for more details, see https://github.com/salsa-rs/salsa/pull/612.
-        #[doc(hidden)]
-        #[allow(non_camel_case_types)]
-        $vis struct $fn_name {
-            _priv: ::std::convert::Infallible,
-        }
+                #[inline]
+                fn fn_ingredient_<'z>(db: &dyn $Db, zalsa: &'z $zalsa::Zalsa) -> &'z $zalsa::function::IngredientImpl<$Configuration> {
+                    $Configuration::fn_ingredient_(db, zalsa)
+                }
+            }
+        };
     };
 }

--- a/tests/cycle.rs
+++ b/tests/cycle.rs
@@ -170,7 +170,7 @@ where
 
 /// Query minimum value of inputs, with cycle recovery.
 #[salsa::tracked(cycle_fn=cycle_recover, cycle_initial=min_initial)]
-fn min_iterate<'db>(db: &'db dyn Db, inputs: Inputs) -> Value {
+fn min_iterate(db: &dyn Db, inputs: Inputs) -> Value {
     fold_values(inputs.values(db), u8::min)
 }
 
@@ -180,7 +180,7 @@ fn min_initial(_db: &dyn Db, _id: salsa::Id, _inputs: Inputs) -> Value {
 
 /// Query maximum value of inputs, with cycle recovery.
 #[salsa::tracked(cycle_fn=cycle_recover, cycle_initial=max_initial)]
-fn max_iterate<'db>(db: &'db dyn Db, inputs: Inputs) -> Value {
+fn max_iterate(db: &dyn Db, inputs: Inputs) -> Value {
     fold_values(inputs.values(db), u8::max)
 }
 
@@ -190,13 +190,13 @@ fn max_initial(_db: &dyn Db, _id: salsa::Id, _inputs: Inputs) -> Value {
 
 /// Query minimum value of inputs, without cycle recovery.
 #[salsa::tracked]
-fn min_panic<'db>(db: &'db dyn Db, inputs: Inputs) -> Value {
+fn min_panic(db: &dyn Db, inputs: Inputs) -> Value {
     fold_values(inputs.values(db), u8::min)
 }
 
 /// Query maximum value of inputs, without cycle recovery.
 #[salsa::tracked]
-fn max_panic<'db>(db: &'db dyn Db, inputs: Inputs) -> Value {
+fn max_panic(db: &dyn Db, inputs: Inputs) -> Value {
     fold_values(inputs.values(db), u8::max)
 }
 

--- a/tests/cycle_dependency_order_different_entry_queries.rs
+++ b/tests/cycle_dependency_order_different_entry_queries.rs
@@ -20,7 +20,7 @@ struct Interned {
 }
 
 #[salsa::tracked(cycle_initial=|db, _| Interned::new(db, 0))]
-fn query_b<'db>(db: &'db dyn Database) -> Interned<'db> {
+fn query_b(db: &dyn Database) -> Interned<'_> {
     query_c(db);
     Interned::new(db, 2)
 }

--- a/tests/cycle_input_different_cycle_head.rs
+++ b/tests/cycle_input_different_cycle_head.rs
@@ -62,7 +62,7 @@ struct Interned {
 }
 
 #[salsa::tracked(cycle_initial=cycle_initial)]
-fn query_b<'db>(db: &'db dyn MyDb) -> u32 {
+fn query_b(db: &dyn MyDb) -> u32 {
     query_c(db)
 }
 

--- a/tests/cycle_left_recursive_query.rs
+++ b/tests/cycle_left_recursive_query.rs
@@ -7,7 +7,7 @@ use salsa::{Database, Durability, Id};
 mod common;
 
 #[salsa::tracked(cycle_initial=cycle_initial)]
-fn query_a<'db>(db: &'db dyn salsa::Database) -> Interned<'db> {
+fn query_a(db: &dyn salsa::Database) -> Interned<'_> {
     let interned = query_b(db);
     let value = interned.value(db);
 
@@ -19,7 +19,7 @@ fn query_a<'db>(db: &'db dyn salsa::Database) -> Interned<'db> {
 }
 
 #[salsa::tracked]
-fn query_b<'db>(db: &'db dyn Database) -> Interned<'db> {
+fn query_b(db: &dyn Database) -> Interned<'_> {
     let interned = query_a(db);
     query_x(db, interned);
     interned

--- a/tests/cycle_maybe_changed_after.rs
+++ b/tests/cycle_maybe_changed_after.rs
@@ -18,12 +18,12 @@ struct Output<'db> {
 }
 
 #[salsa::tracked(cycle_initial=query_a_initial)]
-fn query_c<'db>(db: &'db dyn salsa::Database, input: Input) -> u32 {
+fn query_c(db: &dyn salsa::Database, input: Input) -> u32 {
     query_d(db, input)
 }
 
 #[salsa::tracked]
-fn query_d<'db>(db: &'db dyn salsa::Database, input: Input) -> u32 {
+fn query_d(db: &dyn salsa::Database, input: Input) -> u32 {
     let value = query_c(db, input);
     if value < input.max(db) * 2 {
         // Only the first iteration depends on value but the entire
@@ -46,12 +46,12 @@ fn query_a_initial(_db: &dyn Database, _id: salsa::Id, _input: Input) -> u32 {
 #[test_log::test]
 fn first_iteration_input_only() {
     #[salsa::tracked(cycle_initial=query_a_initial)]
-    fn query_a<'db>(db: &'db dyn salsa::Database, input: Input) -> u32 {
+    fn query_a(db: &dyn salsa::Database, input: Input) -> u32 {
         query_b(db, input)
     }
 
     #[salsa::tracked]
-    fn query_b<'db>(db: &'db dyn salsa::Database, input: Input) -> u32 {
+    fn query_b(db: &dyn salsa::Database, input: Input) -> u32 {
         let value = query_a(db, input);
 
         if value < input.max(db) {
@@ -118,7 +118,7 @@ fn nested_cycle_fewer_dependencies_in_first_iteration() {
     }
 
     #[salsa::tracked(cycle_initial=head_initial)]
-    fn cycle_head<'db>(db: &'db dyn salsa::Database, input: Input) -> Option<ClassLiteral<'db>> {
+    fn cycle_head(db: &dyn salsa::Database, input: Input) -> Option<ClassLiteral<'_>> {
         let b = cycle_outer(db, input);
         tracing::info!("query_b = {b:?}");
 
@@ -133,15 +133,12 @@ fn nested_cycle_fewer_dependencies_in_first_iteration() {
     }
 
     #[salsa::tracked]
-    fn cycle_outer<'db>(db: &'db dyn salsa::Database, input: Input) -> Option<ClassLiteral<'db>> {
+    fn cycle_outer(db: &dyn salsa::Database, input: Input) -> Option<ClassLiteral<'_>> {
         cycle_participant(db, input)
     }
 
     #[salsa::tracked]
-    fn cycle_participant<'db>(
-        db: &'db dyn salsa::Database,
-        input: Input,
-    ) -> Option<ClassLiteral<'db>> {
+    fn cycle_participant(db: &dyn salsa::Database, input: Input) -> Option<ClassLiteral<'_>> {
         let value = cycle_head(db, input);
         tracing::info!("cycle_head = {value:?}");
 
@@ -154,7 +151,7 @@ fn nested_cycle_fewer_dependencies_in_first_iteration() {
     }
 
     #[salsa::tracked(returns(ref))]
-    fn index<'db>(db: &'db dyn salsa::Database, input: Input) -> Index<'db> {
+    fn index(db: &dyn salsa::Database, input: Input) -> Index<'_> {
         Index {
             scope: Scope::new(db, input.value(db) * 2),
         }

--- a/tests/cycle_tracked.rs
+++ b/tests/cycle_tracked.rs
@@ -207,10 +207,7 @@ struct IterationNode<'db> {
 /// 4. Third iteration (only for variant=1): returns `[iter_0, iter_1, iter_2]`
 /// 5. Further iterations: no change, fixpoint reached
 #[salsa::tracked(cycle_initial=initial_with_structs)]
-fn create_tracked_in_cycle<'db>(
-    db: &'db dyn Database,
-    input: GraphInput,
-) -> Vec<IterationNode<'db>> {
+fn create_tracked_in_cycle(db: &dyn Database, input: GraphInput) -> Vec<IterationNode<'_>> {
     // Check if we should create more nodes based on the input.
     let variant = input.fixpoint_variant(db);
 

--- a/tests/cycle_tracked_own_input.rs
+++ b/tests/cycle_tracked_own_input.rs
@@ -53,7 +53,7 @@ impl Type<'_> {
 }
 
 #[salsa::tracked(cycle_initial=infer_class_initial)]
-fn infer_class<'db>(db: &'db dyn salsa::Database, node: ClassNode) -> Type<'db> {
+fn infer_class(db: &dyn salsa::Database, node: ClassNode) -> Type<'_> {
     Type::Class(Class::new(
         db,
         node.name(db),
@@ -62,7 +62,7 @@ fn infer_class<'db>(db: &'db dyn salsa::Database, node: ClassNode) -> Type<'db> 
 }
 
 #[salsa::tracked]
-fn infer_type_param<'db>(db: &'db dyn salsa::Database, node: TypeParamNode) -> TypeParam<'db> {
+fn infer_type_param(db: &dyn salsa::Database, node: TypeParamNode) -> TypeParam<'_> {
     if let Some(constraint) = node.constraint(db) {
         // Reuse the type param from the class if any.
         // The example is a bit silly, because it's a reduction of what we have in Astral's type checker

--- a/tests/dataflow.rs
+++ b/tests/dataflow.rs
@@ -51,7 +51,7 @@ impl Type {
 }
 
 #[salsa::tracked(cycle_fn=use_cycle_recover, cycle_initial=use_cycle_initial)]
-fn infer_use<'db>(db: &'db dyn Db, u: Use) -> Type {
+fn infer_use(db: &dyn Db, u: Use) -> Type {
     let defs = u.reaching_definitions(db);
     match defs[..] {
         [] => Type::Bottom,
@@ -61,7 +61,7 @@ fn infer_use<'db>(db: &'db dyn Db, u: Use) -> Type {
 }
 
 #[salsa::tracked(cycle_fn=def_cycle_recover, cycle_initial=def_cycle_initial)]
-fn infer_definition<'db>(db: &'db dyn Db, def: Definition) -> Type {
+fn infer_definition(db: &dyn Db, def: Definition) -> Type {
     let increment_ty = Type::Values(Box::from([def.increment(db)]));
     if let Some(base) = def.base(db) {
         let base_ty = infer_use(db, base);

--- a/tests/interned-revisions.rs
+++ b/tests/interned-revisions.rs
@@ -39,7 +39,7 @@ struct NestedInterned<'db> {
 #[test]
 fn test_intern_new() {
     #[salsa::tracked]
-    fn function<'db>(db: &'db dyn Database, input: Input) -> Interned<'db> {
+    fn function(db: &dyn Database, input: Input) -> Interned<'_> {
         Interned::new(db, BadHash(input.field1(db)))
     }
 
@@ -106,7 +106,7 @@ fn test_reintern() {
 #[test]
 fn test_durability() {
     #[salsa::tracked]
-    fn function<'db>(db: &'db dyn Database, _input: Input) -> Interned<'db> {
+    fn function(db: &dyn Database, _input: Input) -> Interned<'_> {
         Interned::new(db, BadHash(0))
     }
 
@@ -143,7 +143,7 @@ struct Immortal<'db> {
 #[test]
 fn test_immortal() {
     #[salsa::tracked]
-    fn function<'db>(db: &'db dyn Database, input: Input) -> Immortal<'db> {
+    fn function(db: &dyn Database, input: Input) -> Immortal<'_> {
         Immortal::new(db, BadHash(input.field1(db)))
     }
 
@@ -167,7 +167,7 @@ fn test_immortal() {
 #[test]
 fn test_reuse() {
     #[salsa::tracked]
-    fn function<'db>(db: &'db dyn Database, input: Input) -> Interned<'db> {
+    fn function(db: &dyn Database, input: Input) -> Interned<'_> {
         Interned::new(db, BadHash(input.field1(db)))
     }
 
@@ -267,12 +267,12 @@ fn test_reuse() {
 #[test]
 fn test_reuse_indirect() {
     #[salsa::tracked]
-    fn intern<'db>(db: &'db dyn Database, input: Input, value: usize) -> Interned<'db> {
+    fn intern(db: &dyn Database, input: Input, value: usize) -> Interned<'_> {
         intern_inner(db, input, value)
     }
 
     #[salsa::tracked]
-    fn intern_inner<'db>(db: &'db dyn Database, input: Input, value: usize) -> Interned<'db> {
+    fn intern_inner(db: &dyn Database, input: Input, value: usize) -> Interned<'_> {
         let _i = input.field1(db); // Only low durability interned values are garbage collected.
         Interned::new(db, BadHash(value))
     }
@@ -313,7 +313,7 @@ fn test_reuse_indirect() {
 fn test_reuse_interned_input() {
     // A query that creates an interned value.
     #[salsa::tracked]
-    fn create_interned<'db>(db: &'db dyn Database, input: Input) -> Interned<'db> {
+    fn create_interned(db: &dyn Database, input: Input) -> Interned<'_> {
         Interned::new(db, BadHash(input.field1(db)))
     }
 
@@ -355,7 +355,7 @@ fn test_reuse_interned_input() {
 fn test_reuse_multiple_interned_input() {
     // A query that creates an interned value.
     #[salsa::tracked]
-    fn create_interned<'db>(db: &'db dyn Database, input: Input) -> Interned<'db> {
+    fn create_interned(db: &dyn Database, input: Input) -> Interned<'_> {
         Interned::new(db, BadHash(input.field1(db)))
     }
 
@@ -422,7 +422,7 @@ fn test_reuse_multiple_interned_input() {
 #[test]
 fn test_durability_increase() {
     #[salsa::tracked]
-    fn intern<'db>(db: &'db dyn Database, input: Input, value: usize) -> Interned<'db> {
+    fn intern(db: &dyn Database, input: Input, value: usize) -> Interned<'_> {
         let _f = input.field1(db);
         Interned::new(db, BadHash(value))
     }

--- a/tests/memory-usage.rs
+++ b/tests/memory-usage.rs
@@ -16,22 +16,22 @@ struct MyInterned<'db> {
 }
 
 #[salsa::tracked]
-fn input_to_interned<'db>(db: &'db dyn salsa::Database, input: MyInput) -> MyInterned<'db> {
+fn input_to_interned(db: &dyn salsa::Database, input: MyInput) -> MyInterned<'_> {
     MyInterned::new(db, input.field(db))
 }
 
 #[salsa::tracked]
-fn input_to_tracked<'db>(db: &'db dyn salsa::Database, input: MyInput) -> MyTracked<'db> {
+fn input_to_tracked(db: &dyn salsa::Database, input: MyInput) -> MyTracked<'_> {
     MyTracked::new(db, input.field(db))
 }
 
 #[salsa::tracked]
-fn input_to_string<'db>(_db: &'db dyn salsa::Database) -> String {
+fn input_to_string(_db: &dyn salsa::Database) -> String {
     "a".repeat(1000)
 }
 
 #[salsa::tracked(heap_size = string_size_of)]
-fn input_to_string_get_size<'db>(_db: &'db dyn salsa::Database) -> String {
+fn input_to_string_get_size(_db: &dyn salsa::Database) -> String {
     "a".repeat(1000)
 }
 
@@ -44,10 +44,10 @@ fn string_tuple_size_of((x,): &(String,)) -> usize {
 }
 
 #[salsa::tracked]
-fn input_to_tracked_tuple<'db>(
-    db: &'db dyn salsa::Database,
+fn input_to_tracked_tuple(
+    db: &dyn salsa::Database,
     input: MyInput,
-) -> (MyTracked<'db>, MyTracked<'db>) {
+) -> (MyTracked<'_>, MyTracked<'_>) {
     (
         MyTracked::new(db, input.field(db)),
         MyTracked::new(db, input.field(db)),

--- a/tests/persistence.rs
+++ b/tests/persistence.rs
@@ -317,13 +317,13 @@ fn partial_query() {
     use salsa::plumbing::ZalsaDatabase;
 
     #[salsa::tracked(persist)]
-    fn query<'db>(db: &'db dyn salsa::Database, input: MyInput) -> usize {
+    fn query(db: &dyn salsa::Database, input: MyInput) -> usize {
         inner_query(db, input) + 1
     }
 
     // Note that the inner query is not persisted, but we should still preserve the dependency on `input.field`.
     #[salsa::tracked]
-    fn inner_query<'db>(db: &'db dyn salsa::Database, input: MyInput) -> usize {
+    fn inner_query(db: &dyn salsa::Database, input: MyInput) -> usize {
         input.field(db)
     }
 
@@ -427,17 +427,13 @@ fn partial_query_interned() {
     use salsa::plumbing::{AsId, ZalsaDatabase};
 
     #[salsa::tracked(persist)]
-    fn intern<'db>(db: &'db dyn salsa::Database, input: MyInput, value: usize) -> MyInterned<'db> {
+    fn intern(db: &dyn salsa::Database, input: MyInput, value: usize) -> MyInterned<'_> {
         do_intern(db, input, value)
     }
 
     // Note that the inner query is not persisted, but we should still preserve the dependency on `MyInterned`.
     #[salsa::tracked]
-    fn do_intern<'db>(
-        db: &'db dyn salsa::Database,
-        input: MyInput,
-        value: usize,
-    ) -> MyInterned<'db> {
+    fn do_intern(db: &dyn salsa::Database, input: MyInput, value: usize) -> MyInterned<'_> {
         let _i = input.field(db); // Only low durability interned values are garbage collected.
         MyInterned::new(db, value.to_string())
     }
@@ -572,7 +568,7 @@ fn partial_query_interned() {
 #[should_panic(expected = "must be persistable")]
 fn invalid_specified_dependency() {
     #[salsa::tracked]
-    fn specify<'db>(db: &'db dyn salsa::Database) {
+    fn specify(db: &dyn salsa::Database) {
         let tracked = MyTracked::new(db, "a".to_string());
         specified_query::specify(db, tracked, 2222);
     }

--- a/tests/tracked-struct-id-field-bad-hash.rs
+++ b/tests/tracked-struct-id-field-bad-hash.rs
@@ -55,7 +55,7 @@ fn execute() {
 }
 
 #[salsa::tracked]
-fn create_tracked<'db>(db: &'db dyn Db, input: MyInput) -> MyTracked<'db> {
+fn create_tracked(db: &dyn Db, input: MyInput) -> MyTracked<'_> {
     MyTracked::new(db, BadHash::from(input.field(db)))
 }
 

--- a/tests/tracked_struct_durability.rs
+++ b/tests/tracked_struct_durability.rs
@@ -57,13 +57,13 @@ struct Inference<'db> {
 }
 
 #[salsa::tracked]
-fn index<'db>(db: &'db dyn Db, file: File) -> Index<'db> {
+fn index(db: &dyn Db, file: File) -> Index<'_> {
     let _ = file.field(db);
     Index::new(db, Definitions::new(db, Definition::new(db, file)))
 }
 
 #[salsa::tracked]
-fn definitions<'db>(db: &'db dyn Db, file: File) -> Definitions<'db> {
+fn definitions(db: &dyn Db, file: File) -> Definitions<'_> {
     index(db, file).definitions(db)
 }
 
@@ -81,7 +81,7 @@ fn infer<'db>(db: &'db dyn Db, definition: Definition<'db>) -> Inference<'db> {
 }
 
 #[salsa::tracked]
-fn check<'db>(db: &'db dyn Db, file: File) -> Inference<'db> {
+fn check(db: &dyn Db, file: File) -> Inference<'_> {
     let defs = definitions(db, file);
     infer(db, defs.definition(db))
 }


### PR DESCRIPTION
It was a bad idea from the beginning, but now rust-analyzer started reporting trait errors, and since it cannot find those impls it report errors on any tracked fn, which is... not fun.

Closes https://github.com/salsa-rs/salsa/issues/607