### PR TITLE
Refresh trybuild snapshots for Rust 1.96

### DIFF
--- a/tests/compile-fail/tracked_fn_return_not_update.stderr
+++ b/tests/compile-fail/tracked_fn_return_not_update.stderr
@@ -15,14 +15,14 @@ help: consider annotating `NotUpdate` with `#[derive(PartialEq)]`
  8 | struct NotUpdate;
    |
 
-error[E0599]: the function or associated item `maybe_update` exists for struct `salsa::plumbing::UpdateDispatch<NotUpdate>`, but its trait bounds were not satisfied
+error[E0599]: the associated function or constant `maybe_update` exists for struct `salsa::plumbing::UpdateDispatch<NotUpdate>`, but its trait bounds were not satisfied
   --> tests/compile-fail/tracked_fn_return_not_update.rs:10:56
    |
  7 | struct NotUpdate;
    | ---------------- doesn't satisfy `NotUpdate: PartialEq` or `NotUpdate: Update`
 ...
 10 | fn tracked_fn<'db>(db: &'db dyn Db, input: MyInput) -> NotUpdate {
-   |                                                        ^^^^^^^^^ function or associated item cannot be called on `salsa::plumbing::UpdateDispatch<NotUpdate>` due to unsatisfied trait bounds
+   |                                                        ^^^^^^^^^ associated function or constant cannot be called on `salsa::plumbing::UpdateDispatch<NotUpdate>` due to unsatisfied trait bounds
    |
   ::: src/update.rs
    |

--- a/tests/compile-fail/tracked_struct_not_update.stderr
+++ b/tests/compile-fail/tracked_struct_not_update.stderr
@@ -1,8 +1,8 @@
-error[E0599]: the function or associated item `maybe_update` exists for struct `salsa::plumbing::UpdateDispatch<NotUpdate>`, but its trait bounds were not satisfied
+error[E0599]: the associated function or constant `maybe_update` exists for struct `salsa::plumbing::UpdateDispatch<NotUpdate>`, but its trait bounds were not satisfied
  --> tests/compile-fail/tracked_struct_not_update.rs:1:1
   |
 1 | #[salsa::tracked]
-  | ^^^^^^^^^^^^^^^^^ function or associated item cannot be called on `salsa::plumbing::UpdateDispatch<NotUpdate>` due to unsatisfied trait bounds
+  | ^^^^^^^^^^^^^^^^^ associated function or constant cannot be called on `salsa::plumbing::UpdateDispatch<NotUpdate>` due to unsatisfied trait bounds
 ...
 7 | struct NotUpdate;
   | ---------------- doesn't satisfy `NotUpdate: PartialEq` or `NotUpdate: Update`


### PR DESCRIPTION
## Summary

Rust 1.96 changed the E0599 diagnostic wording, causing the stable CI trybuild suite to fail without a Salsa behavior change. This surfaced in https://github.com/salsa-rs/salsa/actions/runs/26809144934/job/79034228255?pr=1100.

