### PR TITLE
Skip memory usage tests on 32-bit (non-64-bit) targets

### DIFF
--- a/tests/memory-usage.rs
+++ b/tests/memory-usage.rs
@@ -1,4 +1,6 @@
 #![cfg(feature = "inventory")]
+// Expected sizes assume a 64-bit target.
+#![cfg(target_pointer_width = "64")]
 
 #[salsa::input(heap_size = string_tuple_size_of)]
 struct MyInput {


### PR DESCRIPTION
The expected data structure sizes are based on 64-bit targets, so these tests fail on 32-bit targets. It probably makes more sense to restrict these tests to 64-bit targets than to maintain an alternative set of expectations for 32-bit targets.