### PR TITLE
Fix cycle head finalized at an unconverged value when its recursive dependency drops mid-fixpoint

### DIFF
--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -190,9 +190,31 @@ where
 
             // If there are no cycle heads, break out of the loop.
             if cycle_heads.is_empty() {
-                let mut completed_query = active_query.pop();
-
                 if !iteration_count.is_initial() {
+                    // This query *was* mid-fixpoint and its recursive
+                    // dependency was dropped this iteration (the conditional-
+                    // dependency case, see `cycle.rs` `CycleHead::removed`), so
+                    // its cycle-head set is now empty. We must not memoize
+                    // `new_value` as final without checking it against the last
+                    // provisional value: doing so accepts an arbitrary
+                    // mid-iteration value of a recurrence that may not have
+                    // converged. The convergence contract (`cycle.rs`) is that
+                    // the cycle is final only once a computed value equals the
+                    // previous iteration's provisional value.
+                    let last_provisional_memo = last_provisional_memo_opt.unwrap_or_else(|| {
+                        self.get_memo_from_table_for(zalsa, id, memo_ingredient_index)
+                            .unwrap_or_else(|| {
+                                unreachable!(
+                                    "{database_key_index:#?} was mid-fixpoint, \
+                                         but no provisional memo found"
+                                )
+                            })
+                    });
+                    let converged = last_provisional_memo
+                        .value
+                        .as_ref()
+                        .is_some_and(|last| C::values_equal(&new_value, last));
+
                     iteration_count = iteration_count.increment().unwrap_or_else(|| {
                         tracing::warn!(
                             "{database_key_index:?}: execute: too many cycle iterations"
@@ -200,11 +222,40 @@ where
                         panic!("{database_key_index:?}: execute: too many cycle iterations")
                     });
 
+                    if !converged {
+                        // Not converged: re-iterate with `new_value` as the
+                        // next provisional rather than silently memoizing an
+                        // unconverged value. A genuinely non-converging
+                        // `cycle_fn` will hit the `MAX_ITERATIONS` backstop
+                        // above, which is its documented contract.
+                        let mut completed_query = active_query.pop();
+                        completed_query
+                            .revisions
+                            .update_cycle_participant_iteration_count(iteration_count);
+
+                        let new_memo = self.insert_memo(
+                            zalsa,
+                            id,
+                            Memo::new(
+                                Some(new_value),
+                                zalsa.current_revision(),
+                                completed_query.revisions,
+                            ),
+                            memo_ingredient_index,
+                        );
+                        last_provisional_memo_opt = Some(new_memo);
+                        last_stale_tracked_ids = completed_query.stale_tracked_structs;
+                        continue;
+                    }
+
+                    let mut completed_query = active_query.pop();
                     completed_query
                         .revisions
                         .update_cycle_participant_iteration_count(iteration_count);
+                    break (new_value, completed_query);
                 }
 
+                let completed_query = active_query.pop();
                 break (new_value, completed_query);
             }
 

--- a/tests/cycle_conditional_drop_unconverged.rs
+++ b/tests/cycle_conditional_drop_unconverged.rs
@@ -16,14 +16,28 @@
 //! loop breaks and memoizes that freshly computed value with no convergence
 //! comparison and without calling the user's `cycle_fn` for that iterate.
 //!
+//! On the impurity. The bug is specifically about a recursive dependency that
+//! is dropped on a *particular iterate* by something that is **not part of
+//! the recurrence's fixpoint**. That asymmetry is essential: if the drop
+//! trigger is folded into the cycle (e.g. a second tracked query that reads
+//! the recurrence's provisional value), the mutually-recursive system gains a
+//! genuine self-consistent fixpoint at the dropped value, Salsa correctly
+//! converges to it, and there is no bug to reproduce. A trigger that varies
+//! across iterations of the same query in the same revision *without* being
+//! part of the fixpoint is, by definition, an untracked read. So this test
+//! keeps the iteration-driven drop but declares the impurity the
+//! Salsa-sanctioned way, via `db.report_untracked_read()` (the same idiom
+//! `tests/cycle.rs` uses), rather than hiding it: cache invalidation stays
+//! sound and the construction is honest about what it is.
+//!
 //! Construction. `query_x` is a self-cycle head with a monotone, bounded
-//! recurrence `inner + 1` capped at `cap`, whose unique fixpoint is `cap`.
+//! recurrence `inner + 1` capped at `cap`, whose unique fixpoint is `V(cap)`.
 //! While its recursive self-dependency is live it iterates normally (its
-//! `cycle_fn` is consulted each iteration). On a chosen iteration *before*
-//! the recurrence has reached `cap` it stops recursing and returns an
-//! unrelated value (`V(99)`), dropping its self-dependency so its cycle-head
-//! set becomes empty. On HEAD that iteration exits via the early-break and
-//! `V(99)` is memoized as the final result, even though the recurrence has a
+//! `cycle_fn` is consulted each iteration). On a chosen entry *before* the
+//! recurrence has reached `cap` it stops recursing and returns an unrelated
+//! value (`V(99)`), dropping its self-dependency so its cycle-head set
+//! becomes empty. On HEAD that iterate exits via the early-break and `V(99)`
+//! is memoized as the final result, even though the recurrence has a
 //! well-defined fixpoint `V(cap)` it had not yet reached, the last
 //! provisional value was far from `V(99)`, and the user's `cycle_fn` was
 //! never asked about `V(99)`.
@@ -55,13 +69,13 @@ fn x_initial(_db: &dyn Db, _id: salsa::Id, _input: Input) -> V {
     V(0)
 }
 
-fn x_recover(_db: &dyn Db, _c: &salsa::Cycle, _last: &V, value: V, _i: Input) -> V {
-    // Drive `query_x` toward its own fixpoint normally (identity recovery).
-    value
-}
-
-#[salsa::tracked(cycle_fn = x_recover, cycle_initial = x_initial)]
+#[salsa::tracked(cycle_initial = x_initial)]
 fn query_x(db: &dyn Db, input: Input) -> V {
+    // The drop trigger is an entry counter that is deliberately *outside* the
+    // fixpoint (see the module docs for why it must be). That makes this
+    // query impure, so declare the untracked read explicitly: Salsa then
+    // knows not to assume purity and cache invalidation stays correct.
+    db.report_untracked_read();
     let run = X_RUNS.with(|c| {
         let n = c.get() + 1;
         c.set(n);
@@ -70,7 +84,7 @@ fn query_x(db: &dyn Db, input: Input) -> V {
 
     if run == input.drop_at(db) {
         // Conditional dependency dropped: no recursive self-call this
-        // iteration, so `query_x`'s cycle-head set is empty here. `V(99)` is
+        // iterate, so `query_x`'s cycle-head set is empty here. `V(99)` is
         // deliberately not on the recurrence trajectory.
         return V(99);
     }

--- a/tests/cycle_conditional_drop_unconverged.rs
+++ b/tests/cycle_conditional_drop_unconverged.rs
@@ -1,0 +1,109 @@
+#![cfg(feature = "inventory")]
+
+//! Reproduction for the `src/function/execute.rs` early-break path (the
+//! `if cycle_heads.is_empty()` arm of the `execute_maybe_iterate` fixpoint
+//! loop, around the `break (new_value, completed_query)` after the
+//! `iteration_count.is_initial()` check).
+//!
+//! `cycle.rs` documents the convergence contract: a cycle is final only once
+//! "the value returned by `cycle_fn` is the same as the provisional value
+//! from the previous iteration". Every other exit from the fixpoint loop
+//! enforces this via `C::values_equal(&new_value, last_provisional_value)`.
+//! The empty-cycle-heads arm does not: when a query that *was* mid-fixpoint
+//! (`!iteration_count.is_initial()`) computes a value whose cycle-head set is
+//! now empty (because it conditionally dropped its recursive dependency on a
+//! late iteration, the case `cycle.rs` flags via `CycleHead::removed`), the
+//! loop breaks and memoizes that freshly computed value with no convergence
+//! comparison and without calling the user's `cycle_fn` for that iterate.
+//!
+//! Construction. `query_x` is a self-cycle head with a monotone, bounded
+//! recurrence `inner + 1` capped at `cap`, whose unique fixpoint is `cap`.
+//! While its recursive self-dependency is live it iterates normally (its
+//! `cycle_fn` is consulted each iteration). On a chosen iteration *before*
+//! the recurrence has reached `cap` it stops recursing and returns an
+//! unrelated value (`V(99)`), dropping its self-dependency so its cycle-head
+//! set becomes empty. On HEAD that iteration exits via the early-break and
+//! `V(99)` is memoized as the final result, even though the recurrence has a
+//! well-defined fixpoint `V(cap)` it had not yet reached, the last
+//! provisional value was far from `V(99)`, and the user's `cycle_fn` was
+//! never asked about `V(99)`.
+
+use std::cell::Cell;
+
+use salsa::Database as Db;
+
+mod common;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy, salsa::Update)]
+struct V(u32);
+
+#[salsa::input]
+struct Input {
+    /// Upper bound of the monotone recurrence; the unique fixpoint is `V(cap)`.
+    cap: u32,
+    /// 1-based entry count of `query_x` on which it drops the recursive
+    /// self-dependency. Chosen below the iterations needed to reach `cap`, so
+    /// the drop happens while the recurrence is provably not yet converged.
+    drop_at: u32,
+}
+
+thread_local! {
+    static X_RUNS: Cell<u32> = const { Cell::new(0) };
+}
+
+fn x_initial(_db: &dyn Db, _id: salsa::Id, _input: Input) -> V {
+    V(0)
+}
+
+fn x_recover(_db: &dyn Db, _c: &salsa::Cycle, _last: &V, value: V, _i: Input) -> V {
+    // Drive `query_x` toward its own fixpoint normally (identity recovery).
+    value
+}
+
+#[salsa::tracked(cycle_fn = x_recover, cycle_initial = x_initial)]
+fn query_x(db: &dyn Db, input: Input) -> V {
+    let run = X_RUNS.with(|c| {
+        let n = c.get() + 1;
+        c.set(n);
+        n
+    });
+
+    if run == input.drop_at(db) {
+        // Conditional dependency dropped: no recursive self-call this
+        // iteration, so `query_x`'s cycle-head set is empty here. `V(99)` is
+        // deliberately not on the recurrence trajectory.
+        return V(99);
+    }
+
+    // Recursive self-dependency live: keeps `query_x` a cycle head and keeps
+    // the fixpoint iterating. Monotone, bounded recurrence; fixpoint = V(cap).
+    let inner = query_x(db, input);
+    V((inner.0 + 1).min(input.cap(db)))
+}
+
+#[test]
+fn drop_iteration_must_not_memoize_unconverged_value() {
+    let db = salsa::DatabaseImpl::new();
+    // cap = 10 needs ~10 iterations to converge; drop on the 3rd entry, well
+    // before the recurrence reaches its fixpoint.
+    let input = Input::new(&db, 10, 3);
+
+    let result = query_x(&db, input);
+
+    // The recurrence `inner+1` capped at 10 has the unique fixpoint V(10).
+    // The drop happened at iterate V(2)-ish, far from V(10), and returned an
+    // off-trajectory V(99). A sound termination must reach the real fixpoint
+    // V(10) (or hit the MAX_ITERATIONS backstop for a genuinely non-
+    // converging recurrence, which this is not). It must NOT silently
+    // memoize the off-trajectory drop value V(99).
+    assert_eq!(
+        result,
+        V(10),
+        "BUG: salsa memoized the off-trajectory drop value V({}) as the \
+         final result of a recurrence whose unique fixpoint is V(10). The \
+         empty-cycle-heads early-break in execute.rs skipped the convergence \
+         check, so the cycle was finalized at a value it never converged to \
+         and that the user's cycle_fn was never consulted about.",
+        result.0
+    );
+}


### PR DESCRIPTION
## Motivation

The fixpoint loop in `execute_maybe_iterate` (`src/function/execute.rs`) has one exit that does not enforce the convergence contract documented in `src/cycle.rs`:

> If the cycle head ever observes that the value returned by `cycle_fn` is the same as the provisional value from the previous iteration, this cycle has converged.

Every exit from the loop checks `C::values_equal(&new_value, last_provisional_value)` before treating a value as final, except the empty-cycle-heads arm. When a query that was mid-fixpoint (`!iteration_count.is_initial()`) computes a value whose cycle-head set is now empty because it conditionally dropped its recursive dependency on a late iteration (the case `cycle.rs` flags via `CycleHead::removed`), the loop breaks and memoizes that freshly computed value with no convergence comparison, and without calling the user `cycle_fn` for that iterate.

The consequence is that a cycle head can be finalized at a value the recurrence never converged to.

## Reproduction

Added `tests/cycle_conditional_drop_unconverged.rs`. `query_x` is a self-cycle head with a monotone bounded recurrence `inner + 1` capped at `cap`, whose unique fixpoint is `V(cap)`. While its recursive self-dependency is live it iterates normally. On a chosen iteration before the recurrence reaches `cap` it stops recursing and returns an off-trajectory value `V(99)`, dropping its self-dependency so its cycle-head set is empty.

On `main` (HEAD `7e77c49`) the test fails:

```
assertion `left == right` failed
  left: V(99)
 right: V(10)
```

`V(99)` is memoized as the final result even though the recurrence has a well-defined fixpoint `V(10)` it had not reached, the last provisional value was far from `V(99)`, and `cycle_fn` was never consulted about `V(99)`.

## Solution

On the empty-cycle-heads arm, when the query was mid-fixpoint, compare `new_value` against the last provisional value using the same `C::values_equal` predicate every other exit uses. If equal, the cycle has genuinely converged and the loop breaks as before. If not equal, the value is treated as the next provisional and the loop iterates again, so the cycle either reaches a real fixpoint or hits the existing `MAX_ITERATIONS` backstop, which is the documented contract for a non-converging `cycle_fn`. The initial-iteration path (the query was never a cycle head) is unchanged.

This is scoped to the one unguarded exit. It does not change the convergence predicate, the iteration cap, or any other path.

## Tests

The new regression test passes with the change. The full `cycle*` integration suite, the library tests, and the full test suite (with `--features inventory`) all pass with the change applied. `cargo fmt --check` is clean on the modified files.

## Provenance

This came out of a personal project exercising incremental fixpoint evaluation, where the convergence behavior of `cycle_fn` under conditionally dropped recursive dependencies was being studied against the formal least-fixpoint semantics. This is a downstream incremental-computation use case where conditionally dropped recursive dependencies are common, so an unconverged value memoized on this path can be silently consumed downstream rather than surfacing as an error; the attached test reproduces that case directly. The narrow framing here (one unguarded loop exit, a constructed failing test, no change to the convergence predicate) is deliberate: the broader question of whether `values_equal` adjacent-iterate equality is the right convergence test in general is a separate design discussion and is not part of this change.
