### PR TITLE
Skip dependencies on non-reusable interned values

### DIFF
--- a/src/interned.rs
+++ b/src/interned.rs
@@ -187,6 +187,11 @@ struct ValueShared {
 impl ValueShared {
     /// Returns `true` if this value slot can be reused when interning, and should be added to the LRU.
     fn is_reusable<C: Configuration>(&self) -> bool {
+        Self::is_reusable_with_durability::<C>(self.durability)
+    }
+
+    /// Returns `true` if a value slot with the given durability can be reused when interning.
+    fn is_reusable_with_durability<C: Configuration>(durability: Durability) -> bool {
         // Garbage collection is disabled.
         if C::REVISIONS == IMMORTAL {
             return false;
@@ -198,18 +203,18 @@ impl ValueShared {
         // necessary because `maybe_changed_after` for interned values is not "pure"; it updates
         // the `last_interned_at` field before validating a given value to ensure that it is not
         // reused after read in the current revision.
-        self.durability == Durability::LOW
+        durability == Durability::LOW
     }
 
     /// Record a dependency on this value if its slot can be reused.
     fn report_tracked_read_if_reusable<C: Configuration>(
-        &self,
         zalsa_local: &ZalsaLocal,
         index: DatabaseKeyIndex,
         current_revision: Revision,
+        durability: Durability,
     ) {
-        if self.is_reusable::<C>() {
-            zalsa_local.report_tracked_read_simple(index, self.durability, current_revision);
+        if Self::is_reusable_with_durability::<C>(durability) {
+            zalsa_local.report_tracked_read_simple(index, durability, current_revision);
         }
     }
 }
@@ -441,7 +446,12 @@ where
             // See `intern_id_cold` for why we need to use `current_revision` here. Note that just
             // because this value was previously interned does not mean it was previously interned
             // by *our query*, so the same considerations apply.
-            value_shared.report_tracked_read_if_reusable::<C>(zalsa_local, index, current_revision);
+            ValueShared::report_tracked_read_if_reusable::<C>(
+                zalsa_local,
+                index,
+                current_revision,
+                value_shared.durability,
+            );
 
             return value_shared.id;
         }
@@ -514,7 +524,12 @@ where
             // Record a dependency on the new value if its slot can be reused.
             //
             // See `intern_id_cold` for why we need to use `current_revision` here.
-            value_shared.report_tracked_read_if_reusable::<C>(zalsa_local, index, current_revision);
+            ValueShared::report_tracked_read_if_reusable::<C>(
+                zalsa_local,
+                index,
+                current_revision,
+                value_shared.durability,
+            );
 
             zalsa.event(&|| {
                 Event::new(EventKind::DidReuseInternedValue {
@@ -641,12 +656,11 @@ where
         // the query has changed without a corresponding input changing. Using `current_revision`
         // for dependencies on interned values encodes the fact that interned IDs are not stable
         // across revisions.
-        //
-        // SAFETY: We hold the lock for the shard containing the value.
-        unsafe { &*value.shared.get() }.report_tracked_read_if_reusable::<C>(
+        ValueShared::report_tracked_read_if_reusable::<C>(
             zalsa_local,
             index,
             current_revision,
+            durability,
         );
 
         zalsa.event(&|| {

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -169,9 +169,9 @@ struct ValueShared {
     /// on queries that *read* from an interned value, as any memos dependent
     /// on the previous value will not match the new ID.
     ///
-    /// However, reusing a slot invalidates the previous ID, so dependency edges
-    /// on queries that *create* an interned value are still required to ensure
-    /// the value is re-interned with a new ID.
+    /// However, reusing a slot invalidates the previous ID, so queries that
+    /// *create* a reusable interned value record dependency edges to ensure the
+    /// value is re-interned with a new ID.
     id: Id,
 
     /// The revision the value was most-recently interned in.
@@ -199,6 +199,18 @@ impl ValueShared {
         // the `last_interned_at` field before validating a given value to ensure that it is not
         // reused after read in the current revision.
         self.durability == Durability::LOW
+    }
+
+    /// Record a dependency on this value if its slot can be reused.
+    fn report_tracked_read_if_reusable<C: Configuration>(
+        &self,
+        zalsa_local: &ZalsaLocal,
+        index: DatabaseKeyIndex,
+        current_revision: Revision,
+    ) {
+        if self.is_reusable::<C>() {
+            zalsa_local.report_tracked_read_simple(index, self.durability, current_revision);
+        }
     }
 }
 
@@ -424,16 +436,12 @@ where
                 }
             }
 
-            // Record a dependency on the value.
+            // Record a dependency on the value if its slot can be reused.
             //
             // See `intern_id_cold` for why we need to use `current_revision` here. Note that just
             // because this value was previously interned does not mean it was previously interned
             // by *our query*, so the same considerations apply.
-            zalsa_local.report_tracked_read_simple(
-                index,
-                value_shared.durability,
-                current_revision,
-            );
+            value_shared.report_tracked_read_if_reusable::<C>(zalsa_local, index, current_revision);
 
             return value_shared.id;
         }
@@ -503,14 +511,10 @@ where
 
             let index = self.database_key_index(value_shared.id);
 
-            // Record a dependency on the new value.
+            // Record a dependency on the new value if its slot can be reused.
             //
             // See `intern_id_cold` for why we need to use `current_revision` here.
-            zalsa_local.report_tracked_read_simple(
-                index,
-                value_shared.durability,
-                current_revision,
-            );
+            value_shared.report_tracked_read_if_reusable::<C>(zalsa_local, index, current_revision);
 
             zalsa.event(&|| {
                 Event::new(EventKind::DidReuseInternedValue {
@@ -629,7 +633,7 @@ where
 
         let index = self.database_key_index(id);
 
-        // Record a dependency on the newly interned value.
+        // Record a dependency on the newly interned value if its slot can be reused.
         //
         // Note that the ID is unique to this use of the interned slot, so it seems logical to use
         // `Revision::start()` here. However, it is possible that the ID we read is different from
@@ -637,7 +641,13 @@ where
         // the query has changed without a corresponding input changing. Using `current_revision`
         // for dependencies on interned values encodes the fact that interned IDs are not stable
         // across revisions.
-        zalsa_local.report_tracked_read_simple(index, durability, current_revision);
+        //
+        // SAFETY: We hold the lock for the shard containing the value.
+        unsafe { &*value.shared.get() }.report_tracked_read_if_reusable::<C>(
+            zalsa_local,
+            index,
+            current_revision,
+        );
 
         zalsa.event(&|| {
             Event::new(EventKind::DidInternValue {
@@ -781,16 +791,19 @@ where
                 // SAFETY: We hold the lock for the shard containing the value.
                 let value_shared = unsafe { &mut *value.shared.get() };
 
-                let last_changed_revision = zalsa.last_changed_revision(value_shared.durability);
-                ({ value_shared.last_interned_at }) >= last_changed_revision
+                !value_shared.is_reusable::<C>() || {
+                    let last_changed_revision =
+                        zalsa.last_changed_revision(value_shared.durability);
+                    ({ value_shared.last_interned_at }) >= last_changed_revision
+                }
             },
-            "Data for `{database_key:?}` was not interned in the latest revision for its durability.",
+            "Data for reusable `{database_key:?}` was not interned in the latest revision for its durability.",
             database_key = self.database_key_index(id),
         );
 
-        // SAFETY: Interned values are only exposed if they have been validated in the
-        // current revision, as checked by the assertion above, which ensures that they
-        // are not reused while being accessed.
+        // SAFETY: Reusable interned values are only exposed if they have been validated
+        // in the current revision, as checked by the assertion above, which ensures that
+        // they are not reused while being accessed. Non-reusable values are never reused.
         unsafe { Self::from_internal_data(&*value.fields.get()) }
     }
 

--- a/tests/cycle.rs
+++ b/tests/cycle.rs
@@ -1244,13 +1244,13 @@ fn repeat_query_participating_in_cycle() {
     // Ultimately, this can easily be more expensive than running the cycle head again.
     db.assert_logs(expect![[r#"
         [
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(400)), revision: R2 })",
             "salsa_event(WillExecute { database_key: head(Id(0)) })",
             "salsa_event(WillExecute { database_key: query_a(Id(0)) })",
             "salsa_event(WillExecute { database_key: query_b(Id(0)) })",
             "salsa_event(WillExecute { database_key: query_c(Id(0)) })",
             "salsa_event(WillExecute { database_key: query_d(Id(0)) })",
             "salsa_event(WillExecute { database_key: query_hot(Id(0)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(400)), revision: R2 })",
             "salsa_event(WillIterateCycle { database_key: head(Id(0)), iteration: 1 })",
             "salsa_event(WillExecute { database_key: query_a(Id(0)) })",
             "salsa_event(WillExecute { database_key: query_b(Id(0)) })",
@@ -1348,10 +1348,10 @@ fn repeat_query_participating_in_cycle2() {
     // Salsa would end up recusively validating the hot query over and over again.
     db.assert_logs(expect![[r#"
         [
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(400)), revision: R2 })",
             "salsa_event(WillExecute { database_key: head(Id(0)) })",
             "salsa_event(WillExecute { database_key: query_a(Id(0)) })",
             "salsa_event(WillExecute { database_key: query_hot(Id(0)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(400)), revision: R2 })",
             "salsa_event(WillExecute { database_key: query_b(Id(0)) })",
             "salsa_event(WillExecute { database_key: query_c(Id(0)) })",
             "salsa_event(WillExecute { database_key: query_d(Id(0)) })",

--- a/tests/cycle.rs
+++ b/tests/cycle.rs
@@ -1168,6 +1168,7 @@ fn repeat_query_participating_in_cycle() {
     #[salsa::input]
     struct Input {
         value: u32,
+        stable: u32,
     }
 
     #[salsa::interned]
@@ -1216,6 +1217,8 @@ fn repeat_query_participating_in_cycle() {
     fn query_hot(db: &dyn Db, input: Input) -> u32 {
         let value = head(db, input);
 
+        let _ = input.stable(db);
+
         let _ = Interned::new(db, 2);
 
         let _ = input.value(db);
@@ -1225,7 +1228,7 @@ fn repeat_query_participating_in_cycle() {
 
     let mut db = ExecuteValidateLoggerDatabase::default();
 
-    let input = Input::new(&db, 1);
+    let input = Input::new(&db, 1, 0);
 
     assert_eq!(head(&db, input), 2);
 
@@ -1244,13 +1247,13 @@ fn repeat_query_participating_in_cycle() {
     // Ultimately, this can easily be more expensive than running the cycle head again.
     db.assert_logs(expect![[r#"
         [
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(400)), revision: R2 })",
             "salsa_event(WillExecute { database_key: head(Id(0)) })",
             "salsa_event(WillExecute { database_key: query_a(Id(0)) })",
             "salsa_event(WillExecute { database_key: query_b(Id(0)) })",
             "salsa_event(WillExecute { database_key: query_c(Id(0)) })",
             "salsa_event(WillExecute { database_key: query_d(Id(0)) })",
             "salsa_event(WillExecute { database_key: query_hot(Id(0)) })",
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(400)), revision: R2 })",
             "salsa_event(WillIterateCycle { database_key: head(Id(0)), iteration: 1 })",
             "salsa_event(WillExecute { database_key: query_a(Id(0)) })",
             "salsa_event(WillExecute { database_key: query_b(Id(0)) })",
@@ -1274,6 +1277,7 @@ fn repeat_query_participating_in_cycle2() {
     #[salsa::input]
     struct Input {
         value: u32,
+        stable: u32,
     }
 
     #[salsa::interned]
@@ -1322,6 +1326,8 @@ fn repeat_query_participating_in_cycle2() {
 
     #[salsa::tracked]
     fn query_hot(db: &dyn Db, input: Input) -> u32 {
+        let _ = input.stable(db);
+
         let _ = Interned::new(db, 2);
 
         let _ = head(db, input);
@@ -1331,7 +1337,7 @@ fn repeat_query_participating_in_cycle2() {
 
     let mut db = ExecuteValidateLoggerDatabase::default();
 
-    let input = Input::new(&db, 1);
+    let input = Input::new(&db, 1, 0);
 
     assert_eq!(head(&db, input), 2);
 
@@ -1348,10 +1354,10 @@ fn repeat_query_participating_in_cycle2() {
     // Salsa would end up recusively validating the hot query over and over again.
     db.assert_logs(expect![[r#"
         [
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(400)), revision: R2 })",
             "salsa_event(WillExecute { database_key: head(Id(0)) })",
             "salsa_event(WillExecute { database_key: query_a(Id(0)) })",
             "salsa_event(WillExecute { database_key: query_hot(Id(0)) })",
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(400)), revision: R2 })",
             "salsa_event(WillExecute { database_key: query_b(Id(0)) })",
             "salsa_event(WillExecute { database_key: query_c(Id(0)) })",
             "salsa_event(WillExecute { database_key: query_d(Id(0)) })",

--- a/tests/cycle_dependency_order_different_entry_queries.rs
+++ b/tests/cycle_dependency_order_different_entry_queries.rs
@@ -6,36 +6,30 @@ use salsa::{Database, Durability};
 
 mod common;
 
-#[salsa::input]
-struct Input {
-    stable: (),
-}
-
 #[salsa::tracked(cycle_initial=a_cycle_initial)]
-fn query_a(db: &dyn Database, input: Input) {
-    let _ = input.stable(db);
-    let b = query_b(db, input);
+fn query_a(db: &dyn Database) {
+    let b = query_b(db);
     query_d(db, b);
 }
 
-fn a_cycle_initial(_db: &dyn Database, _id: salsa::Id, _input: Input) {}
+fn a_cycle_initial(_db: &dyn Database, _id: salsa::Id) {}
 
 #[salsa::interned]
 struct Interned {
     value: u32,
 }
 
-#[salsa::tracked(cycle_initial=|db, _, _| Interned::new(db, 0))]
-fn query_b(db: &dyn Database, input: Input) -> Interned<'_> {
-    let _ = input.stable(db);
-    query_c(db, input);
+#[salsa::tracked(cycle_initial=|db, _| Interned::new(db, 0))]
+fn query_b(db: &dyn Database) -> Interned<'_> {
+    query_c(db);
+    // Keep this value reusable so the test still covers validation ordering.
+    db.report_untracked_read();
     Interned::new(db, 2)
 }
 
 #[salsa::tracked]
-fn query_c(db: &dyn Database, input: Input) {
-    let _ = input.stable(db);
-    query_a(db, input);
+fn query_c(db: &dyn Database) {
+    query_a(db);
 }
 
 #[salsa::tracked]
@@ -46,25 +40,26 @@ fn query_d<'db>(_db: &'db dyn Database, _i: Interned<'db>) {
 #[test_log::test]
 fn the_test() {
     let mut db = ExecuteValidateLoggerDatabase::default();
-    let input = Input::new(&db, ());
 
     // We compute the result starting from query a...
-    query_a(&db, input);
+    query_a(&db);
 
     db.clear_logs();
     db.synthetic_write(Durability::HIGH);
 
     // ...but we now verify query_b
-    query_b(&db, input);
+    query_b(&db);
 
     // What this test captures is that `Interned(Id(c00))` must be verified **before** `query_d(Id(c00))`
     // as we would when starting from `query_a`
     db.assert_logs(expect![[r#"
         [
-            "salsa_event(WillExecute { database_key: query_b(Id(0)) })",
-            "salsa_event(WillExecute { database_key: query_c(Id(0)) })",
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(400)), revision: R2 })",
-            "salsa_event(DidValidateMemoizedValue { database_key: query_d(Id(400)) })",
+            "salsa_event(DidValidateInternedValue { key: query_b::interned_arguments(Id(400)), revision: R2 })",
+            "salsa_event(WillExecute { database_key: query_b(Id(400)) })",
+            "salsa_event(DidValidateInternedValue { key: query_c::interned_arguments(Id(800)), revision: R2 })",
+            "salsa_event(WillExecute { database_key: query_c(Id(800)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(c00)), revision: R2 })",
+            "salsa_event(DidValidateMemoizedValue { database_key: query_d(Id(c00)) })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_a(Id(0)) })",
         ]"#]]);
 }

--- a/tests/cycle_dependency_order_different_entry_queries.rs
+++ b/tests/cycle_dependency_order_different_entry_queries.rs
@@ -48,19 +48,17 @@ fn the_test() {
     // ...but we now verify query_b
     query_b(&db);
 
-    // What this test captures is that `Interned(Id(c00))` must be verified **before** `query_d(Id(c00))`
-    // as we would when starting from `query_a`
+    // `Interned(Id(c00))` has high durability, so its slot cannot be reused and `query_d(Id(c00))`
+    // can be verified without first validating the interned value. We still validate the interned
+    // value when `query_b` reaches its constructor after returning from the cycle.
     db.assert_logs(expect![[r#"
         [
             "salsa_event(DidValidateInternedValue { key: query_b::interned_arguments(Id(400)), revision: R2 })",
             "salsa_event(WillExecute { database_key: query_b(Id(400)) })",
             "salsa_event(DidValidateInternedValue { key: query_c::interned_arguments(Id(800)), revision: R2 })",
             "salsa_event(WillExecute { database_key: query_c(Id(800)) })",
-            "salsa_event(DidValidateInternedValue { key: query_b::interned_arguments(Id(400)), revision: R2 })",
-            "salsa_event(DidValidateInternedValue { key: query_c::interned_arguments(Id(800)), revision: R2 })",
-            "salsa_event(DidValidateInternedValue { key: query_a::interned_arguments(Id(0)), revision: R2 })",
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(c00)), revision: R2 })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_d(Id(c00)) })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_a(Id(0)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(c00)), revision: R2 })",
         ]"#]]);
 }

--- a/tests/cycle_dependency_order_different_entry_queries.rs
+++ b/tests/cycle_dependency_order_different_entry_queries.rs
@@ -6,28 +6,36 @@ use salsa::{Database, Durability};
 
 mod common;
 
+#[salsa::input]
+struct Input {
+    stable: (),
+}
+
 #[salsa::tracked(cycle_initial=a_cycle_initial)]
-fn query_a(db: &dyn Database) {
-    let b = query_b(db);
+fn query_a(db: &dyn Database, input: Input) {
+    let _ = input.stable(db);
+    let b = query_b(db, input);
     query_d(db, b);
 }
 
-fn a_cycle_initial(_db: &dyn Database, _id: salsa::Id) {}
+fn a_cycle_initial(_db: &dyn Database, _id: salsa::Id, _input: Input) {}
 
 #[salsa::interned]
 struct Interned {
     value: u32,
 }
 
-#[salsa::tracked(cycle_initial=|db, _| Interned::new(db, 0))]
-fn query_b(db: &dyn Database) -> Interned<'_> {
-    query_c(db);
+#[salsa::tracked(cycle_initial=|db, _, _| Interned::new(db, 0))]
+fn query_b(db: &dyn Database, input: Input) -> Interned<'_> {
+    let _ = input.stable(db);
+    query_c(db, input);
     Interned::new(db, 2)
 }
 
 #[salsa::tracked]
-fn query_c(db: &dyn Database) {
-    query_a(db);
+fn query_c(db: &dyn Database, input: Input) {
+    let _ = input.stable(db);
+    query_a(db, input);
 }
 
 #[salsa::tracked]
@@ -38,27 +46,25 @@ fn query_d<'db>(_db: &'db dyn Database, _i: Interned<'db>) {
 #[test_log::test]
 fn the_test() {
     let mut db = ExecuteValidateLoggerDatabase::default();
+    let input = Input::new(&db, ());
 
     // We compute the result starting from query a...
-    query_a(&db);
+    query_a(&db, input);
 
     db.clear_logs();
     db.synthetic_write(Durability::HIGH);
 
     // ...but we now verify query_b
-    query_b(&db);
+    query_b(&db, input);
 
-    // `Interned(Id(c00))` has high durability, so its slot cannot be reused and `query_d(Id(c00))`
-    // can be verified without first validating the interned value. We still validate the interned
-    // value when `query_b` reaches its constructor after returning from the cycle.
+    // What this test captures is that `Interned(Id(c00))` must be verified **before** `query_d(Id(c00))`
+    // as we would when starting from `query_a`
     db.assert_logs(expect![[r#"
         [
-            "salsa_event(DidValidateInternedValue { key: query_b::interned_arguments(Id(400)), revision: R2 })",
-            "salsa_event(WillExecute { database_key: query_b(Id(400)) })",
-            "salsa_event(DidValidateInternedValue { key: query_c::interned_arguments(Id(800)), revision: R2 })",
-            "salsa_event(WillExecute { database_key: query_c(Id(800)) })",
-            "salsa_event(DidValidateMemoizedValue { database_key: query_d(Id(c00)) })",
+            "salsa_event(WillExecute { database_key: query_b(Id(0)) })",
+            "salsa_event(WillExecute { database_key: query_c(Id(0)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(400)), revision: R2 })",
+            "salsa_event(DidValidateMemoizedValue { database_key: query_d(Id(400)) })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_a(Id(0)) })",
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(c00)), revision: R2 })",
         ]"#]]);
 }

--- a/tests/cycle_left_recursive_query.rs
+++ b/tests/cycle_left_recursive_query.rs
@@ -6,9 +6,15 @@ use salsa::{Database, Durability, Id};
 
 mod common;
 
+#[salsa::input]
+struct Input {
+    stable: (),
+}
+
 #[salsa::tracked(cycle_initial=cycle_initial)]
-fn query_a(db: &dyn salsa::Database) -> Interned<'_> {
-    let interned = query_b(db);
+fn query_a(db: &dyn salsa::Database, input: Input) -> Interned<'_> {
+    let _ = input.stable(db);
+    let interned = query_b(db, input);
     let value = interned.value(db);
 
     if value < 10 {
@@ -19,8 +25,9 @@ fn query_a(db: &dyn salsa::Database) -> Interned<'_> {
 }
 
 #[salsa::tracked]
-fn query_b(db: &dyn Database) -> Interned<'_> {
-    let interned = query_a(db);
+fn query_b(db: &dyn Database, input: Input) -> Interned<'_> {
+    let _ = input.stable(db);
+    let interned = query_a(db, input);
     query_x(db, interned);
     interned
 }
@@ -28,7 +35,7 @@ fn query_b(db: &dyn Database) -> Interned<'_> {
 #[salsa::tracked]
 fn query_x<'db>(_db: &'db dyn Database, _i: Interned<'db>) {}
 
-fn cycle_initial(db: &dyn Database, _id: Id) -> Interned<'_> {
+fn cycle_initial(db: &dyn Database, _id: Id, _input: Input) -> Interned<'_> {
     Interned::new(db, 0)
 }
 
@@ -40,33 +47,44 @@ struct Interned {
 #[test_log::test]
 fn the_test() {
     let mut db = ExecuteValidateLoggerDatabase::default();
+    let input = Input::new(&db, ());
 
-    let result = query_a(&db);
+    let result = query_a(&db, input);
 
     assert_eq!(result.value(&db), 10);
 
     db.clear_logs();
     db.synthetic_write(Durability::HIGH);
 
-    let result = query_a(&db);
+    let result = query_a(&db, input);
 
     assert_eq!(result.value(&db), 10);
 
-    // The interned values have high durability, so their slots cannot be reused and the
-    // corresponding `query_x` calls can be validated without first validating their keys.
+    // What this test captures is that the interned values **must** be validated before validating their corresponding `query_x` call.
     db.assert_logs(expect![[r#"
         [
-            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(800)) })",
-            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(801)) })",
-            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(802)) })",
-            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(803)) })",
-            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(804)) })",
-            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(805)) })",
-            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(806)) })",
-            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(807)) })",
-            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(808)) })",
-            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(809)) })",
-            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(80a)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(400)), revision: R2 })",
+            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(400)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(401)), revision: R2 })",
+            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(401)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(402)), revision: R2 })",
+            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(402)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(403)), revision: R2 })",
+            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(403)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(404)), revision: R2 })",
+            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(404)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(405)), revision: R2 })",
+            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(405)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(406)), revision: R2 })",
+            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(406)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(407)), revision: R2 })",
+            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(407)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(408)), revision: R2 })",
+            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(408)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(409)), revision: R2 })",
+            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(409)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(40a)), revision: R2 })",
+            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(40a)) })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_a(Id(0)) })",
         ]"#]]);
 }

