### PR TITLE
chore: use GitHub runners for CodSpeed benchmarks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,7 +130,7 @@ jobs:
     # https://github.com/CodSpeedHQ/action/issues/126
     if: github.repository == 'salsa-rs/salsa' &&github.event_name != 'merge_group'
     name: Benchmarks
-    runs-on: codspeed-macro
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
Use GitHub-hosted runners for CodSpeed benchmarks while keeping the existing simulation and memory modes.

We ran out of macro runner credits and I didn't get the impression that the macro runners helped to reduce flakiness.