### PR TITLE
chore: classify automated dependency updates

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -9,3 +9,15 @@ version_group = "salsa"
 [[package]]
 name = "salsa-macro-rules"
 version_group = "salsa"
+
+[changelog]
+commit_parsers = [
+    { message = "^feat", group = "added" },
+    { message = "^changed", group = "changed" },
+    { message = "^deprecated", group = "deprecated" },
+    { message = "^removed", group = "removed" },
+    { message = "^fix", group = "fixed" },
+    { message = "^security", group = "security" },
+    { message = "^chore", skip = true },
+    { message = ".*", group = "other" },
+]

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,7 @@
       "matchManagers": [
         "github-actions"
       ],
+      "commitMessagePrefix": "chore:",
       "pinDigests": true
     },
     {
@@ -33,6 +34,7 @@
       "matchManagers": [
         "rust-toolchain"
       ],
+      "commitMessagePrefix": "chore:",
       "minimumReleaseAge": "0 days"
     },
     {
@@ -40,6 +42,7 @@
       "matchManagers": [
         "cargo"
       ],
+      "commitMessagePrefix": "changed:",
       "rangeStrategy": "replace"
     },
     {
@@ -50,6 +53,7 @@
       "matchDepTypes": [
         "dev-dependencies"
       ],
+      "commitMessagePrefix": "chore:",
       "rangeStrategy": "pin"
     }
   ]


### PR DESCRIPTION
Classify Renovate updates so runtime dependency bumps appear under Changed while dev dependencies, GitHub Actions, and Rust toolchain updates use chore.

Exclude chore commits from release-plz changelogs while preserving its default parser mappings.