--- a/tests/cycle_left_recursive_query.rs
+++ b/tests/cycle_left_recursive_query.rs
@@ -6,15 +6,9 @@ use salsa::{Database, Durability, Id};
 
 mod common;
 
-#[salsa::input]
-struct Input {
-    stable: (),
-}
-
 #[salsa::tracked(cycle_initial=cycle_initial)]
-fn query_a(db: &dyn salsa::Database, input: Input) -> Interned<'_> {
-    let _ = input.stable(db);
-    let interned = query_b(db, input);
+fn query_a(db: &dyn salsa::Database) -> Interned<'_> {
+    let interned = query_b(db);
     let value = interned.value(db);
 
     if value < 10 {
@@ -25,9 +19,8 @@ fn query_a(db: &dyn salsa::Database, input: Input) -> Interned<'_> {
 }
 
 #[salsa::tracked]
-fn query_b(db: &dyn Database, input: Input) -> Interned<'_> {
-    let _ = input.stable(db);
-    let interned = query_a(db, input);
+fn query_b(db: &dyn Database) -> Interned<'_> {
+    let interned = query_a(db);
     query_x(db, interned);
     interned
 }
@@ -35,7 +28,9 @@ fn query_b(db: &dyn Database, input: Input) -> Interned<'_> {
 #[salsa::tracked]
 fn query_x<'db>(_db: &'db dyn Database, _i: Interned<'db>) {}
 
