### PR TITLE
chore: schedule GitHub Actions updates on Fridays

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,12 +11,15 @@
   ],
   "packageRules": [
     {
-      "description": "Pin GitHub Actions to immutable commit SHAs",
+      "description": "Pin GitHub Actions to immutable commit SHAs and update them on Fridays",
       "matchManagers": [
         "github-actions"
       ],
       "commitMessagePrefix": "chore:",
-      "pinDigests": true
+      "pinDigests": true,
+      "schedule": [
+        "* * * * 5"
+      ]
     },
     {
       "description": "Do not pin the synthetic Miri branch because only master commits are safe to pin",


### PR DESCRIPTION
Limit creation of GitHub Actions dependency-update branches to Fridays, batching action releases into a predictable weekly review cadence. Existing update pull requests can still be refreshed between scheduled runs.

Testing: Validated the Renovate configuration.
