### PR TITLE
Avoid Miri cache save races

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,8 @@ jobs:
         run: rustup override set "${{ steps.rust-toolchain.outputs.name }}"
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          # Matrix shards share a cache key, so only one can reserve it for saving.
+          save-if: ${{ github.ref == 'refs/heads/master' && matrix.partition == 'slice:1/4' }}
       - uses: taiki-e/install-action@25435dc8dd3baed7417e0c96d3fe89013a5b2e09 # v2.81.3
         with:
           tool: cargo-nextest


### PR DESCRIPTION
All Miri shards share the same Rust cache key, which makes them race to reserve it after a cache miss. Restrict cache saves to the first shard while allowing every shard to restore the shared cache.

Testing: Validated the workflow configuration locally.