-fn cycle_initial(db: &dyn Database, _id: Id, _input: Input) -> Interned<'_> {
+fn cycle_initial(db: &dyn Database, _id: Id) -> Interned<'_> {
+    // Keep cycle-created values reusable so the test still covers validation ordering.
+    db.report_untracked_read();
     Interned::new(db, 0)
 }
 
@@ -47,44 +42,43 @@ struct Interned {
 #[test_log::test]
 fn the_test() {
     let mut db = ExecuteValidateLoggerDatabase::default();
-    let input = Input::new(&db, ());
 
-    let result = query_a(&db, input);
+    let result = query_a(&db);
 
     assert_eq!(result.value(&db), 10);
 
     db.clear_logs();
     db.synthetic_write(Durability::HIGH);
 
-    let result = query_a(&db, input);
+    let result = query_a(&db);
 
     assert_eq!(result.value(&db), 10);
 
     // What this test captures is that the interned values **must** be validated before validating their corresponding `query_x` call.
     db.assert_logs(expect![[r#"
         [
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(400)), revision: R2 })",
-            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(400)) })",
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(401)), revision: R2 })",
-            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(401)) })",
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(402)), revision: R2 })",
-            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(402)) })",
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(403)), revision: R2 })",
-            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(403)) })",
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(404)), revision: R2 })",
-            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(404)) })",
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(405)), revision: R2 })",
-            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(405)) })",
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(406)), revision: R2 })",
-            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(406)) })",
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(407)), revision: R2 })",
-            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(407)) })",
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(408)), revision: R2 })",
-            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(408)) })",
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(409)), revision: R2 })",
-            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(409)) })",
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(40a)), revision: R2 })",
-            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(40a)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(800)), revision: R2 })",
+            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(800)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(801)), revision: R2 })",
+            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(801)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(802)), revision: R2 })",
+            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(802)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(803)), revision: R2 })",
+            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(803)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(804)), revision: R2 })",
+            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(804)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(805)), revision: R2 })",
+            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(805)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(806)), revision: R2 })",
+            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(806)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(807)), revision: R2 })",
+            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(807)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(808)), revision: R2 })",
+            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(808)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(809)), revision: R2 })",
+            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(809)) })",
+            "salsa_event(DidValidateInternedValue { key: Interned(Id(80a)), revision: R2 })",
+            "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(80a)) })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_a(Id(0)) })",
         ]"#]]);
 }

