### PR TITLE
fix: accumulated values lost when reused tracked fn skips re-execution

### DIFF
--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -190,8 +190,23 @@ where
             return Some(if old_memo.revisions.changed_at > revision {
                 VerifyResult::changed()
             } else {
-                // Returns unchanged but propagates the accumulated values
-                deep_verify
+                // Propagate accumulated values from inputs *and* from this memo itself.
+                // Without the own-accumulated check, a caller querying accumulated values
+                // would see `Empty` and skip traversing into this subtree even though
+                // this memo directly pushed accumulated values.
+                VerifyResult::unchanged_with_accumulated(
+                    #[cfg(feature = "accumulator")]
+                    {
+                        let VerifyResult::Unchanged { accumulated } = deep_verify else {
+                            unreachable!()
+                        };
+                        if old_memo.revisions.accumulated().is_some() {
+                            InputAccumulatedValues::Any
+                        } else {
+                            accumulated
+                        }
+                    },
+                )
             });
         }
 

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -185,7 +185,11 @@ where
 
         let deep_verify = self.deep_verify_memo(db, zalsa, old_memo, database_key_index);
 
-        if deep_verify.is_unchanged() {
+        if let VerifyResult::Unchanged {
+            #[cfg(feature = "accumulator")]
+            accumulated,
+        } = deep_verify
+        {
             // Check if the inputs are still valid. We can just compare `changed_at`.
             return Some(if old_memo.revisions.changed_at > revision {
                 VerifyResult::changed()
@@ -197,9 +201,6 @@ where
                 VerifyResult::unchanged_with_accumulated(
                     #[cfg(feature = "accumulator")]
                     {
-                        let VerifyResult::Unchanged { accumulated } = deep_verify else {
-                            unreachable!()
-                        };
                         if old_memo.revisions.accumulated().is_some() {
                             InputAccumulatedValues::Any
                         } else {

--- a/tests/accumulate-behind-tracked-fn.rs
+++ b/tests/accumulate-behind-tracked-fn.rs
@@ -1,0 +1,74 @@
+#![cfg(all(feature = "inventory", feature = "accumulator"))]
+
+//! Regression test for https://github.com/salsa-rs/salsa/issues/923.
+//!
+//! Accumulated values were silently dropped when a tracked fn that calls
+//! another tracked fn (which does the actual accumulating) is re-used
+//! without re-executing (its inputs haven't changed).
+
+use expect_test::expect;
+use salsa::{Accumulator, Setter};
+use test_log::test;
+
+#[salsa::input(debug)]
+struct List {
+    value: u32,
+    next: Option<List>,
+}
+
+#[allow(unused)]
+#[salsa::accumulator]
+#[derive(Copy, Clone, Debug)]
+struct Integers(u32);
+
+/// Outer tracked fn: iterates the list and delegates accumulation to `compute_single`.
+#[salsa::tracked]
+fn compute(db: &dyn salsa::Database, input: List) {
+    compute_single(db, input);
+    if let Some(next) = input.next(db) {
+        compute(db, next);
+    }
+}
+
+/// Inner tracked fn: performs the actual accumulation.
+#[salsa::tracked]
+fn compute_single(db: &dyn salsa::Database, input: List) {
+    Integers(input.value(db)).accumulate(db);
+}
+
+#[test]
+fn accumulated_values_not_lost_after_partial_reuse() {
+    let mut db = salsa::DatabaseImpl::new();
+
+    let l0 = List::new(&db, 1, None);
+    let l1 = List::new(&db, 10, Some(l0));
+
+    compute(&db, l1);
+    expect![[r#"
+        [
+            Integers(
+                10,
+            ),
+            Integers(
+                1,
+            ),
+        ]
+    "#]]
+    .assert_debug_eq(&compute::accumulated::<Integers>(&db, l1));
+
+    // Mutate l1; l0 is unchanged so compute(l0) / compute_single(l0) should be reused.
+    // Reused memos must still report their accumulated values so callers don't skip them.
+    l1.set_value(&mut db).to(11);
+    compute(&db, l1);
+    expect![[r#"
+        [
+            Integers(
+                11,
+            ),
+            Integers(
+                1,
+            ),
+        ]
+    "#]]
+    .assert_debug_eq(&compute::accumulated::<Integers>(&db, l1));
+}


### PR DESCRIPTION
When a tracked fn's inputs haven't changed, `maybe_changed_after_cold` fast-paths through `deep_verify_memo` and returns the `VerifyResult` directly. That result carries the accumulated flag from the fn's *edge inputs* only; if the fn itself pushed accumulated values, those are ignored. Callers upstream then see `Empty` and skip traversing this subtree, so accumulated values are silently dropped.

Fix: after `deep_verify` succeeds, check whether the memo's own `AccumulatedMap` is non-empty and return `Any` in that case, matching what the re-execute path already does (lines 229-232).

Fixes #923.