### PR TITLE
Add packed `QueryOrigin`

### DIFF
--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -11,9 +11,7 @@ use crate::key::DatabaseKeyIndex;
 use crate::runtime::Stamp;
 use crate::sync::atomic::AtomicBool;
 use crate::tracked_struct::{Disambiguator, DisambiguatorMap, IdentityHash, IdentityMap};
-use crate::zalsa_local::{
-    QueryEdge, QueryEdgeKind, QueryOrigin, QueryRevisions, QueryRevisionsExtra,
-};
+use crate::zalsa_local::{QueryEdge, QueryOrigin, QueryRevisions, QueryRevisionsExtra};
 use crate::{
     Id,
     cycle::{CycleHeads, IterationCount},
@@ -85,11 +83,7 @@ impl ActiveQuery {
 
         // Copy over outputs for `diff_outputs`, don't copy inputs because cycle heads
         // flatten all input dependencies.
-        self.input_outputs.extend(
-            edges
-                .iter()
-                .filter(|edge| matches!(edge.kind(), QueryEdgeKind::Output(_))),
-        );
+        self.input_outputs.extend(edges.iter_outputs());
         self.durability = self.durability.min(durability);
         self.changed_at = self.changed_at.max(changed_at);
         self.untracked_read |= untracked_read;

--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -6,13 +6,12 @@ use crate::accumulator::{
     Accumulator,
     accumulated_map::{AccumulatedMap, AtomicInputAccumulatedValues, InputAccumulatedValues},
 };
-use crate::hash::FxIndexSet;
 use crate::key::DatabaseKeyIndex;
 use crate::runtime::Stamp;
 use crate::sync::atomic::AtomicBool;
 use crate::tracked_struct::{Disambiguator, DisambiguatorMap, IdentityHash, IdentityMap};
 use crate::zalsa_local::{
-    QueryEdge, QueryEdgeKind, QueryOrigin, QueryRevisions, QueryRevisionsExtra,
+    ActiveQueryEdges, QueryEdge, QueryEdgeKind, QueryRevisions, QueryRevisionsExtra,
 };
 use crate::{
     Id,
@@ -37,7 +36,7 @@ pub(crate) struct ActiveQuery {
     ///
     /// * invocations of `specify`
     /// * accumulators pushed to
-    input_outputs: FxIndexSet<QueryEdge>,
+    input_outputs: ActiveQueryEdges,
 
     /// True if there was an untracked read.
     untracked_read: bool,
@@ -183,7 +182,7 @@ impl ActiveQuery {
             database_key_index,
             durability: Durability::MAX,
             changed_at: Revision::start(),
-            input_outputs: FxIndexSet::default(),
+            input_outputs: ActiveQueryEdges::default(),
             untracked_read: false,
             disambiguator_map: Default::default(),
             tracked_struct_ids: Default::default(),
@@ -213,11 +212,7 @@ impl ActiveQuery {
             accumulated_inputs,
         } = self;
 
-        let origin = if untracked_read {
-            QueryOrigin::derived_untracked(input_outputs.drain(..))
-        } else {
-            QueryOrigin::derived(input_outputs.drain(..))
-        };
+        let origin = input_outputs.take_origin(untracked_read);
         disambiguator_map.clear();
 
         #[cfg(feature = "accumulator")]

--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -77,7 +77,7 @@ impl ActiveQuery {
         &mut self,
         durability: Durability,
         changed_at: Revision,
-        edges: &[QueryEdge],
+        edges: crate::zalsa_local::QueryEdges<'_>,
         untracked_read: bool,
         active_tracked_ids: &[(Identity, Id)],
     ) {
@@ -88,8 +88,7 @@ impl ActiveQuery {
         self.input_outputs.extend(
             edges
                 .iter()
-                .filter(|edge| matches!(edge.kind(), QueryEdgeKind::Output(_)))
-                .copied(),
+                .filter(|edge| matches!(edge.kind(), QueryEdgeKind::Output(_))),
         );
         self.durability = self.durability.min(durability);
         self.changed_at = self.changed_at.max(changed_at);

--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -6,12 +6,13 @@ use crate::accumulator::{
     Accumulator,
     accumulated_map::{AccumulatedMap, AtomicInputAccumulatedValues, InputAccumulatedValues},
 };
+use crate::hash::FxIndexSet;
 use crate::key::DatabaseKeyIndex;
 use crate::runtime::Stamp;
 use crate::sync::atomic::AtomicBool;
 use crate::tracked_struct::{Disambiguator, DisambiguatorMap, IdentityHash, IdentityMap};
 use crate::zalsa_local::{
-    ActiveQueryEdges, QueryEdge, QueryEdgeKind, QueryRevisions, QueryRevisionsExtra,
+    QueryEdge, QueryEdgeKind, QueryOrigin, QueryRevisions, QueryRevisionsExtra,
 };
 use crate::{
     Id,
@@ -36,7 +37,7 @@ pub(crate) struct ActiveQuery {
     ///
     /// * invocations of `specify`
     /// * accumulators pushed to
-    input_outputs: ActiveQueryEdges,
+    input_outputs: FxIndexSet<QueryEdge>,
 
     /// True if there was an untracked read.
     untracked_read: bool,
@@ -182,7 +183,7 @@ impl ActiveQuery {
             database_key_index,
             durability: Durability::MAX,
             changed_at: Revision::start(),
-            input_outputs: ActiveQueryEdges::default(),
+            input_outputs: FxIndexSet::default(),
             untracked_read: false,
             disambiguator_map: Default::default(),
             tracked_struct_ids: Default::default(),
@@ -212,7 +213,11 @@ impl ActiveQuery {
             accumulated_inputs,
         } = self;
 
-        let origin = input_outputs.take_origin(untracked_read);
+        let origin = if untracked_read {
+            QueryOrigin::derived_untracked(input_outputs.drain(..))
+        } else {
+            QueryOrigin::derived(input_outputs.drain(..))
+        };
         disambiguator_map.clear();
 
         #[cfg(feature = "accumulator")]

--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -214,9 +214,9 @@ impl ActiveQuery {
         } = self;
 
         let origin = if untracked_read {
-            QueryOrigin::derived_untracked(input_outputs.drain(..).collect())
+            QueryOrigin::derived_untracked(input_outputs.drain(..))
         } else {
-            QueryOrigin::derived(input_outputs.drain(..).collect())
+            QueryOrigin::derived(input_outputs.drain(..))
         };
         disambiguator_map.clear();
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -350,19 +350,19 @@ where
         // Collect the minimum dependency tree.
         for edge in origin.edges() {
             // Avoid forming cycles.
-            if visited_edges.contains(edge) {
+            if visited_edges.contains(&edge) {
                 continue;
             }
 
             // Avoid flattening edges that we're going to serialize directly.
-            if serialized_edges.contains(edge) {
+            if serialized_edges.contains(&edge) {
                 continue;
             }
 
             let dependency = zalsa.lookup_ingredient(edge.key().ingredient_index());
             dependency.collect_minimum_serialized_edges(
                 zalsa,
-                *edge,
+                edge,
                 serialized_edges,
                 visited_edges,
             )
@@ -753,11 +753,11 @@ mod persistence {
     // Flatten the dependency edges before serialization.
     fn collect_minimum_serialized_edges(
         zalsa: &Zalsa,
-        edges: &[QueryEdge],
+        edges: crate::zalsa_local::QueryEdges<'_>,
         visited_edges: &mut FxHashSet<QueryEdge>,
         flattened_edges: &mut FxIndexSet<QueryEdge>,
     ) {
-        for &edge in edges {
+        for edge in edges {
             let dependency = zalsa.lookup_ingredient(edge.key().ingredient_index());
 
             if dependency.is_persistable() {

--- a/src/function.rs
+++ b/src/function.rs
@@ -707,7 +707,7 @@ mod persistence {
                                 &mut flattened_edges,
                             );
 
-                            QueryOrigin::derived(flattened_edges.drain(..).collect())
+                            QueryOrigin::derived(flattened_edges.drain(..))
                         }
                         QueryOriginRef::DerivedUntracked(edges) => {
                             collect_minimum_serialized_edges(
@@ -717,7 +717,7 @@ mod persistence {
                                 &mut flattened_edges,
                             );
 
-                            QueryOrigin::derived_untracked(flattened_edges.drain(..).collect())
+                            QueryOrigin::derived_untracked(flattened_edges.drain(..))
                         }
                         QueryOriginRef::Assigned(key) => {
                             let dependency = zalsa.lookup_ingredient(key.ingredient_index());

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -837,9 +837,10 @@ fn flatten_cycle_dependencies(zalsa: &Zalsa, head: &mut QueryRevisions) {
         }
     }
 
-    head.origin
-        .set_edges(flattened.drain(..).collect())
-        .expect("Executing query to always be derived or derived untracked.");
+    assert!(
+        head.origin.set_edges(flattened.drain(..)).is_ok(),
+        "Executing query to always be derived or derived untracked."
+    );
 
     seen.clear();
 

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -832,7 +832,7 @@ fn flatten_cycle_dependencies(zalsa: &Zalsa, head: &mut QueryRevisions) {
             QueryEdgeKind::Output(_) => {
                 // Unlike `ingredient.collect_flattened_cycle_inputs`, carry over outputs
                 // created by the query head because those are owned by this query.
-                flattened.insert(*edge);
+                flattened.insert(edge);
             }
         }
     }

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -819,7 +819,8 @@ fn flatten_cycle_dependencies(zalsa: &Zalsa, head: &mut QueryRevisions) {
 
     for edge in head.origin.as_ref().edges() {
         match edge.kind() {
-            QueryEdgeKind::Input(input) => {
+            QueryEdgeKind::Input => {
+                let input = edge.key();
                 let ingredient = zalsa.lookup_ingredient(input.ingredient_index());
                 ingredient.flatten_cycle_head_dependencies(
                     zalsa,
@@ -829,7 +830,7 @@ fn flatten_cycle_dependencies(zalsa: &Zalsa, head: &mut QueryRevisions) {
                 );
             }
 
-            QueryEdgeKind::Output(_) => {
+            QueryEdgeKind::Output => {
                 // Unlike `ingredient.collect_flattened_cycle_inputs`, carry over outputs
                 // created by the query head because those are owned by this query.
                 flattened.insert(edge);

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -461,14 +461,14 @@ fn deep_verify_edges(
     // they executed. It's possible that if the value of some input I0 is no longer
     // valid, then some later input I1 might never have executed at all, so verifying
     // it is still up to date is meaningless.
-    if let std::ops::ControlFlow::Break(result) = edges.try_for_each(|edge| {
+    for edge in edges {
         match edge.kind() {
             QueryEdgeKind::Input(dependency_index) => {
                 let input_result = dependency_index.maybe_changed_after(db, zalsa, old_verified_at);
 
                 match input_result {
                     VerifyResult::Changed => {
-                        return std::ops::ControlFlow::Break(VerifyResult::changed());
+                        return VerifyResult::changed();
                     }
                     #[cfg(feature = "accumulator")]
                     VerifyResult::Unchanged { accumulated } => {
@@ -498,11 +498,7 @@ fn deep_verify_edges(
                 dependency_index.mark_validated_output(zalsa, database_key_index);
             }
         }
-        std::ops::ControlFlow::Continue(())
-    }) {
-        return result;
     }
-
     let result = VerifyResult::unchanged_with_accumulated(
         #[cfg(feature = "accumulator")]
         inputs,

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::Ordering;
 
 use crate::key::DatabaseKeyIndex;
 use crate::zalsa::{MemoIngredientIndex, Zalsa, ZalsaDatabase};
-use crate::zalsa_local::{QueryEdge, QueryEdgeKind, QueryOriginRef, QueryRevisions, ZalsaLocal};
+use crate::zalsa_local::{QueryEdgeKind, QueryEdges, QueryOriginRef, QueryRevisions, ZalsaLocal};
 use crate::{Id, Revision};
 
 /// Result of memo validation.
@@ -449,7 +449,7 @@ fn deep_verify_edges(
     zalsa: &Zalsa,
     #[allow(unused)] old_revisions: &QueryRevisions,
     old_verified_at: Revision,
-    edges: &[QueryEdge],
+    edges: QueryEdges<'_>,
     database_key_index: DatabaseKeyIndex,
 ) -> VerifyResult {
     #[cfg(feature = "accumulator")]
@@ -461,7 +461,7 @@ fn deep_verify_edges(
     // they executed. It's possible that if the value of some input I0 is no longer
     // valid, then some later input I1 might never have executed at all, so verifying
     // it is still up to date is meaningless.
-    for &edge in edges {
+    for edge in edges {
         match edge.kind() {
             QueryEdgeKind::Input(dependency_index) => {
                 let input_result = dependency_index.maybe_changed_after(db, zalsa, old_verified_at);

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -463,7 +463,8 @@ fn deep_verify_edges(
     // it is still up to date is meaningless.
     for edge in edges {
         match edge.kind() {
-            QueryEdgeKind::Input(dependency_index) => {
+            QueryEdgeKind::Input => {
+                let dependency_index = edge.key();
                 let input_result = dependency_index.maybe_changed_after(db, zalsa, old_verified_at);
 
                 match input_result {
@@ -478,7 +479,8 @@ fn deep_verify_edges(
                     VerifyResult::Unchanged { .. } => {}
                 }
             }
-            QueryEdgeKind::Output(dependency_index) => {
+            QueryEdgeKind::Output => {
+                let dependency_index = edge.key();
                 // Subtle: Mark outputs as validated now, even though we may
                 // later find an input that requires us to re-execute the function.
                 // Even if it re-execute, the function will wind up writing the same value,

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -461,14 +461,14 @@ fn deep_verify_edges(
     // they executed. It's possible that if the value of some input I0 is no longer
     // valid, then some later input I1 might never have executed at all, so verifying
     // it is still up to date is meaningless.
-    for edge in edges {
+    if let std::ops::ControlFlow::Break(result) = edges.try_for_each(|edge| {
         match edge.kind() {
             QueryEdgeKind::Input(dependency_index) => {
                 let input_result = dependency_index.maybe_changed_after(db, zalsa, old_verified_at);
 
                 match input_result {
                     VerifyResult::Changed => {
-                        return VerifyResult::changed();
+                        return std::ops::ControlFlow::Break(VerifyResult::changed());
                     }
                     #[cfg(feature = "accumulator")]
                     VerifyResult::Unchanged { accumulated } => {
@@ -498,7 +498,11 @@ fn deep_verify_edges(
                 dependency_index.mark_validated_output(zalsa, database_key_index);
             }
         }
+        std::ops::ControlFlow::Continue(())
+    }) {
+        return result;
     }
+
     let result = VerifyResult::unchanged_with_accumulated(
         #[cfg(feature = "accumulator")]
         inputs,

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -90,12 +90,12 @@ impl IngredientIndex {
     /// # Safety
     ///
     /// The index must be less than or equal to `IngredientIndex::MAX_INDEX`.
-    pub(crate) unsafe fn new_unchecked(v: u32) -> Self {
+    pub(crate) const unsafe fn new_unchecked(v: u32) -> Self {
         Self(v)
     }
 
     /// Convert the ingredient index back into a `u32`.
-    pub(crate) fn as_u32(self) -> u32 {
+    pub(crate) const fn as_u32(self) -> u32 {
         self.0
     }
 
@@ -104,14 +104,14 @@ impl IngredientIndex {
     }
 
     /// Returns a new `IngredientIndex` with the tag bit set to the provided value.
-    pub(crate) fn with_tag(mut self, tag: bool) -> IngredientIndex {
+    pub(crate) const fn with_tag(mut self, tag: bool) -> IngredientIndex {
         self.0 &= Self::MAX_INDEX;
         self.0 |= (tag as u32) << 31;
         self
     }
 
     /// Returns the value of the tag bit.
-    pub(crate) fn tag(self) -> bool {
+    pub(crate) const fn tag(self) -> bool {
         self.0 & !Self::MAX_INDEX != 0
     }
 }

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -988,6 +988,8 @@ pub struct QueryOrigin {
     metadata: u32,
 }
 
+const _: [(); std::mem::size_of::<QueryOrigin>()] = [(); 13];
+
 /// The data portion of `PackedQueryOrigin`.
 union QueryOriginData {
     /// Query edges for the derived variants.
@@ -1113,6 +1115,7 @@ impl QueryOrigin {
     /// Create a query origin of type `QueryOriginKind::Assigned`, with the given key.
     pub fn assigned(key: DatabaseKeyIndex) -> QueryOrigin {
         QueryOrigin {
+            // Assigned origins do not store edges, so the layout bit is unused.
             tag: QueryOriginTag::new(QueryOriginKind::Assigned, QueryEdgeLayout::Packed),
             metadata: key.ingredient_index().as_u32(),
             data: QueryOriginData {
@@ -1254,6 +1257,8 @@ pub struct QueryEdge {
     ingredient: IngredientIndex,
 }
 
+const _: [(); std::mem::size_of::<QueryEdge>()] = [(); 12];
+
 impl QueryEdge {
     /// Create an input query edge with the given index.
     pub const fn input(key: DatabaseKeyIndex) -> QueryEdge {
@@ -1268,9 +1273,13 @@ impl QueryEdge {
 
     /// Create an output query edge with the given index.
     pub const fn output(key: DatabaseKeyIndex) -> QueryEdge {
-        let mut edge = Self::input(key);
-        edge.ingredient = edge.ingredient.with_tag(true);
-        edge
+        let id = key.key_index();
+
+        QueryEdge {
+            index: id.index(),
+            generation: id.generation(),
+            ingredient: key.ingredient_index().with_tag(true),
+        }
     }
 
     /// Return the key of this query edge.
@@ -1325,7 +1334,14 @@ impl<'de> serde::Deserialize<'de> for QueryEdge {
     where
         D: serde::Deserializer<'de>,
     {
-        DatabaseKeyIndex::deserialize(deserializer).map(QueryEdge::input)
+        let key = DatabaseKeyIndex::deserialize(deserializer)?;
+        let id = key.key_index();
+
+        Ok(QueryEdge {
+            index: id.index(),
+            generation: id.generation(),
+            ingredient: key.ingredient_index(),
+        })
     }
 }
 
@@ -1349,6 +1365,8 @@ struct PackedQueryEdge {
     index: u32,
     metadata: u32,
 }
+
+const _: [(); std::mem::size_of::<PackedQueryEdge>()] = [(); 8];
 
 impl PackedQueryEdge {
     const INGREDIENT_SHIFT: u32 = 20;
@@ -1436,6 +1454,7 @@ impl<'a> QueryEdges<'a> {
         }
     }
 
+    #[cfg(any(test, feature = "salsa_unstable"))]
     pub(crate) fn allocation_size(self) -> usize {
         match self.data {
             QueryEdgesData::Packed(edges) => std::mem::size_of_val(edges),
@@ -1724,14 +1743,6 @@ mod tests {
     use crate::{DatabaseKeyIndex, Id, IngredientIndex};
 
     #[test]
-    fn packed_query_edges_use_eight_bytes() {
-        assert_eq!(size_of::<PackedQueryEdge>(), 8);
-        assert_eq!(size_of::<QueryEdge>(), 12);
-        assert_eq!(size_of::<QueryEdgeKind>(), 1);
-        assert_eq!(size_of::<QueryOrigin>(), 13);
-    }
-
-    #[test]
     fn query_origin_packs_edges_that_fit() {
         let input = QueryEdge::input(key(231, 10_842_122, 41));
         let other_input = QueryEdge::input(key(232, 10_842_123, 42));
@@ -1791,7 +1802,7 @@ mod tests {
     #[test]
     fn query_origin_spills_all_edges_if_generation_does_not_fit() {
         let packed = QueryEdge::input(key(231, 10_842_122, 41));
-        let wide = QueryEdge::output(key(232, 10_842_123, PackedQueryEdge::GENERATION_MASK + 1));
+        let wide = QueryEdge::input(key(232, 10_842_123, PackedQueryEdge::GENERATION_MASK + 1));
         let origin = QueryOrigin::derived([packed, wide]);
         let QueryOriginRef::Derived(edges) = origin.as_ref() else {
             panic!("expected derived origin");

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -518,7 +518,7 @@ impl QueryRevisions {
         if let QueryOriginRef::Derived(query_edges)
         | QueryOriginRef::DerivedUntracked(query_edges) = origin.as_ref()
         {
-            memory += std::mem::size_of_val(query_edges);
+            memory += query_edges.allocation_size();
         }
 
         if let Some(extra) = extra.0.as_ref() {
@@ -852,13 +852,13 @@ pub enum QueryOriginRef<'a> {
     /// The value was derived by executing a function
     /// and we were able to track ALL of that function's inputs.
     /// Those inputs are described in [`QueryEdges`].
-    Derived(&'a [QueryEdge]) = QueryOriginKind::Derived as u8,
+    Derived(QueryEdges<'a>) = QueryOriginKind::DerivedPacked as u8,
 
     /// The value was derived by executing a function
     /// but that function also reported that it read untracked inputs.
     /// The [`QueryEdges`] argument contains a listing of all the inputs we saw
     /// (but we know there were more).
-    DerivedUntracked(&'a [QueryEdge]) = QueryOriginKind::DerivedUntracked as u8,
+    DerivedUntracked(QueryEdges<'a>) = QueryOriginKind::DerivedUntrackedPacked as u8,
 }
 
 impl<'a> QueryOriginRef<'a> {
@@ -882,13 +882,13 @@ impl<'a> QueryOriginRef<'a> {
     }
 
     #[inline]
-    pub(crate) fn edges(self) -> &'a [QueryEdge] {
+    pub(crate) fn edges(self) -> QueryEdges<'a> {
         let opt_edges = match self {
             QueryOriginRef::Derived(edges) | QueryOriginRef::DerivedUntracked(edges) => Some(edges),
             QueryOriginRef::Assigned(_) => None,
         };
 
-        opt_edges.unwrap_or_default()
+        opt_edges.unwrap_or_else(|| QueryEdges::wide(&[]))
     }
 }
 
@@ -901,15 +901,21 @@ enum QueryOriginKind {
     /// The value was assigned as the output of another query.
     ///
     /// This can, for example, can occur when `specify` is used.
-    Assigned = 0b01,
+    Assigned = 0b001,
 
     /// The value was derived by executing a function
     /// _and_ Salsa was able to track all of said function's inputs.
-    Derived = 0b11,
+    DerivedPacked = 0b011,
 
     /// The value was derived by executing a function
     /// but that function also reported that it read untracked inputs.
-    DerivedUntracked = 0b10,
+    DerivedUntrackedPacked = 0b010,
+
+    /// Like [`QueryOriginKind::DerivedPacked`], but using full-width query edges.
+    DerivedWide = 0b111,
+
+    /// Like [`QueryOriginKind::DerivedUntrackedPacked`], but using full-width query edges.
+    DerivedUntrackedWide = 0b110,
 }
 
 /// Tracks how a memoized value for a given query was created.
@@ -919,7 +925,7 @@ enum QueryOriginKind {
 pub struct QueryOrigin {
     /// The tag of this enum.
     ///
-    /// Note that this tag only requires two bits and could likely be packed into
+    /// Note that this tag only requires three bits and could likely be packed into
     /// some other field. However, we get this byte for free thanks to alignment.
     kind: QueryOriginKind,
 
@@ -928,8 +934,7 @@ pub struct QueryOrigin {
 
     /// The metadata of this enum.
     ///
-    /// For `QueryOriginKind::Derived` and `QueryOriginKind::DerivedUntracked`, this
-    /// is the length of the `input_outputs` allocation.
+    /// For the derived variants, this is the length of the `input_outputs` allocation.
     ///
     /// For `QueryOriginKind::Assigned`, this is the `IngredientIndex` of assigning query.
     /// Combined with the `Id` data, this forms a complete `DatabaseKeyIndex`.
@@ -938,7 +943,7 @@ pub struct QueryOrigin {
 
 /// The data portion of `PackedQueryOrigin`.
 union QueryOriginData {
-    /// Query edges for `QueryOriginKind::Derived` or `QueryOriginKind::DerivedUntracked`.
+    /// Query edges for the derived variants.
     ///
     /// The query edges are between a memoized value and other queries in the dependency graph,
     /// including both dependency edges (e.g., when creating the memoized value for Q0
@@ -954,7 +959,7 @@ union QueryOriginData {
     /// Important:
     ///
     /// * The inputs must be in **execution order** for the red-green algorithm to work.
-    input_outputs: NonNull<QueryEdge>,
+    input_outputs: NonNull<()>,
 
     /// The identity of the assigning query for `QueryOriginKind::Assigned`.
     index: Id,
@@ -967,21 +972,56 @@ unsafe impl Sync for QueryOriginData {}
 
 impl QueryOrigin {
     pub fn is_derived_untracked(&self) -> bool {
-        matches!(self.kind, QueryOriginKind::DerivedUntracked)
+        matches!(
+            self.kind,
+            QueryOriginKind::DerivedUntrackedPacked | QueryOriginKind::DerivedUntrackedWide
+        )
     }
 
     /// Create a query origin of type `QueryOriginKind::Derived`, with the given edges.
     pub fn derived(input_outputs: Box<[QueryEdge]>) -> QueryOrigin {
+        Self::derived_with_kinds(
+            input_outputs,
+            QueryOriginKind::DerivedPacked,
+            QueryOriginKind::DerivedWide,
+        )
+    }
+
+    fn derived_with_kinds(
+        input_outputs: Box<[QueryEdge]>,
+        packed_kind: QueryOriginKind,
+        wide_kind: QueryOriginKind,
+    ) -> QueryOrigin {
         // Exceeding `u32::MAX` query edges should never happen in real-world usage.
         let length = u32::try_from(input_outputs.len())
             .expect("exceeded more than `u32::MAX` query edges; this should never happen.");
 
-        // SAFETY: `Box::into_raw` returns a non-null pointer.
-        let input_outputs =
-            unsafe { NonNull::new_unchecked(Box::into_raw(input_outputs).cast::<QueryEdge>()) };
+        let (kind, input_outputs) = if input_outputs.iter().copied().all(PackedQueryEdge::fits) {
+            let input_outputs: Box<[PackedQueryEdge]> = input_outputs
+                .iter()
+                .copied()
+                .map(PackedQueryEdge::new)
+                .collect();
+
+            // SAFETY: `Box::into_raw` returns a non-null pointer.
+            let input_outputs = unsafe {
+                NonNull::new_unchecked(Box::into_raw(input_outputs).cast::<PackedQueryEdge>())
+                    .cast::<()>()
+            };
+
+            (packed_kind, input_outputs)
+        } else {
+            // SAFETY: `Box::into_raw` returns a non-null pointer.
+            let input_outputs = unsafe {
+                NonNull::new_unchecked(Box::into_raw(input_outputs).cast::<QueryEdge>())
+                    .cast::<()>()
+            };
+
+            (wide_kind, input_outputs)
+        };
 
         QueryOrigin {
-            kind: QueryOriginKind::Derived,
+            kind,
             metadata: length,
             data: QueryOriginData { input_outputs },
         }
@@ -989,48 +1029,28 @@ impl QueryOrigin {
 
     /// Create a query origin of type `QueryOriginKind::DerivedUntracked`, with the given edges.
     pub fn derived_untracked(input_outputs: Box<[QueryEdge]>) -> QueryOrigin {
-        let mut origin = QueryOrigin::derived(input_outputs);
-        origin.kind = QueryOriginKind::DerivedUntracked;
-        origin
+        Self::derived_with_kinds(
+            input_outputs,
+            QueryOriginKind::DerivedUntrackedPacked,
+            QueryOriginKind::DerivedUntrackedWide,
+        )
     }
 
     /// Sets the `input_outputs` of this query's origin if it's derived or derived untracked.
     /// Returns `Err` if the query origin isn't derived.
-    pub fn set_edges(
+    pub(crate) fn set_edges(
         &mut self,
         input_outputs: Box<[QueryEdge]>,
-    ) -> Result<Box<[QueryEdge]>, Box<[QueryEdge]>> {
+    ) -> Result<(), Box<[QueryEdge]>> {
         match self.kind {
             QueryOriginKind::Assigned => Err(input_outputs),
-            QueryOriginKind::Derived | QueryOriginKind::DerivedUntracked => {
-                // Exceeding `u32::MAX` query edges should never happen in real-world usage.
-                let length = u32::try_from(input_outputs.len())
-                    .expect("exceeded more than `u32::MAX` query edges; this should never happen.");
-
-                // SAFETY: `data.input_outputs` is initialized when the tag is `QueryOriginKind::Derived`
-                // or `QueryOriginKind::DerivedUntracked`.
-                let prev_input_outputs = unsafe { self.data.input_outputs };
-                let prev_length = self.metadata as usize;
-
-                // SAFETY: `input_outputs` and `self.metadata` form a valid slice when the tag is
-                // `QueryOriginKind::DerivedUntracked` or `QueryOriginKind::DerivedUntracked`, and
-                // we have `&mut self`.
-                let prev_input_outputs: Box<[QueryEdge]> = unsafe {
-                    Box::from_raw(ptr::slice_from_raw_parts_mut(
-                        prev_input_outputs.as_ptr(),
-                        prev_length,
-                    ))
-                };
-
-                // SAFETY: `Box::into_raw` returns a non-null pointer.
-                let input_outputs = unsafe {
-                    NonNull::new_unchecked(Box::into_raw(input_outputs).cast::<QueryEdge>())
-                };
-
-                self.data = QueryOriginData { input_outputs };
-                self.metadata = length;
-
-                Ok(prev_input_outputs)
+            QueryOriginKind::DerivedPacked | QueryOriginKind::DerivedWide => {
+                *self = QueryOrigin::derived(input_outputs);
+                Ok(())
+            }
+            QueryOriginKind::DerivedUntrackedPacked | QueryOriginKind::DerivedUntrackedWide => {
+                *self = QueryOrigin::derived_untracked(input_outputs);
+                Ok(())
             }
         }
     }
@@ -1060,30 +1080,24 @@ impl QueryOrigin {
                 QueryOriginRef::Assigned(DatabaseKeyIndex::new(ingredient_index, index))
             }
 
-            QueryOriginKind::Derived => {
-                // SAFETY: `data.input_outputs` is initialized when the tag is `QueryOriginKind::Derived`.
+            QueryOriginKind::DerivedPacked | QueryOriginKind::DerivedWide => {
+                // SAFETY: `data.input_outputs` is initialized for both derived origin kinds.
                 let input_outputs = unsafe { self.data.input_outputs };
                 let length = self.metadata as usize;
 
-                // SAFETY: `input_outputs` and `self.metadata` form a valid slice when the
-                // tag is `QueryOriginKind::Derived`.
-                let input_outputs =
-                    unsafe { std::slice::from_raw_parts(input_outputs.as_ptr(), length) };
-
-                QueryOriginRef::Derived(input_outputs)
+                QueryOriginRef::Derived(QueryEdges::from_raw(self.kind, input_outputs, length))
             }
 
-            QueryOriginKind::DerivedUntracked => {
-                // SAFETY: `data.input_outputs` is initialized when the tag is `QueryOriginKind::DerivedUntracked`.
+            QueryOriginKind::DerivedUntrackedPacked | QueryOriginKind::DerivedUntrackedWide => {
+                // SAFETY: `data.input_outputs` is initialized for both untracked origin kinds.
                 let input_outputs = unsafe { self.data.input_outputs };
                 let length = self.metadata as usize;
 
-                // SAFETY: `input_outputs` and `self.metadata` form a valid slice when the
-                // tag is `QueryOriginKind::DerivedUntracked`.
-                let input_outputs =
-                    unsafe { std::slice::from_raw_parts(input_outputs.as_ptr(), length) };
-
-                QueryOriginRef::DerivedUntracked(input_outputs)
+                QueryOriginRef::DerivedUntracked(QueryEdges::from_raw(
+                    self.kind,
+                    input_outputs,
+                    length,
+                ))
             }
         }
     }
@@ -1111,8 +1125,8 @@ impl<'de> serde::Deserialize<'de> for QueryOrigin {
         #[serde(rename = "QueryOrigin")]
         pub enum QueryOriginOwned {
             Assigned(DatabaseKeyIndex) = QueryOriginKind::Assigned as u8,
-            Derived(Box<[QueryEdge]>) = QueryOriginKind::Derived as u8,
-            DerivedUntracked(Box<[QueryEdge]>) = QueryOriginKind::DerivedUntracked as u8,
+            Derived(Box<[QueryEdge]>) = QueryOriginKind::DerivedPacked as u8,
+            DerivedUntracked(Box<[QueryEdge]>) = QueryOriginKind::DerivedUntrackedPacked as u8,
         }
 
         Ok(match QueryOriginOwned::deserialize(deserializer)? {
@@ -1126,21 +1140,35 @@ impl<'de> serde::Deserialize<'de> for QueryOrigin {
 impl Drop for QueryOrigin {
     fn drop(&mut self) {
         match self.kind {
-            QueryOriginKind::Derived | QueryOriginKind::DerivedUntracked => {
-                // SAFETY: `data.input_outputs` is initialized when the tag is `QueryOriginKind::Derived`
-                // or `QueryOriginKind::DerivedUntracked`.
+            QueryOriginKind::DerivedPacked
+            | QueryOriginKind::DerivedUntrackedPacked
+            | QueryOriginKind::DerivedWide
+            | QueryOriginKind::DerivedUntrackedWide => {
+                // SAFETY: Derived origin kinds initialize `data.input_outputs`.
                 let input_outputs = unsafe { self.data.input_outputs };
                 let length = self.metadata as usize;
 
-                // SAFETY: `input_outputs` and `self.metadata` form a valid slice when the tag is
-                // `QueryOriginKind::DerivedUntracked` or `QueryOriginKind::DerivedUntracked`, and
-                // we have `&mut self`.
-                let _input_outputs: Box<[QueryEdge]> = unsafe {
-                    Box::from_raw(ptr::slice_from_raw_parts_mut(
-                        input_outputs.as_ptr(),
-                        length,
-                    ))
-                };
+                match self.kind {
+                    QueryOriginKind::DerivedPacked | QueryOriginKind::DerivedUntrackedPacked => {
+                        // SAFETY: Packed origin kinds store a boxed slice of `PackedQueryEdge`.
+                        drop(unsafe {
+                            Box::from_raw(ptr::slice_from_raw_parts_mut(
+                                input_outputs.cast::<PackedQueryEdge>().as_ptr(),
+                                length,
+                            ))
+                        });
+                    }
+                    QueryOriginKind::DerivedWide | QueryOriginKind::DerivedUntrackedWide => {
+                        // SAFETY: Wide origin kinds store a boxed slice of `QueryEdge`.
+                        drop(unsafe {
+                            Box::from_raw(ptr::slice_from_raw_parts_mut(
+                                input_outputs.cast::<QueryEdge>().as_ptr(),
+                                length,
+                            ))
+                        });
+                    }
+                    QueryOriginKind::Assigned => unreachable!(),
+                }
             }
 
             // The data stored for this variant is `Copy`.
@@ -1208,6 +1236,206 @@ impl std::fmt::Debug for QueryEdge {
     }
 }
 
+/// A retained 8-byte query edge.
+///
+/// Query origins use this representation when every edge fits. Otherwise, the origin
+/// retains the existing full-width [`QueryEdge`] slice.
+#[derive(Copy, Clone)]
+struct PackedQueryEdge(u64);
+
+impl PackedQueryEdge {
+    // [output: 1][ingredient: 12][generation: 19][index: 32]
+    const GENERATION_SHIFT: u32 = 32;
+    const INGREDIENT_SHIFT: u32 = 51;
+    const OUTPUT_SHIFT: u32 = 63;
+    const GENERATION_MASK: u64 = 0x7FFFF;
+    const INGREDIENT_MASK: u64 = 0xFFF;
+
+    fn fits(edge: QueryEdge) -> bool {
+        let ingredient = edge.key.ingredient_index().with_tag(false).as_u32();
+        let id = edge.key.key_index();
+
+        u64::from(ingredient) <= Self::INGREDIENT_MASK
+            && u64::from(id.generation()) <= Self::GENERATION_MASK
+    }
+
+    fn new(edge: QueryEdge) -> Self {
+        debug_assert!(Self::fits(edge));
+
+        let ingredient_index = edge.key.ingredient_index();
+        let ingredient = ingredient_index.with_tag(false).as_u32();
+        let id = edge.key.key_index();
+
+        PackedQueryEdge(
+            u64::from(id.index())
+                | (u64::from(id.generation()) << Self::GENERATION_SHIFT)
+                | (u64::from(ingredient) << Self::INGREDIENT_SHIFT)
+                | (u64::from(ingredient_index.tag()) << Self::OUTPUT_SHIFT),
+        )
+    }
+
+    fn edge(self) -> QueryEdge {
+        let index = self.0 as u32;
+        let generation = ((self.0 >> Self::GENERATION_SHIFT) & Self::GENERATION_MASK) as u32;
+        let ingredient = ((self.0 >> Self::INGREDIENT_SHIFT) & Self::INGREDIENT_MASK) as u32;
+        let is_output = self.0 >> Self::OUTPUT_SHIFT != 0;
+
+        // SAFETY: The index came from a valid `Id` in `PackedQueryEdge::new`.
+        let id = unsafe { Id::from_index(index) }.with_generation(generation);
+        // SAFETY: The ingredient came from a valid `IngredientIndex` in `PackedQueryEdge::new`.
+        let ingredient = unsafe { IngredientIndex::new_unchecked(ingredient) };
+
+        QueryEdge {
+            key: DatabaseKeyIndex::new(ingredient.with_tag(is_output), id),
+        }
+    }
+}
+
+/// A read-only view over the retained edges for a query origin.
+#[derive(Copy, Clone)]
+pub struct QueryEdges<'a> {
+    data: QueryEdgesData<'a>,
+}
+
+#[derive(Copy, Clone)]
+enum QueryEdgesData<'a> {
+    Packed(&'a [PackedQueryEdge]),
+    Wide(&'a [QueryEdge]),
+}
+
+impl<'a> QueryEdges<'a> {
+    fn packed(edges: &'a [PackedQueryEdge]) -> Self {
+        QueryEdges {
+            data: QueryEdgesData::Packed(edges),
+        }
+    }
+
+    fn wide(edges: &'a [QueryEdge]) -> Self {
+        QueryEdges {
+            data: QueryEdgesData::Wide(edges),
+        }
+    }
+
+    fn from_raw(kind: QueryOriginKind, input_outputs: NonNull<()>, length: usize) -> Self {
+        match kind {
+            QueryOriginKind::DerivedPacked | QueryOriginKind::DerivedUntrackedPacked => {
+                // SAFETY: Packed origin kinds store a boxed slice of `PackedQueryEdge`.
+                QueryEdges::packed(unsafe {
+                    std::slice::from_raw_parts(
+                        input_outputs.cast::<PackedQueryEdge>().as_ptr(),
+                        length,
+                    )
+                })
+            }
+            QueryOriginKind::DerivedWide | QueryOriginKind::DerivedUntrackedWide => {
+                // SAFETY: Wide origin kinds store a boxed slice of `QueryEdge`.
+                QueryEdges::wide(unsafe {
+                    std::slice::from_raw_parts(input_outputs.cast::<QueryEdge>().as_ptr(), length)
+                })
+            }
+            QueryOriginKind::Assigned => unreachable!("assigned queries do not store query edges"),
+        }
+    }
+
+    pub(crate) fn len(self) -> usize {
+        match self.data {
+            QueryEdgesData::Packed(edges) => edges.len(),
+            QueryEdgesData::Wide(edges) => edges.len(),
+        }
+    }
+
+    pub(crate) fn allocation_size(self) -> usize {
+        match self.data {
+            QueryEdgesData::Packed(edges) => std::mem::size_of_val(edges),
+            QueryEdgesData::Wide(edges) => std::mem::size_of_val(edges),
+        }
+    }
+
+    pub(crate) fn iter(self) -> QueryEdgeIter<'a> {
+        let data = match self.data {
+            QueryEdgesData::Packed(edges) => QueryEdgeIterData::Packed(edges.iter()),
+            QueryEdgesData::Wide(edges) => QueryEdgeIterData::Wide(edges.iter()),
+        };
+
+        QueryEdgeIter { data }
+    }
+
+    #[cfg(test)]
+    fn is_packed(self) -> bool {
+        matches!(self.data, QueryEdgesData::Packed(_))
+    }
+}
+
+pub struct QueryEdgeIter<'a> {
+    data: QueryEdgeIterData<'a>,
+}
+
+enum QueryEdgeIterData<'a> {
+    Packed(std::slice::Iter<'a, PackedQueryEdge>),
+    Wide(std::slice::Iter<'a, QueryEdge>),
+}
+
+impl Iterator for QueryEdgeIter<'_> {
+    type Item = QueryEdge;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.data {
+            QueryEdgeIterData::Packed(edges) => edges.next().copied().map(PackedQueryEdge::edge),
+            QueryEdgeIterData::Wide(edges) => edges.next().copied(),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+}
+
+impl DoubleEndedIterator for QueryEdgeIter<'_> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        match &mut self.data {
+            QueryEdgeIterData::Packed(edges) => {
+                edges.next_back().copied().map(PackedQueryEdge::edge)
+            }
+            QueryEdgeIterData::Wide(edges) => edges.next_back().copied(),
+        }
+    }
+}
+
+impl ExactSizeIterator for QueryEdgeIter<'_> {
+    fn len(&self) -> usize {
+        match &self.data {
+            QueryEdgeIterData::Packed(edges) => edges.len(),
+            QueryEdgeIterData::Wide(edges) => edges.len(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for QueryEdges<'a> {
+    type Item = QueryEdge;
+    type IntoIter = QueryEdgeIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl std::fmt::Debug for QueryEdges<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_list().entries(self.iter()).finish()
+    }
+}
+
+#[cfg(feature = "persistence")]
+impl serde::Serialize for QueryEdges<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.iter())
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum QueryEdgeKind {
     Input(DatabaseKeyIndex),
@@ -1218,9 +1446,9 @@ pub enum QueryEdgeKind {
 ///
 /// These will always be in execution order.
 pub(crate) fn input_edges(
-    input_outputs: &[QueryEdge],
+    input_outputs: QueryEdges<'_>,
 ) -> impl DoubleEndedIterator<Item = DatabaseKeyIndex> + use<'_> {
-    input_outputs.iter().filter_map(|&edge| match edge.kind() {
+    input_outputs.iter().filter_map(|edge| match edge.kind() {
         QueryEdgeKind::Input(dependency_index) => Some(dependency_index),
         QueryEdgeKind::Output(_) => None,
     })
@@ -1230,12 +1458,126 @@ pub(crate) fn input_edges(
 ///
 /// These will always be in execution order.
 pub(crate) fn output_edges(
-    input_outputs: &[QueryEdge],
+    input_outputs: QueryEdges<'_>,
 ) -> impl DoubleEndedIterator<Item = DatabaseKeyIndex> + use<'_> {
-    input_outputs.iter().filter_map(|&edge| match edge.kind() {
+    input_outputs.iter().filter_map(|edge| match edge.kind() {
         QueryEdgeKind::Output(dependency_index) => Some(dependency_index),
         QueryEdgeKind::Input(_) => None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::mem::size_of;
+
+    use super::{PackedQueryEdge, QueryEdge, QueryOrigin, QueryOriginRef};
+    use crate::{DatabaseKeyIndex, Id, IngredientIndex};
+
+    #[test]
+    fn packed_query_edges_use_eight_bytes() {
+        assert_eq!(size_of::<PackedQueryEdge>(), 8);
+        assert_eq!(size_of::<QueryEdge>(), 12);
+    }
+
+    #[test]
+    fn query_origin_packs_edges_that_fit() {
+        let input = QueryEdge::input(key(231, 10_842_122, 41));
+        let output = QueryEdge::output(key(232, 10_842_123, 42));
+        let origin = QueryOrigin::derived(Box::new([input, output]));
+        let QueryOriginRef::Derived(edges) = origin.as_ref() else {
+            panic!("expected derived origin");
+        };
+
+        assert!(edges.is_packed());
+        assert_eq!(edges.allocation_size(), 2 * size_of::<PackedQueryEdge>());
+        assert_eq!(edges.iter().collect::<Vec<_>>(), vec![input, output]);
+        assert_eq!(edges.iter().rev().collect::<Vec<_>>(), vec![output, input]);
+    }
+
+    #[test]
+    fn query_origin_spills_all_edges_if_generation_does_not_fit() {
+        let packed = QueryEdge::input(key(231, 10_842_122, 41));
+        let wide = QueryEdge::output(key(
+            232,
+            10_842_123,
+            PackedQueryEdge::GENERATION_MASK as u32 + 1,
+        ));
+        let origin = QueryOrigin::derived(Box::new([packed, wide]));
+        let QueryOriginRef::Derived(edges) = origin.as_ref() else {
+            panic!("expected derived origin");
+        };
+
+        assert!(!edges.is_packed());
+        assert_eq!(edges.allocation_size(), 2 * size_of::<QueryEdge>());
+        assert_eq!(edges.iter().collect::<Vec<_>>(), vec![packed, wide]);
+    }
+
+    #[test]
+    fn query_origin_spills_if_ingredient_does_not_fit() {
+        let wide = QueryEdge::input(key(
+            PackedQueryEdge::INGREDIENT_MASK as u32 + 1,
+            10_842_122,
+            41,
+        ));
+        let origin = QueryOrigin::derived(Box::new([wide]));
+        let QueryOriginRef::Derived(edges) = origin.as_ref() else {
+            panic!("expected derived origin");
+        };
+
+        assert!(!edges.is_packed());
+        assert_eq!(edges.iter().collect::<Vec<_>>(), vec![wide]);
+    }
+
+    #[test]
+    fn replacing_query_origin_edges_can_change_layout() {
+        let packed = QueryEdge::input(key(231, 10_842_122, 41));
+        let wide = QueryEdge::input(key(
+            PackedQueryEdge::INGREDIENT_MASK as u32 + 1,
+            10_842_123,
+            42,
+        ));
+        let mut origin = QueryOrigin::derived(Box::new([packed]));
+
+        origin.set_edges(Box::new([wide])).unwrap();
+        assert!(!origin.as_ref().edges().is_packed());
+
+        origin.set_edges(Box::new([packed])).unwrap();
+        assert!(origin.as_ref().edges().is_packed());
+    }
+
+    #[cfg(feature = "persistence")]
+    #[test]
+    fn query_origin_serde_round_trip_preserves_edges() {
+        let input = QueryEdge::input(key(231, 10_842_122, 41));
+        let output = QueryEdge::output(key(
+            232,
+            10_842_123,
+            PackedQueryEdge::GENERATION_MASK as u32 + 1,
+        ));
+        let origin = QueryOrigin::derived_untracked(Box::new([input, output]));
+        let serialized = serde_json::to_string(&origin).unwrap();
+        let deserialized: QueryOrigin = serde_json::from_str(&serialized).unwrap();
+        let QueryOriginRef::DerivedUntracked(edges) = deserialized.as_ref() else {
+            panic!("expected untracked derived origin");
+        };
+
+        assert!(!edges.is_packed());
+        assert_eq!(edges.iter().collect::<Vec<_>>(), vec![input, output]);
+        assert_eq!(
+            edges.iter().map(QueryEdge::kind).collect::<Vec<_>>(),
+            vec![
+                super::QueryEdgeKind::Input(input.key()),
+                super::QueryEdgeKind::Output(output.key())
+            ]
+        );
+    }
+
+    fn key(ingredient: u32, index: u32, generation: u32) -> DatabaseKeyIndex {
+        // SAFETY: Test inputs are valid `Id` indices.
+        let id = unsafe { Id::from_index(index) }.with_generation(generation);
+
+        DatabaseKeyIndex::new(IngredientIndex::new(ingredient), id)
+    }
 }
 
 /// When a query is pushed onto the `active_query` stack, this guard

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -17,6 +17,7 @@ use crate::accumulator::{
 use crate::active_query::{CompletedQuery, QueryStack};
 use crate::cycle::{AtomicIterationCount, CycleHeads, IterationCount, empty_cycle_heads};
 use crate::durability::Durability;
+use crate::hash::FxIndexSet;
 use crate::key::DatabaseKeyIndex;
 use crate::runtime::Stamp;
 use crate::sync::atomic::AtomicBool;
@@ -1037,43 +1038,51 @@ impl QueryOrigin {
         mut input_outputs: impl ExactSizeIterator<Item = QueryEdge>,
         kind: QueryOriginKind,
     ) -> QueryOrigin {
-        // Exceeding `u32::MAX` query edges should never happen in real-world usage.
-        let length = u32::try_from(input_outputs.len())
-            .expect("exceeded more than `u32::MAX` query edges; this should never happen.");
+        let mut packed_input_outputs = Vec::with_capacity(input_outputs.len());
 
-        let mut packed_input_outputs = Vec::with_capacity(length as usize);
-
-        let (layout, input_outputs) = 'edges: {
+        let input_outputs = 'edges: {
             for edge in input_outputs.by_ref() {
                 let Some(edge) = PackedQueryEdge::new(edge) else {
-                    let input_outputs = packed_input_outputs
-                        .into_iter()
-                        .map(PackedQueryEdge::edge)
-                        .chain(std::iter::once(edge))
-                        .chain(input_outputs)
-                        .collect::<Box<[QueryEdge]>>();
-
-                    // SAFETY: `Box::into_raw` returns a non-null pointer.
-                    let input_outputs = unsafe {
-                        NonNull::new_unchecked(Box::into_raw(input_outputs).cast::<QueryEdge>())
-                            .cast::<()>()
-                    };
-
-                    break 'edges (QueryEdgeLayout::Wide, input_outputs);
+                    break 'edges OwnedQueryEdges::Wide(
+                        packed_input_outputs
+                            .into_iter()
+                            .map(PackedQueryEdge::edge)
+                            .chain(std::iter::once(edge))
+                            .chain(input_outputs)
+                            .collect(),
+                    );
                 };
 
                 packed_input_outputs.push(edge);
             }
 
-            let input_outputs = packed_input_outputs.into_boxed_slice();
+            OwnedQueryEdges::Packed(packed_input_outputs.into_boxed_slice())
+        };
 
-            // SAFETY: `Box::into_raw` returns a non-null pointer.
-            let input_outputs = unsafe {
-                NonNull::new_unchecked(Box::into_raw(input_outputs).cast::<PackedQueryEdge>())
-                    .cast::<()>()
-            };
+        QueryOrigin::from_owned_edges(kind, input_outputs)
+    }
 
-            (QueryEdgeLayout::Packed, input_outputs)
+    fn from_owned_edges(kind: QueryOriginKind, input_outputs: OwnedQueryEdges) -> QueryOrigin {
+        let length = u32::try_from(input_outputs.len())
+            .expect("exceeded more than `u32::MAX` query edges; this should never happen.");
+
+        let (layout, input_outputs) = match input_outputs {
+            OwnedQueryEdges::Packed(input_outputs) => {
+                // SAFETY: `Box::into_raw` returns a non-null pointer.
+                let input_outputs = unsafe {
+                    NonNull::new_unchecked(Box::into_raw(input_outputs).cast::<PackedQueryEdge>())
+                        .cast::<()>()
+                };
+                (QueryEdgeLayout::Packed, input_outputs)
+            }
+            OwnedQueryEdges::Wide(input_outputs) => {
+                // SAFETY: `Box::into_raw` returns a non-null pointer.
+                let input_outputs = unsafe {
+                    NonNull::new_unchecked(Box::into_raw(input_outputs).cast::<QueryEdge>())
+                        .cast::<()>()
+                };
+                (QueryEdgeLayout::Wide, input_outputs)
+            }
         };
 
         QueryOrigin {
@@ -1158,6 +1167,20 @@ impl QueryOrigin {
                     length,
                 ))
             }
+        }
+    }
+}
+
+enum OwnedQueryEdges {
+    Packed(Box<[PackedQueryEdge]>),
+    Wide(Box<[QueryEdge]>),
+}
+
+impl OwnedQueryEdges {
+    fn len(&self) -> usize {
+        match self {
+            OwnedQueryEdges::Packed(edges) => edges.len(),
+            OwnedQueryEdges::Wide(edges) => edges.len(),
         }
     }
 }
@@ -1307,10 +1330,104 @@ impl std::fmt::Debug for QueryEdge {
 /// tag on the [`IngredientIndex`]. The ingredient index and generation must fit in
 /// their respective fields; if either does not, [`QueryOrigin`] uses the wide
 /// layout.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 struct PackedQueryEdge {
     index: u32,
     metadata: u32,
+}
+
+#[derive(Debug)]
+pub(crate) struct ActiveQueryEdges {
+    data: ActiveQueryEdgesData,
+}
+
+#[derive(Debug)]
+enum ActiveQueryEdgesData {
+    Packed(FxIndexSet<PackedQueryEdge>),
+    Wide(FxIndexSet<QueryEdge>),
+}
+
+impl Default for ActiveQueryEdges {
+    fn default() -> Self {
+        ActiveQueryEdges {
+            data: ActiveQueryEdgesData::Packed(FxIndexSet::default()),
+        }
+    }
+}
+
+impl ActiveQueryEdges {
+    pub(crate) fn is_empty(&self) -> bool {
+        match &self.data {
+            ActiveQueryEdgesData::Packed(edges) => edges.is_empty(),
+            ActiveQueryEdgesData::Wide(edges) => edges.is_empty(),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn insert(&mut self, edge: QueryEdge) -> bool {
+        match &mut self.data {
+            ActiveQueryEdgesData::Packed(edges) => {
+                let Some(packed_edge) = PackedQueryEdge::new(edge) else {
+                    let (wide_edges, inserted) = Self::spill(edges, edge);
+                    self.data = wide_edges;
+                    return inserted;
+                };
+
+                edges.insert(packed_edge)
+            }
+            ActiveQueryEdgesData::Wide(edges) => edges.insert(edge),
+        }
+    }
+
+    #[cold]
+    fn spill(
+        packed_edges: &mut FxIndexSet<PackedQueryEdge>,
+        edge: QueryEdge,
+    ) -> (ActiveQueryEdgesData, bool) {
+        let mut wide_edges =
+            FxIndexSet::with_capacity_and_hasher(packed_edges.len() + 1, Default::default());
+        wide_edges.extend(packed_edges.drain(..).map(PackedQueryEdge::edge));
+        let inserted = wide_edges.insert(edge);
+        (ActiveQueryEdgesData::Wide(wide_edges), inserted)
+    }
+
+    pub(crate) fn extend(&mut self, input_outputs: impl IntoIterator<Item = QueryEdge>) {
+        for edge in input_outputs {
+            self.insert(edge);
+        }
+    }
+
+    pub(crate) fn clear(&mut self) {
+        match &mut self.data {
+            ActiveQueryEdgesData::Packed(edges) => edges.clear(),
+            ActiveQueryEdgesData::Wide(_) => *self = ActiveQueryEdges::default(),
+        }
+    }
+
+    pub(crate) fn take_origin(&mut self, untracked_read: bool) -> QueryOrigin {
+        let kind = if untracked_read {
+            QueryOriginKind::DerivedUntracked
+        } else {
+            QueryOriginKind::Derived
+        };
+
+        let edges = match &mut self.data {
+            ActiveQueryEdgesData::Packed(edges) => {
+                OwnedQueryEdges::Packed(edges.drain(..).collect())
+            }
+            ActiveQueryEdgesData::Wide(_) => {
+                let ActiveQueryEdgesData::Wide(mut edges) = std::mem::replace(
+                    &mut self.data,
+                    ActiveQueryEdgesData::Packed(FxIndexSet::default()),
+                ) else {
+                    unreachable!()
+                };
+                OwnedQueryEdges::Wide(edges.drain(..).collect())
+            }
+        };
+
+        QueryOrigin::from_owned_edges(kind, edges)
+    }
 }
 
 impl PackedQueryEdge {
@@ -1419,6 +1536,27 @@ impl<'a> QueryEdges<'a> {
         };
 
         QueryEdgeIter { data }
+    }
+
+    #[inline]
+    pub(crate) fn try_for_each<B>(
+        self,
+        mut f: impl FnMut(QueryEdge) -> std::ops::ControlFlow<B>,
+    ) -> std::ops::ControlFlow<B> {
+        match self.data {
+            QueryEdgesData::Packed(edges) => {
+                for edge in edges {
+                    f(edge.edge())?;
+                }
+            }
+            QueryEdgesData::Wide(edges) => {
+                for &edge in edges {
+                    f(edge)?;
+                }
+            }
+        }
+
+        std::ops::ControlFlow::Continue(())
     }
 
     #[cfg(test)]
@@ -1690,7 +1828,7 @@ pub(crate) mod persistence {
 mod tests {
     use std::mem::size_of;
 
-    use super::{PackedQueryEdge, QueryEdge, QueryOrigin, QueryOriginRef};
+    use super::{ActiveQueryEdges, PackedQueryEdge, QueryEdge, QueryOrigin, QueryOriginRef};
     use crate::{DatabaseKeyIndex, Id, IngredientIndex};
 
     #[test]
@@ -1739,6 +1877,34 @@ mod tests {
 
         assert!(!edges.is_packed());
         assert_eq!(edges.iter().collect::<Vec<_>>(), vec![wide]);
+    }
+
+    #[test]
+    fn active_query_edges_spill_once_and_reset_after_completion() {
+        let packed = QueryEdge::input(key(231, 10_842_122, 41));
+        let wide = QueryEdge::output(key(PackedQueryEdge::INGREDIENT_MASK + 1, 10_842_123, 42));
+        let mut input_outputs = ActiveQueryEdges::default();
+
+        assert!(input_outputs.insert(packed));
+        assert!(!input_outputs.insert(packed));
+        assert!(input_outputs.insert(wide));
+
+        let origin = input_outputs.take_origin(false);
+        let QueryOriginRef::Derived(edges) = origin.as_ref() else {
+            panic!("expected derived origin");
+        };
+        assert!(!edges.is_packed());
+        assert_eq!(edges.iter().collect::<Vec<_>>(), vec![packed, wide]);
+
+        assert!(input_outputs.is_empty());
+        assert!(input_outputs.insert(packed));
+
+        let origin = input_outputs.take_origin(true);
+        let QueryOriginRef::DerivedUntracked(edges) = origin.as_ref() else {
+            panic!("expected untracked derived origin");
+        };
+        assert!(edges.is_packed());
+        assert_eq!(edges.iter().collect::<Vec<_>>(), vec![packed]);
     }
 
     #[test]

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -1739,7 +1739,9 @@ pub(crate) mod persistence {
 mod tests {
     use std::mem::size_of;
 
-    use super::{PackedQueryEdge, QueryEdge, QueryEdgeKind, QueryOrigin, QueryOriginRef};
+    #[cfg(feature = "persistence")]
+    use super::QueryEdgeKind;
+    use super::{PackedQueryEdge, QueryEdge, QueryOrigin, QueryOriginRef};
     use crate::{DatabaseKeyIndex, Id, IngredientIndex};
 
     #[test]

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -17,7 +17,6 @@ use crate::accumulator::{
 use crate::active_query::{CompletedQuery, QueryStack};
 use crate::cycle::{AtomicIterationCount, CycleHeads, IterationCount, empty_cycle_heads};
 use crate::durability::Durability;
-use crate::hash::FxIndexSet;
 use crate::key::DatabaseKeyIndex;
 use crate::runtime::Stamp;
 use crate::sync::atomic::AtomicBool;
@@ -1038,51 +1037,43 @@ impl QueryOrigin {
         mut input_outputs: impl ExactSizeIterator<Item = QueryEdge>,
         kind: QueryOriginKind,
     ) -> QueryOrigin {
-        let mut packed_input_outputs = Vec::with_capacity(input_outputs.len());
+        // Exceeding `u32::MAX` query edges should never happen in real-world usage.
+        let length = u32::try_from(input_outputs.len())
+            .expect("exceeded more than `u32::MAX` query edges; this should never happen.");
 
-        let input_outputs = 'edges: {
+        let mut packed_input_outputs = Vec::with_capacity(length as usize);
+
+        let (layout, input_outputs) = 'edges: {
             for edge in input_outputs.by_ref() {
                 let Some(edge) = PackedQueryEdge::new(edge) else {
-                    break 'edges OwnedQueryEdges::Wide(
-                        packed_input_outputs
-                            .into_iter()
-                            .map(PackedQueryEdge::edge)
-                            .chain(std::iter::once(edge))
-                            .chain(input_outputs)
-                            .collect(),
-                    );
+                    let input_outputs = packed_input_outputs
+                        .into_iter()
+                        .map(PackedQueryEdge::edge)
+                        .chain(std::iter::once(edge))
+                        .chain(input_outputs)
+                        .collect::<Box<[QueryEdge]>>();
+
+                    // SAFETY: `Box::into_raw` returns a non-null pointer.
+                    let input_outputs = unsafe {
+                        NonNull::new_unchecked(Box::into_raw(input_outputs).cast::<QueryEdge>())
+                            .cast::<()>()
+                    };
+
+                    break 'edges (QueryEdgeLayout::Wide, input_outputs);
                 };
 
                 packed_input_outputs.push(edge);
             }
 
-            OwnedQueryEdges::Packed(packed_input_outputs.into_boxed_slice())
-        };
+            let input_outputs = packed_input_outputs.into_boxed_slice();
 
-        QueryOrigin::from_owned_edges(kind, input_outputs)
-    }
+            // SAFETY: `Box::into_raw` returns a non-null pointer.
+            let input_outputs = unsafe {
+                NonNull::new_unchecked(Box::into_raw(input_outputs).cast::<PackedQueryEdge>())
+                    .cast::<()>()
+            };
 
-    fn from_owned_edges(kind: QueryOriginKind, input_outputs: OwnedQueryEdges) -> QueryOrigin {
-        let length = u32::try_from(input_outputs.len())
-            .expect("exceeded more than `u32::MAX` query edges; this should never happen.");
-
-        let (layout, input_outputs) = match input_outputs {
-            OwnedQueryEdges::Packed(input_outputs) => {
-                // SAFETY: `Box::into_raw` returns a non-null pointer.
-                let input_outputs = unsafe {
-                    NonNull::new_unchecked(Box::into_raw(input_outputs).cast::<PackedQueryEdge>())
-                        .cast::<()>()
-                };
-                (QueryEdgeLayout::Packed, input_outputs)
-            }
-            OwnedQueryEdges::Wide(input_outputs) => {
-                // SAFETY: `Box::into_raw` returns a non-null pointer.
-                let input_outputs = unsafe {
-                    NonNull::new_unchecked(Box::into_raw(input_outputs).cast::<QueryEdge>())
-                        .cast::<()>()
-                };
-                (QueryEdgeLayout::Wide, input_outputs)
-            }
+            (QueryEdgeLayout::Packed, input_outputs)
         };
 
         QueryOrigin {
@@ -1167,20 +1158,6 @@ impl QueryOrigin {
                     length,
                 ))
             }
-        }
-    }
-}
-
-enum OwnedQueryEdges {
-    Packed(Box<[PackedQueryEdge]>),
-    Wide(Box<[QueryEdge]>),
-}
-
-impl OwnedQueryEdges {
-    fn len(&self) -> usize {
-        match self {
-            OwnedQueryEdges::Packed(edges) => edges.len(),
-            OwnedQueryEdges::Wide(edges) => edges.len(),
         }
     }
 }
@@ -1330,104 +1307,10 @@ impl std::fmt::Debug for QueryEdge {
 /// tag on the [`IngredientIndex`]. The ingredient index and generation must fit in
 /// their respective fields; if either does not, [`QueryOrigin`] uses the wide
 /// layout.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone)]
 struct PackedQueryEdge {
     index: u32,
     metadata: u32,
-}
-
-#[derive(Debug)]
-pub(crate) struct ActiveQueryEdges {
-    data: ActiveQueryEdgesData,
-}
-
-#[derive(Debug)]
-enum ActiveQueryEdgesData {
-    Packed(FxIndexSet<PackedQueryEdge>),
-    Wide(FxIndexSet<QueryEdge>),
-}
-
-impl Default for ActiveQueryEdges {
-    fn default() -> Self {
-        ActiveQueryEdges {
-            data: ActiveQueryEdgesData::Packed(FxIndexSet::default()),
-        }
-    }
-}
-
-impl ActiveQueryEdges {
-    pub(crate) fn is_empty(&self) -> bool {
-        match &self.data {
-            ActiveQueryEdgesData::Packed(edges) => edges.is_empty(),
-            ActiveQueryEdgesData::Wide(edges) => edges.is_empty(),
-        }
-    }
-
-    #[inline]
-    pub(crate) fn insert(&mut self, edge: QueryEdge) -> bool {
-        match &mut self.data {
-            ActiveQueryEdgesData::Packed(edges) => {
-                let Some(packed_edge) = PackedQueryEdge::new(edge) else {
-                    let (wide_edges, inserted) = Self::spill(edges, edge);
-                    self.data = wide_edges;
-                    return inserted;
-                };
-
-                edges.insert(packed_edge)
-            }
-            ActiveQueryEdgesData::Wide(edges) => edges.insert(edge),
-        }
-    }
-
-    #[cold]
-    fn spill(
-        packed_edges: &mut FxIndexSet<PackedQueryEdge>,
-        edge: QueryEdge,
-    ) -> (ActiveQueryEdgesData, bool) {
-        let mut wide_edges =
-            FxIndexSet::with_capacity_and_hasher(packed_edges.len() + 1, Default::default());
-        wide_edges.extend(packed_edges.drain(..).map(PackedQueryEdge::edge));
-        let inserted = wide_edges.insert(edge);
-        (ActiveQueryEdgesData::Wide(wide_edges), inserted)
-    }
-
-    pub(crate) fn extend(&mut self, input_outputs: impl IntoIterator<Item = QueryEdge>) {
-        for edge in input_outputs {
-            self.insert(edge);
-        }
-    }
-
-    pub(crate) fn clear(&mut self) {
-        match &mut self.data {
-            ActiveQueryEdgesData::Packed(edges) => edges.clear(),
-            ActiveQueryEdgesData::Wide(_) => *self = ActiveQueryEdges::default(),
-        }
-    }
-
-    pub(crate) fn take_origin(&mut self, untracked_read: bool) -> QueryOrigin {
-        let kind = if untracked_read {
-            QueryOriginKind::DerivedUntracked
-        } else {
-            QueryOriginKind::Derived
-        };
-
-        let edges = match &mut self.data {
-            ActiveQueryEdgesData::Packed(edges) => {
-                OwnedQueryEdges::Packed(edges.drain(..).collect())
-            }
-            ActiveQueryEdgesData::Wide(_) => {
-                let ActiveQueryEdgesData::Wide(mut edges) = std::mem::replace(
-                    &mut self.data,
-                    ActiveQueryEdgesData::Packed(FxIndexSet::default()),
-                ) else {
-                    unreachable!()
-                };
-                OwnedQueryEdges::Wide(edges.drain(..).collect())
-            }
-        };
-
-        QueryOrigin::from_owned_edges(kind, edges)
-    }
 }
 
 impl PackedQueryEdge {
@@ -1828,7 +1711,7 @@ pub(crate) mod persistence {
 mod tests {
     use std::mem::size_of;
 
-    use super::{ActiveQueryEdges, PackedQueryEdge, QueryEdge, QueryOrigin, QueryOriginRef};
+    use super::{PackedQueryEdge, QueryEdge, QueryOrigin, QueryOriginRef};
     use crate::{DatabaseKeyIndex, Id, IngredientIndex};
 
     #[test]
@@ -1877,34 +1760,6 @@ mod tests {
 
         assert!(!edges.is_packed());
         assert_eq!(edges.iter().collect::<Vec<_>>(), vec![wide]);
-    }
-
-    #[test]
-    fn active_query_edges_spill_once_and_reset_after_completion() {
-        let packed = QueryEdge::input(key(231, 10_842_122, 41));
-        let wide = QueryEdge::output(key(PackedQueryEdge::INGREDIENT_MASK + 1, 10_842_123, 42));
-        let mut input_outputs = ActiveQueryEdges::default();
-
-        assert!(input_outputs.insert(packed));
-        assert!(!input_outputs.insert(packed));
-        assert!(input_outputs.insert(wide));
-
-        let origin = input_outputs.take_origin(false);
-        let QueryOriginRef::Derived(edges) = origin.as_ref() else {
-            panic!("expected derived origin");
-        };
-        assert!(!edges.is_packed());
-        assert_eq!(edges.iter().collect::<Vec<_>>(), vec![packed, wide]);
-
-        assert!(input_outputs.is_empty());
-        assert!(input_outputs.insert(packed));
-
-        let origin = input_outputs.take_origin(true);
-        let QueryOriginRef::DerivedUntracked(edges) = origin.as_ref() else {
-            panic!("expected untracked derived origin");
-        };
-        assert!(edges.is_packed());
-        assert_eq!(edges.iter().collect::<Vec<_>>(), vec![packed]);
     }
 
     #[test]

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -693,7 +693,7 @@ impl QueryRevisions {
         Self {
             changed_at: Revision::start(),
             durability: Durability::MAX,
-            origin: QueryOrigin::derived(Box::default()),
+            origin: QueryOrigin::derived([]),
             #[cfg(feature = "accumulator")]
             accumulated_inputs: Default::default(),
             verified_final: AtomicBool::new(false),
@@ -915,19 +915,29 @@ enum QueryOriginKind {
 #[derive(Clone, Copy)]
 #[repr(u8)]
 enum QueryEdgeLayout {
+    /// Every edge in the origin fits in [`PackedQueryEdge`].
+    ///
+    /// The origin stores one `Box<[PackedQueryEdge]>`, reducing each retained edge
+    /// from 12 bytes to 8 bytes.
     Packed = 0b000,
+
+    /// At least one edge in the origin does not fit in [`PackedQueryEdge`].
+    ///
+    /// The origin retains the original `Box<[QueryEdge]>`. Spilling the entire origin
+    /// avoids allocating a separate overflow object for each wide edge.
     Wide = 0b100,
 }
 
 #[derive(Clone, Copy)]
 #[repr(transparent)]
+/// Encodes the semantic origin kind and retained edge layout in a single byte.
 struct QueryOriginTag(u8);
 
 impl QueryOriginTag {
     const KIND_MASK: u8 = 0b011;
     const LAYOUT_MASK: u8 = 0b100;
 
-    fn new(kind: QueryOriginKind, layout: QueryEdgeLayout) -> Self {
+    const fn new(kind: QueryOriginKind, layout: QueryEdgeLayout) -> Self {
         QueryOriginTag(kind as u8 | layout as u8)
     }
 
@@ -940,7 +950,7 @@ impl QueryOriginTag {
         }
     }
 
-    fn layout(self) -> QueryEdgeLayout {
+    const fn layout(self) -> QueryEdgeLayout {
         if self.0 & Self::LAYOUT_MASK == 0 {
             QueryEdgeLayout::Packed
         } else {
@@ -950,6 +960,14 @@ impl QueryOriginTag {
 }
 
 /// Tracks how a memoized value for a given query was created.
+///
+/// Derived origins retain their edges in a single allocation. If every edge fits in
+/// [`PackedQueryEdge`], the origin stores a `Box<[PackedQueryEdge]>`. Otherwise, it keeps
+/// the original `Box<[QueryEdge]>`, avoiding separate allocations for overflowing edges.
+///
+/// [`QueryOriginTag`] stores the semantic origin kind independently from the retained
+/// [`QueryEdgeLayout`]. Consumers see the same assigned, derived, and untracked-derived
+/// origins regardless of how their edges are stored.
 ///
 /// This type is a manual enum packed to 13 bytes to reduce the size of `QueryRevisions`.
 #[repr(Rust, packed)]
@@ -1007,21 +1025,47 @@ impl QueryOrigin {
     }
 
     /// Create a query origin of type `QueryOriginKind::Derived`, with the given edges.
-    pub fn derived(input_outputs: Box<[QueryEdge]>) -> QueryOrigin {
-        Self::derived_with_kind(input_outputs, QueryOriginKind::Derived)
+    pub fn derived<I>(input_outputs: I) -> QueryOrigin
+    where
+        I: IntoIterator<Item = QueryEdge>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        Self::derived_with_kind(input_outputs.into_iter(), QueryOriginKind::Derived)
     }
 
-    fn derived_with_kind(input_outputs: Box<[QueryEdge]>, kind: QueryOriginKind) -> QueryOrigin {
+    fn derived_with_kind(
+        mut input_outputs: impl ExactSizeIterator<Item = QueryEdge>,
+        kind: QueryOriginKind,
+    ) -> QueryOrigin {
         // Exceeding `u32::MAX` query edges should never happen in real-world usage.
         let length = u32::try_from(input_outputs.len())
             .expect("exceeded more than `u32::MAX` query edges; this should never happen.");
 
-        let (layout, input_outputs) = if input_outputs.iter().copied().all(PackedQueryEdge::fits) {
-            let input_outputs: Box<[PackedQueryEdge]> = input_outputs
-                .iter()
-                .copied()
-                .map(PackedQueryEdge::new)
-                .collect();
+        let mut packed_input_outputs = Vec::with_capacity(length as usize);
+
+        let (layout, input_outputs) = 'edges: {
+            for edge in input_outputs.by_ref() {
+                let Some(edge) = PackedQueryEdge::new(edge) else {
+                    let input_outputs = packed_input_outputs
+                        .into_iter()
+                        .map(PackedQueryEdge::edge)
+                        .chain(std::iter::once(edge))
+                        .chain(input_outputs)
+                        .collect::<Box<[QueryEdge]>>();
+
+                    // SAFETY: `Box::into_raw` returns a non-null pointer.
+                    let input_outputs = unsafe {
+                        NonNull::new_unchecked(Box::into_raw(input_outputs).cast::<QueryEdge>())
+                            .cast::<()>()
+                    };
+
+                    break 'edges (QueryEdgeLayout::Wide, input_outputs);
+                };
+
+                packed_input_outputs.push(edge);
+            }
+
+            let input_outputs = packed_input_outputs.into_boxed_slice();
 
             // SAFETY: `Box::into_raw` returns a non-null pointer.
             let input_outputs = unsafe {
@@ -1030,14 +1074,6 @@ impl QueryOrigin {
             };
 
             (QueryEdgeLayout::Packed, input_outputs)
-        } else {
-            // SAFETY: `Box::into_raw` returns a non-null pointer.
-            let input_outputs = unsafe {
-                NonNull::new_unchecked(Box::into_raw(input_outputs).cast::<QueryEdge>())
-                    .cast::<()>()
-            };
-
-            (QueryEdgeLayout::Wide, input_outputs)
         };
 
         QueryOrigin {
@@ -1048,16 +1084,19 @@ impl QueryOrigin {
     }
 
     /// Create a query origin of type `QueryOriginKind::DerivedUntracked`, with the given edges.
-    pub fn derived_untracked(input_outputs: Box<[QueryEdge]>) -> QueryOrigin {
-        Self::derived_with_kind(input_outputs, QueryOriginKind::DerivedUntracked)
+    pub fn derived_untracked<I>(input_outputs: I) -> QueryOrigin
+    where
+        I: IntoIterator<Item = QueryEdge>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        Self::derived_with_kind(input_outputs.into_iter(), QueryOriginKind::DerivedUntracked)
     }
 
-    /// Sets the `input_outputs` of this query's origin if it's derived or derived untracked.
-    /// Returns `Err` if the query origin isn't derived.
-    pub(crate) fn set_edges(
-        &mut self,
-        input_outputs: Box<[QueryEdge]>,
-    ) -> Result<(), Box<[QueryEdge]>> {
+    pub(crate) fn set_edges<I>(&mut self, input_outputs: I) -> Result<(), I>
+    where
+        I: IntoIterator<Item = QueryEdge>,
+        I::IntoIter: ExactSizeIterator,
+    {
         match self.tag.kind() {
             QueryOriginKind::Assigned => Err(input_outputs),
             QueryOriginKind::Derived => {
@@ -1214,12 +1253,12 @@ pub struct QueryEdge {
 
 impl QueryEdge {
     /// Create an input query edge with the given index.
-    pub fn input(key: DatabaseKeyIndex) -> QueryEdge {
+    pub const fn input(key: DatabaseKeyIndex) -> QueryEdge {
         Self { key }
     }
 
     /// Create an output query edge with the given index.
-    pub fn output(key: DatabaseKeyIndex) -> QueryEdge {
+    pub const fn output(key: DatabaseKeyIndex) -> QueryEdge {
         let ingredient_index = key.ingredient_index().with_tag(true);
 
         Self {
@@ -1228,7 +1267,7 @@ impl QueryEdge {
     }
 
     /// Return the key of this query edge.
-    pub fn key(self) -> DatabaseKeyIndex {
+    pub const fn key(self) -> DatabaseKeyIndex {
         // Clear the tag to restore the original index.
         DatabaseKeyIndex::new(
             self.key.ingredient_index().with_tag(false),
@@ -1237,7 +1276,7 @@ impl QueryEdge {
     }
 
     /// Returns the kind of this query edge.
-    pub fn kind(self) -> QueryEdgeKind {
+    pub const fn kind(self) -> QueryEdgeKind {
         if self.key.ingredient_index().tag() {
             QueryEdgeKind::Output(self.key())
         } else {
@@ -1256,48 +1295,55 @@ impl std::fmt::Debug for QueryEdge {
 ///
 /// Query origins use this representation when every edge fits. Otherwise, the origin
 /// retains the existing full-width [`QueryEdge`] slice.
+///
+/// `metadata` has the following layout, from most significant to least significant
+/// bit:
+///
+/// ```text
+/// [output: 1][ingredient: 12][generation: 19]
+/// ```
+///
+/// `index` stores the complete 32-bit key index separately. `output` preserves the
+/// tag on the [`IngredientIndex`]. The ingredient index and generation must fit in
+/// their respective fields; if either does not, [`QueryOrigin`] uses the wide
+/// layout.
 #[derive(Copy, Clone)]
-struct PackedQueryEdge(u64);
+struct PackedQueryEdge {
+    index: u32,
+    metadata: u32,
+}
 
 impl PackedQueryEdge {
-    // [output: 1][ingredient: 12][generation: 19][index: 32]
-    const GENERATION_SHIFT: u32 = 32;
-    const INGREDIENT_SHIFT: u32 = 51;
-    const OUTPUT_SHIFT: u32 = 63;
-    const GENERATION_MASK: u64 = 0x7FFFF;
-    const INGREDIENT_MASK: u64 = 0xFFF;
+    const INGREDIENT_SHIFT: u32 = 19;
+    const OUTPUT_SHIFT: u32 = 31;
+    const GENERATION_MASK: u32 = 0x7FFFF;
+    const INGREDIENT_MASK: u32 = 0xFFF;
 
-    fn fits(edge: QueryEdge) -> bool {
+    const fn new(edge: QueryEdge) -> Option<Self> {
         let ingredient = edge.key.ingredient_index().with_tag(false).as_u32();
         let id = edge.key.key_index();
 
-        u64::from(ingredient) <= Self::INGREDIENT_MASK
-            && u64::from(id.generation()) <= Self::GENERATION_MASK
-    }
-
-    fn new(edge: QueryEdge) -> Self {
-        debug_assert!(Self::fits(edge));
+        if ingredient > Self::INGREDIENT_MASK || id.generation() > Self::GENERATION_MASK {
+            return None;
+        }
 
         let ingredient_index = edge.key.ingredient_index();
-        let ingredient = ingredient_index.with_tag(false).as_u32();
-        let id = edge.key.key_index();
 
-        PackedQueryEdge(
-            u64::from(id.index())
-                | (u64::from(id.generation()) << Self::GENERATION_SHIFT)
-                | (u64::from(ingredient) << Self::INGREDIENT_SHIFT)
-                | (u64::from(ingredient_index.tag()) << Self::OUTPUT_SHIFT),
-        )
+        Some(PackedQueryEdge {
+            index: id.index(),
+            metadata: id.generation()
+                | (ingredient << Self::INGREDIENT_SHIFT)
+                | ((ingredient_index.tag() as u32) << Self::OUTPUT_SHIFT),
+        })
     }
 
-    fn edge(self) -> QueryEdge {
-        let index = self.0 as u32;
-        let generation = ((self.0 >> Self::GENERATION_SHIFT) & Self::GENERATION_MASK) as u32;
-        let ingredient = ((self.0 >> Self::INGREDIENT_SHIFT) & Self::INGREDIENT_MASK) as u32;
-        let is_output = self.0 >> Self::OUTPUT_SHIFT != 0;
+    const fn edge(self) -> QueryEdge {
+        let generation = self.metadata & Self::GENERATION_MASK;
+        let ingredient = (self.metadata >> Self::INGREDIENT_SHIFT) & Self::INGREDIENT_MASK;
+        let is_output = self.metadata >> Self::OUTPUT_SHIFT != 0;
 
         // SAFETY: The index came from a valid `Id` in `PackedQueryEdge::new`.
-        let id = unsafe { Id::from_index(index) }.with_generation(generation);
+        let id = unsafe { Id::from_index(self.index) }.with_generation(generation);
         // SAFETY: The ingredient came from a valid `IngredientIndex` in `PackedQueryEdge::new`.
         let ingredient = unsafe { IngredientIndex::new_unchecked(ingredient) };
 
@@ -1481,121 +1527,6 @@ pub(crate) fn output_edges(
     })
 }
 
-#[cfg(test)]
-mod tests {
-    use std::mem::size_of;
-
-    use super::{PackedQueryEdge, QueryEdge, QueryOrigin, QueryOriginRef};
-    use crate::{DatabaseKeyIndex, Id, IngredientIndex};
-
-    #[test]
-    fn packed_query_edges_use_eight_bytes() {
-        assert_eq!(size_of::<PackedQueryEdge>(), 8);
-        assert_eq!(size_of::<QueryEdge>(), 12);
-        assert_eq!(size_of::<QueryOrigin>(), 13);
-    }
-
-    #[test]
-    fn query_origin_packs_edges_that_fit() {
-        let input = QueryEdge::input(key(231, 10_842_122, 41));
-        let output = QueryEdge::output(key(232, 10_842_123, 42));
-        let origin = QueryOrigin::derived(Box::new([input, output]));
-        let QueryOriginRef::Derived(edges) = origin.as_ref() else {
-            panic!("expected derived origin");
-        };
-
-        assert!(edges.is_packed());
-        assert_eq!(edges.allocation_size(), 2 * size_of::<PackedQueryEdge>());
-        assert_eq!(edges.iter().collect::<Vec<_>>(), vec![input, output]);
-        assert_eq!(edges.iter().rev().collect::<Vec<_>>(), vec![output, input]);
-    }
-
-    #[test]
-    fn query_origin_spills_all_edges_if_generation_does_not_fit() {
-        let packed = QueryEdge::input(key(231, 10_842_122, 41));
-        let wide = QueryEdge::output(key(
-            232,
-            10_842_123,
-            PackedQueryEdge::GENERATION_MASK as u32 + 1,
-        ));
-        let origin = QueryOrigin::derived(Box::new([packed, wide]));
-        let QueryOriginRef::Derived(edges) = origin.as_ref() else {
-            panic!("expected derived origin");
-        };
-
-        assert!(!edges.is_packed());
-        assert_eq!(edges.allocation_size(), 2 * size_of::<QueryEdge>());
-        assert_eq!(edges.iter().collect::<Vec<_>>(), vec![packed, wide]);
-    }
-
-    #[test]
-    fn query_origin_spills_if_ingredient_does_not_fit() {
-        let wide = QueryEdge::input(key(
-            PackedQueryEdge::INGREDIENT_MASK as u32 + 1,
-            10_842_122,
-            41,
-        ));
-        let origin = QueryOrigin::derived(Box::new([wide]));
-        let QueryOriginRef::Derived(edges) = origin.as_ref() else {
-            panic!("expected derived origin");
-        };
-
-        assert!(!edges.is_packed());
-        assert_eq!(edges.iter().collect::<Vec<_>>(), vec![wide]);
-    }
-
-    #[test]
-    fn replacing_query_origin_edges_can_change_layout() {
-        let packed = QueryEdge::input(key(231, 10_842_122, 41));
-        let wide = QueryEdge::input(key(
-            PackedQueryEdge::INGREDIENT_MASK as u32 + 1,
-            10_842_123,
-            42,
-        ));
-        let mut origin = QueryOrigin::derived(Box::new([packed]));
-
-        origin.set_edges(Box::new([wide])).unwrap();
-        assert!(!origin.as_ref().edges().is_packed());
-
-        origin.set_edges(Box::new([packed])).unwrap();
-        assert!(origin.as_ref().edges().is_packed());
-    }
-
-    #[cfg(feature = "persistence")]
-    #[test]
-    fn query_origin_serde_round_trip_preserves_edges() {
-        let input = QueryEdge::input(key(231, 10_842_122, 41));
-        let output = QueryEdge::output(key(
-            232,
-            10_842_123,
-            PackedQueryEdge::GENERATION_MASK as u32 + 1,
-        ));
-        let origin = QueryOrigin::derived_untracked(Box::new([input, output]));
-        let serialized = serde_json::to_string(&origin).unwrap();
-        let deserialized: QueryOrigin = serde_json::from_str(&serialized).unwrap();
-        let QueryOriginRef::DerivedUntracked(edges) = deserialized.as_ref() else {
-            panic!("expected untracked derived origin");
-        };
-
-        assert!(!edges.is_packed());
-        assert_eq!(edges.iter().collect::<Vec<_>>(), vec![input, output]);
-        assert_eq!(
-            edges.iter().map(QueryEdge::kind).collect::<Vec<_>>(),
-            vec![
-                super::QueryEdgeKind::Input(input.key()),
-                super::QueryEdgeKind::Output(output.key())
-            ]
-        );
-    }
-
-    fn key(ingredient: u32, index: u32, generation: u32) -> DatabaseKeyIndex {
-        // SAFETY: Test inputs are valid `Id` indices.
-        let id = unsafe { Id::from_index(index) }.with_generation(generation);
-
-        DatabaseKeyIndex::new(IngredientIndex::new(ingredient), id)
-    }
-}
-
 /// When a query is pushed onto the `active_query` stack, this guard
 /// is returned to represent its slot. The guard can be used to pop
 /// the query from the stack -- in the case of unwinding, the guard's
@@ -1752,5 +1683,104 @@ pub(crate) mod persistence {
         {
             serde::Deserialize::deserialize(deserializer).map(AtomicBool::new)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::mem::size_of;
+
+    use super::{PackedQueryEdge, QueryEdge, QueryOrigin, QueryOriginRef};
+    use crate::{DatabaseKeyIndex, Id, IngredientIndex};
+
+    #[test]
+    fn packed_query_edges_use_eight_bytes() {
+        assert_eq!(size_of::<PackedQueryEdge>(), 8);
+        assert_eq!(size_of::<QueryEdge>(), 12);
+        assert_eq!(size_of::<QueryOrigin>(), 13);
+    }
+
+    #[test]
+    fn query_origin_packs_edges_that_fit() {
+        let input = QueryEdge::input(key(231, 10_842_122, 41));
+        let output = QueryEdge::output(key(232, 10_842_123, 42));
+        let origin = QueryOrigin::derived([input, output]);
+        let QueryOriginRef::Derived(edges) = origin.as_ref() else {
+            panic!("expected derived origin");
+        };
+
+        assert!(edges.is_packed());
+        assert_eq!(edges.allocation_size(), 2 * size_of::<PackedQueryEdge>());
+        assert_eq!(edges.iter().collect::<Vec<_>>(), vec![input, output]);
+        assert_eq!(edges.iter().rev().collect::<Vec<_>>(), vec![output, input]);
+    }
+
+    #[test]
+    fn query_origin_spills_all_edges_if_generation_does_not_fit() {
+        let packed = QueryEdge::input(key(231, 10_842_122, 41));
+        let wide = QueryEdge::output(key(232, 10_842_123, PackedQueryEdge::GENERATION_MASK + 1));
+        let origin = QueryOrigin::derived([packed, wide]);
+        let QueryOriginRef::Derived(edges) = origin.as_ref() else {
+            panic!("expected derived origin");
+        };
+
+        assert!(!edges.is_packed());
+        assert_eq!(edges.allocation_size(), 2 * size_of::<QueryEdge>());
+        assert_eq!(edges.iter().collect::<Vec<_>>(), vec![packed, wide]);
+    }
+
+    #[test]
+    fn query_origin_spills_if_ingredient_does_not_fit() {
+        let wide = QueryEdge::input(key(PackedQueryEdge::INGREDIENT_MASK + 1, 10_842_122, 41));
+        let origin = QueryOrigin::derived([wide]);
+        let QueryOriginRef::Derived(edges) = origin.as_ref() else {
+            panic!("expected derived origin");
+        };
+
+        assert!(!edges.is_packed());
+        assert_eq!(edges.iter().collect::<Vec<_>>(), vec![wide]);
+    }
+
+    #[test]
+    fn replacing_query_origin_edges_can_change_layout() {
+        let packed = QueryEdge::input(key(231, 10_842_122, 41));
+        let wide = QueryEdge::input(key(PackedQueryEdge::INGREDIENT_MASK + 1, 10_842_123, 42));
+        let mut origin = QueryOrigin::derived([packed]);
+
+        origin.set_edges([wide]).unwrap();
+        assert!(!origin.as_ref().edges().is_packed());
+
+        origin.set_edges([packed]).unwrap();
+        assert!(origin.as_ref().edges().is_packed());
+    }
+
+    #[cfg(feature = "persistence")]
+    #[test]
+    fn query_origin_serde_round_trip_preserves_edges() {
+        let input = QueryEdge::input(key(231, 10_842_122, 41));
+        let output = QueryEdge::output(key(232, 10_842_123, PackedQueryEdge::GENERATION_MASK + 1));
+        let origin = QueryOrigin::derived_untracked([input, output]);
+        let serialized = serde_json::to_string(&origin).unwrap();
+        let deserialized: QueryOrigin = serde_json::from_str(&serialized).unwrap();
+        let QueryOriginRef::DerivedUntracked(edges) = deserialized.as_ref() else {
+            panic!("expected untracked derived origin");
+        };
+
+        assert!(!edges.is_packed());
+        assert_eq!(edges.iter().collect::<Vec<_>>(), vec![input, output]);
+        assert_eq!(
+            edges.iter().map(QueryEdge::kind).collect::<Vec<_>>(),
+            vec![
+                super::QueryEdgeKind::Input(input.key()),
+                super::QueryEdgeKind::Output(output.key())
+            ]
+        );
+    }
+
+    fn key(ingredient: u32, index: u32, generation: u32) -> DatabaseKeyIndex {
+        // SAFETY: Test inputs are valid `Id` indices.
+        let id = unsafe { Id::from_index(index) }.with_generation(generation);
+
+        DatabaseKeyIndex::new(IngredientIndex::new(ingredient), id)
     }
 }

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -882,12 +882,10 @@ impl<'a> QueryOriginRef<'a> {
 
     #[inline]
     pub(crate) fn edges(self) -> QueryEdges<'a> {
-        let opt_edges = match self {
-            QueryOriginRef::Derived(edges) | QueryOriginRef::DerivedUntracked(edges) => Some(edges),
-            QueryOriginRef::Assigned(_) => None,
-        };
-
-        opt_edges.unwrap_or_else(|| QueryEdges::wide(&[]))
+        match self {
+            QueryOriginRef::Derived(edges) | QueryOriginRef::DerivedUntracked(edges) => edges,
+            QueryOriginRef::Assigned(_) => QueryEdges::wide(&[]),
+        }
     }
 }
 
@@ -927,9 +925,9 @@ enum QueryEdgeLayout {
     Wide = 0b100,
 }
 
+/// Encodes the semantic origin kind and retained edge layout in a single byte.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
-/// Encodes the semantic origin kind and retained edge layout in a single byte.
 struct QueryOriginTag(u8);
 
 impl QueryOriginTag {
@@ -937,6 +935,7 @@ impl QueryOriginTag {
     const LAYOUT_MASK: u8 = 0b100;
 
     const fn new(kind: QueryOriginKind, layout: QueryEdgeLayout) -> Self {
+        debug_assert!(kind as u8 & layout as u8 == 0);
         QueryOriginTag(kind as u8 | layout as u8)
     }
 
@@ -1091,6 +1090,8 @@ impl QueryOrigin {
         Self::derived_with_kind(input_outputs.into_iter(), QueryOriginKind::DerivedUntracked)
     }
 
+    /// Sets the `input_outputs` of this query's origin if it's derived or derived untracked.
+    /// Returns `Err` if the query origin isn't derived.
     pub(crate) fn set_edges<I>(&mut self, input_outputs: I) -> Result<(), I>
     where
         I: IntoIterator<Item = QueryEdge>,
@@ -1256,12 +1257,18 @@ pub struct QueryEdge {
 impl QueryEdge {
     /// Create an input query edge with the given index.
     pub const fn input(key: DatabaseKeyIndex) -> QueryEdge {
-        Self::from_key(key)
+        let id = key.key_index();
+
+        QueryEdge {
+            index: id.index(),
+            generation: id.generation(),
+            ingredient: key.ingredient_index(),
+        }
     }
 
     /// Create an output query edge with the given index.
     pub const fn output(key: DatabaseKeyIndex) -> QueryEdge {
-        let mut edge = Self::from_key(key);
+        let mut edge = Self::input(key);
         edge.ingredient = edge.ingredient.with_tag(true);
         edge
     }
@@ -1281,33 +1288,24 @@ impl QueryEdge {
         }
     }
 
-    const fn from_key(key: DatabaseKeyIndex) -> QueryEdge {
-        let id = key.key_index();
-
-        QueryEdge {
-            index: id.index(),
-            generation: id.generation(),
-            ingredient: key.ingredient_index(),
-        }
-    }
-
     #[cfg(feature = "persistence")]
     const fn raw_key(self) -> DatabaseKeyIndex {
         DatabaseKeyIndex::new(self.ingredient, self.id())
     }
 
     const fn id(self) -> Id {
-        // SAFETY: `index` came from a valid `Id` in `QueryEdge::from_key`.
+        // SAFETY: `index` came from a valid `Id` in `QueryEdge::input`.
         unsafe { Id::from_index(self.index) }.with_generation(self.generation)
     }
 }
 
 impl std::fmt::Debug for QueryEdge {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.kind() {
-            QueryEdgeKind::Input => f.debug_tuple("Input").field(&self.key()).finish(),
-            QueryEdgeKind::Output => f.debug_tuple("Output").field(&self.key()).finish(),
-        }
+        let mut tuple = match self.kind() {
+            QueryEdgeKind::Input => f.debug_tuple("Input"),
+            QueryEdgeKind::Output => f.debug_tuple("Output"),
+        };
+        tuple.field(&self.key()).finish()
     }
 }
 
@@ -1327,7 +1325,7 @@ impl<'de> serde::Deserialize<'de> for QueryEdge {
     where
         D: serde::Deserializer<'de>,
     {
-        DatabaseKeyIndex::deserialize(deserializer).map(QueryEdge::from_key)
+        DatabaseKeyIndex::deserialize(deserializer).map(QueryEdge::input)
     }
 }
 

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -1300,13 +1300,12 @@ impl std::fmt::Debug for QueryEdge {
 /// bit:
 ///
 /// ```text
-/// [output: 1][ingredient: 12][generation: 19]
+/// [ingredient: 12][generation: 20]
 /// ```
 ///
-/// `index` stores the complete 32-bit key index separately. `output` preserves the
-/// tag on the [`IngredientIndex`]. The ingredient index and generation must fit in
-/// their respective fields; if either does not, [`QueryOrigin`] uses the wide
-/// layout.
+/// `index` stores the complete 32-bit key index separately. Only input edges can use
+/// this representation. Output edges, ingredient indices, and generations that do
+/// not fit use the wide [`QueryEdge`] layout.
 #[derive(Copy, Clone)]
 struct PackedQueryEdge {
     index: u32,
@@ -1314,42 +1313,38 @@ struct PackedQueryEdge {
 }
 
 impl PackedQueryEdge {
-    const INGREDIENT_SHIFT: u32 = 19;
-    const OUTPUT_SHIFT: u32 = 31;
-    const GENERATION_MASK: u32 = 0x7FFFF;
+    const INGREDIENT_SHIFT: u32 = 20;
+    const GENERATION_MASK: u32 = 0xFFFFF;
     const INGREDIENT_MASK: u32 = 0xFFF;
 
     const fn new(edge: QueryEdge) -> Option<Self> {
-        let ingredient = edge.key.ingredient_index().with_tag(false).as_u32();
+        let ingredient = edge.key.ingredient_index().as_u32();
         let id = edge.key.key_index();
 
         if ingredient > Self::INGREDIENT_MASK || id.generation() > Self::GENERATION_MASK {
             return None;
         }
 
-        let ingredient_index = edge.key.ingredient_index();
-
         Some(PackedQueryEdge {
             index: id.index(),
-            metadata: id.generation()
-                | (ingredient << Self::INGREDIENT_SHIFT)
-                | ((ingredient_index.tag() as u32) << Self::OUTPUT_SHIFT),
+            metadata: id.generation() | (ingredient << Self::INGREDIENT_SHIFT),
         })
     }
 
-    const fn edge(self) -> QueryEdge {
+    const fn key(self) -> DatabaseKeyIndex {
         let generation = self.metadata & Self::GENERATION_MASK;
-        let ingredient = (self.metadata >> Self::INGREDIENT_SHIFT) & Self::INGREDIENT_MASK;
-        let is_output = self.metadata >> Self::OUTPUT_SHIFT != 0;
+        let ingredient = self.metadata >> Self::INGREDIENT_SHIFT;
 
         // SAFETY: The index came from a valid `Id` in `PackedQueryEdge::new`.
         let id = unsafe { Id::from_index(self.index) }.with_generation(generation);
         // SAFETY: The ingredient came from a valid `IngredientIndex` in `PackedQueryEdge::new`.
         let ingredient = unsafe { IngredientIndex::new_unchecked(ingredient) };
 
-        QueryEdge {
-            key: DatabaseKeyIndex::new(ingredient.with_tag(is_output), id),
-        }
+        DatabaseKeyIndex::new(ingredient, id)
+    }
+
+    const fn edge(self) -> QueryEdge {
+        QueryEdge { key: self.key() }
     }
 }
 
@@ -1509,10 +1504,24 @@ pub enum QueryEdgeKind {
 pub(crate) fn input_edges(
     input_outputs: QueryEdges<'_>,
 ) -> impl DoubleEndedIterator<Item = DatabaseKeyIndex> + use<'_> {
-    input_outputs.iter().filter_map(|edge| match edge.kind() {
-        QueryEdgeKind::Input(dependency_index) => Some(dependency_index),
-        QueryEdgeKind::Output(_) => None,
-    })
+    let (packed_inputs, wide_edges) = match input_outputs.data {
+        QueryEdgesData::Packed(inputs) => (inputs, &[][..]),
+        QueryEdgesData::Wide(edges) => (&[][..], edges),
+    };
+
+    packed_inputs
+        .iter()
+        .copied()
+        .map(PackedQueryEdge::key)
+        .chain(
+            wide_edges
+                .iter()
+                .copied()
+                .filter_map(|edge| match edge.kind() {
+                    QueryEdgeKind::Input(dependency_index) => Some(dependency_index),
+                    QueryEdgeKind::Output(_) => None,
+                }),
+        )
 }
 
 /// Returns the (tracked) outputs that were executed in computing this memoized value.
@@ -1521,10 +1530,18 @@ pub(crate) fn input_edges(
 pub(crate) fn output_edges(
     input_outputs: QueryEdges<'_>,
 ) -> impl DoubleEndedIterator<Item = DatabaseKeyIndex> + use<'_> {
-    input_outputs.iter().filter_map(|edge| match edge.kind() {
-        QueryEdgeKind::Output(dependency_index) => Some(dependency_index),
-        QueryEdgeKind::Input(_) => None,
-    })
+    let wide_edges = match input_outputs.data {
+        QueryEdgesData::Packed(_) => &[][..],
+        QueryEdgesData::Wide(edges) => edges,
+    };
+
+    wide_edges
+        .iter()
+        .copied()
+        .filter_map(|edge| match edge.kind() {
+            QueryEdgeKind::Output(dependency_index) => Some(dependency_index),
+            QueryEdgeKind::Input(_) => None,
+        })
 }
 
 /// When a query is pushed onto the `active_query` stack, this guard
@@ -1703,16 +1720,58 @@ mod tests {
     #[test]
     fn query_origin_packs_edges_that_fit() {
         let input = QueryEdge::input(key(231, 10_842_122, 41));
-        let output = QueryEdge::output(key(232, 10_842_123, 42));
-        let origin = QueryOrigin::derived([input, output]);
+        let other_input = QueryEdge::input(key(232, 10_842_123, 42));
+        let origin = QueryOrigin::derived([input, other_input]);
         let QueryOriginRef::Derived(edges) = origin.as_ref() else {
             panic!("expected derived origin");
         };
 
         assert!(edges.is_packed());
         assert_eq!(edges.allocation_size(), 2 * size_of::<PackedQueryEdge>());
+        assert_eq!(edges.iter().collect::<Vec<_>>(), vec![input, other_input]);
+        assert_eq!(
+            edges.iter().rev().collect::<Vec<_>>(),
+            vec![other_input, input]
+        );
+        assert_eq!(
+            origin.as_ref().inputs().collect::<Vec<_>>(),
+            vec![input.key(), other_input.key()]
+        );
+        assert_eq!(origin.as_ref().outputs().collect::<Vec<_>>(), vec![]);
+    }
+
+    #[test]
+    fn query_origin_spills_all_edges_if_it_contains_an_output() {
+        let input = QueryEdge::input(key(231, 10_842_122, 41));
+        let output = QueryEdge::output(key(232, 10_842_123, 42));
+        let origin = QueryOrigin::derived([input, output]);
+        let QueryOriginRef::Derived(edges) = origin.as_ref() else {
+            panic!("expected derived origin");
+        };
+
+        assert!(!edges.is_packed());
+        assert_eq!(edges.allocation_size(), 2 * size_of::<QueryEdge>());
         assert_eq!(edges.iter().collect::<Vec<_>>(), vec![input, output]);
-        assert_eq!(edges.iter().rev().collect::<Vec<_>>(), vec![output, input]);
+        assert_eq!(
+            origin.as_ref().inputs().collect::<Vec<_>>(),
+            vec![input.key()]
+        );
+        assert_eq!(
+            origin.as_ref().outputs().collect::<Vec<_>>(),
+            vec![output.key()]
+        );
+    }
+
+    #[test]
+    fn query_origin_packs_largest_supported_generation() {
+        let input = QueryEdge::input(key(231, 10_842_122, PackedQueryEdge::GENERATION_MASK));
+        let origin = QueryOrigin::derived([input]);
+        let QueryOriginRef::Derived(edges) = origin.as_ref() else {
+            panic!("expected derived origin");
+        };
+
+        assert!(edges.is_packed());
+        assert_eq!(edges.iter().collect::<Vec<_>>(), vec![input]);
     }
 
     #[test]

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -1421,27 +1421,6 @@ impl<'a> QueryEdges<'a> {
         QueryEdgeIter { data }
     }
 
-    #[inline]
-    pub(crate) fn try_for_each<B>(
-        self,
-        mut f: impl FnMut(QueryEdge) -> std::ops::ControlFlow<B>,
-    ) -> std::ops::ControlFlow<B> {
-        match self.data {
-            QueryEdgesData::Packed(edges) => {
-                for edge in edges {
-                    f(edge.edge())?;
-                }
-            }
-            QueryEdgesData::Wide(edges) => {
-                for &edge in edges {
-                    f(edge)?;
-                }
-            }
-        }
-
-        std::ops::ControlFlow::Continue(())
-    }
-
     #[cfg(test)]
     fn is_packed(self) -> bool {
         matches!(self.data, QueryEdgesData::Packed(_))

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -852,13 +852,13 @@ pub enum QueryOriginRef<'a> {
     /// The value was derived by executing a function
     /// and we were able to track ALL of that function's inputs.
     /// Those inputs are described in [`QueryEdges`].
-    Derived(QueryEdges<'a>) = QueryOriginKind::DerivedPacked as u8,
+    Derived(QueryEdges<'a>) = QueryOriginKind::Derived as u8,
 
     /// The value was derived by executing a function
     /// but that function also reported that it read untracked inputs.
     /// The [`QueryEdges`] argument contains a listing of all the inputs we saw
     /// (but we know there were more).
-    DerivedUntracked(QueryEdges<'a>) = QueryOriginKind::DerivedUntrackedPacked as u8,
+    DerivedUntracked(QueryEdges<'a>) = QueryOriginKind::DerivedUntracked as u8,
 }
 
 impl<'a> QueryOriginRef<'a> {
@@ -901,21 +901,52 @@ enum QueryOriginKind {
     /// The value was assigned as the output of another query.
     ///
     /// This can, for example, can occur when `specify` is used.
-    Assigned = 0b001,
+    Assigned = 0b01,
 
     /// The value was derived by executing a function
     /// _and_ Salsa was able to track all of said function's inputs.
-    DerivedPacked = 0b011,
+    Derived = 0b11,
 
     /// The value was derived by executing a function
     /// but that function also reported that it read untracked inputs.
-    DerivedUntrackedPacked = 0b010,
+    DerivedUntracked = 0b10,
+}
 
-    /// Like [`QueryOriginKind::DerivedPacked`], but using full-width query edges.
-    DerivedWide = 0b111,
+#[derive(Clone, Copy)]
+#[repr(u8)]
+enum QueryEdgeLayout {
+    Packed = 0b000,
+    Wide = 0b100,
+}
 
-    /// Like [`QueryOriginKind::DerivedUntrackedPacked`], but using full-width query edges.
-    DerivedUntrackedWide = 0b110,
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+struct QueryOriginTag(u8);
+
+impl QueryOriginTag {
+    const KIND_MASK: u8 = 0b011;
+    const LAYOUT_MASK: u8 = 0b100;
+
+    fn new(kind: QueryOriginKind, layout: QueryEdgeLayout) -> Self {
+        QueryOriginTag(kind as u8 | layout as u8)
+    }
+
+    fn kind(self) -> QueryOriginKind {
+        match self.0 & Self::KIND_MASK {
+            0b01 => QueryOriginKind::Assigned,
+            0b11 => QueryOriginKind::Derived,
+            0b10 => QueryOriginKind::DerivedUntracked,
+            _ => unreachable!("invalid query origin kind"),
+        }
+    }
+
+    fn layout(self) -> QueryEdgeLayout {
+        if self.0 & Self::LAYOUT_MASK == 0 {
+            QueryEdgeLayout::Packed
+        } else {
+            QueryEdgeLayout::Wide
+        }
+    }
 }
 
 /// Tracks how a memoized value for a given query was created.
@@ -927,7 +958,7 @@ pub struct QueryOrigin {
     ///
     /// Note that this tag only requires three bits and could likely be packed into
     /// some other field. However, we get this byte for free thanks to alignment.
-    kind: QueryOriginKind,
+    tag: QueryOriginTag,
 
     /// The data portion of this enum.
     data: QueryOriginData,
@@ -972,31 +1003,20 @@ unsafe impl Sync for QueryOriginData {}
 
 impl QueryOrigin {
     pub fn is_derived_untracked(&self) -> bool {
-        matches!(
-            self.kind,
-            QueryOriginKind::DerivedUntrackedPacked | QueryOriginKind::DerivedUntrackedWide
-        )
+        matches!(self.tag.kind(), QueryOriginKind::DerivedUntracked)
     }
 
     /// Create a query origin of type `QueryOriginKind::Derived`, with the given edges.
     pub fn derived(input_outputs: Box<[QueryEdge]>) -> QueryOrigin {
-        Self::derived_with_kinds(
-            input_outputs,
-            QueryOriginKind::DerivedPacked,
-            QueryOriginKind::DerivedWide,
-        )
+        Self::derived_with_kind(input_outputs, QueryOriginKind::Derived)
     }
 
-    fn derived_with_kinds(
-        input_outputs: Box<[QueryEdge]>,
-        packed_kind: QueryOriginKind,
-        wide_kind: QueryOriginKind,
-    ) -> QueryOrigin {
+    fn derived_with_kind(input_outputs: Box<[QueryEdge]>, kind: QueryOriginKind) -> QueryOrigin {
         // Exceeding `u32::MAX` query edges should never happen in real-world usage.
         let length = u32::try_from(input_outputs.len())
             .expect("exceeded more than `u32::MAX` query edges; this should never happen.");
 
-        let (kind, input_outputs) = if input_outputs.iter().copied().all(PackedQueryEdge::fits) {
+        let (layout, input_outputs) = if input_outputs.iter().copied().all(PackedQueryEdge::fits) {
             let input_outputs: Box<[PackedQueryEdge]> = input_outputs
                 .iter()
                 .copied()
@@ -1009,7 +1029,7 @@ impl QueryOrigin {
                     .cast::<()>()
             };
 
-            (packed_kind, input_outputs)
+            (QueryEdgeLayout::Packed, input_outputs)
         } else {
             // SAFETY: `Box::into_raw` returns a non-null pointer.
             let input_outputs = unsafe {
@@ -1017,11 +1037,11 @@ impl QueryOrigin {
                     .cast::<()>()
             };
 
-            (wide_kind, input_outputs)
+            (QueryEdgeLayout::Wide, input_outputs)
         };
 
         QueryOrigin {
-            kind,
+            tag: QueryOriginTag::new(kind, layout),
             metadata: length,
             data: QueryOriginData { input_outputs },
         }
@@ -1029,11 +1049,7 @@ impl QueryOrigin {
 
     /// Create a query origin of type `QueryOriginKind::DerivedUntracked`, with the given edges.
     pub fn derived_untracked(input_outputs: Box<[QueryEdge]>) -> QueryOrigin {
-        Self::derived_with_kinds(
-            input_outputs,
-            QueryOriginKind::DerivedUntrackedPacked,
-            QueryOriginKind::DerivedUntrackedWide,
-        )
+        Self::derived_with_kind(input_outputs, QueryOriginKind::DerivedUntracked)
     }
 
     /// Sets the `input_outputs` of this query's origin if it's derived or derived untracked.
@@ -1042,13 +1058,13 @@ impl QueryOrigin {
         &mut self,
         input_outputs: Box<[QueryEdge]>,
     ) -> Result<(), Box<[QueryEdge]>> {
-        match self.kind {
+        match self.tag.kind() {
             QueryOriginKind::Assigned => Err(input_outputs),
-            QueryOriginKind::DerivedPacked | QueryOriginKind::DerivedWide => {
+            QueryOriginKind::Derived => {
                 *self = QueryOrigin::derived(input_outputs);
                 Ok(())
             }
-            QueryOriginKind::DerivedUntrackedPacked | QueryOriginKind::DerivedUntrackedWide => {
+            QueryOriginKind::DerivedUntracked => {
                 *self = QueryOrigin::derived_untracked(input_outputs);
                 Ok(())
             }
@@ -1058,7 +1074,7 @@ impl QueryOrigin {
     /// Create a query origin of type `QueryOriginKind::Assigned`, with the given key.
     pub fn assigned(key: DatabaseKeyIndex) -> QueryOrigin {
         QueryOrigin {
-            kind: QueryOriginKind::Assigned,
+            tag: QueryOriginTag::new(QueryOriginKind::Assigned, QueryEdgeLayout::Packed),
             metadata: key.ingredient_index().as_u32(),
             data: QueryOriginData {
                 index: key.key_index(),
@@ -1068,7 +1084,7 @@ impl QueryOrigin {
 
     /// Return a read-only reference to this query origin.
     pub fn as_ref(&self) -> QueryOriginRef<'_> {
-        match self.kind {
+        match self.tag.kind() {
             QueryOriginKind::Assigned => {
                 // SAFETY: `data.index` is initialized when the tag is `QueryOriginKind::Assigned`.
                 let index = unsafe { self.data.index };
@@ -1080,21 +1096,25 @@ impl QueryOrigin {
                 QueryOriginRef::Assigned(DatabaseKeyIndex::new(ingredient_index, index))
             }
 
-            QueryOriginKind::DerivedPacked | QueryOriginKind::DerivedWide => {
-                // SAFETY: `data.input_outputs` is initialized for both derived origin kinds.
+            QueryOriginKind::Derived => {
+                // SAFETY: `data.input_outputs` is initialized for derived origins.
                 let input_outputs = unsafe { self.data.input_outputs };
                 let length = self.metadata as usize;
 
-                QueryOriginRef::Derived(QueryEdges::from_raw(self.kind, input_outputs, length))
+                QueryOriginRef::Derived(QueryEdges::from_raw(
+                    self.tag.layout(),
+                    input_outputs,
+                    length,
+                ))
             }
 
-            QueryOriginKind::DerivedUntrackedPacked | QueryOriginKind::DerivedUntrackedWide => {
-                // SAFETY: `data.input_outputs` is initialized for both untracked origin kinds.
+            QueryOriginKind::DerivedUntracked => {
+                // SAFETY: `data.input_outputs` is initialized for untracked derived origins.
                 let input_outputs = unsafe { self.data.input_outputs };
                 let length = self.metadata as usize;
 
                 QueryOriginRef::DerivedUntracked(QueryEdges::from_raw(
-                    self.kind,
+                    self.tag.layout(),
                     input_outputs,
                     length,
                 ))
@@ -1125,8 +1145,8 @@ impl<'de> serde::Deserialize<'de> for QueryOrigin {
         #[serde(rename = "QueryOrigin")]
         pub enum QueryOriginOwned {
             Assigned(DatabaseKeyIndex) = QueryOriginKind::Assigned as u8,
-            Derived(Box<[QueryEdge]>) = QueryOriginKind::DerivedPacked as u8,
-            DerivedUntracked(Box<[QueryEdge]>) = QueryOriginKind::DerivedUntrackedPacked as u8,
+            Derived(Box<[QueryEdge]>) = QueryOriginKind::Derived as u8,
+            DerivedUntracked(Box<[QueryEdge]>) = QueryOriginKind::DerivedUntracked as u8,
         }
 
         Ok(match QueryOriginOwned::deserialize(deserializer)? {
@@ -1139,18 +1159,15 @@ impl<'de> serde::Deserialize<'de> for QueryOrigin {
 
 impl Drop for QueryOrigin {
     fn drop(&mut self) {
-        match self.kind {
-            QueryOriginKind::DerivedPacked
-            | QueryOriginKind::DerivedUntrackedPacked
-            | QueryOriginKind::DerivedWide
-            | QueryOriginKind::DerivedUntrackedWide => {
+        match self.tag.kind() {
+            QueryOriginKind::Derived | QueryOriginKind::DerivedUntracked => {
                 // SAFETY: Derived origin kinds initialize `data.input_outputs`.
                 let input_outputs = unsafe { self.data.input_outputs };
                 let length = self.metadata as usize;
 
-                match self.kind {
-                    QueryOriginKind::DerivedPacked | QueryOriginKind::DerivedUntrackedPacked => {
-                        // SAFETY: Packed origin kinds store a boxed slice of `PackedQueryEdge`.
+                match self.tag.layout() {
+                    QueryEdgeLayout::Packed => {
+                        // SAFETY: Packed layouts store a boxed slice of `PackedQueryEdge`.
                         drop(unsafe {
                             Box::from_raw(ptr::slice_from_raw_parts_mut(
                                 input_outputs.cast::<PackedQueryEdge>().as_ptr(),
@@ -1158,8 +1175,8 @@ impl Drop for QueryOrigin {
                             ))
                         });
                     }
-                    QueryOriginKind::DerivedWide | QueryOriginKind::DerivedUntrackedWide => {
-                        // SAFETY: Wide origin kinds store a boxed slice of `QueryEdge`.
+                    QueryEdgeLayout::Wide => {
+                        // SAFETY: Wide layouts store a boxed slice of `QueryEdge`.
                         drop(unsafe {
                             Box::from_raw(ptr::slice_from_raw_parts_mut(
                                 input_outputs.cast::<QueryEdge>().as_ptr(),
@@ -1167,7 +1184,6 @@ impl Drop for QueryOrigin {
                             ))
                         });
                     }
-                    QueryOriginKind::Assigned => unreachable!(),
                 }
             }
 
@@ -1316,10 +1332,10 @@ impl<'a> QueryEdges<'a> {
         }
     }
 
-    fn from_raw(kind: QueryOriginKind, input_outputs: NonNull<()>, length: usize) -> Self {
-        match kind {
-            QueryOriginKind::DerivedPacked | QueryOriginKind::DerivedUntrackedPacked => {
-                // SAFETY: Packed origin kinds store a boxed slice of `PackedQueryEdge`.
+    fn from_raw(layout: QueryEdgeLayout, input_outputs: NonNull<()>, length: usize) -> Self {
+        match layout {
+            QueryEdgeLayout::Packed => {
+                // SAFETY: Packed layouts store a boxed slice of `PackedQueryEdge`.
                 QueryEdges::packed(unsafe {
                     std::slice::from_raw_parts(
                         input_outputs.cast::<PackedQueryEdge>().as_ptr(),
@@ -1327,13 +1343,12 @@ impl<'a> QueryEdges<'a> {
                     )
                 })
             }
-            QueryOriginKind::DerivedWide | QueryOriginKind::DerivedUntrackedWide => {
-                // SAFETY: Wide origin kinds store a boxed slice of `QueryEdge`.
+            QueryEdgeLayout::Wide => {
+                // SAFETY: Wide layouts store a boxed slice of `QueryEdge`.
                 QueryEdges::wide(unsafe {
                     std::slice::from_raw_parts(input_outputs.cast::<QueryEdge>().as_ptr(), length)
                 })
             }
-            QueryOriginKind::Assigned => unreachable!("assigned queries do not store query edges"),
         }
     }
 
@@ -1477,6 +1492,7 @@ mod tests {
     fn packed_query_edges_use_eight_bytes() {
         assert_eq!(size_of::<PackedQueryEdge>(), 8);
         assert_eq!(size_of::<QueryEdge>(), 12);
+        assert_eq!(size_of::<QueryOrigin>(), 13);
     }
 
     #[test]

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -865,11 +865,10 @@ impl<'a> QueryOriginRef<'a> {
     /// Indices for queries *read* by this query
     #[inline]
     pub(crate) fn inputs(self) -> impl DoubleEndedIterator<Item = DatabaseKeyIndex> + use<'a> {
-        let opt_edges = match self {
-            QueryOriginRef::Derived(edges) | QueryOriginRef::DerivedUntracked(edges) => Some(edges),
-            QueryOriginRef::Assigned(_) => None,
-        };
-        opt_edges.into_iter().flat_map(input_edges)
+        self.edges().iter().filter_map(|edge| match edge.kind() {
+            QueryEdgeKind::Input => Some(edge.key()),
+            QueryEdgeKind::Output => None,
+        })
     }
 
     /// Indices for queries *written* by this query (if any)
@@ -941,12 +940,12 @@ impl QueryOriginTag {
         QueryOriginTag(kind as u8 | layout as u8)
     }
 
-    fn kind(self) -> QueryOriginKind {
+    const fn kind(self) -> QueryOriginKind {
         match self.0 & Self::KIND_MASK {
             0b01 => QueryOriginKind::Assigned,
             0b11 => QueryOriginKind::Derived,
             0b10 => QueryOriginKind::DerivedUntracked,
-            _ => unreachable!("invalid query origin kind"),
+            _ => panic!("invalid query origin kind"),
         }
     }
 
@@ -1020,7 +1019,7 @@ unsafe impl Send for QueryOriginData {}
 unsafe impl Sync for QueryOriginData {}
 
 impl QueryOrigin {
-    pub fn is_derived_untracked(&self) -> bool {
+    pub const fn is_derived_untracked(&self) -> bool {
         matches!(self.tag.kind(), QueryOriginKind::DerivedUntracked)
     }
 
@@ -1046,12 +1045,12 @@ impl QueryOrigin {
         let (layout, input_outputs) = 'edges: {
             for edge in input_outputs.by_ref() {
                 let Some(edge) = PackedQueryEdge::new(edge) else {
-                    let input_outputs = packed_input_outputs
-                        .into_iter()
-                        .map(PackedQueryEdge::edge)
-                        .chain(std::iter::once(edge))
-                        .chain(input_outputs)
-                        .collect::<Box<[QueryEdge]>>();
+                    let mut wide_input_outputs = Vec::with_capacity(length as usize);
+                    wide_input_outputs
+                        .extend(packed_input_outputs.into_iter().map(PackedQueryEdge::edge));
+                    wide_input_outputs.push(edge);
+                    wide_input_outputs.extend(input_outputs);
+                    let input_outputs = wide_input_outputs.into_boxed_slice();
 
                     // SAFETY: `Box::into_raw` returns a non-null pointer.
                     let input_outputs = unsafe {
@@ -1136,27 +1135,27 @@ impl QueryOrigin {
             }
 
             QueryOriginKind::Derived => {
-                // SAFETY: `data.input_outputs` is initialized for derived origins.
-                let input_outputs = unsafe { self.data.input_outputs };
-                let length = self.metadata as usize;
-
-                QueryOriginRef::Derived(QueryEdges::from_raw(
-                    self.tag.layout(),
-                    input_outputs,
-                    length,
-                ))
+                // SAFETY: Derived origins initialize `data.input_outputs` with a boxed slice
+                // matching `tag.layout()`, and `metadata` stores that slice's length.
+                QueryOriginRef::Derived(unsafe {
+                    QueryEdges::from_raw(
+                        self.tag.layout(),
+                        self.data.input_outputs,
+                        self.metadata as usize,
+                    )
+                })
             }
 
             QueryOriginKind::DerivedUntracked => {
-                // SAFETY: `data.input_outputs` is initialized for untracked derived origins.
-                let input_outputs = unsafe { self.data.input_outputs };
-                let length = self.metadata as usize;
-
-                QueryOriginRef::DerivedUntracked(QueryEdges::from_raw(
-                    self.tag.layout(),
-                    input_outputs,
-                    length,
-                ))
+                // SAFETY: Untracked derived origins initialize `data.input_outputs` with a boxed
+                // slice matching `tag.layout()`, and `metadata` stores that slice's length.
+                QueryOriginRef::DerivedUntracked(unsafe {
+                    QueryEdges::from_raw(
+                        self.tag.layout(),
+                        self.data.input_outputs,
+                        self.metadata as usize,
+                    )
+                })
             }
         }
     }
@@ -1240,15 +1239,15 @@ impl std::fmt::Debug for QueryOrigin {
 
 /// An input or output query edge.
 ///
-/// This type is a packed version of `QueryEdgeKind`, tagging the `IngredientIndex`
-/// in `key` with a discriminator for the input and output variants without increasing
-/// the size of the type. Notably, this type is 12 bytes as opposed to the 16 byte
-/// `QueryEdgeKind`, which is meaningful as inputs and outputs are stored contiguously.
+/// This type stores the [`QueryEdgeKind`] as a tag on the `IngredientIndex` without
+/// increasing the size of the type. Its 12-byte size is meaningful because inputs and
+/// outputs are stored contiguously.
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct QueryEdge {
-    // Store the key parts directly rather than as a `DatabaseKeyIndex`. Packed origins
-    // unpack many transient `QueryEdge`s while flattening cycles; keeping the fields
-    // split lets `kind`, `Hash`, and `Eq` operate on the decoded words directly.
+    // Store a normalized zero-based index rather than nesting an `Id`, whose index uses a
+    // `NonZeroU32(index + 1)` representation. Packed origins unpack many transient
+    // `QueryEdge`s while flattening cycles; keeping the fields split lets that conversion,
+    // `kind`, `Hash`, and `Eq` operate on the decoded words directly.
     index: u32,
     generation: u32,
     ingredient: IngredientIndex,
@@ -1262,9 +1261,9 @@ impl QueryEdge {
 
     /// Create an output query edge with the given index.
     pub const fn output(key: DatabaseKeyIndex) -> QueryEdge {
-        let ingredient_index = key.ingredient_index().with_tag(true);
-
-        Self::from_key(DatabaseKeyIndex::new(ingredient_index, key.key_index()))
+        let mut edge = Self::from_key(key);
+        edge.ingredient = edge.ingredient.with_tag(true);
+        edge
     }
 
     /// Return the key of this query edge.
@@ -1276,9 +1275,9 @@ impl QueryEdge {
     /// Returns the kind of this query edge.
     pub const fn kind(self) -> QueryEdgeKind {
         if self.ingredient.tag() {
-            QueryEdgeKind::Output(self.key())
+            QueryEdgeKind::Output
         } else {
-            QueryEdgeKind::Input(self.key())
+            QueryEdgeKind::Input
         }
     }
 
@@ -1305,7 +1304,10 @@ impl QueryEdge {
 
 impl std::fmt::Debug for QueryEdge {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.kind().fmt(f)
+        match self.kind() {
+            QueryEdgeKind::Input => f.debug_tuple("Input").field(&self.key()).finish(),
+            QueryEdgeKind::Output => f.debug_tuple("Output").field(&self.key()).finish(),
+        }
     }
 }
 
@@ -1357,32 +1359,26 @@ impl PackedQueryEdge {
 
     const fn new(edge: QueryEdge) -> Option<Self> {
         let ingredient = edge.ingredient.as_u32();
-        let id = edge.id();
 
-        if ingredient > Self::INGREDIENT_MASK || id.generation() > Self::GENERATION_MASK {
+        if ingredient > Self::INGREDIENT_MASK || edge.generation > Self::GENERATION_MASK {
             return None;
         }
 
         Some(PackedQueryEdge {
-            index: id.index(),
-            metadata: id.generation() | (ingredient << Self::INGREDIENT_SHIFT),
+            index: edge.index,
+            metadata: edge.generation | (ingredient << Self::INGREDIENT_SHIFT),
         })
     }
 
-    const fn key(self) -> DatabaseKeyIndex {
-        let generation = self.metadata & Self::GENERATION_MASK;
-        let ingredient = self.metadata >> Self::INGREDIENT_SHIFT;
-
-        // SAFETY: The index came from a valid `Id` in `PackedQueryEdge::new`.
-        let id = unsafe { Id::from_index(self.index) }.with_generation(generation);
-        // SAFETY: The ingredient came from a valid `IngredientIndex` in `PackedQueryEdge::new`.
-        let ingredient = unsafe { IngredientIndex::new_unchecked(ingredient) };
-
-        DatabaseKeyIndex::new(ingredient, id)
-    }
-
     const fn edge(self) -> QueryEdge {
-        QueryEdge::input(self.key())
+        QueryEdge {
+            index: self.index,
+            generation: self.metadata & Self::GENERATION_MASK,
+            // SAFETY: `metadata` was built from an `IngredientIndex` in `PackedQueryEdge::new`.
+            ingredient: unsafe {
+                IngredientIndex::new_unchecked(self.metadata >> Self::INGREDIENT_SHIFT)
+            },
+        }
     }
 }
 
@@ -1411,10 +1407,14 @@ impl<'a> QueryEdges<'a> {
         }
     }
 
-    fn from_raw(layout: QueryEdgeLayout, input_outputs: NonNull<()>, length: usize) -> Self {
+    /// # Safety
+    ///
+    /// `input_outputs` and `length` must form a valid slice of the type selected by `layout`
+    /// for the lifetime `'a`.
+    unsafe fn from_raw(layout: QueryEdgeLayout, input_outputs: NonNull<()>, length: usize) -> Self {
         match layout {
             QueryEdgeLayout::Packed => {
-                // SAFETY: Packed layouts store a boxed slice of `PackedQueryEdge`.
+                // SAFETY: Caller obligation.
                 QueryEdges::packed(unsafe {
                     std::slice::from_raw_parts(
                         input_outputs.cast::<PackedQueryEdge>().as_ptr(),
@@ -1423,7 +1423,7 @@ impl<'a> QueryEdges<'a> {
                 })
             }
             QueryEdgeLayout::Wide => {
-                // SAFETY: Wide layouts store a boxed slice of `QueryEdge`.
+                // SAFETY: Caller obligation.
                 QueryEdges::wide(unsafe {
                     std::slice::from_raw_parts(input_outputs.cast::<QueryEdge>().as_ptr(), length)
                 })
@@ -1452,6 +1452,18 @@ impl<'a> QueryEdges<'a> {
         };
 
         QueryEdgeIter { data }
+    }
+
+    pub(crate) fn iter_outputs(self) -> impl DoubleEndedIterator<Item = QueryEdge> + use<'a> {
+        let wide_edges = match self.data {
+            QueryEdgesData::Packed(_) => &[][..],
+            QueryEdgesData::Wide(edges) => edges,
+        };
+
+        wide_edges
+            .iter()
+            .copied()
+            .filter(|edge| matches!(edge.kind(), QueryEdgeKind::Output))
     }
 
     #[cfg(test)]
@@ -1505,6 +1517,8 @@ impl ExactSizeIterator for QueryEdgeIter<'_> {
     }
 }
 
+impl std::iter::FusedIterator for QueryEdgeIter<'_> {}
+
 impl<'a> IntoIterator for QueryEdges<'a> {
     type Item = QueryEdge;
     type IntoIter = QueryEdgeIter<'a>;
@@ -1532,34 +1546,8 @@ impl serde::Serialize for QueryEdges<'_> {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum QueryEdgeKind {
-    Input(DatabaseKeyIndex),
-    Output(DatabaseKeyIndex),
-}
-
-/// Returns the (tracked) inputs that were executed in computing this memoized value.
-///
-/// These will always be in execution order.
-pub(crate) fn input_edges(
-    input_outputs: QueryEdges<'_>,
-) -> impl DoubleEndedIterator<Item = DatabaseKeyIndex> + use<'_> {
-    let (packed_inputs, wide_edges) = match input_outputs.data {
-        QueryEdgesData::Packed(inputs) => (inputs, &[][..]),
-        QueryEdgesData::Wide(edges) => (&[][..], edges),
-    };
-
-    packed_inputs
-        .iter()
-        .copied()
-        .map(PackedQueryEdge::key)
-        .chain(
-            wide_edges
-                .iter()
-                .copied()
-                .filter_map(|edge| match edge.kind() {
-                    QueryEdgeKind::Input(dependency_index) => Some(dependency_index),
-                    QueryEdgeKind::Output(_) => None,
-                }),
-        )
+    Input,
+    Output,
 }
 
 /// Returns the (tracked) outputs that were executed in computing this memoized value.
@@ -1568,18 +1556,7 @@ pub(crate) fn input_edges(
 pub(crate) fn output_edges(
     input_outputs: QueryEdges<'_>,
 ) -> impl DoubleEndedIterator<Item = DatabaseKeyIndex> + use<'_> {
-    let wide_edges = match input_outputs.data {
-        QueryEdgesData::Packed(_) => &[][..],
-        QueryEdgesData::Wide(edges) => edges,
-    };
-
-    wide_edges
-        .iter()
-        .copied()
-        .filter_map(|edge| match edge.kind() {
-            QueryEdgeKind::Output(dependency_index) => Some(dependency_index),
-            QueryEdgeKind::Input(_) => None,
-        })
+    input_outputs.iter_outputs().map(QueryEdge::key)
 }
 
 /// When a query is pushed onto the `active_query` stack, this guard
@@ -1745,13 +1722,14 @@ pub(crate) mod persistence {
 mod tests {
     use std::mem::size_of;
 
-    use super::{PackedQueryEdge, QueryEdge, QueryOrigin, QueryOriginRef};
+    use super::{PackedQueryEdge, QueryEdge, QueryEdgeKind, QueryOrigin, QueryOriginRef};
     use crate::{DatabaseKeyIndex, Id, IngredientIndex};
 
     #[test]
     fn packed_query_edges_use_eight_bytes() {
         assert_eq!(size_of::<PackedQueryEdge>(), 8);
         assert_eq!(size_of::<QueryEdge>(), 12);
+        assert_eq!(size_of::<QueryEdgeKind>(), 1);
         assert_eq!(size_of::<QueryOrigin>(), 13);
     }
 
@@ -1867,10 +1845,7 @@ mod tests {
         assert_eq!(edges.iter().collect::<Vec<_>>(), vec![input, output]);
         assert_eq!(
             edges.iter().map(QueryEdge::kind).collect::<Vec<_>>(),
-            vec![
-                super::QueryEdgeKind::Input(input.key()),
-                super::QueryEdgeKind::Output(output.key())
-            ]
+            vec![QueryEdgeKind::Input, QueryEdgeKind::Output]
         );
     }
 

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -1245,49 +1245,87 @@ impl std::fmt::Debug for QueryOrigin {
 /// the size of the type. Notably, this type is 12 bytes as opposed to the 16 byte
 /// `QueryEdgeKind`, which is meaningful as inputs and outputs are stored contiguously.
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "persistence", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "persistence", serde(transparent))]
 pub struct QueryEdge {
-    key: DatabaseKeyIndex,
+    // Store the key parts directly rather than as a `DatabaseKeyIndex`. Packed origins
+    // unpack many transient `QueryEdge`s while flattening cycles; keeping the fields
+    // split lets `kind`, `Hash`, and `Eq` operate on the decoded words directly.
+    index: u32,
+    generation: u32,
+    ingredient: IngredientIndex,
 }
 
 impl QueryEdge {
     /// Create an input query edge with the given index.
     pub const fn input(key: DatabaseKeyIndex) -> QueryEdge {
-        Self { key }
+        Self::from_key(key)
     }
 
     /// Create an output query edge with the given index.
     pub const fn output(key: DatabaseKeyIndex) -> QueryEdge {
         let ingredient_index = key.ingredient_index().with_tag(true);
 
-        Self {
-            key: DatabaseKeyIndex::new(ingredient_index, key.key_index()),
-        }
+        Self::from_key(DatabaseKeyIndex::new(ingredient_index, key.key_index()))
     }
 
     /// Return the key of this query edge.
     pub const fn key(self) -> DatabaseKeyIndex {
         // Clear the tag to restore the original index.
-        DatabaseKeyIndex::new(
-            self.key.ingredient_index().with_tag(false),
-            self.key.key_index(),
-        )
+        DatabaseKeyIndex::new(self.ingredient.with_tag(false), self.id())
     }
 
     /// Returns the kind of this query edge.
     pub const fn kind(self) -> QueryEdgeKind {
-        if self.key.ingredient_index().tag() {
+        if self.ingredient.tag() {
             QueryEdgeKind::Output(self.key())
         } else {
             QueryEdgeKind::Input(self.key())
         }
+    }
+
+    const fn from_key(key: DatabaseKeyIndex) -> QueryEdge {
+        let id = key.key_index();
+
+        QueryEdge {
+            index: id.index(),
+            generation: id.generation(),
+            ingredient: key.ingredient_index(),
+        }
+    }
+
+    #[cfg(feature = "persistence")]
+    const fn raw_key(self) -> DatabaseKeyIndex {
+        DatabaseKeyIndex::new(self.ingredient, self.id())
+    }
+
+    const fn id(self) -> Id {
+        // SAFETY: `index` came from a valid `Id` in `QueryEdge::from_key`.
+        unsafe { Id::from_index(self.index) }.with_generation(self.generation)
     }
 }
 
 impl std::fmt::Debug for QueryEdge {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.kind().fmt(f)
+    }
+}
+
+#[cfg(feature = "persistence")]
+impl serde::Serialize for QueryEdge {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.raw_key().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "persistence")]
+impl<'de> serde::Deserialize<'de> for QueryEdge {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        DatabaseKeyIndex::deserialize(deserializer).map(QueryEdge::from_key)
     }
 }
 
@@ -1318,8 +1356,8 @@ impl PackedQueryEdge {
     const INGREDIENT_MASK: u32 = 0xFFF;
 
     const fn new(edge: QueryEdge) -> Option<Self> {
-        let ingredient = edge.key.ingredient_index().as_u32();
-        let id = edge.key.key_index();
+        let ingredient = edge.ingredient.as_u32();
+        let id = edge.id();
 
         if ingredient > Self::INGREDIENT_MASK || id.generation() > Self::GENERATION_MASK {
             return None;
@@ -1344,7 +1382,7 @@ impl PackedQueryEdge {
     }
 
     const fn edge(self) -> QueryEdge {
-        QueryEdge { key: self.key() }
+        QueryEdge::input(self.key())
     }
 }
 

--- a/tests/memory-usage.rs
+++ b/tests/memory-usage.rs
@@ -138,7 +138,7 @@ fn test() {
                 IngredientInfo {
                     debug_name: "memory_usage::MyInterned<'_>",
                     count: 3,
-                    size_of_metadata: 192,
+                    size_of_metadata: 168,
                     size_of_fields: 24,
                     heap_size_of_fields: None,
                 },
@@ -170,7 +170,7 @@ fn test() {
                 IngredientInfo {
                     debug_name: "memory_usage::MyTracked<'_>",
                     count: 2,
-                    size_of_metadata: 168,
+                    size_of_metadata: 160,
                     size_of_fields: 16,
                     heap_size_of_fields: None,
                 },
@@ -180,7 +180,7 @@ fn test() {
                 IngredientInfo {
                     debug_name: "(memory_usage::MyTracked<'_>, memory_usage::MyTracked<'_>)",
                     count: 1,
-                    size_of_metadata: 108,
+                    size_of_metadata: 104,
                     size_of_fields: 16,
                     heap_size_of_fields: None,
                 },


### PR DESCRIPTION
## Summary

This PR introduces a new packed `QueryOrigin` that uses 8 bytes to represent a query edge instead of 12 for as long as all edges

* `ingredient index <= 4095`
* `generation <= 1,048,575`
* it's an output (only used by specify)


Which should be true for most edges. The implementation uses the same 12 byte representation as we use today if any edge has an ingredient index or a generation larger than those limits. 

This PR is entirely written by codex and i mainly want to get some initial feedback on if this is an optimization we want or if we'd prefer https://github.com/salsa-rs/salsa/compare/master...MichaReiser:salsa:micha/query-edge-compact-boxed?expand=1 which implements a similar optimization but where the packing happens at the `QueryEdge` level (edges with larger ingredient index or generations are boxed). 


I'm leaning towards this approach because the characteristics between the packed and non packed remain mostly the same. That is, it doesn't introduce extra allocations. It's just that the allocated query edges is somewhat bigger. 

This reduces ty's memory usage by about 10%