--- a/tests/cycle_left_recursive_query.rs
+++ b/tests/cycle_left_recursive_query.rs
@@ -52,32 +52,20 @@ fn the_test() {
 
     assert_eq!(result.value(&db), 10);
 
-    // What this test captures is that the interned values **must** be validated before validating their corresponding `query_x` call.
+    // The interned values have high durability, so their slots cannot be reused and the
+    // corresponding `query_x` calls can be validated without first validating their keys.
     db.assert_logs(expect![[r#"
         [
-            "salsa_event(DidValidateInternedValue { key: query_b::interned_arguments(Id(400)), revision: R2 })",
-            "salsa_event(DidValidateInternedValue { key: query_a::interned_arguments(Id(0)), revision: R2 })",
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(800)), revision: R2 })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(800)) })",
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(801)), revision: R2 })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(801)) })",
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(802)), revision: R2 })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(802)) })",
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(803)), revision: R2 })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(803)) })",
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(804)), revision: R2 })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(804)) })",
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(805)), revision: R2 })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(805)) })",
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(806)), revision: R2 })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(806)) })",
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(807)), revision: R2 })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(807)) })",
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(808)), revision: R2 })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(808)) })",
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(809)), revision: R2 })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(809)) })",
-            "salsa_event(DidValidateInternedValue { key: Interned(Id(80a)), revision: R2 })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_x(Id(80a)) })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_a(Id(0)) })",
         ]"#]]);

