### PR TITLE
fix: annotate return type in closure

### DIFF
--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -530,7 +530,7 @@ impl fmt::Display for Backtrace {
                     }
                     writeln!(fmt)?;
                 }
-                Ok(())
+                Ok::<(), std::fmt::Error>(())
             })
             .transpose()?;
         }


### PR DESCRIPTION
When importing several packages with a `From<std::fmt::Error>` impl, I get the following error (I'm on rust 1.95.0):

```
error[E0283]: type annotations needed
   --> /home/fredr/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/salsa-0.26.2/src/active_query.rs:533:17
    |
518 |                 writeln!(fmt, "{indent}at {}:{}", loc.file, loc.line)?;
    |                                                                      - type must be known at this point
...
533 |                 Ok(())
    |                 ^^ cannot infer type of the type parameter `E` declared on the enum `Result`
    |
    = note: multiple `impl`s satisfying `_: From<std::fmt::Error>` found in the following crates: `log`, `serde_fmt`, `value_bag`:
            - impl From<std::fmt::Error> for serde_fmt::Error;
            - impl From<std::fmt::Error> for tracing::log::kv::error::Error;
            - impl From<std::fmt::Error> for value_bag::error::Error;
 ```

This pr fixes that by annotating the types in the closure in the Display implementation for Backtrace.

A simple way to reproduce is to specify these deps in Cargo.toml and then run `cargo build`:
```
[dependencies]
salsa = "=0.26.2"
tracing = { version = "0.1", features = ["log"] }
log = { version = "0.4", features = ["kv_serde"] }
```