--- a/tests/cycle_output.rs
+++ b/tests/cycle_output.rs
@@ -139,7 +139,6 @@ fn revalidate_no_changes() {
         [
             "salsa_event(DidSetCancellationFlag)",
             "salsa_event(DidValidateMemoizedValue { database_key: read_value(Id(400)) })",
-            "salsa_event(DidValidateInternedValue { key: query_d::interned_arguments(Id(800)), revision: R2 })",
             "salsa_event(DidValidateMemoizedValue { database_key: query_d(Id(800)) })",
             "salsa_event(DidValidateMemoizedValue { database_key: read_value(Id(401)) })",
             "salsa_event(DidValidateMemoizedValue { database_key: read_value(Id(402)) })",
@@ -169,10 +168,10 @@ fn revalidate_with_change_after_output_read() {
         [
             "salsa_event(DidSetCancellationFlag)",
             "salsa_event(DidValidateMemoizedValue { database_key: read_value(Id(400)) })",
-            "salsa_event(DidValidateInternedValue { key: query_d::interned_arguments(Id(800)), revision: R2 })",
             "salsa_event(WillExecute { database_key: query_d(Id(800)) })",
             "salsa_event(WillExecute { database_key: query_b(Id(0)) })",
             "salsa_event(WillExecute { database_key: query_a(Id(0)) })",
+            "salsa_event(DidValidateInternedValue { key: query_d::interned_arguments(Id(800)), revision: R2 })",
             "salsa_event(WillDiscardStaleOutput { execute_key: query_a(Id(0)), output_key: Output(Id(401)) })",
             "salsa_event(DidDiscard { key: Output(Id(401)) })",
             "salsa_event(DidDiscard { key: read_value(Id(401)) })",

--- a/tests/interned-revisions.rs
+++ b/tests/interned-revisions.rs
@@ -134,6 +134,62 @@ fn test_durability() {
         ]"#]]);
 }
 
+#[test]
+fn test_non_reusable_new_value_does_not_record_dependency() {
+    #[salsa::tracked]
+    fn function(db: &dyn Database, input: Input) -> Interned<'_> {
+        let _ = input.field1(db);
+        Interned::new(db, BadHash(0))
+    }
+
+    for durability in [Durability::MEDIUM, Durability::HIGH] {
+        let mut db = common::EventLoggerDatabase::default();
+        let input = Input::builder(0).durability(durability).new(&db);
+
+        let _ = function(&db, input);
+        db.clear_logs();
+
+        db.synthetic_write(durability);
+
+        let _ = function(&db, input);
+        db.assert_logs(expect![[r#"
+            [
+                "DidSetCancellationFlag",
+                "WillCheckCancellation",
+                "DidValidateMemoizedValue { database_key: function(Id(0)) }",
+            ]"#]]);
+    }
+}
+
+#[test]
+fn test_non_reusable_existing_value_does_not_record_dependency() {
+    #[salsa::tracked]
+    fn function(db: &dyn Database, input: Input) -> Interned<'_> {
+        let _ = input.field1(db);
+        Interned::new(db, BadHash(0))
+    }
+
+    for durability in [Durability::MEDIUM, Durability::HIGH] {
+        let mut db = common::EventLoggerDatabase::default();
+        let input0 = Input::builder(0).durability(durability).new(&db);
+        let input1 = Input::builder(0).durability(durability).new(&db);
+
+        let _ = function(&db, input0);
+        let _ = function(&db, input1);
+        db.clear_logs();
+
+        db.synthetic_write(durability);
+
+        let _ = function(&db, input1);
+        db.assert_logs(expect![[r#"
+            [
+                "DidSetCancellationFlag",
+                "WillCheckCancellation",
+                "DidValidateMemoizedValue { database_key: function(Id(1)) }",
+            ]"#]]);
+    }
+}
+
 #[salsa::interned(revisions = usize::MAX)]
 #[derive(Debug)]
 struct Immortal<'db> {

--- a/tests/persistence.rs
+++ b/tests/persistence.rs
@@ -271,12 +271,7 @@ fn everything() {
                   "changed_at": 1,
                   "durability": 2,
                   "origin": {
-                    "Derived": [
-                      [
-                        3073,
-                        4
-                      ]
-                    ]
+                    "Derived": []
                   },
                   "verified_final": true,
                   "extra": null


### PR DESCRIPTION
## Summary

Today, Salsa only supports GCing interned values with durability Low (I don't remember the details why). The way we guarantee that interned values are re-created is that the creating query has a read dependency on the created interned value. During validation, the creating query is considered changed and is re-executed if any of the interned value it creates got collected. We don't add dependencies when reading the interned value (we use generations for that). 

Now, we do know that interned values with durability Medium or High can never be garbage collected. That means, it's unnecessary for us to add a read dependency from the creating query, the interned value never needs to be recreated.

This is what this PR implements. For medium and high durability interned values, skip adding the read dependency to the constructing query. 

This saves about 277MB (or 4%) memory when running ty on homeassisstant (https://github.com/astral-sh/ruff/pull/25627). 

## Persistent caching

We may need the edge in the future when we want to run a GC during persistent caching. However, given that persistent caching isn't used today, this seems a worthwhile memory win.

