### PR TITLE
feat: add volatile tracked query caching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ exclude = [
 salsa-macro-rules = { version = "0.27.2", path = "components/salsa-macro-rules" }
 salsa-macros = { version = "0.27.2", path = "components/salsa-macros", optional = true }
 
+arc-swap = "1"
 boxcar = "0.2.14"
 crossbeam-queue = "0.3.12"
 crossbeam-utils = "0.8.21"
@@ -31,6 +32,7 @@ intrusive-collections = "0.10.1"
 parking_lot = "0.12"
 portable-atomic = "1"
 rustc-hash = "2"
+seize = "0.5.1"
 smallvec = { version = "1", features = ["const_new"] }
 thin-vec = { version = "0.2.14" }
 tracing = { version = "0.1", default-features = false, features = ["std"] }

--- a/benches/eviction.rs
+++ b/benches/eviction.rs
@@ -35,7 +35,7 @@ fn main() {
 /// small per-hit costs can add up. Every result remains resident, which isolates
 /// hit-path bookkeeping. `NoEviction` shows the tracked-query cost without an
 /// eviction policy.
-#[divan::bench(args = [Policy::NoEviction, Policy::Lru])]
+#[divan::bench(args = [Policy::NoEviction, Policy::Lru, Policy::Sieve])]
 fn fast_path(bencher: divan::Bencher, policy: Policy) {
     const ITEMS: usize = 1_024;
 
@@ -59,7 +59,7 @@ fn fast_path(bencher: divan::Bencher, policy: Policy) {
 /// tracked function. This measures the remaining disabled-policy branch on the
 /// hit path. `NoEviction` is the policy-free reference for how cheap this path
 /// could be.
-#[divan::bench(args = [Policy::NoEviction, Policy::Lru])]
+#[divan::bench(args = [Policy::NoEviction, Policy::Lru, Policy::Sieve])]
 fn disabled_eviction(bencher: divan::Bencher, policy: Policy) {
     const ITEMS: usize = 1_024;
 
@@ -82,7 +82,7 @@ fn disabled_eviction(bencher: divan::Bencher, policy: Policy) {
 /// reads a fully resident working set and then triggers a sweep, separating
 /// steady-state sweep bookkeeping from victim selection and destruction.
 #[divan::bench(
-    args = [Policy::NoEviction, Policy::Lru],
+    args = [Policy::NoEviction, Policy::Lru, Policy::Sieve],
     sample_count = 20,
     sample_size = 1
 )]
@@ -116,7 +116,7 @@ fn fast_path_and_sweep(bencher: divan::Bencher, policy: Policy) {
 /// selection, and value destruction. `NoEviction` provides the computation
 /// baseline; setup and final database destruction remain outside timing.
 #[divan::bench(
-    args = [Policy::NoEviction, Policy::Lru],
+    args = [Policy::NoEviction, Policy::Lru, Policy::Sieve],
     sample_count = 20,
     sample_size = 1
 )]

--- a/benches/eviction/support.rs
+++ b/benches/eviction/support.rs
@@ -19,10 +19,16 @@ pub(crate) fn lru_value(db: &dyn salsa::Database, item: Item) -> Value {
     compute_value(item.value(db))
 }
 
+#[salsa::tracked(returns(copy), sieve = 4096)]
+pub(crate) fn sieve_value(db: &dyn salsa::Database, item: Item) -> Value {
+    compute_value(item.value(db))
+}
+
 #[derive(Clone, Copy)]
 pub(crate) enum Policy {
     NoEviction,
     Lru,
+    Sieve,
 }
 
 impl Policy {
@@ -30,6 +36,7 @@ impl Policy {
         match self {
             Self::NoEviction => {}
             Self::Lru => lru_value::set_lru_capacity(db, capacity),
+            Self::Sieve => sieve_value::set_lru_capacity(db, capacity),
         }
     }
 }
@@ -39,6 +46,7 @@ impl std::fmt::Display for Policy {
         formatter.write_str(match self {
             Self::NoEviction => "NoEviction",
             Self::Lru => "Lru",
+            Self::Sieve => "Sieve",
         })
     }
 }
@@ -52,6 +60,7 @@ pub(crate) fn access_all(
     match policy {
         Policy::NoEviction => access_all_with(db, items, no_eviction_value),
         Policy::Lru => access_all_with(db, items, lru_value),
+        Policy::Sieve => access_all_with(db, items, sieve_value),
     }
 }
 

--- a/benches/eviction_walltime.rs
+++ b/benches/eviction_walltime.rs
@@ -22,7 +22,7 @@ mod support;
 
 use support::{
     Item, Policy, Value, access_all, access_all_with, lru_value, new_items, no_eviction_value,
-    prewarm,
+    prewarm, sieve_value,
 };
 
 fn main() {
@@ -64,7 +64,7 @@ fn main() {
 /// active entries that did not survive and how quickly the policy stabilizes
 /// around the smaller working set.
 #[divan::bench(
-    args = [Policy::NoEviction, Policy::Lru],
+    args = [Policy::NoEviction, Policy::Lru, Policy::Sieve],
     sample_count = 20,
     sample_size = 1
 )]
@@ -125,7 +125,7 @@ fn project_check_then_incremental(bencher: divan::Bencher, policy: Policy) {
 /// recurring-only round charges for entries displaced by the last scan.
 /// `NoEviction` shows the cost when recurring values are never displaced.
 #[divan::bench(
-    args = [Policy::NoEviction, Policy::Lru],
+    args = [Policy::NoEviction, Policy::Lru, Policy::Sieve],
     sample_count = 20,
     sample_size = 1
 )]
@@ -201,7 +201,7 @@ fn scan_resistance(bencher: divan::Bencher, policy: Policy) {
 /// provides the computation baseline; retaining cold entries cannot create hits
 /// because they are never accessed again.
 #[divan::bench(
-    args = [Policy::NoEviction, Policy::Lru],
+    args = [Policy::NoEviction, Policy::Lru, Policy::Sieve],
     sample_count = 20,
     sample_size = 1
 )]
@@ -256,7 +256,7 @@ fn one_hit_wonders(bencher: divan::Bencher, policy: Policy) {
 /// the policy-free baseline: it retains both phases, but only the second phase
 /// is accessed after the switch.
 #[divan::bench(
-    args = [Policy::NoEviction, Policy::Lru],
+    args = [Policy::NoEviction, Policy::Lru, Policy::Sieve],
     sample_count = 20,
     sample_size = 1
 )]
@@ -295,7 +295,7 @@ fn phase_change(bencher: divan::Bencher, policy: Policy) {
 /// misses and contention on the query itself. This isolates contention in the
 /// eviction policy's hit bookkeeping; `NoEviction` provides the baseline.
 #[divan::bench(
-    args = [Policy::NoEviction, Policy::Lru],
+    args = [Policy::NoEviction, Policy::Lru, Policy::Sieve],
     sample_count = 20,
     sample_size = 1
 )]
@@ -349,6 +349,7 @@ impl Workload {
         match policy {
             Policy::NoEviction => self.run_with(no_eviction_value),
             Policy::Lru => self.run_with(lru_value),
+            Policy::Sieve => self.run_with(sieve_value),
         }
     }
 
@@ -373,6 +374,7 @@ fn parallel_access_repeated(
             parallel_access_repeated_with(jobs, accesses_per_item, no_eviction_value)
         }
         Policy::Lru => parallel_access_repeated_with(jobs, accesses_per_item, lru_value),
+        Policy::Sieve => parallel_access_repeated_with(jobs, accesses_per_item, sieve_value),
     }
 }
 

--- a/book/src/tuning.md
+++ b/book/src/tuning.md
@@ -40,6 +40,30 @@ my_query::set_lru_capacity(&mut db, 256);
 **Note:** The `set_lru_capacity` method is only generated for functions that have
 an `lru` attribute. Functions without LRU enabled do not have this method.
 
+### Within-Revision Collection
+
+For values that are cheap to recompute and useful only during a short burst of
+queries, use the `volatile` option:
+
+```rust
+#[salsa::tracked(volatile = 4096, returns(clone))]
+fn lower(db: &dyn Db, input: SourceFile) -> Arc<LoweredFile> {
+    // ...
+}
+```
+
+Unlike `lru`, volatile collection runs within a revision. Once the cache reaches
+its configured capacity, each new value selects a resident with the same SIEVE
+policy used by `sieve`: recently visited values get a second chance, and the
+first unvisited value found by the moving hand is evicted immediately. Cache
+hits only set a block-indexed visited bit and do not take the policy's state
+mutex.
+
+Volatile queries must explicitly return values using `returns(copy)` or
+`returns(clone)`. The default reference return mode and an explicit
+`returns(ref)` are rejected because volatile values may be dropped before the
+next revision.
+
 ### Memory Management
 
 LRU evicts memoized values, not query keys or dependency metadata. Salsa also

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -484,14 +484,14 @@ macro_rules! setup_tracked_fn {
                     }
                 }
 
-                /// Sets the lru capacity
+                /// Sets the eviction policy's tuning value.
                 ///
                 /// **WARNING:** Just like an ordinary write, this method triggers
                 /// cancellation. If you invoke it while a snapshot exists, it
                 /// will block until that snapshot is dropped -- if that snapshot
                 /// is owned by the current thread, this could trigger deadlock.
                 fn set_lru_capacity(db: &mut dyn $Db, value: usize) where for<'trivial_bounds> $Eviction: $zalsa::function::HasCapacity {
-                    $Configuration::fn_ingredient_mut(db).set_capacity(value);
+                    $Configuration::fn_ingredient_mut(db).set_tuning(value);
                 }
 
                 $zalsa::macro_if! { $needs_interner =>

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -64,6 +64,9 @@ macro_rules! setup_tracked_fn {
         // LRU capacity (a literal, maybe 0)
         lru: $lru:tt,
 
+        // If true, the query is volatile and may retire memo values within a revision.
+        is_volatile: $is_volatile:tt,
+
         // The return mode for the function, see `salsa_macros::options::Option::returns`
         return_mode: $return_mode:tt,
 
@@ -92,25 +95,38 @@ macro_rules! setup_tracked_fn {
         $vis fn $fn_name<$db_lt>(
             $db: &$db_lt dyn $Db,
             $($input_id: $input_ty,)*
-        ) -> ::salsa::plumbing::return_mode_ty!(($return_mode, __), $db_lt, $output_ty) {
+        ) -> ::salsa::plumbing::macro_if! {
+            if $is_volatile {
+                ::salsa::Volatile<$output_ty>
+            } else {
+                ::salsa::plumbing::return_mode_ty!(($return_mode, __), $db_lt, $output_ty)
+            }
+        } {
             use ::salsa::plumbing as $zalsa;
 
             $zalsa::attach($db, || {
                 let (zalsa, zalsa_local) = $db.zalsas();
-                let result = $zalsa::macro_if! {
+                let ingredient = $fn_name::fn_ingredient_($db, zalsa);
+                let key = $zalsa::macro_if! {
                     if $needs_interner {
                         {
-                            let key = $fn_name::intern_ingredient_(zalsa).intern_id(zalsa, zalsa_local, ($($input_id),*), |_, data| data);
-                            $fn_name::fn_ingredient_($db, zalsa).fetch($db, zalsa, zalsa_local, key)
+                            $fn_name::intern_ingredient_(zalsa).intern_id(zalsa, zalsa_local, ($($input_id),*), |_, data| data)
                         }
                     } else {
                         {
-                            $fn_name::fn_ingredient_($db, zalsa).fetch($db, zalsa, zalsa_local, $zalsa::AsId::as_id(&($($input_id),*)))
+                            $zalsa::AsId::as_id(&($($input_id),*))
                         }
                     }
                 };
 
-                $zalsa::return_mode_expression!(($return_mode, __), $output_ty, result,)
+                $zalsa::macro_if! {
+                    if $is_volatile {
+                        ingredient.fetch_volatile($db, zalsa, zalsa_local, key)
+                    } else {
+                        let result = ingredient.fetch($db, zalsa, zalsa_local, key);
+                        $zalsa::return_mode_expression!(($return_mode, __), $output_ty, result,)
+                    }
+                }
             })
         }
 

--- a/components/salsa-macros/src/accumulator.rs
+++ b/components/salsa-macros/src/accumulator.rs
@@ -43,6 +43,7 @@ impl AllowedOptions for Accumulator {
     const CYCLE_RESULT: bool = false;
     const LRU: bool = false;
     const SIEVE: bool = false;
+    const VOLATILE: bool = false;
     const CONSTRUCTOR_NAME: bool = false;
     const ID: bool = false;
     const REVISIONS: bool = false;

--- a/components/salsa-macros/src/accumulator.rs
+++ b/components/salsa-macros/src/accumulator.rs
@@ -42,6 +42,7 @@ impl AllowedOptions for Accumulator {
     const CYCLE_INITIAL: bool = false;
     const CYCLE_RESULT: bool = false;
     const LRU: bool = false;
+    const SIEVE: bool = false;
     const CONSTRUCTOR_NAME: bool = false;
     const ID: bool = false;
     const REVISIONS: bool = false;

--- a/components/salsa-macros/src/input.rs
+++ b/components/salsa-macros/src/input.rs
@@ -59,6 +59,8 @@ impl AllowedOptions for InputStruct {
 
     const LRU: bool = false;
 
+    const SIEVE: bool = false;
+
     const CONSTRUCTOR_NAME: bool = true;
 
     const ID: bool = false;

--- a/components/salsa-macros/src/input.rs
+++ b/components/salsa-macros/src/input.rs
@@ -58,8 +58,8 @@ impl AllowedOptions for InputStruct {
     const CYCLE_RESULT: bool = false;
 
     const LRU: bool = false;
-
     const SIEVE: bool = false;
+    const VOLATILE: bool = false;
 
     const CONSTRUCTOR_NAME: bool = true;
 

--- a/components/salsa-macros/src/interned.rs
+++ b/components/salsa-macros/src/interned.rs
@@ -59,6 +59,8 @@ impl AllowedOptions for InternedStruct {
 
     const LRU: bool = false;
 
+    const SIEVE: bool = false;
+
     const CONSTRUCTOR_NAME: bool = true;
 
     const ID: bool = true;

--- a/components/salsa-macros/src/interned.rs
+++ b/components/salsa-macros/src/interned.rs
@@ -58,8 +58,8 @@ impl AllowedOptions for InternedStruct {
     const CYCLE_RESULT: bool = false;
 
     const LRU: bool = false;
-
     const SIEVE: bool = false;
+    const VOLATILE: bool = false;
 
     const CONSTRUCTOR_NAME: bool = true;
 

--- a/components/salsa-macros/src/options.rs
+++ b/components/salsa-macros/src/options.rs
@@ -89,6 +89,11 @@ pub(crate) struct Options<A: AllowedOptions> {
     /// If this is `Some`, the value is the `<usize>`.
     pub lru: Option<usize>,
 
+    /// The `sieve = <usize>` option is used to set the SIEVE capacity for a tracked function.
+    ///
+    /// If this is `Some`, the value is the `<usize>`.
+    pub sieve: Option<usize>,
+
     /// The `constructor = <ident>` option lets the user specify the name of
     /// the constructor of a salsa struct.
     ///
@@ -153,6 +158,7 @@ impl<A: AllowedOptions> Default for Options<A> {
             constructor_name: Default::default(),
             phantom: Default::default(),
             lru: Default::default(),
+            sieve: Default::default(),
             singleton: Default::default(),
             id: Default::default(),
             revisions: Default::default(),
@@ -178,6 +184,7 @@ pub(crate) trait AllowedOptions {
     const CYCLE_INITIAL: bool;
     const CYCLE_RESULT: bool;
     const LRU: bool;
+    const SIEVE: bool;
     const CONSTRUCTOR_NAME: bool;
     const ID: bool;
     const REVISIONS: bool;
@@ -460,6 +467,20 @@ impl<A: AllowedOptions> syn::parse::Parse for Options<A> {
                         "`lru` option not allowed here",
                     ));
                 }
+            } else if ident == "sieve" {
+                if A::SIEVE {
+                    let _eq = Equals::parse(input)?;
+                    let lit = syn::LitInt::parse(input)?;
+                    let value = lit.base10_parse::<usize>()?;
+                    if let Some(old) = options.sieve.replace(value) {
+                        return Err(syn::Error::new(old.span(), "option `sieve` provided twice"));
+                    }
+                } else {
+                    return Err(syn::Error::new(
+                        ident.span(),
+                        "`sieve` option not allowed here",
+                    ));
+                }
             } else if ident == "constructor" {
                 if A::CONSTRUCTOR_NAME {
                     let _eq = Equals::parse(input)?;
@@ -568,6 +589,7 @@ impl<A: AllowedOptions> quote::ToTokens for Options<A> {
             cycle_result,
             data,
             lru,
+            sieve,
             constructor_name,
             id,
             revisions,
@@ -614,6 +636,9 @@ impl<A: AllowedOptions> quote::ToTokens for Options<A> {
         }
         if let Some(lru) = lru {
             tokens.extend(quote::quote! { lru = #lru, });
+        }
+        if let Some(sieve) = sieve {
+            tokens.extend(quote::quote! { sieve = #sieve, });
         }
         if let Some(constructor_name) = constructor_name {
             tokens.extend(quote::quote! { constructor = #constructor_name, });

--- a/components/salsa-macros/src/options.rs
+++ b/components/salsa-macros/src/options.rs
@@ -94,6 +94,11 @@ pub(crate) struct Options<A: AllowedOptions> {
     /// If this is `Some`, the value is the `<usize>`.
     pub sieve: Option<usize>,
 
+    /// The `volatile` option marks a tracked function's values as aggressively evictable.
+    ///
+    /// If this is `Some`, the value is the `volatile` identifier and capacity.
+    pub volatile: Option<VolatileOptions>,
+
     /// The `constructor = <ident>` option lets the user specify the name of
     /// the constructor of a salsa struct.
     ///
@@ -141,6 +146,12 @@ pub struct PersistOptions {
     pub deserialize_fn: Option<syn::Path>,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct VolatileOptions {
+    pub ident: syn::Ident,
+    pub capacity: usize,
+}
+
 impl<A: AllowedOptions> Default for Options<A> {
     fn default() -> Self {
         Self {
@@ -159,6 +170,7 @@ impl<A: AllowedOptions> Default for Options<A> {
             phantom: Default::default(),
             lru: Default::default(),
             sieve: Default::default(),
+            volatile: Default::default(),
             singleton: Default::default(),
             id: Default::default(),
             revisions: Default::default(),
@@ -185,6 +197,7 @@ pub(crate) trait AllowedOptions {
     const CYCLE_RESULT: bool;
     const LRU: bool;
     const SIEVE: bool;
+    const VOLATILE: bool;
     const CONSTRUCTOR_NAME: bool;
     const ID: bool;
     const REVISIONS: bool;
@@ -481,6 +494,27 @@ impl<A: AllowedOptions> syn::parse::Parse for Options<A> {
                         "`sieve` option not allowed here",
                     ));
                 }
+            } else if ident == "volatile" {
+                if A::VOLATILE {
+                    let _eq = Equals::parse(input)?;
+                    let lit = syn::LitInt::parse(input)?;
+                    let capacity = lit.base10_parse::<usize>()?;
+
+                    if let Some(old) = options
+                        .volatile
+                        .replace(VolatileOptions { ident, capacity })
+                    {
+                        return Err(syn::Error::new(
+                            old.ident.span(),
+                            "option `volatile` provided twice",
+                        ));
+                    }
+                } else {
+                    return Err(syn::Error::new(
+                        ident.span(),
+                        "`volatile` option not allowed here",
+                    ));
+                }
             } else if ident == "constructor" {
                 if A::CONSTRUCTOR_NAME {
                     let _eq = Equals::parse(input)?;
@@ -590,6 +624,7 @@ impl<A: AllowedOptions> quote::ToTokens for Options<A> {
             data,
             lru,
             sieve,
+            volatile,
             constructor_name,
             id,
             revisions,
@@ -639,6 +674,10 @@ impl<A: AllowedOptions> quote::ToTokens for Options<A> {
         }
         if let Some(sieve) = sieve {
             tokens.extend(quote::quote! { sieve = #sieve, });
+        }
+        if let Some(volatile) = volatile {
+            let capacity = volatile.capacity;
+            tokens.extend(quote::quote! { volatile = #capacity, });
         }
         if let Some(constructor_name) = constructor_name {
             tokens.extend(quote::quote! { constructor = #constructor_name, });

--- a/components/salsa-macros/src/tracked_fn.rs
+++ b/components/salsa-macros/src/tracked_fn.rs
@@ -51,8 +51,8 @@ impl AllowedOptions for TrackedFn {
     const CYCLE_RESULT: bool = true;
 
     const LRU: bool = true;
-
     const SIEVE: bool = true;
+    const VOLATILE: bool = true;
 
     const CONSTRUCTOR_NAME: bool = false;
 
@@ -177,18 +177,60 @@ impl Macro {
             ));
         }
 
+        if let (Some(volatile), Some(_)) = (&self.args.volatile, &self.args.lru) {
+            return Err(syn::Error::new_spanned(
+                &volatile.ident,
+                "the `volatile` and `lru` options cannot be used together",
+            ));
+        }
+
+        if let (Some(_), Some(token)) = (&self.args.volatile, &self.args.specify) {
+            return Err(syn::Error::new_spanned(
+                token,
+                "the `volatile` and `specify` options cannot be used together",
+            ));
+        }
+
+        if let (Some(_), Some(token)) = (&self.args.volatile, &self.args.non_update_types) {
+            return Err(syn::Error::new_spanned(
+                token,
+                "the `volatile` and `unsafe(non_update_types)` options cannot be used together",
+            ));
+        }
+
+        if let (Some(volatile), Some(_)) = (&self.args.volatile, &self.args.sieve) {
+            return Err(syn::Error::new_spanned(
+                &volatile.ident,
+                "the `volatile` and `sieve` options cannot be used together",
+            ));
+        }
+
         let needs_interner = match function_type {
             FunctionType::Constant | FunctionType::RequiresInterning => true,
             FunctionType::SalsaStruct => false,
         };
 
-        let lru = Literal::usize_unsuffixed(self.args.lru.or(self.args.sieve).unwrap_or(0));
+        let eviction_capacity = self
+            .args
+            .lru
+            .or(self.args.sieve)
+            .or_else(|| {
+                self.args
+                    .volatile
+                    .as_ref()
+                    .map(|volatile| volatile.capacity)
+            })
+            .unwrap_or(0);
+        let eviction_capacity = Literal::usize_unsuffixed(eviction_capacity);
+        let is_volatile = self.args.volatile.is_some();
 
         // Determine the eviction policy type based on whether LRU capacity is specified
         let eviction_type = if self.args.lru.is_some() {
             quote!(::salsa::plumbing::function::Lru)
         } else if self.args.sieve.is_some() {
             quote!(::salsa::plumbing::function::Sieve)
+        } else if self.args.volatile.is_some() {
+            quote!(::salsa::plumbing::function::Volatile)
         } else {
             quote!(::salsa::plumbing::function::NoopEviction)
         };
@@ -210,9 +252,29 @@ impl Macro {
             ));
         }
 
+        if self.args.volatile.is_some()
+            && matches!(
+                return_mode.to_string().as_str(),
+                "ref" | "deref" | "as_ref" | "as_deref"
+            )
+        {
+            return Err(syn::Error::new(
+                return_mode.span(),
+                "the `volatile` option cannot be used with reference return modes",
+            ));
+        }
+
         let persist = self.args.persist();
 
-        let assert_types_are_update = if requires_update {
+        let assert_types_are_update = if self.args.volatile.is_some() {
+            let output = crate::update::assert_impl_update(&db_lt, &zalsa, &output_ty);
+            let inputs = needs_interner
+                .then(|| crate::update::assert_update(&db_lt, &zalsa, interned_input_tys.clone()));
+            quote! {
+                #output
+                #inputs
+            }
+        } else if requires_update {
             let mut assert_update = vec![output_ty.clone()];
             if needs_interner {
                 assert_update.extend(interned_input_tys.clone());
@@ -248,7 +310,8 @@ impl Macro {
                 needs_interner: #needs_interner,
                 heap_size_fn: #(#heap_size_fn)*,
                 eviction: #eviction_type,
-                lru: #lru,
+                lru: #eviction_capacity,
+                is_volatile: #is_volatile,
                 return_mode: #return_mode,
                 persist: #persist,
                 assert_types_are_update: { #assert_types_are_update },

--- a/components/salsa-macros/src/tracked_fn.rs
+++ b/components/salsa-macros/src/tracked_fn.rs
@@ -52,6 +52,8 @@ impl AllowedOptions for TrackedFn {
 
     const LRU: bool = true;
 
+    const SIEVE: bool = true;
+
     const CONSTRUCTOR_NAME: bool = false;
 
     const ID: bool = false;
@@ -161,16 +163,32 @@ impl Macro {
             ));
         }
 
+        if let (Some(_), Some(token)) = (&self.args.sieve, &self.args.specify) {
+            return Err(syn::Error::new_spanned(
+                token,
+                "the `specify` and `sieve` options cannot be used together",
+            ));
+        }
+
+        if let (Some(_), Some(token)) = (&self.args.lru, &self.args.sieve) {
+            return Err(syn::Error::new_spanned(
+                token,
+                "the `lru` and `sieve` options cannot be used together",
+            ));
+        }
+
         let needs_interner = match function_type {
             FunctionType::Constant | FunctionType::RequiresInterning => true,
             FunctionType::SalsaStruct => false,
         };
 
-        let lru = Literal::usize_unsuffixed(self.args.lru.unwrap_or(0));
+        let lru = Literal::usize_unsuffixed(self.args.lru.or(self.args.sieve).unwrap_or(0));
 
         // Determine the eviction policy type based on whether LRU capacity is specified
         let eviction_type = if self.args.lru.is_some() {
             quote!(::salsa::plumbing::function::Lru)
+        } else if self.args.sieve.is_some() {
+            quote!(::salsa::plumbing::function::Sieve)
         } else {
             quote!(::salsa::plumbing::function::NoopEviction)
         };

--- a/components/salsa-macros/src/tracked_struct.rs
+++ b/components/salsa-macros/src/tracked_struct.rs
@@ -55,6 +55,8 @@ impl AllowedOptions for TrackedStruct {
 
     const LRU: bool = false;
 
+    const SIEVE: bool = false;
+
     const CONSTRUCTOR_NAME: bool = true;
 
     const ID: bool = false;

--- a/components/salsa-macros/src/tracked_struct.rs
+++ b/components/salsa-macros/src/tracked_struct.rs
@@ -54,8 +54,8 @@ impl AllowedOptions for TrackedStruct {
     const CYCLE_RESULT: bool = false;
 
     const LRU: bool = false;
-
     const SIEVE: bool = false;
+    const VOLATILE: bool = false;
 
     const CONSTRUCTOR_NAME: bool = true;
 

--- a/components/salsa-macros/src/update.rs
+++ b/components/salsa-macros/src/update.rs
@@ -351,3 +351,17 @@ pub(crate) fn assert_update(
         }
     }
 }
+
+pub(crate) fn assert_impl_update(
+    db_lt: &syn::Lifetime,
+    zalsa: &syn::Ident,
+    ty: &syn::Type,
+) -> TokenStream {
+    quote_spanned! {ty.span() =>
+        #[allow(clippy::all, warnings)]
+        fn _assert_volatile_return_type_is_update<#db_lt>() {
+            fn assert_update<T: #zalsa::Update>() {}
+            assert_update::<#ty>();
+        }
+    }
+}

--- a/src/cycle.rs
+++ b/src/cycle.rs
@@ -500,11 +500,11 @@ impl Cycle<'_> {
 }
 
 #[derive(Debug)]
-pub enum ProvisionalStatus<'db> {
+pub enum ProvisionalStatus {
     Provisional {
         iteration: IterationStamp,
         verified_at: Revision,
-        cycle_heads: &'db CycleHeads,
+        cycle_heads: CycleHeads,
     },
     Final {
         iteration: IterationStamp,
@@ -512,8 +512,8 @@ pub enum ProvisionalStatus<'db> {
     },
 }
 
-impl<'db> ProvisionalStatus<'db> {
-    pub(crate) fn cycle_heads(&self) -> &'db CycleHeads {
+impl ProvisionalStatus {
+    pub(crate) fn cycle_heads(&self) -> &CycleHeads {
         match self {
             ProvisionalStatus::Provisional { cycle_heads, .. } => cycle_heads,
             ProvisionalStatus::Final { .. } => empty_cycle_heads(),

--- a/src/function.rs
+++ b/src/function.rs
@@ -37,7 +37,7 @@ mod memo;
 mod specify;
 mod sync;
 
-pub use eviction::{EvictionContext, EvictionPolicy, HasCapacity, Lru, NoopEviction};
+pub use eviction::{EvictionContext, EvictionPolicy, HasCapacity, Lru, NoopEviction, Sieve};
 
 pub type Memo<C> = memo::Memo<'static, C>;
 
@@ -278,17 +278,9 @@ where
         // We convert to a `NonNull` here as soon as possible because we are going to alias
         // into the `Box`, which is a `noalias` type.
         // FIXME: Use `Box::into_non_null` once stable
-        let has_value = memo.value.is_some();
         let memo = NonNull::from(Box::leak(Box::new(memo)));
 
         let old_value = self.insert_memo_into_table_for(zalsa, id, memo, memo_ingredient_index);
-        let became_resident = has_value
-            && old_value.is_none_or(|old_value| {
-                // SAFETY: The old memo remains allocated in `deleted_entries` until the next
-                // revision, so it is valid to inspect here.
-                unsafe { old_value.as_ref().value.is_none() }
-            });
-
         if let Some(old_value) = old_value {
             // In case there is a reference to the old memo out there, we have to store it
             // in the deleted entries. This will get cleared when a new revision starts.
@@ -296,9 +288,6 @@ where
             // SAFETY: Once the revision starts, there will be no outstanding borrows to the
             // memo contents, and so it will be safe to free.
             unsafe { self.deleted_entries.push(old_value) };
-        }
-        if became_resident {
-            self.eviction.record_insert(id);
         }
         // SAFETY: memo has been inserted into the table
         unsafe { self.extend_memo_lifetime(memo.as_ref()) }

--- a/src/function.rs
+++ b/src/function.rs
@@ -37,7 +37,7 @@ mod memo;
 mod specify;
 mod sync;
 
-pub use eviction::{EvictionContext, EvictionPolicy, HasCapacity, Lru, NoopEviction, Sieve};
+pub use eviction::{EvictionPolicy, HasCapacity, Lru, NoopEviction, Sieve};
 
 pub type Memo<C> = memo::Memo<'static, C>;
 
@@ -466,11 +466,13 @@ where
     }
 
     fn reset_for_new_revision(&mut self, table: &mut Table) {
-        let mut context = FunctionEvictionContext::<C> {
-            table,
-            memo_ingredient_indices: &self.memo_ingredient_indices,
-        };
-        self.eviction.start_new_revision(&mut context);
+        self.eviction.for_each_evicted(|evict| {
+            let ingredient_index = table.ingredient_index(evict);
+            Self::evict_value_from_memo_for(
+                table.memos_mut(evict),
+                self.memo_ingredient_indices.get(ingredient_index),
+            )
+        });
 
         self.deleted_entries.clear();
     }
@@ -553,29 +555,6 @@ where
         };
 
         serde::de::DeserializeSeed::deserialize(deserialize, deserializer)
-    }
-}
-
-struct FunctionEvictionContext<'a, C: Configuration> {
-    table: &'a mut Table,
-    memo_ingredient_indices: &'a <C::SalsaStruct<'static> as SalsaStructInDb>::MemoIngredientMap,
-}
-
-impl<C: Configuration> EvictionContext for FunctionEvictionContext<'_, C> {
-    fn last_verified_at(&mut self, id: Id) -> Option<Revision> {
-        let ingredient_index = self.table.ingredient_index(id);
-        IngredientImpl::<C>::last_verified_at_for(
-            self.table.memos_mut(id),
-            self.memo_ingredient_indices.get(ingredient_index),
-        )
-    }
-
-    fn evict_value(&mut self, id: Id) {
-        let ingredient_index = self.table.ingredient_index(id);
-        IngredientImpl::<C>::evict_value_from_memo_for(
-            self.table.memos_mut(id),
-            self.memo_ingredient_indices.get(ingredient_index),
-        )
     }
 }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -20,7 +20,7 @@ use crate::table::Table;
 use crate::table::memo::MemoTableTypes;
 use crate::views::DatabaseDownCaster;
 use crate::zalsa::{IngredientIndex, JarKind, MemoIngredientIndex, Zalsa};
-use crate::zalsa_local::{QueryEdge, QueryOriginRef};
+use crate::zalsa_local::QueryEdge;
 use crate::{Cycle, Id, Revision};
 
 #[cfg(feature = "accumulator")]
@@ -37,7 +37,7 @@ mod memo;
 mod specify;
 mod sync;
 
-pub use eviction::{EvictionPolicy, HasCapacity, Lru, NoopEviction, Sieve};
+pub use eviction::{EvictionPolicy, HasCapacity, Lru, MemoValue, NoopEviction, Sieve, Volatile};
 
 pub type Memo<C> = memo::Memo<'static, C>;
 
@@ -251,11 +251,9 @@ where
 
     /// Returns a reference to the memo value that lives as long as self.
     /// This is UNSAFE: the caller is responsible for ensuring that the
-    /// memo will not be released so long as the `&self` is valid.
-    /// This is done by (a) ensuring the memo is present in the memo-map
-    /// when this function is called and (b) ensuring that any entries
-    /// removed from the memo-map are added to `deleted_entries`, which is
-    /// only cleared with `&mut self`.
+    /// memo will not be released while the returned reference is used.
+    /// Non-retiring policies keep removed memos in `deleted_entries` until
+    /// the next revision; retiring policies require a reclamation guard.
     unsafe fn extend_memo_lifetime<'this>(
         &'this self,
         memo: &memo::Memo<'this, C>,
@@ -271,6 +269,8 @@ where
         mut memo: memo::Memo<'db, C>,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> &'db memo::Memo<'db, C> {
+        let guard = C::Eviction::RETIRES_VALUES.then(|| zalsa.memo_read_guard());
+
         if let Some(tracked_struct_ids) = memo.header.revisions.tracked_struct_ids_mut() {
             tracked_struct_ids.shrink_to_fit();
         }
@@ -280,15 +280,21 @@ where
         // FIXME: Use `Box::into_non_null` once stable
         let memo = NonNull::from(Box::leak(Box::new(memo)));
 
-        let old_value = self.insert_memo_into_table_for(zalsa, id, memo, memo_ingredient_index);
-        if let Some(old_value) = old_value {
-            // In case there is a reference to the old memo out there, we have to store it
-            // in the deleted entries. This will get cleared when a new revision starts.
-            //
-            // SAFETY: Once the revision starts, there will be no outstanding borrows to the
-            // memo contents, and so it will be safe to free.
-            unsafe { self.deleted_entries.push(old_value) };
+        if let Some(old_memo) =
+            self.insert_memo_into_table_for(zalsa, id, memo, memo_ingredient_index)
+        {
+            // SAFETY: Volatile memo accesses are guarded. Memos containing accumulated
+            // values remain revision-delayed because those values can escape by reference.
+            unsafe {
+                if C::Eviction::RETIRES_VALUES && old_memo.as_ref().can_evict_volatile() {
+                    self.deleted_entries
+                        .push_retired(old_memo, guard.as_ref().unwrap());
+                } else {
+                    self.deleted_entries.push(old_memo);
+                }
+            }
         }
+
         // SAFETY: memo has been inserted into the table
         unsafe { self.extend_memo_lifetime(memo.as_ref()) }
     }
@@ -336,6 +342,7 @@ where
         serialized_edges: &mut FxIndexSet<QueryEdge>,
         visited_edges: &mut FxHashSet<QueryEdge>,
     ) {
+        let _guard = C::Eviction::RETIRES_VALUES.then(|| zalsa.memo_read_guard());
         let input = edge.key().key_index();
 
         let Some(memo) =
@@ -352,11 +359,8 @@ where
     ///
     /// Otherwise, the value is still provisional. For both final and provisional, it also
     /// returns the iteration in which this memo was created (always 0 except for cycle heads).
-    fn provisional_status<'db>(
-        &self,
-        zalsa: &'db Zalsa,
-        input: Id,
-    ) -> Option<ProvisionalStatus<'db>> {
+    fn provisional_status(&self, zalsa: &Zalsa, input: Id) -> Option<ProvisionalStatus> {
+        let _guard = C::Eviction::RETIRES_VALUES.then(|| zalsa.memo_read_guard());
         let memo =
             self.get_memo_from_table_for(zalsa, input, self.memo_ingredient_index(zalsa, input))?;
 
@@ -364,6 +368,7 @@ where
     }
 
     fn set_cycle_iteration_count(&self, zalsa: &Zalsa, input: Id, iteration: IterationStamp) {
+        let _guard = C::Eviction::RETIRES_VALUES.then(|| zalsa.memo_read_guard());
         let Some(memo) =
             self.get_memo_from_table_for(zalsa, input, self.memo_ingredient_index(zalsa, input))
         else {
@@ -375,6 +380,7 @@ where
     }
 
     fn finalize_cycle_head(&self, zalsa: &Zalsa, input: Id) {
+        let _guard = C::Eviction::RETIRES_VALUES.then(|| zalsa.memo_read_guard());
         let Some(memo) =
             self.get_memo_from_table_for(zalsa, input, self.memo_ingredient_index(zalsa, input))
         else {
@@ -391,6 +397,7 @@ where
         flattened_input_outputs: &mut FxIndexSet<QueryEdge>,
         seen: &mut FxHashSet<DatabaseKeyIndex>,
     ) {
+        let _guard = C::Eviction::RETIRES_VALUES.then(|| zalsa.memo_read_guard());
         let memo_index = self.memo_ingredient_index(zalsa, id);
         let Some(memo) = self.get_memo_from_table_for(zalsa, id, memo_index) else {
             return;
@@ -406,6 +413,7 @@ where
     }
 
     fn cycle_converged(&self, zalsa: &Zalsa, input: Id) -> bool {
+        let _guard = C::Eviction::RETIRES_VALUES.then(|| zalsa.memo_read_guard());
         let Some(memo) =
             self.get_memo_from_table_for(zalsa, input, self.memo_ingredient_index(zalsa, input))
         else {
@@ -437,8 +445,8 @@ where
         }
     }
 
-    fn origin<'db>(&self, zalsa: &'db Zalsa, key: Id) -> Option<QueryOriginRef<'db>> {
-        self.origin(zalsa, key)
+    fn extend_origin_inputs(&self, zalsa: &Zalsa, key: Id, inputs: &mut Vec<DatabaseKeyIndex>) {
+        self.extend_origin_inputs(zalsa, key, inputs)
     }
 
     fn mark_validated_output(
@@ -471,7 +479,7 @@ where
             Self::evict_value_from_memo_for(
                 table.memos_mut(evict),
                 self.memo_ingredient_indices.get(ingredient_index),
-            )
+            );
         });
 
         self.deleted_entries.clear();
@@ -590,7 +598,7 @@ impl memo::MemoHeader {
         }
     }
 
-    fn provisional_status(&self) -> ProvisionalStatus<'_> {
+    fn provisional_status(&self) -> ProvisionalStatus {
         let iteration = self.revisions.iteration();
         let verified_at = self.verified_at.load();
 
@@ -603,7 +611,7 @@ impl memo::MemoHeader {
             ProvisionalStatus::Provisional {
                 iteration,
                 verified_at,
-                cycle_heads: self.cycle_heads(),
+                cycle_heads: self.cycle_heads().clone(),
             }
         }
     }
@@ -693,7 +701,7 @@ where
 
 #[cfg(feature = "persistence")]
 mod persistence {
-    use super::{Configuration, IngredientImpl, Memo};
+    use super::{Configuration, EvictionPolicy, IngredientImpl, Memo};
     use crate::hash::{FxHashSet, FxIndexSet};
     use crate::plumbing::{MemoIngredientMap, SalsaStructInDb};
     use crate::zalsa::Zalsa;
@@ -894,6 +902,7 @@ mod persistence {
                     memo_ingredient_index,
                     // FIXME: Use `Box::into_non_null` once stable.
                     NonNull::from(Box::leak(Box::new(memo))),
+                    C::Eviction::RETIRES_VALUES,
                 );
             }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -37,7 +37,7 @@ mod memo;
 mod specify;
 mod sync;
 
-pub use eviction::{EvictionPolicy, HasCapacity, Lru, NoopEviction};
+pub use eviction::{EvictionContext, EvictionPolicy, HasCapacity, Lru, NoopEviction};
 
 pub type Memo<C> = memo::Memo<'static, C>;
 
@@ -239,12 +239,14 @@ where
         DatabaseKeyIndex::new(self.index, key)
     }
 
-    /// Set eviction capacity. Only available when eviction policy supports it.
-    pub fn set_capacity(&mut self, capacity: usize)
+    /// Sets the eviction policy's tuning value.
+    ///
+    /// Only available when the eviction policy supports runtime tuning.
+    pub fn set_tuning(&mut self, tuning: usize)
     where
         C::Eviction: HasCapacity,
     {
-        self.eviction.set_capacity(capacity);
+        self.eviction.set_tuning(tuning);
     }
 
     /// Returns a reference to the memo value that lives as long as self.
@@ -276,17 +278,27 @@ where
         // We convert to a `NonNull` here as soon as possible because we are going to alias
         // into the `Box`, which is a `noalias` type.
         // FIXME: Use `Box::into_non_null` once stable
+        let has_value = memo.value.is_some();
         let memo = NonNull::from(Box::leak(Box::new(memo)));
 
-        if let Some(old_value) =
-            self.insert_memo_into_table_for(zalsa, id, memo, memo_ingredient_index)
-        {
+        let old_value = self.insert_memo_into_table_for(zalsa, id, memo, memo_ingredient_index);
+        let became_resident = has_value
+            && old_value.is_none_or(|old_value| {
+                // SAFETY: The old memo remains allocated in `deleted_entries` until the next
+                // revision, so it is valid to inspect here.
+                unsafe { old_value.as_ref().value.is_none() }
+            });
+
+        if let Some(old_value) = old_value {
             // In case there is a reference to the old memo out there, we have to store it
             // in the deleted entries. This will get cleared when a new revision starts.
             //
             // SAFETY: Once the revision starts, there will be no outstanding borrows to the
             // memo contents, and so it will be safe to free.
             unsafe { self.deleted_entries.push(old_value) };
+        }
+        if became_resident {
+            self.eviction.record_insert(id);
         }
         // SAFETY: memo has been inserted into the table
         unsafe { self.extend_memo_lifetime(memo.as_ref()) }
@@ -465,13 +477,11 @@ where
     }
 
     fn reset_for_new_revision(&mut self, table: &mut Table) {
-        self.eviction.for_each_evicted(|evict| {
-            let ingredient_index = table.ingredient_index(evict);
-            Self::evict_value_from_memo_for(
-                table.memos_mut(evict),
-                self.memo_ingredient_indices.get(ingredient_index),
-            )
-        });
+        let mut context = FunctionEvictionContext::<C> {
+            table,
+            memo_ingredient_indices: &self.memo_ingredient_indices,
+        };
+        self.eviction.start_new_revision(&mut context);
 
         self.deleted_entries.clear();
     }
@@ -554,6 +564,29 @@ where
         };
 
         serde::de::DeserializeSeed::deserialize(deserialize, deserializer)
+    }
+}
+
+struct FunctionEvictionContext<'a, C: Configuration> {
+    table: &'a mut Table,
+    memo_ingredient_indices: &'a <C::SalsaStruct<'static> as SalsaStructInDb>::MemoIngredientMap,
+}
+
+impl<C: Configuration> EvictionContext for FunctionEvictionContext<'_, C> {
+    fn last_verified_at(&mut self, id: Id) -> Option<Revision> {
+        let ingredient_index = self.table.ingredient_index(id);
+        IngredientImpl::<C>::last_verified_at_for(
+            self.table.memos_mut(id),
+            self.memo_ingredient_indices.get(ingredient_index),
+        )
+    }
+
+    fn evict_value(&mut self, id: Id) {
+        let ingredient_index = self.table.ingredient_index(id);
+        IngredientImpl::<C>::evict_value_from_memo_for(
+            self.table.memos_mut(id),
+            self.memo_ingredient_indices.get(ingredient_index),
+        )
     }
 }
 

--- a/src/function/accumulated.rs
+++ b/src/function/accumulated.rs
@@ -4,7 +4,6 @@ use crate::function::eviction::EvictionPolicy;
 use crate::function::{Configuration, IngredientImpl};
 use crate::hash::FxHashSet;
 use crate::zalsa::ZalsaDatabase;
-use crate::zalsa_local::QueryOriginRef;
 use crate::{DatabaseKeyIndex, Id};
 
 impl<C> IngredientImpl<C>
@@ -18,6 +17,7 @@ where
         A: accumulator::Accumulator,
     {
         let (zalsa, zalsa_local) = db.zalsas();
+        let _guard = C::Eviction::RETIRES_VALUES.then(|| zalsa.memo_read_guard());
 
         // NOTE: We don't have a precise way to track accumulated values at present,
         // so we report any read of them as an untracked read.
@@ -38,7 +38,11 @@ where
         let mut output = vec![];
 
         // First ensure the result is up to date
-        self.fetch(db, zalsa, zalsa_local, key);
+        if C::Eviction::RETIRES_VALUES {
+            drop(self.fetch_volatile(db, zalsa, zalsa_local, key));
+        } else {
+            self.fetch(db, zalsa, zalsa_local, key);
+        }
 
         let db_key = self.database_key_index(key);
         let mut visited: FxHashSet<DatabaseKeyIndex> = FxHashSet::default();
@@ -65,22 +69,9 @@ where
                 continue;
             }
 
-            // Find the inputs of `k` and push them onto the stack.
-            //
-            // Careful: to ensure the user gets a consistent ordering in their
-            // output vector, we want to push in execution order, so reverse order to
-            // ensure the first child that was executed will be the first child popped
-            // from the stack.
-            let Some(origin) = ingredient.origin(zalsa, k.key_index()) else {
-                continue;
-            };
-
-            if let QueryOriginRef::Derived(edges) | QueryOriginRef::DerivedUntracked(edges) = origin
-            {
-                stack.reserve(edges.len());
-            }
-
-            stack.extend(origin.inputs().rev());
+            // Find the inputs of `k` and push them onto the stack. Inputs are appended
+            // in reverse execution order so the first child executed is popped first.
+            ingredient.extend_origin_inputs(zalsa, k.key_index(), &mut stack);
 
             visited.reserve(stack.len());
         }
@@ -94,8 +85,13 @@ where
         key: Id,
     ) -> (Option<&'db AccumulatedMap>, InputAccumulatedValues) {
         let (zalsa, zalsa_local) = db.zalsas();
+        let _guard = C::Eviction::RETIRES_VALUES.then(|| zalsa.memo_read_guard());
         let memo = self.refresh_memo(db, zalsa, zalsa_local, key);
-        self.eviction.record_use(key);
+        // Volatile memos with accumulated values remain revision-delayed because
+        // the returned references can outlive `_guard`.
+        if !C::Eviction::RETIRES_VALUES {
+            self.eviction.record_use(key);
+        }
         (
             memo.header.revisions.accumulated(),
             memo.header.revisions.accumulated_inputs.load(),

--- a/src/function/accumulated.rs
+++ b/src/function/accumulated.rs
@@ -1,5 +1,6 @@
 use crate::accumulator::accumulated_map::{AccumulatedMap, InputAccumulatedValues};
 use crate::accumulator::{self};
+use crate::function::eviction::EvictionPolicy;
 use crate::function::{Configuration, IngredientImpl};
 use crate::hash::FxHashSet;
 use crate::zalsa::ZalsaDatabase;
@@ -93,8 +94,8 @@ where
         key: Id,
     ) -> (Option<&'db AccumulatedMap>, InputAccumulatedValues) {
         let (zalsa, zalsa_local) = db.zalsas();
-        // NEXT STEP: stash and refactor `fetch` to return an `&Memo` so we can make this work
         let memo = self.refresh_memo(db, zalsa, zalsa_local, key);
+        self.eviction.record_use(key);
         (
             memo.header.revisions.accumulated(),
             memo.header.revisions.accumulated_inputs.load(),

--- a/src/function/backdate.rs
+++ b/src/function/backdate.rs
@@ -1,5 +1,6 @@
 use crate::Backtrace;
 use crate::DatabaseKeyIndex;
+use crate::function::eviction::MemoValue;
 use crate::function::memo::{Memo, MemoHeader};
 use crate::function::{Configuration, IngredientImpl};
 use crate::zalsa_local::QueryRevisions;
@@ -22,8 +23,8 @@ where
         if old_memo.header.can_backdate(revisions)
             && old_memo
                 .value
-                .as_ref()
-                .is_some_and(|old_value| C::values_equal(old_value, value))
+                .load()
+                .is_some_and(|old_value| C::values_equal(&old_value, value))
         {
             old_memo.header.backdate(index, revisions);
         }

--- a/src/function/delete.rs
+++ b/src/function/delete.rs
@@ -2,10 +2,9 @@ use std::ptr::NonNull;
 
 use crate::function::Configuration;
 use crate::function::memo::Memo;
+use crate::zalsa::MemoReadGuard;
 
-/// Stores the list of memos that have been deleted so they can be freed
-/// once the next revision starts. See the comment on the field
-/// `deleted_entries` of [`FunctionIngredient`][] for more details.
+/// Stores memos that must remain alive until the next revision.
 pub(super) struct DeletedEntries<C: Configuration> {
     memos: boxcar::Vec<SharedBox<Memo<'static, C>>>,
 }
@@ -26,16 +25,45 @@ impl<C: Configuration> Default for DeletedEntries<C> {
 impl<C: Configuration> DeletedEntries<C> {
     /// # Safety
     ///
-    /// The memo must be valid and safe to free when the `DeletedEntries` list is cleared or dropped.
+    /// The memo must be valid and safe to free when this list is cleared or dropped.
     pub(super) unsafe fn push(&self, memo: NonNull<Memo<'_, C>>) {
-        // Safety: The memo must be valid and safe to free when the `DeletedEntries` list is cleared or dropped.
+        // SAFETY: The memo is kept alive until the next revision.
         let memo =
             unsafe { std::mem::transmute::<NonNull<Memo<'_, C>>, NonNull<Memo<'static, C>>>(memo) };
 
         self.memos.push(SharedBox(memo));
     }
 
-    /// Free all deleted memos, keeping the list available for reuse.
+    /// Defers freeing a retired volatile memo until active readers have exited.
+    ///
+    /// # Safety
+    ///
+    /// The memo must have been removed from the memo table.
+    pub(super) unsafe fn push_retired(
+        &self,
+        memo: NonNull<Memo<'_, C>>,
+        guard: &MemoReadGuard<'_>,
+    ) {
+        #[cfg(feature = "shuttle")]
+        {
+            let _ = guard;
+            return unsafe { self.push(memo) };
+        }
+
+        #[cfg(not(feature = "shuttle"))]
+        {
+            use seize::Guard;
+
+            // SAFETY: The allocation remains valid until the deferred callback runs.
+            let memo = unsafe {
+                std::mem::transmute::<NonNull<Memo<'_, C>>, NonNull<Memo<'static, C>>>(memo)
+            };
+            // SAFETY: The memo was removed from the table and was allocated by `Box`.
+            unsafe { guard.defer_retire(memo.as_ptr(), seize::reclaim::boxed) };
+        }
+    }
+
+    /// Free all revision-delayed memos, keeping the list available for reuse.
     pub(super) fn clear(&mut self) {
         self.memos.clear();
     }
@@ -46,7 +74,7 @@ struct SharedBox<T>(NonNull<T>);
 
 impl<T> Drop for SharedBox<T> {
     fn drop(&mut self) {
-        // SAFETY: Guaranteed by the caller of `DeletedEntries::push`.
-        unsafe { drop(Box::from_raw(self.0.as_ptr())) };
+        // SAFETY: Guaranteed by the caller of `DeletedEntries::push` or `push_retired`.
+        unsafe { drop(Box::from_raw(self.0.as_ptr())) }
     }
 }

--- a/src/function/eviction.rs
+++ b/src/function/eviction.rs
@@ -5,9 +5,11 @@
 
 mod lru;
 mod noop;
+mod sieve;
 
 pub use lru::Lru;
 pub use noop::NoopEviction;
+pub use sieve::Sieve;
 
 use crate::{Id, Revision};
 
@@ -21,10 +23,7 @@ pub trait EvictionPolicy: Send + Sync {
     /// A value of zero disables eviction.
     fn new(tuning: usize) -> Self;
 
-    /// Records that `id` transitioned from having no cached value to having one.
-    fn record_insert(&self, _id: Id) {}
-
-    /// Records that a resident value was used.
+    /// Records that a value was used.
     ///
     /// Implementations may treat this as a best-effort hint.
     fn record_use(&self, _id: Id) {}

--- a/src/function/eviction.rs
+++ b/src/function/eviction.rs
@@ -11,7 +11,7 @@ pub use lru::Lru;
 pub use noop::NoopEviction;
 pub use sieve::Sieve;
 
-use crate::{Id, Revision};
+use crate::Id;
 
 /// Trait for cache eviction strategies.
 ///
@@ -33,22 +33,11 @@ pub trait EvictionPolicy: Send + Sync {
     /// A value of zero disables eviction.
     fn set_tuning(&mut self, tuning: usize);
 
-    /// Processes the start of a new revision.
+    /// Invokes `evict` for each value that should be evicted.
     ///
-    /// The policy may update its state, inspect memo metadata, and evict
-    /// resident values through `context`.
-    fn start_new_revision(&mut self, context: &mut impl EvictionContext);
-}
-
-/// Memo operations available when starting a new revision.
-pub trait EvictionContext {
-    /// Returns the revision in which `id`'s resident value was last verified.
-    ///
-    /// Returns `None` if the memo no longer contains a resident value.
-    fn last_verified_at(&mut self, id: Id) -> Option<Revision>;
-
-    /// Evicts `id`'s cached value while retaining its memo metadata.
-    fn evict_value(&mut self, id: Id);
+    /// Called once per revision. Implementations may also perform any
+    /// revision-boundary maintenance before returning.
+    fn for_each_evicted(&mut self, evict: impl FnMut(Id));
 }
 
 /// Marker trait for eviction policies whose tuning can be changed at runtime.

--- a/src/function/eviction.rs
+++ b/src/function/eviction.rs
@@ -9,32 +9,52 @@ mod noop;
 pub use lru::Lru;
 pub use noop::NoopEviction;
 
-use crate::Id;
+use crate::{Id, Revision};
 
 /// Trait for cache eviction strategies.
 ///
 /// Implementations control when memoized values are evicted from the cache.
 /// The eviction policy is selected at compile time via the `Configuration` trait.
 pub trait EvictionPolicy: Send + Sync {
-    /// Create a new eviction policy with the given capacity.
-    fn new(capacity: usize) -> Self;
-
-    /// Record that an item was accessed.
-    fn record_use(&self, id: Id);
-
-    /// Set the maximum capacity.
-    fn set_capacity(&mut self, capacity: usize);
-
-    /// Iterate over items that should be evicted.
+    /// Creates a policy from its configured tuning value.
     ///
-    /// Called once per revision during `reset_for_new_revision`.
-    /// The callback `cb` should be invoked for each item to evict.
-    fn for_each_evicted(&mut self, cb: impl FnMut(Id));
+    /// A value of zero disables eviction.
+    fn new(tuning: usize) -> Self;
+
+    /// Records that `id` transitioned from having no cached value to having one.
+    fn record_insert(&self, _id: Id) {}
+
+    /// Records that a resident value was used.
+    ///
+    /// Implementations may treat this as a best-effort hint.
+    fn record_use(&self, _id: Id) {}
+
+    /// Changes the policy's tuning value.
+    ///
+    /// A value of zero disables eviction.
+    fn set_tuning(&mut self, tuning: usize);
+
+    /// Processes the start of a new revision.
+    ///
+    /// The policy may update its state, inspect memo metadata, and evict
+    /// resident values through `context`.
+    fn start_new_revision(&mut self, context: &mut impl EvictionContext);
 }
 
-/// Marker trait for eviction policies that have a configurable capacity.
+/// Memo operations available when starting a new revision.
+pub trait EvictionContext {
+    /// Returns the revision in which `id`'s resident value was last verified.
+    ///
+    /// Returns `None` if the memo no longer contains a resident value.
+    fn last_verified_at(&mut self, id: Id) -> Option<Revision>;
+
+    /// Evicts `id`'s cached value while retaining its memo metadata.
+    fn evict_value(&mut self, id: Id);
+}
+
+/// Marker trait for eviction policies whose tuning can be changed at runtime.
 ///
 /// This trait is used to conditionally generate the `set_lru_capacity` method
 /// on tracked functions. Only policies that implement this trait will expose
-/// runtime capacity configuration.
+/// runtime tuning.
 pub trait HasCapacity: EvictionPolicy {}

--- a/src/function/eviction.rs
+++ b/src/function/eviction.rs
@@ -4,12 +4,16 @@
 //! eviction strategies to be used for salsa tracked functions.
 
 mod lru;
+mod memo_value;
 mod noop;
 mod sieve;
+mod volatile;
 
 pub use lru::Lru;
+pub use memo_value::MemoValue;
 pub use noop::NoopEviction;
 pub use sieve::Sieve;
+pub use volatile::Volatile;
 
 use crate::Id;
 
@@ -18,6 +22,17 @@ use crate::Id;
 /// Implementations control when memoized values are evicted from the cache.
 /// The eviction policy is selected at compile time via the `Configuration` trait.
 pub trait EvictionPolicy: Send + Sync {
+    /// Storage used for memoized values under this policy.
+    #[doc(hidden)]
+    type Value<T: Send + Sync>: MemoValue<T>;
+
+    /// Whether the memo allocation contains the output value itself.
+    #[doc(hidden)]
+    const STORES_VALUE_INLINE: bool = true;
+
+    /// Whether this policy can retire memo values within a revision.
+    const RETIRES_VALUES: bool = false;
+
     /// Creates a policy from its configured tuning value.
     ///
     /// A value of zero disables eviction.
@@ -27,6 +42,15 @@ pub trait EvictionPolicy: Send + Sync {
     ///
     /// Implementations may treat this as a best-effort hint.
     fn record_use(&self, _id: Id) {}
+
+    /// Records that an item was accessed through an owned volatile handle.
+    ///
+    /// Returns an item whose cached value should be retired after the caller
+    /// has acquired the handle.
+    fn record_volatile_use(&self, id: Id) -> Option<Id> {
+        self.record_use(id);
+        None
+    }
 
     /// Changes the policy's tuning value.
     ///

--- a/src/function/eviction/lru.rs
+++ b/src/function/eviction/lru.rs
@@ -9,7 +9,7 @@ use crate::Id;
 use crate::hash::FxLinkedHashSet;
 use crate::sync::Mutex;
 
-use super::{EvictionPolicy, HasCapacity};
+use super::{EvictionContext, EvictionPolicy, HasCapacity};
 
 /// Least Recently Used eviction policy.
 ///
@@ -43,21 +43,21 @@ impl EvictionPolicy for Lru {
         }
     }
 
-    fn set_capacity(&mut self, capacity: usize) {
+    fn set_tuning(&mut self, capacity: usize) {
         self.capacity = NonZeroUsize::new(capacity);
         if self.capacity.is_none() {
             self.set.get_mut().clear();
         }
     }
 
-    fn for_each_evicted(&mut self, mut cb: impl FnMut(Id)) {
+    fn start_new_revision(&mut self, context: &mut impl EvictionContext) {
         let Some(cap) = self.capacity else {
             return;
         };
         let set = self.set.get_mut();
         while set.len() > cap.get() {
             if let Some(id) = set.pop_front() {
-                cb(id);
+                context.evict_value(id);
             }
         }
     }

--- a/src/function/eviction/lru.rs
+++ b/src/function/eviction/lru.rs
@@ -9,7 +9,7 @@ use crate::Id;
 use crate::hash::FxLinkedHashSet;
 use crate::sync::Mutex;
 
-use super::{EvictionContext, EvictionPolicy, HasCapacity};
+use super::{EvictionPolicy, HasCapacity};
 
 /// Least Recently Used eviction policy.
 ///
@@ -50,14 +50,14 @@ impl EvictionPolicy for Lru {
         }
     }
 
-    fn start_new_revision(&mut self, context: &mut impl EvictionContext) {
+    fn for_each_evicted(&mut self, mut evict: impl FnMut(Id)) {
         let Some(cap) = self.capacity else {
             return;
         };
         let set = self.set.get_mut();
         while set.len() > cap.get() {
             if let Some(id) = set.pop_front() {
-                context.evict_value(id);
+                evict(id);
             }
         }
     }

--- a/src/function/eviction/lru.rs
+++ b/src/function/eviction/lru.rs
@@ -29,6 +29,8 @@ impl Lru {
 }
 
 impl EvictionPolicy for Lru {
+    type Value<T: Send + Sync> = Option<T>;
+
     fn new(cap: usize) -> Self {
         Self {
             capacity: NonZeroUsize::new(cap),

--- a/src/function/eviction/memo_value.rs
+++ b/src/function/eviction/memo_value.rs
@@ -1,0 +1,87 @@
+use std::ops::Deref;
+use std::sync::Arc;
+
+use arc_swap::ArcSwapOption;
+
+/// Policy-specific storage for a memoized query value.
+#[doc(hidden)]
+pub trait MemoValue<T>: Send + Sync {
+    type Guard<'a>: Deref<Target = T>
+    where
+        Self: 'a;
+
+    fn new(value: Option<T>) -> Self;
+    fn load(&self) -> Option<Self::Guard<'_>>;
+    fn is_some(&self) -> bool;
+    /// Clears the value, returning whether one was present.
+    fn clear(&self) -> bool;
+
+    /// Borrows an inline value. Volatile storage cannot implement this because
+    /// its value may be concurrently removed.
+    fn borrow_inline(&self) -> Option<&T>;
+
+    /// Acquires an owned handle. Only volatile storage implements this.
+    fn load_volatile(&self) -> Option<Arc<T>>;
+}
+
+impl<T: Send + Sync> MemoValue<T> for Option<T> {
+    type Guard<'a>
+        = &'a T
+    where
+        Self: 'a;
+
+    fn new(value: Option<T>) -> Self {
+        value
+    }
+
+    fn load(&self) -> Option<Self::Guard<'_>> {
+        self.as_ref()
+    }
+
+    fn is_some(&self) -> bool {
+        Option::is_some(self)
+    }
+
+    fn clear(&self) -> bool {
+        panic!("inline memo values require exclusive access for eviction")
+    }
+
+    fn borrow_inline(&self) -> Option<&T> {
+        self.as_ref()
+    }
+
+    fn load_volatile(&self) -> Option<Arc<T>> {
+        panic!("inline memo values cannot produce volatile handles")
+    }
+}
+
+impl<T: Send + Sync> MemoValue<T> for ArcSwapOption<T> {
+    type Guard<'a>
+        = Arc<T>
+    where
+        Self: 'a;
+
+    fn new(value: Option<T>) -> Self {
+        ArcSwapOption::from(value.map(Arc::new))
+    }
+
+    fn load(&self) -> Option<Self::Guard<'_>> {
+        self.load_full()
+    }
+
+    fn is_some(&self) -> bool {
+        self.load().is_some()
+    }
+
+    fn clear(&self) -> bool {
+        self.swap(None).is_some()
+    }
+
+    fn borrow_inline(&self) -> Option<&T> {
+        panic!("volatile memo values cannot be borrowed")
+    }
+
+    fn load_volatile(&self) -> Option<Arc<T>> {
+        self.load_full()
+    }
+}

--- a/src/function/eviction/noop.rs
+++ b/src/function/eviction/noop.rs
@@ -8,6 +8,8 @@ use crate::{Id, function::EvictionPolicy};
 pub struct NoopEviction;
 
 impl EvictionPolicy for NoopEviction {
+    type Value<T: Send + Sync> = Option<T>;
+
     fn new(_cap: usize) -> Self {
         Self
     }

--- a/src/function/eviction/noop.rs
+++ b/src/function/eviction/noop.rs
@@ -2,7 +2,7 @@
 //!
 //! This is the default eviction policy when no LRU capacity is specified.
 
-use crate::function::{EvictionContext, EvictionPolicy};
+use crate::{Id, function::EvictionPolicy};
 
 /// No eviction - cache grows unbounded.
 pub struct NoopEviction;
@@ -16,5 +16,5 @@ impl EvictionPolicy for NoopEviction {
     fn set_tuning(&mut self, _capacity: usize) {}
 
     #[inline(always)]
-    fn start_new_revision(&mut self, _context: &mut impl EvictionContext) {}
+    fn for_each_evicted(&mut self, _evict: impl FnMut(Id)) {}
 }

--- a/src/function/eviction/noop.rs
+++ b/src/function/eviction/noop.rs
@@ -2,7 +2,7 @@
 //!
 //! This is the default eviction policy when no LRU capacity is specified.
 
-use crate::{Id, function::EvictionPolicy};
+use crate::function::{EvictionContext, EvictionPolicy};
 
 /// No eviction - cache grows unbounded.
 pub struct NoopEviction;
@@ -13,11 +13,8 @@ impl EvictionPolicy for NoopEviction {
     }
 
     #[inline(always)]
-    fn record_use(&self, _id: Id) {}
+    fn set_tuning(&mut self, _capacity: usize) {}
 
     #[inline(always)]
-    fn set_capacity(&mut self, _capacity: usize) {}
-
-    #[inline(always)]
-    fn for_each_evicted(&mut self, _cb: impl FnMut(Id)) {}
+    fn start_new_revision(&mut self, _context: &mut impl EvictionContext) {}
 }

--- a/src/function/eviction/sieve.rs
+++ b/src/function/eviction/sieve.rs
@@ -59,6 +59,7 @@ impl EvictionPolicy for Sieve {
         }
     }
 
+    #[inline]
     fn record_use(&self, id: Id) {
         if let Some(capacity) = self.capacity {
             if let Some((page, slot)) = page_and_slot_if_allocated(&self.page_states, id) {
@@ -394,6 +395,7 @@ unsafe impl MaybeZeroable for PageSlot {
 }
 
 impl PageSlot {
+    #[inline]
     fn get(&self) -> Option<&PageState> {
         let ptr = self.ptr.load(Ordering::Acquire);
         ptr::NonNull::new(ptr).map(|ptr| {
@@ -455,18 +457,19 @@ struct PageState {
 }
 
 impl PageState {
+    #[inline]
     fn record_use(&self, slot: usize) -> bool {
         let (word, resident, visited) = slot_state(slot);
         let word = &self.words[word];
         let mut state = word.load(Ordering::Relaxed);
 
         loop {
-            if state & resident == 0 {
-                return false;
-            }
-
             if state & visited != 0 {
                 return true;
+            }
+
+            if state & resident == 0 {
+                return false;
             }
 
             match word.compare_exchange_weak(
@@ -579,6 +582,7 @@ fn page_and_slot(page_states: &PageStates, id: Id) -> (&PageState, usize) {
     page_and_slot_if_allocated(page_states, id).expect("SIEVE page state should be allocated")
 }
 
+#[inline]
 fn page_and_slot_if_allocated(page_states: &PageStates, id: Id) -> Option<(&PageState, usize)> {
     let (index, slot) = page_state_index_and_slot(id);
     page_states
@@ -587,10 +591,12 @@ fn page_and_slot_if_allocated(page_states: &PageStates, id: Id) -> Option<(&Page
         .map(|page| (page, slot))
 }
 
+#[inline]
 fn page_state_index_and_slot(id: Id) -> (PageStateIndex, usize) {
     let (page, slot) = split_id(id);
-    let index = PageStateIndex::new(page.as_usize())
-        .expect("page index should fit in SIEVE page state table");
+    // SAFETY: `Id` is a `u32`, and `PageStates` has enough buckets for every
+    // page representable by an `Id` after removing the slot bits.
+    let index = unsafe { PageStateIndex::new_unchecked(page.as_usize()) };
     (index, slot.as_usize())
 }
 

--- a/src/function/eviction/sieve.rs
+++ b/src/function/eviction/sieve.rs
@@ -13,101 +13,102 @@
 //! resident, selection force-evicts the resident at the hand so admissions
 //! cannot starve without changing the scan order.
 //!
-//! Hits update the page-indexed visited bits without taking the state mutex.
+//! Hits update the block-indexed visited bits without taking the state mutex.
 //! Admissions, hand movement, and the pending-eviction queue are serialized by
 //! that mutex. Selecting a victim removes it from the resident list immediately,
 //! but its value is evicted at the next revision only if it was not re-admitted.
-//! A separate page-indexed bitmap ensures each id appears in that queue at most
+//! A separate block-indexed bitmap ensures each id appears in that queue at most
 //! once per revision.
+//!
+//! State is divided into independently allocated blocks. Within each block,
+//! interleaved resident/visited bits cover 32 ids per atomic word, while the
+//! pending bitmap covers 64 ids per word. This keeps SIEVE's allocation
+//! granularity independent of the memo table's page size.
 
-use std::num::NonZeroUsize;
 use std::ptr;
 
 use crate::Id;
 use crate::sync::Mutex;
 use crate::sync::atomic::{AtomicPtr, AtomicU64, Ordering};
-use crate::table::{PAGE_LEN, PAGE_LEN_BITS, split_id};
 
 use super::{EvictionPolicy, HasCapacity};
 use boxcar::buckets::{Buckets, Index, MaybeZeroable, buckets_for_index_bits};
 
 const SLOT_STATE_BITS: usize = 2;
 const SLOTS_PER_STATE_WORD: usize = u64::BITS as usize / SLOT_STATE_BITS;
-const STATE_WORDS: usize = PAGE_LEN.div_ceil(SLOTS_PER_STATE_WORD);
 const SLOTS_PER_PENDING_WORD: usize = u64::BITS as usize;
-const PENDING_WORDS: usize = PAGE_LEN.div_ceil(SLOTS_PER_PENDING_WORD);
+const BLOCK_LEN_BITS: usize = 10;
+const BLOCK_LEN: usize = 1 << BLOCK_LEN_BITS;
+const STATE_WORDS: usize = BLOCK_LEN / SLOTS_PER_STATE_WORD;
+const PENDING_WORDS: usize = BLOCK_LEN / SLOTS_PER_PENDING_WORD;
 
-type PageStates = Buckets<PageSlot, { buckets_for_index_bits(u32::BITS - PAGE_LEN_BITS as u32) }>;
-type PageStateIndex = Index<{ buckets_for_index_bits(u32::BITS - PAGE_LEN_BITS as u32) }>;
+type StateBlocks =
+    Buckets<BlockSlot, { buckets_for_index_bits(u32::BITS - BLOCK_LEN_BITS as u32) }>;
+type StateBlockIndex = Index<{ buckets_for_index_bits(u32::BITS - BLOCK_LEN_BITS as u32) }>;
 
 /// SIEVE eviction policy.
 ///
-/// Values enter at the front of a FIFO queue. Uses set a page-indexed atomic
+/// Values enter at the front of a FIFO queue. Uses set a block-indexed atomic
 /// visited bit; they do not move the value in the queue.
 pub struct Sieve {
-    capacity: Option<NonZeroUsize>,
+    capacity: usize,
     state: Mutex<State>,
-    page_states: PageStates,
+    state_blocks: StateBlocks,
 }
 
 impl EvictionPolicy for Sieve {
     fn new(capacity: usize) -> Self {
         Self {
-            capacity: NonZeroUsize::new(capacity),
+            capacity,
             state: Mutex::default(),
-            page_states: PageStates::new(),
+            state_blocks: StateBlocks::new(),
         }
     }
 
     #[inline]
     fn record_use(&self, id: Id) {
-        if let Some(capacity) = self.capacity {
-            if let Some((page, slot)) = page_and_slot_if_allocated(&self.page_states, id) {
-                if page.record_use(slot) {
-                    return;
-                }
+        // Probe residency before capacity: resident hits do not need the capacity,
+        // while admissions already take the cold path below.
+        if let Some((block, slot)) = block_and_slot_if_allocated(&self.state_blocks, id) {
+            if block.record_use(slot) {
+                return;
             }
+        }
 
-            self.record_admission(id, capacity.get());
+        if self.capacity != 0 {
+            self.record_admission(id, self.capacity);
         }
     }
 
     fn set_tuning(&mut self, capacity: usize) {
-        self.capacity = NonZeroUsize::new(capacity);
-        let page_states = &self.page_states;
-        let state = self.state.get_mut();
-        if let Some(capacity) = self.capacity {
-            state.schedule_evictions(capacity.get(), page_states);
+        self.capacity = capacity;
+        if capacity == 0 {
+            *self.state.get_mut() = State::default();
+            self.state_blocks = StateBlocks::new();
         } else {
-            for id in state
-                .residents
-                .resident_ids()
-                .chain(state.pending_evictions.iter().copied())
-            {
-                if let Some((page, slot)) = page_and_slot_if_allocated(page_states, id) {
-                    page.clear(slot);
-                }
-            }
-            *state = State::default();
+            self.state
+                .get_mut()
+                .schedule_evictions(capacity, &self.state_blocks);
         }
     }
 
     fn for_each_evicted(&mut self, mut evict: impl FnMut(Id)) {
-        let Some(capacity) = self.capacity else {
+        let capacity = self.capacity;
+        if capacity == 0 {
             return;
-        };
+        }
 
         let state = self.state.get_mut();
         for id in state.pending_evictions.drain(..) {
-            let (page, slot) = page_and_slot(&self.page_states, id);
-            if !page.is_resident(slot) {
+            let (block, slot) = block_and_slot(&self.state_blocks, id);
+            if !block.is_resident(slot) {
                 evict(id);
             }
-            page.clear_pending(slot);
+            block.clear_pending(slot);
         }
         state
             .pending_evictions
-            .shrink_to(capacity.get().saturating_mul(2));
+            .shrink_to(capacity.saturating_mul(2));
     }
 }
 
@@ -115,15 +116,15 @@ impl HasCapacity for Sieve {}
 
 impl Sieve {
     fn record_admission(&self, id: Id, capacity: usize) {
-        let (page, slot) = page_and_slot_or_alloc(&self.page_states, id);
+        let (block, slot) = block_and_slot_or_alloc(&self.state_blocks, id);
         let mut state = self.state.lock();
 
-        if page.is_resident(slot) {
-            page.record_use(slot);
+        if block.is_resident(slot) {
+            block.record_use(slot);
             return;
         }
 
-        state.insert(id, page, slot, capacity, &self.page_states);
+        state.insert(id, block, slot, capacity, &self.state_blocks);
     }
 }
 
@@ -138,9 +139,9 @@ struct State {
 
 struct SelectedVictim<'a> {
     id: Id,
-    /// The already-resolved location avoids another page-table lookup when the
+    /// The already-resolved location avoids another state-directory lookup when the
     /// victim is added to the pending-eviction queue.
-    page: &'a PageState,
+    block: &'a StateBlock,
     slot: usize,
 }
 
@@ -148,43 +149,43 @@ impl State {
     fn insert(
         &mut self,
         id: Id,
-        page: &PageState,
+        block: &StateBlock,
         slot: usize,
         capacity: usize,
-        page_states: &PageStates,
+        state_blocks: &StateBlocks,
     ) {
         debug_assert!(self.residents.len() <= capacity);
         if self.residents.len() == capacity {
             assert!(
-                self.schedule_eviction(page_states),
+                self.schedule_eviction(state_blocks),
                 "full resident list should have an eviction candidate"
             );
         }
 
         let node = self.residents.push_front(id);
-        page.admit(slot);
+        block.admit(slot);
 
         if self.hand == 0 {
             self.hand = node;
         }
     }
 
-    fn schedule_evictions(&mut self, capacity: usize, page_states: &PageStates) {
+    fn schedule_evictions(&mut self, capacity: usize, state_blocks: &StateBlocks) {
         self.pending_evictions
             .reserve(self.residents.len().saturating_sub(capacity));
         while self.residents.len() > capacity {
-            if !self.schedule_eviction(page_states) {
+            if !self.schedule_eviction(state_blocks) {
                 return;
             }
         }
     }
 
-    fn schedule_eviction(&mut self, page_states: &PageStates) -> bool {
-        let Some(victim) = self.select_victim(page_states) else {
+    fn schedule_eviction(&mut self, state_blocks: &StateBlocks) -> bool {
+        let Some(victim) = self.select_victim(state_blocks) else {
             return false;
         };
 
-        if victim.page.mark_pending(victim.slot) {
+        if victim.block.mark_pending(victim.slot) {
             self.pending_evictions.push(victim.id);
         }
         true
@@ -195,7 +196,7 @@ impl State {
     /// The scan performs at most two inspections per current resident. The
     /// second pass preserves second chances for concurrent re-marks; exhausting
     /// both passes force-evicts at the hand to guarantee progress.
-    fn select_victim<'a>(&mut self, page_states: &'a PageStates) -> Option<SelectedVictim<'a>> {
+    fn select_victim<'a>(&mut self, state_blocks: &'a StateBlocks) -> Option<SelectedVictim<'a>> {
         if self.hand == 0 {
             return None;
         }
@@ -204,12 +205,12 @@ impl State {
         for _ in 0..inspection_budget {
             let index = self.hand;
             let id = self.residents.id(index);
-            let (page, slot) = page_and_slot(page_states, id);
+            let (block, slot) = block_and_slot(state_blocks, id);
 
-            if page.select(slot).was_visited() {
+            if block.select(slot).was_visited() {
                 self.hand = self.residents.advance_towards_front(index);
             } else {
-                return Some(self.remove_victim(index, page, slot));
+                return Some(self.remove_victim(index, block, slot));
             }
         }
 
@@ -217,21 +218,21 @@ impl State {
         // preserve SIEVE's scan order while guaranteeing progress.
         let index = self.hand;
         let id = self.residents.id(index);
-        let (page, slot) = page_and_slot(page_states, id);
-        page.clear_resident(slot);
-        Some(self.remove_victim(index, page, slot))
+        let (block, slot) = block_and_slot(state_blocks, id);
+        block.clear_resident(slot);
+        Some(self.remove_victim(index, block, slot))
     }
 
     fn remove_victim<'a>(
         &mut self,
         index: ResidentIndex,
-        page: &'a PageState,
+        block: &'a StateBlock,
         slot: usize,
     ) -> SelectedVictim<'a> {
         self.hand = self.residents.hand_after_remove(index);
         SelectedVictim {
             id: self.residents.remove(index),
-            page,
+            block,
             slot,
         }
     }
@@ -328,6 +329,7 @@ impl Residents {
         if prev == 0 { self.node(0).prev } else { prev }
     }
 
+    #[cfg(test)]
     fn resident_ids(&self) -> ResidentIds<'_> {
         ResidentIds {
             residents: self,
@@ -362,11 +364,13 @@ impl Residents {
     }
 }
 
+#[cfg(test)]
 struct ResidentIds<'a> {
     residents: &'a Residents,
     next: ResidentIndex,
 }
 
+#[cfg(test)]
 impl Iterator for ResidentIds<'_> {
     type Item = Id;
 
@@ -382,72 +386,73 @@ impl Iterator for ResidentIds<'_> {
 }
 
 #[derive(Default)]
-struct PageSlot {
-    ptr: AtomicPtr<PageState>,
+struct BlockSlot {
+    ptr: AtomicPtr<StateBlock>,
 }
 
-// SAFETY: `PageSlot`'s all-zero representation is valid because a null
-// `AtomicPtr` is valid.
-unsafe impl MaybeZeroable for PageSlot {
+// SAFETY: Outside Shuttle, `BlockSlot` contains an atomic pointer whose
+// all-zero representation is a valid null pointer. Shuttle atomics require
+// construction.
+unsafe impl MaybeZeroable for BlockSlot {
     fn zeroable() -> bool {
-        true
+        cfg!(not(feature = "shuttle"))
     }
 }
 
-impl PageSlot {
+impl BlockSlot {
     #[inline]
-    fn get(&self) -> Option<&PageState> {
+    fn get(&self) -> Option<&StateBlock> {
         let ptr = self.ptr.load(Ordering::Acquire);
         ptr::NonNull::new(ptr).map(|ptr| {
             // SAFETY: A non-null pointer was allocated by `get_or_alloc` and
-            // remains owned by this `PageSlot` until it is dropped.
+            // remains owned by this slot until the directory is dropped.
             unsafe { ptr.as_ref() }
         })
     }
 
-    fn get_or_alloc(&self) -> &PageState {
-        if let Some(page) = self.get() {
-            return page;
+    fn get_or_alloc(&self) -> &StateBlock {
+        if let Some(block) = self.get() {
+            return block;
         }
 
-        let new_page = Box::into_raw(Box::new(PageState::default()));
+        let new_block = Box::into_raw(Box::new(StateBlock::default()));
         match self.ptr.compare_exchange(
             ptr::null_mut(),
-            new_page,
+            new_block,
             Ordering::Release,
             Ordering::Acquire,
         ) {
             Ok(_) => {
                 // SAFETY: We just installed this allocation.
-                unsafe { &*new_page }
+                unsafe { &*new_block }
             }
             Err(existing) => {
                 // SAFETY: This allocation was not published, so this thread
                 // still owns it.
-                unsafe { drop(Box::from_raw(new_page)) };
+                unsafe { drop(Box::from_raw(new_block)) };
 
-                // SAFETY: `existing` came from a successful install by another
-                // thread and remains owned by this `PageSlot`.
+                // SAFETY: `existing` was installed by another thread and
+                // remains owned by this slot.
                 unsafe { &*existing }
             }
         }
     }
 }
 
-impl Drop for PageSlot {
+impl Drop for BlockSlot {
     fn drop(&mut self) {
         let ptr = *self.ptr.get_mut();
         if !ptr.is_null() {
-            // SAFETY: Dropping the `PageSlot` requires exclusive access, so no
-            // more readers can access the pointed-to page.
+            // SAFETY: Dropping the slot requires exclusive access, so no reader
+            // can still access the allocation.
             unsafe { drop(Box::from_raw(ptr)) };
         }
     }
 }
 
-#[derive(Default)]
-struct PageState {
-    words: [AtomicU64; STATE_WORDS],
+struct StateBlock {
+    /// Interleaved resident and visited bits for all slots in the block.
+    state: [AtomicU64; STATE_WORDS],
     /// Slots that already occur in `State::pending_evictions`.
     ///
     /// These words are only accessed while holding the state mutex or during
@@ -456,11 +461,20 @@ struct PageState {
     pending: [AtomicU64; PENDING_WORDS],
 }
 
-impl PageState {
+impl Default for StateBlock {
+    fn default() -> Self {
+        Self {
+            state: std::array::from_fn(|_| AtomicU64::default()),
+            pending: std::array::from_fn(|_| AtomicU64::default()),
+        }
+    }
+}
+
+impl StateBlock {
     #[inline]
     fn record_use(&self, slot: usize) -> bool {
         let (word, resident, visited) = slot_state(slot);
-        let word = &self.words[word];
+        let word = &self.state[word];
         let mut state = word.load(Ordering::Relaxed);
 
         loop {
@@ -486,7 +500,7 @@ impl PageState {
 
     fn admit(&self, slot: usize) {
         let (word, resident, visited) = slot_state(slot);
-        let word = &self.words[word];
+        let word = &self.state[word];
         let mut state = word.load(Ordering::Relaxed);
 
         loop {
@@ -501,7 +515,7 @@ impl PageState {
 
     fn select(&self, slot: usize) -> Selection {
         let (word, resident, visited) = slot_state(slot);
-        let word = &self.words[word];
+        let word = &self.state[word];
         let mut state = word.load(Ordering::Relaxed);
 
         loop {
@@ -527,7 +541,7 @@ impl PageState {
 
     fn is_resident(&self, slot: usize) -> bool {
         let (word, resident, _) = slot_state(slot);
-        self.words[word].load(Ordering::Relaxed) & resident != 0
+        self.state[word].load(Ordering::Relaxed) & resident != 0
     }
 
     fn mark_pending(&self, slot: usize) -> bool {
@@ -549,14 +563,9 @@ impl PageState {
         word.store(state & !pending, Ordering::Relaxed);
     }
 
-    fn clear(&self, slot: usize) {
-        self.clear_resident(slot);
-        self.clear_pending(slot);
-    }
-
     fn clear_resident(&self, slot: usize) {
         let (word, resident, visited) = slot_state(slot);
-        self.words[word].fetch_and(!(resident | visited), Ordering::Relaxed);
+        self.state[word].fetch_and(!(resident | visited), Ordering::Relaxed);
     }
 }
 
@@ -572,35 +581,38 @@ impl Selection {
     }
 }
 
-fn page_and_slot_or_alloc(page_states: &PageStates, id: Id) -> (&PageState, usize) {
-    let (index, slot) = page_state_index_and_slot(id);
-    (page_states.get_or_alloc(index).get_or_alloc(), slot)
+fn block_and_slot_or_alloc(state_blocks: &StateBlocks, id: Id) -> (&StateBlock, usize) {
+    let (index, slot) = state_block_index_and_slot(id);
+    (state_blocks.get_or_alloc(index).get_or_alloc(), slot)
 }
 
-fn page_and_slot(page_states: &PageStates, id: Id) -> (&PageState, usize) {
-    // Resident and pending ids must already have allocated page state.
-    page_and_slot_if_allocated(page_states, id).expect("SIEVE page state should be allocated")
+fn block_and_slot(state_blocks: &StateBlocks, id: Id) -> (&StateBlock, usize) {
+    // Resident and pending ids must already have allocated state blocks.
+    block_and_slot_if_allocated(state_blocks, id).expect("SIEVE state block should be allocated")
 }
 
 #[inline]
-fn page_and_slot_if_allocated(page_states: &PageStates, id: Id) -> Option<(&PageState, usize)> {
-    let (index, slot) = page_state_index_and_slot(id);
-    page_states
+fn block_and_slot_if_allocated(state_blocks: &StateBlocks, id: Id) -> Option<(&StateBlock, usize)> {
+    let (index, slot) = state_block_index_and_slot(id);
+    state_blocks
         .get(index)
-        .and_then(PageSlot::get)
-        .map(|page| (page, slot))
+        .and_then(BlockSlot::get)
+        .map(|block| (block, slot))
 }
 
 #[inline]
-fn page_state_index_and_slot(id: Id) -> (PageStateIndex, usize) {
-    let (page, slot) = split_id(id);
-    // SAFETY: `Id` is a `u32`, and `PageStates` has enough buckets for every
-    // page representable by an `Id` after removing the slot bits.
-    let index = unsafe { PageStateIndex::new_unchecked(page.as_usize()) };
-    (index, slot.as_usize())
+fn state_block_index_and_slot(id: Id) -> (StateBlockIndex, usize) {
+    let index = id.index() as usize;
+    let block = index >> BLOCK_LEN_BITS;
+    let slot = index & (BLOCK_LEN - 1);
+    // SAFETY: `Id` is a `u32`, and `StateBlocks` has enough buckets for every
+    // block representable by an `Id` after removing the slot bits.
+    let index = unsafe { StateBlockIndex::new_unchecked(block) };
+    (index, slot)
 }
 
 fn slot_state(slot: usize) -> (usize, u64, u64) {
+    debug_assert!(slot < BLOCK_LEN);
     let bit = (slot % SLOTS_PER_STATE_WORD) * SLOT_STATE_BITS;
     let resident = 1 << bit;
     let visited = 1 << (bit + 1);
@@ -608,6 +620,7 @@ fn slot_state(slot: usize) -> (usize, u64, u64) {
 }
 
 fn pending_state(slot: usize) -> (usize, u64) {
+    debug_assert!(slot < BLOCK_LEN);
     let bit = slot % SLOTS_PER_PENDING_WORD;
     (slot / SLOTS_PER_PENDING_WORD, 1 << bit)
 }
@@ -623,20 +636,20 @@ mod tests {
 
     #[test]
     fn all_marked_residents_evict_the_initial_hand() {
-        let page_states = PageStates::new();
+        let state_blocks = StateBlocks::new();
         let mut state = State::default();
         let oldest = id(0);
         let middle = id(1);
         let newest = id(2);
 
         for id in [oldest, middle, newest] {
-            let (page, slot) = page_and_slot_or_alloc(&page_states, id);
-            state.insert(id, page, slot, 3, &page_states);
-            assert!(page.record_use(slot));
+            let (block, slot) = block_and_slot_or_alloc(&state_blocks, id);
+            state.insert(id, block, slot, 3, &state_blocks);
+            assert!(block.record_use(slot));
         }
 
         assert_eq!(
-            state.select_victim(&page_states).map(|victim| victim.id),
+            state.select_victim(&state_blocks).map(|victim| victim.id),
             Some(oldest)
         );
         assert_eq!(state.residents.id(state.hand), middle);
@@ -644,30 +657,46 @@ mod tests {
             state.residents.resident_ids().collect::<Vec<_>>(),
             [newest, middle]
         );
-        let (page, slot) = page_and_slot(&page_states, oldest);
-        assert!(!page.is_resident(slot));
+        let (block, slot) = block_and_slot(&state_blocks, oldest);
+        assert!(!block.is_resident(slot));
     }
 
     #[test]
     fn insertion_selects_a_victim_before_admitting() {
-        let page_states = PageStates::new();
+        let state_blocks = StateBlocks::new();
         let mut state = State::default();
         let oldest = id(0);
         let newest = id(1);
         let incoming = id(2);
 
         for id in [oldest, newest] {
-            let (page, slot) = page_and_slot_or_alloc(&page_states, id);
-            state.insert(id, page, slot, 2, &page_states);
-            assert!(page.record_use(slot));
+            let (block, slot) = block_and_slot_or_alloc(&state_blocks, id);
+            state.insert(id, block, slot, 2, &state_blocks);
+            assert!(block.record_use(slot));
         }
 
-        let (page, slot) = page_and_slot_or_alloc(&page_states, incoming);
-        state.insert(incoming, page, slot, 2, &page_states);
+        let (block, slot) = block_and_slot_or_alloc(&state_blocks, incoming);
+        state.insert(incoming, block, slot, 2, &state_blocks);
 
         assert_eq!(state.pending_evictions, [oldest]);
         assert_eq!(state.residents.nodes.len(), 3);
-        assert!(page.is_resident(slot));
+        assert!(block.is_resident(slot));
+    }
+
+    #[test]
+    fn disabling_discards_state_blocks() {
+        let mut sieve = Sieve::new(1);
+        let resident = id(0);
+
+        sieve.record_use(resident);
+        assert!(block_and_slot_if_allocated(&sieve.state_blocks, resident).is_some());
+
+        sieve.set_tuning(0);
+        assert!(block_and_slot_if_allocated(&sieve.state_blocks, resident).is_none());
+        assert_eq!(sieve.state.get_mut().residents.len(), 0);
+
+        sieve.record_use(resident);
+        assert!(block_and_slot_if_allocated(&sieve.state_blocks, resident).is_none());
     }
 
     #[test]

--- a/src/function/eviction/sieve.rs
+++ b/src/function/eviction/sieve.rs
@@ -57,6 +57,8 @@ pub struct Sieve {
 }
 
 impl EvictionPolicy for Sieve {
+    type Value<T: Send + Sync> = Option<T>;
+
     fn new(capacity: usize) -> Self {
         Self {
             capacity,
@@ -67,12 +69,8 @@ impl EvictionPolicy for Sieve {
 
     #[inline]
     fn record_use(&self, id: Id) {
-        // Probe residency before capacity: resident hits do not need the capacity,
-        // while admissions already take the cold path below.
-        if let Some((block, slot)) = block_and_slot_if_allocated(&self.state_blocks, id) {
-            if block.record_use(slot) {
-                return;
-            }
+        if self.record_resident_use(id) {
+            return;
         }
 
         if self.capacity != 0 {
@@ -115,6 +113,27 @@ impl EvictionPolicy for Sieve {
 impl HasCapacity for Sieve {}
 
 impl Sieve {
+    /// Records a use and returns the selected victim immediately.
+    ///
+    /// Volatile queries use the same SIEVE state machine as revision-delayed
+    /// queries, but can reclaim the victim as soon as the caller owns a handle
+    /// to the value it requested.
+    pub(super) fn record_immediate_use(&self, id: Id) -> Option<Id> {
+        if self.record_resident_use(id) || self.capacity == 0 {
+            return None;
+        }
+
+        self.record_immediate_admission(id, self.capacity)
+    }
+
+    #[inline]
+    fn record_resident_use(&self, id: Id) -> bool {
+        // Probe residency before capacity: resident hits do not need the capacity,
+        // while admissions already take the cold path below.
+        block_and_slot_if_allocated(&self.state_blocks, id)
+            .is_some_and(|(block, slot)| block.record_use(slot))
+    }
+
     fn record_admission(&self, id: Id, capacity: usize) {
         let (block, slot) = block_and_slot_or_alloc(&self.state_blocks, id);
         let mut state = self.state.lock();
@@ -124,7 +143,23 @@ impl Sieve {
             return;
         }
 
-        state.insert(id, block, slot, capacity, &self.state_blocks);
+        if let Some(victim) = state.insert(id, block, slot, capacity, &self.state_blocks) {
+            state.schedule_selected_victim(victim);
+        }
+    }
+
+    fn record_immediate_admission(&self, id: Id, capacity: usize) -> Option<Id> {
+        let (block, slot) = block_and_slot_or_alloc(&self.state_blocks, id);
+        let mut state = self.state.lock();
+
+        if block.is_resident(slot) {
+            block.record_use(slot);
+            return None;
+        }
+
+        state
+            .insert(id, block, slot, capacity, &self.state_blocks)
+            .map(|victim| victim.id)
     }
 }
 
@@ -146,21 +181,23 @@ struct SelectedVictim<'a> {
 }
 
 impl State {
-    fn insert(
+    fn insert<'a>(
         &mut self,
         id: Id,
-        block: &StateBlock,
+        block: &'a StateBlock,
         slot: usize,
         capacity: usize,
-        state_blocks: &StateBlocks,
-    ) {
+        state_blocks: &'a StateBlocks,
+    ) -> Option<SelectedVictim<'a>> {
         debug_assert!(self.residents.len() <= capacity);
-        if self.residents.len() == capacity {
-            assert!(
-                self.schedule_eviction(state_blocks),
-                "full resident list should have an eviction candidate"
-            );
-        }
+        let victim = if self.residents.len() == capacity {
+            Some(
+                self.select_victim(state_blocks)
+                    .expect("full resident list should have an eviction candidate"),
+            )
+        } else {
+            None
+        };
 
         let node = self.residents.push_front(id);
         block.admit(slot);
@@ -168,6 +205,8 @@ impl State {
         if self.hand == 0 {
             self.hand = node;
         }
+
+        victim
     }
 
     fn schedule_evictions(&mut self, capacity: usize, state_blocks: &StateBlocks) {
@@ -185,10 +224,14 @@ impl State {
             return false;
         };
 
+        self.schedule_selected_victim(victim);
+        true
+    }
+
+    fn schedule_selected_victim(&mut self, victim: SelectedVictim<'_>) {
         if victim.block.mark_pending(victim.slot) {
             self.pending_evictions.push(victim.id);
         }
-        true
     }
 
     /// Selects and removes the next resident using a bounded SIEVE scan.
@@ -644,7 +687,7 @@ mod tests {
 
         for id in [oldest, middle, newest] {
             let (block, slot) = block_and_slot_or_alloc(&state_blocks, id);
-            state.insert(id, block, slot, 3, &state_blocks);
+            assert!(state.insert(id, block, slot, 3, &state_blocks).is_none());
             assert!(block.record_use(slot));
         }
 
@@ -671,12 +714,15 @@ mod tests {
 
         for id in [oldest, newest] {
             let (block, slot) = block_and_slot_or_alloc(&state_blocks, id);
-            state.insert(id, block, slot, 2, &state_blocks);
+            assert!(state.insert(id, block, slot, 2, &state_blocks).is_none());
             assert!(block.record_use(slot));
         }
 
         let (block, slot) = block_and_slot_or_alloc(&state_blocks, incoming);
-        state.insert(incoming, block, slot, 2, &state_blocks);
+        let victim = state
+            .insert(incoming, block, slot, 2, &state_blocks)
+            .expect("full SIEVE should select a victim");
+        state.schedule_selected_victim(victim);
 
         assert_eq!(state.pending_evictions, [oldest]);
         assert_eq!(state.residents.nodes.len(), 3);

--- a/src/function/eviction/sieve.rs
+++ b/src/function/eviction/sieve.rs
@@ -28,7 +28,7 @@ use crate::sync::Mutex;
 use crate::sync::atomic::{AtomicPtr, AtomicU64, Ordering};
 use crate::table::{PAGE_LEN, PAGE_LEN_BITS, split_id};
 
-use super::{EvictionContext, EvictionPolicy, HasCapacity};
+use super::{EvictionPolicy, HasCapacity};
 use boxcar::buckets::{Buckets, Index, MaybeZeroable, buckets_for_index_bits};
 
 const SLOT_STATE_BITS: usize = 2;
@@ -91,7 +91,7 @@ impl EvictionPolicy for Sieve {
         }
     }
 
-    fn start_new_revision(&mut self, context: &mut impl EvictionContext) {
+    fn for_each_evicted(&mut self, mut evict: impl FnMut(Id)) {
         let Some(capacity) = self.capacity else {
             return;
         };
@@ -100,7 +100,7 @@ impl EvictionPolicy for Sieve {
         for id in state.pending_evictions.drain(..) {
             let (page, slot) = page_and_slot(&self.page_states, id);
             if !page.is_resident(slot) {
-                context.evict_value(id);
+                evict(id);
             }
             page.clear_pending(slot);
         }
@@ -610,21 +610,6 @@ fn pending_state(slot: usize) -> (usize, u64) {
 mod tests {
     use super::*;
 
-    #[derive(Default)]
-    struct TestEvictionContext {
-        evicted: Vec<Id>,
-    }
-
-    impl EvictionContext for TestEvictionContext {
-        fn last_verified_at(&mut self, _id: Id) -> Option<crate::Revision> {
-            None
-        }
-
-        fn evict_value(&mut self, id: Id) {
-            self.evicted.push(id);
-        }
-    }
-
     fn id(index: u32) -> Id {
         // SAFETY: Test indices are within `Id`'s valid range.
         unsafe { Id::from_index(index) }
@@ -692,10 +677,10 @@ mod tests {
 
         assert_eq!(sieve.state.lock().pending_evictions, [first, second]);
 
-        let mut context = TestEvictionContext::default();
-        sieve.start_new_revision(&mut context);
+        let mut evicted = Vec::new();
+        sieve.for_each_evicted(|id| evicted.push(id));
 
-        assert_eq!(context.evicted, [first]);
+        assert_eq!(evicted, [first]);
         assert!(sieve.state.get_mut().pending_evictions.is_empty());
 
         sieve.record_use(first);

--- a/src/function/eviction/sieve.rs
+++ b/src/function/eviction/sieve.rs
@@ -1,0 +1,515 @@
+//! SIEVE eviction policy.
+//!
+//! This policy keeps resident values in FIFO order and records a single visited
+//! bit for values used after admission. At eviction time, a moving hand gives
+//! visited values one second chance by clearing their bit and continuing toward
+//! newer entries.
+
+use std::num::NonZeroUsize;
+use std::ptr;
+
+use crate::Id;
+use crate::sync::Mutex;
+use crate::sync::atomic::{AtomicPtr, AtomicU64, Ordering};
+use crate::table::{PAGE_LEN, PAGE_LEN_BITS, split_id};
+
+use super::{EvictionContext, EvictionPolicy, HasCapacity};
+use boxcar::buckets::{Buckets, Index, MaybeZeroable, buckets_for_index_bits};
+
+const SLOT_STATE_BITS: usize = 2;
+const SLOTS_PER_STATE_WORD: usize = u64::BITS as usize / SLOT_STATE_BITS;
+const STATE_WORDS: usize = PAGE_LEN.div_ceil(SLOTS_PER_STATE_WORD);
+
+type PageStates = Buckets<PageSlot, { buckets_for_index_bits(u32::BITS - PAGE_LEN_BITS as u32) }>;
+type PageStateIndex = Index<{ buckets_for_index_bits(u32::BITS - PAGE_LEN_BITS as u32) }>;
+
+/// SIEVE eviction policy.
+///
+/// Values enter at the front of a FIFO queue. Uses set a page-indexed atomic
+/// visited bit; they do not move the value in the queue.
+pub struct Sieve {
+    capacity: Option<NonZeroUsize>,
+    state: Mutex<State>,
+    page_states: PageStates,
+}
+
+impl EvictionPolicy for Sieve {
+    fn new(capacity: usize) -> Self {
+        Self {
+            capacity: NonZeroUsize::new(capacity),
+            state: Mutex::default(),
+            page_states: PageStates::new(),
+        }
+    }
+
+    fn record_use(&self, id: Id) {
+        if let Some(capacity) = self.capacity {
+            if let Some(page) = self.page_if_allocated(id) {
+                if page.record_use(slot_offset(id)) {
+                    return;
+                }
+            }
+
+            self.record_admission(id, capacity.get());
+        }
+    }
+
+    fn set_tuning(&mut self, capacity: usize) {
+        self.capacity = NonZeroUsize::new(capacity);
+        let page_states = &self.page_states;
+        let state = self.state.get_mut();
+        if let Some(capacity) = self.capacity {
+            state.schedule_evictions(capacity.get(), page_states);
+        } else {
+            for id in state
+                .residents
+                .resident_ids()
+                .chain(state.pending_evictions.iter().copied())
+            {
+                if let Some(page) = page_if_allocated(page_states, id) {
+                    page.clear(slot_offset(id));
+                }
+            }
+            *state = State::default();
+        }
+    }
+
+    fn start_new_revision(&mut self, context: &mut impl EvictionContext) {
+        if self.capacity.is_none() {
+            return;
+        }
+
+        let state = self.state.get_mut();
+        for id in state.pending_evictions.drain(..) {
+            if !page_if_allocated(&self.page_states, id)
+                .is_some_and(|page| page.is_resident(slot_offset(id)))
+            {
+                context.evict_value(id);
+            }
+        }
+    }
+}
+
+impl HasCapacity for Sieve {}
+
+impl Sieve {
+    fn page_if_allocated(&self, id: Id) -> Option<&PageState> {
+        page_if_allocated(&self.page_states, id)
+    }
+
+    fn record_admission(&self, id: Id, capacity: usize) {
+        let page = page(&self.page_states, id);
+        let slot = slot_offset(id);
+        let mut state = self.state.lock();
+
+        if page.is_resident(slot) {
+            page.record_use(slot);
+            return;
+        }
+
+        state.insert(id, capacity, &self.page_states);
+    }
+}
+
+#[derive(Default)]
+struct State {
+    residents: Residents,
+    /// Index of the next resident candidate to inspect. `0` is the sentinel.
+    hand: ResidentIndex,
+    /// Victims selected by SIEVE admission, waiting for an eviction context.
+    pending_evictions: Vec<Id>,
+}
+
+impl State {
+    fn insert(&mut self, id: Id, capacity: usize, page_states: &PageStates) {
+        let node = self.residents.push_front(id);
+        page(page_states, id).admit(slot_offset(id));
+
+        if self.hand == 0 {
+            self.hand = node;
+        }
+
+        if self.residents.len() > capacity {
+            assert!(
+                self.schedule_eviction(page_states),
+                "resident list should have an eviction candidate after insertion"
+            );
+        }
+    }
+
+    fn schedule_evictions(&mut self, capacity: usize, page_states: &PageStates) {
+        while self.residents.len() > capacity {
+            if !self.schedule_eviction(page_states) {
+                return;
+            }
+        }
+    }
+
+    fn schedule_eviction(&mut self, page_states: &PageStates) -> bool {
+        if let Some(victim) = self.select_victim(page_states) {
+            self.pending_evictions.push(victim);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn select_victim(&mut self, page_states: &PageStates) -> Option<Id> {
+        loop {
+            if self.hand == 0 {
+                return None;
+            }
+
+            let index = self.hand;
+            let id = self.residents.id(index);
+
+            if page(page_states, id).select(slot_offset(id)).was_visited() {
+                self.hand = self.residents.advance_towards_front(index);
+            } else {
+                self.hand = self.residents.hand_after_remove(index);
+                return Some(self.residents.remove(index));
+            }
+        }
+    }
+}
+
+type ResidentIndex = u32;
+
+struct Residents {
+    nodes: Vec<Resident>,
+    free: Vec<ResidentIndex>,
+    len: usize,
+}
+
+struct Resident {
+    id: Option<Id>,
+    /// Newer resident, or the sentinel.
+    prev: ResidentIndex,
+    /// Older resident, or the sentinel.
+    next: ResidentIndex,
+}
+
+impl Default for Residents {
+    fn default() -> Self {
+        Self {
+            nodes: vec![Resident {
+                id: None,
+                prev: 0,
+                next: 0,
+            }],
+            free: Vec::new(),
+            len: 0,
+        }
+    }
+}
+
+impl Residents {
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn push_front(&mut self, id: Id) -> ResidentIndex {
+        let index = self.alloc_node(id);
+        let first = self.node(0).next;
+
+        self.node_mut(index).prev = 0;
+        self.node_mut(index).next = first;
+        self.node_mut(0).next = index;
+        self.node_mut(first).prev = index;
+
+        self.len += 1;
+        index
+    }
+
+    fn remove(&mut self, index: ResidentIndex) -> Id {
+        debug_assert_ne!(index, 0);
+
+        let prev = self.node(index).prev;
+        let next = self.node(index).next;
+        self.node_mut(prev).next = next;
+        self.node_mut(next).prev = prev;
+        self.len -= 1;
+
+        let id = self
+            .node_mut(index)
+            .id
+            .take()
+            .expect("resident node should have an id");
+        self.node_mut(index).prev = 0;
+        self.node_mut(index).next = 0;
+        self.free.push(index);
+        id
+    }
+
+    fn id(&self, index: ResidentIndex) -> Id {
+        self.node(index)
+            .id
+            .expect("resident node should have an id")
+    }
+
+    fn advance_towards_front(&self, index: ResidentIndex) -> ResidentIndex {
+        debug_assert_ne!(index, 0);
+
+        let prev = self.node(index).prev;
+        if prev == 0 { self.node(0).prev } else { prev }
+    }
+
+    fn hand_after_remove(&self, index: ResidentIndex) -> ResidentIndex {
+        debug_assert_ne!(index, 0);
+
+        if self.len == 1 {
+            return 0;
+        }
+
+        let prev = self.node(index).prev;
+        if prev == 0 { self.node(0).prev } else { prev }
+    }
+
+    fn resident_ids(&self) -> ResidentIds<'_> {
+        ResidentIds {
+            residents: self,
+            next: self.node(0).next,
+        }
+    }
+
+    fn alloc_node(&mut self, id: Id) -> ResidentIndex {
+        if let Some(index) = self.free.pop() {
+            self.node_mut(index).id = Some(id);
+            index
+        } else {
+            let index = ResidentIndex::try_from(self.nodes.len())
+                .expect("SIEVE resident capacity should fit in u32");
+            self.nodes.push(Resident {
+                id: Some(id),
+                prev: 0,
+                next: 0,
+            });
+            index
+        }
+    }
+
+    fn node(&self, index: ResidentIndex) -> &Resident {
+        &self.nodes[index as usize]
+    }
+
+    fn node_mut(&mut self, index: ResidentIndex) -> &mut Resident {
+        &mut self.nodes[index as usize]
+    }
+}
+
+struct ResidentIds<'a> {
+    residents: &'a Residents,
+    next: ResidentIndex,
+}
+
+impl Iterator for ResidentIds<'_> {
+    type Item = Id;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.next == 0 {
+            return None;
+        }
+
+        let index = self.next;
+        self.next = self.residents.node(index).next;
+        Some(self.residents.id(index))
+    }
+}
+
+#[derive(Default)]
+struct PageSlot {
+    ptr: AtomicPtr<PageState>,
+}
+
+// SAFETY: `PageSlot`'s all-zero representation is valid because a null
+// `AtomicPtr` is valid.
+unsafe impl MaybeZeroable for PageSlot {
+    fn zeroable() -> bool {
+        true
+    }
+}
+
+impl PageSlot {
+    fn get(&self) -> Option<&PageState> {
+        let ptr = self.ptr.load(Ordering::Acquire);
+        ptr::NonNull::new(ptr).map(|ptr| {
+            // SAFETY: A non-null pointer was allocated by `get_or_alloc` and
+            // remains owned by this `PageSlot` until it is dropped.
+            unsafe { ptr.as_ref() }
+        })
+    }
+
+    fn get_or_alloc(&self) -> &PageState {
+        if let Some(page) = self.get() {
+            return page;
+        }
+
+        let new_page = Box::into_raw(Box::new(PageState::default()));
+        match self.ptr.compare_exchange(
+            ptr::null_mut(),
+            new_page,
+            Ordering::Release,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => {
+                // SAFETY: We just installed this allocation.
+                unsafe { &*new_page }
+            }
+            Err(existing) => {
+                // SAFETY: This allocation was not published, so this thread
+                // still owns it.
+                unsafe { drop(Box::from_raw(new_page)) };
+
+                // SAFETY: `existing` came from a successful install by another
+                // thread and remains owned by this `PageSlot`.
+                unsafe { &*existing }
+            }
+        }
+    }
+}
+
+impl Drop for PageSlot {
+    fn drop(&mut self) {
+        let ptr = *self.ptr.get_mut();
+        if !ptr.is_null() {
+            // SAFETY: Dropping the `PageSlot` requires exclusive access, so no
+            // more readers can access the pointed-to page.
+            unsafe { drop(Box::from_raw(ptr)) };
+        }
+    }
+}
+
+#[derive(Default)]
+struct PageState {
+    words: [AtomicU64; STATE_WORDS],
+}
+
+impl PageState {
+    fn record_use(&self, slot: usize) -> bool {
+        let (word, resident, visited) = slot_state(slot);
+        let word = &self.words[word];
+        let mut state = word.load(Ordering::Relaxed);
+
+        loop {
+            if state & resident == 0 {
+                return false;
+            }
+
+            if state & visited != 0 {
+                return true;
+            }
+
+            match word.compare_exchange_weak(
+                state,
+                state | visited,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return true,
+                Err(new_state) => state = new_state,
+            }
+        }
+    }
+
+    fn admit(&self, slot: usize) {
+        let (word, resident, visited) = slot_state(slot);
+        let word = &self.words[word];
+        let mut state = word.load(Ordering::Relaxed);
+
+        loop {
+            let new_state = (state | resident) & !visited;
+            match word.compare_exchange_weak(state, new_state, Ordering::Relaxed, Ordering::Relaxed)
+            {
+                Ok(_) => return,
+                Err(new_state) => state = new_state,
+            }
+        }
+    }
+
+    fn select(&self, slot: usize) -> Selection {
+        let (word, resident, visited) = slot_state(slot);
+        let word = &self.words[word];
+        let mut state = word.load(Ordering::Relaxed);
+
+        loop {
+            debug_assert_ne!(
+                state & resident,
+                0,
+                "resident list entry should have a resident state bit"
+            );
+
+            let (new_state, selection) = if state & visited == 0 {
+                (state & !(resident | visited), Selection::Evict)
+            } else {
+                (state & !visited, Selection::SecondChance)
+            };
+
+            match word.compare_exchange_weak(state, new_state, Ordering::Relaxed, Ordering::Relaxed)
+            {
+                Ok(_) => return selection,
+                Err(new_state) => state = new_state,
+            }
+        }
+    }
+
+    fn is_resident(&self, slot: usize) -> bool {
+        let (word, resident, _) = slot_state(slot);
+        self.words[word].load(Ordering::Relaxed) & resident != 0
+    }
+
+    fn clear(&self, slot: usize) {
+        let (word, resident, visited) = slot_state(slot);
+        let word = &self.words[word];
+        let mut state = word.load(Ordering::Relaxed);
+
+        loop {
+            let new_state = state & !(resident | visited);
+            match word.compare_exchange_weak(state, new_state, Ordering::Relaxed, Ordering::Relaxed)
+            {
+                Ok(_) => return,
+                Err(new_state) => state = new_state,
+            }
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+enum Selection {
+    SecondChance,
+    Evict,
+}
+
+impl Selection {
+    fn was_visited(self) -> bool {
+        matches!(self, Selection::SecondChance)
+    }
+}
+
+fn page(page_states: &PageStates, id: Id) -> &PageState {
+    page_states
+        .get_or_alloc(page_state_index(id))
+        .get_or_alloc()
+}
+
+fn page_if_allocated(page_states: &PageStates, id: Id) -> Option<&PageState> {
+    page_states
+        .get(page_state_index(id))
+        .and_then(PageSlot::get)
+}
+
+fn page_state_index(id: Id) -> PageStateIndex {
+    let (page, _) = split_id(id);
+    PageStateIndex::new(page.as_usize()).expect("page index should fit in SIEVE page state table")
+}
+
+fn slot_offset(id: Id) -> usize {
+    let (_, slot) = split_id(id);
+    slot.as_usize()
+}
+
+fn slot_state(slot: usize) -> (usize, u64, u64) {
+    let bit = (slot % SLOTS_PER_STATE_WORD) * SLOT_STATE_BITS;
+    let resident = 1 << bit;
+    let visited = 1 << (bit + 1);
+    (slot / SLOTS_PER_STATE_WORD, resident, visited)
+}

--- a/src/function/eviction/sieve.rs
+++ b/src/function/eviction/sieve.rs
@@ -4,6 +4,21 @@
 //! bit for values used after admission. At eviction time, a moving hand gives
 //! visited values one second chance by clearing their bit and continuing toward
 //! newer entries.
+//!
+//! Victim selection is bounded to twice the current resident count. With no
+//! concurrent hits, this behaves like textbook SIEVE: if every resident starts
+//! visited, the first pass clears those bits and the first resident is selected
+//! when the hand reaches it again. A second pass also gives residents re-marked
+//! by concurrent hits another chance. If every inspection still finds a visited
+//! resident, selection force-evicts the resident at the hand so admissions
+//! cannot starve without changing the scan order.
+//!
+//! Hits update the page-indexed visited bits without taking the state mutex.
+//! Admissions, hand movement, and the pending-eviction queue are serialized by
+//! that mutex. Selecting a victim removes it from the resident list immediately,
+//! but its value is evicted at the next revision only if it was not re-admitted.
+//! A separate page-indexed bitmap ensures each id appears in that queue at most
+//! once per revision.
 
 use std::num::NonZeroUsize;
 use std::ptr;
@@ -19,6 +34,8 @@ use boxcar::buckets::{Buckets, Index, MaybeZeroable, buckets_for_index_bits};
 const SLOT_STATE_BITS: usize = 2;
 const SLOTS_PER_STATE_WORD: usize = u64::BITS as usize / SLOT_STATE_BITS;
 const STATE_WORDS: usize = PAGE_LEN.div_ceil(SLOTS_PER_STATE_WORD);
+const SLOTS_PER_PENDING_WORD: usize = u64::BITS as usize;
+const PENDING_WORDS: usize = PAGE_LEN.div_ceil(SLOTS_PER_PENDING_WORD);
 
 type PageStates = Buckets<PageSlot, { buckets_for_index_bits(u32::BITS - PAGE_LEN_BITS as u32) }>;
 type PageStateIndex = Index<{ buckets_for_index_bits(u32::BITS - PAGE_LEN_BITS as u32) }>;
@@ -44,8 +61,8 @@ impl EvictionPolicy for Sieve {
 
     fn record_use(&self, id: Id) {
         if let Some(capacity) = self.capacity {
-            if let Some(page) = self.page_if_allocated(id) {
-                if page.record_use(slot_offset(id)) {
+            if let Some((page, slot)) = page_and_slot_if_allocated(&self.page_states, id) {
+                if page.record_use(slot) {
                     return;
                 }
             }
@@ -66,8 +83,8 @@ impl EvictionPolicy for Sieve {
                 .resident_ids()
                 .chain(state.pending_evictions.iter().copied())
             {
-                if let Some(page) = page_if_allocated(page_states, id) {
-                    page.clear(slot_offset(id));
+                if let Some((page, slot)) = page_and_slot_if_allocated(page_states, id) {
+                    page.clear(slot);
                 }
             }
             *state = State::default();
@@ -75,31 +92,29 @@ impl EvictionPolicy for Sieve {
     }
 
     fn start_new_revision(&mut self, context: &mut impl EvictionContext) {
-        if self.capacity.is_none() {
+        let Some(capacity) = self.capacity else {
             return;
-        }
+        };
 
         let state = self.state.get_mut();
         for id in state.pending_evictions.drain(..) {
-            if !page_if_allocated(&self.page_states, id)
-                .is_some_and(|page| page.is_resident(slot_offset(id)))
-            {
+            let (page, slot) = page_and_slot(&self.page_states, id);
+            if !page.is_resident(slot) {
                 context.evict_value(id);
             }
+            page.clear_pending(slot);
         }
+        state
+            .pending_evictions
+            .shrink_to(capacity.get().saturating_mul(2));
     }
 }
 
 impl HasCapacity for Sieve {}
 
 impl Sieve {
-    fn page_if_allocated(&self, id: Id) -> Option<&PageState> {
-        page_if_allocated(&self.page_states, id)
-    }
-
     fn record_admission(&self, id: Id, capacity: usize) {
-        let page = page(&self.page_states, id);
-        let slot = slot_offset(id);
+        let (page, slot) = page_and_slot_or_alloc(&self.page_states, id);
         let mut state = self.state.lock();
 
         if page.is_resident(slot) {
@@ -107,7 +122,7 @@ impl Sieve {
             return;
         }
 
-        state.insert(id, capacity, &self.page_states);
+        state.insert(id, page, slot, capacity, &self.page_states);
     }
 }
 
@@ -120,24 +135,42 @@ struct State {
     pending_evictions: Vec<Id>,
 }
 
+struct SelectedVictim<'a> {
+    id: Id,
+    /// The already-resolved location avoids another page-table lookup when the
+    /// victim is added to the pending-eviction queue.
+    page: &'a PageState,
+    slot: usize,
+}
+
 impl State {
-    fn insert(&mut self, id: Id, capacity: usize, page_states: &PageStates) {
+    fn insert(
+        &mut self,
+        id: Id,
+        page: &PageState,
+        slot: usize,
+        capacity: usize,
+        page_states: &PageStates,
+    ) {
+        debug_assert!(self.residents.len() <= capacity);
+        if self.residents.len() == capacity {
+            assert!(
+                self.schedule_eviction(page_states),
+                "full resident list should have an eviction candidate"
+            );
+        }
+
         let node = self.residents.push_front(id);
-        page(page_states, id).admit(slot_offset(id));
+        page.admit(slot);
 
         if self.hand == 0 {
             self.hand = node;
         }
-
-        if self.residents.len() > capacity {
-            assert!(
-                self.schedule_eviction(page_states),
-                "resident list should have an eviction candidate after insertion"
-            );
-        }
     }
 
     fn schedule_evictions(&mut self, capacity: usize, page_states: &PageStates) {
+        self.pending_evictions
+            .reserve(self.residents.len().saturating_sub(capacity));
         while self.residents.len() > capacity {
             if !self.schedule_eviction(page_states) {
                 return;
@@ -146,29 +179,59 @@ impl State {
     }
 
     fn schedule_eviction(&mut self, page_states: &PageStates) -> bool {
-        if let Some(victim) = self.select_victim(page_states) {
-            self.pending_evictions.push(victim);
-            true
-        } else {
-            false
+        let Some(victim) = self.select_victim(page_states) else {
+            return false;
+        };
+
+        if victim.page.mark_pending(victim.slot) {
+            self.pending_evictions.push(victim.id);
         }
+        true
     }
 
-    fn select_victim(&mut self, page_states: &PageStates) -> Option<Id> {
-        loop {
-            if self.hand == 0 {
-                return None;
-            }
+    /// Selects and removes the next resident using a bounded SIEVE scan.
+    ///
+    /// The scan performs at most two inspections per current resident. The
+    /// second pass preserves second chances for concurrent re-marks; exhausting
+    /// both passes force-evicts at the hand to guarantee progress.
+    fn select_victim<'a>(&mut self, page_states: &'a PageStates) -> Option<SelectedVictim<'a>> {
+        if self.hand == 0 {
+            return None;
+        }
 
+        let inspection_budget = self.residents.len().saturating_mul(2);
+        for _ in 0..inspection_budget {
             let index = self.hand;
             let id = self.residents.id(index);
+            let (page, slot) = page_and_slot(page_states, id);
 
-            if page(page_states, id).select(slot_offset(id)).was_visited() {
+            if page.select(slot).was_visited() {
                 self.hand = self.residents.advance_towards_front(index);
             } else {
-                self.hand = self.residents.hand_after_remove(index);
-                return Some(self.residents.remove(index));
+                return Some(self.remove_victim(index, page, slot));
             }
+        }
+
+        // Every inspected resident was re-marked. Evict at the hand to
+        // preserve SIEVE's scan order while guaranteeing progress.
+        let index = self.hand;
+        let id = self.residents.id(index);
+        let (page, slot) = page_and_slot(page_states, id);
+        page.clear_resident(slot);
+        Some(self.remove_victim(index, page, slot))
+    }
+
+    fn remove_victim<'a>(
+        &mut self,
+        index: ResidentIndex,
+        page: &'a PageState,
+        slot: usize,
+    ) -> SelectedVictim<'a> {
+        self.hand = self.residents.hand_after_remove(index);
+        SelectedVictim {
+            id: self.residents.remove(index),
+            page,
+            slot,
         }
     }
 }
@@ -177,7 +240,8 @@ type ResidentIndex = u32;
 
 struct Residents {
     nodes: Vec<Resident>,
-    free: Vec<ResidentIndex>,
+    /// Intrusive free list linked through `Resident::next`.
+    free_head: ResidentIndex,
     len: usize,
 }
 
@@ -197,7 +261,7 @@ impl Default for Residents {
                 prev: 0,
                 next: 0,
             }],
-            free: Vec::new(),
+            free_head: 0,
             len: 0,
         }
     }
@@ -230,14 +294,12 @@ impl Residents {
         self.node_mut(next).prev = prev;
         self.len -= 1;
 
-        let id = self
-            .node_mut(index)
-            .id
-            .take()
-            .expect("resident node should have an id");
-        self.node_mut(index).prev = 0;
-        self.node_mut(index).next = 0;
-        self.free.push(index);
+        let free_head = self.free_head;
+        let node = self.node_mut(index);
+        let id = node.id.take().expect("resident node should have an id");
+        node.prev = 0;
+        node.next = free_head;
+        self.free_head = index;
         id
     }
 
@@ -273,7 +335,9 @@ impl Residents {
     }
 
     fn alloc_node(&mut self, id: Id) -> ResidentIndex {
-        if let Some(index) = self.free.pop() {
+        if self.free_head != 0 {
+            let index = self.free_head;
+            self.free_head = self.node(index).next;
             self.node_mut(index).id = Some(id);
             index
         } else {
@@ -382,6 +446,12 @@ impl Drop for PageSlot {
 #[derive(Default)]
 struct PageState {
     words: [AtomicU64; STATE_WORDS],
+    /// Slots that already occur in `State::pending_evictions`.
+    ///
+    /// These words are only accessed while holding the state mutex or during
+    /// an exclusive revision reset. Atomics provide safe interior mutability;
+    /// the mutex provides synchronization.
+    pending: [AtomicU64; PENDING_WORDS],
 }
 
 impl PageState {
@@ -457,19 +527,33 @@ impl PageState {
         self.words[word].load(Ordering::Relaxed) & resident != 0
     }
 
-    fn clear(&self, slot: usize) {
-        let (word, resident, visited) = slot_state(slot);
-        let word = &self.words[word];
-        let mut state = word.load(Ordering::Relaxed);
-
-        loop {
-            let new_state = state & !(resident | visited);
-            match word.compare_exchange_weak(state, new_state, Ordering::Relaxed, Ordering::Relaxed)
-            {
-                Ok(_) => return,
-                Err(new_state) => state = new_state,
-            }
+    fn mark_pending(&self, slot: usize) -> bool {
+        let (word, pending) = pending_state(slot);
+        let word = &self.pending[word];
+        let state = word.load(Ordering::Relaxed);
+        if state & pending != 0 {
+            return false;
         }
+
+        word.store(state | pending, Ordering::Relaxed);
+        true
+    }
+
+    fn clear_pending(&self, slot: usize) {
+        let (word, pending) = pending_state(slot);
+        let word = &self.pending[word];
+        let state = word.load(Ordering::Relaxed);
+        word.store(state & !pending, Ordering::Relaxed);
+    }
+
+    fn clear(&self, slot: usize) {
+        self.clear_resident(slot);
+        self.clear_pending(slot);
+    }
+
+    fn clear_resident(&self, slot: usize) {
+        let (word, resident, visited) = slot_state(slot);
+        self.words[word].fetch_and(!(resident | visited), Ordering::Relaxed);
     }
 }
 
@@ -485,26 +569,29 @@ impl Selection {
     }
 }
 
-fn page(page_states: &PageStates, id: Id) -> &PageState {
-    page_states
-        .get_or_alloc(page_state_index(id))
-        .get_or_alloc()
+fn page_and_slot_or_alloc(page_states: &PageStates, id: Id) -> (&PageState, usize) {
+    let (index, slot) = page_state_index_and_slot(id);
+    (page_states.get_or_alloc(index).get_or_alloc(), slot)
 }
 
-fn page_if_allocated(page_states: &PageStates, id: Id) -> Option<&PageState> {
+fn page_and_slot(page_states: &PageStates, id: Id) -> (&PageState, usize) {
+    // Resident and pending ids must already have allocated page state.
+    page_and_slot_if_allocated(page_states, id).expect("SIEVE page state should be allocated")
+}
+
+fn page_and_slot_if_allocated(page_states: &PageStates, id: Id) -> Option<(&PageState, usize)> {
+    let (index, slot) = page_state_index_and_slot(id);
     page_states
-        .get(page_state_index(id))
+        .get(index)
         .and_then(PageSlot::get)
+        .map(|page| (page, slot))
 }
 
-fn page_state_index(id: Id) -> PageStateIndex {
-    let (page, _) = split_id(id);
-    PageStateIndex::new(page.as_usize()).expect("page index should fit in SIEVE page state table")
-}
-
-fn slot_offset(id: Id) -> usize {
-    let (_, slot) = split_id(id);
-    slot.as_usize()
+fn page_state_index_and_slot(id: Id) -> (PageStateIndex, usize) {
+    let (page, slot) = split_id(id);
+    let index = PageStateIndex::new(page.as_usize())
+        .expect("page index should fit in SIEVE page state table");
+    (index, slot.as_usize())
 }
 
 fn slot_state(slot: usize) -> (usize, u64, u64) {
@@ -512,4 +599,106 @@ fn slot_state(slot: usize) -> (usize, u64, u64) {
     let resident = 1 << bit;
     let visited = 1 << (bit + 1);
     (slot / SLOTS_PER_STATE_WORD, resident, visited)
+}
+
+fn pending_state(slot: usize) -> (usize, u64) {
+    let bit = slot % SLOTS_PER_PENDING_WORD;
+    (slot / SLOTS_PER_PENDING_WORD, 1 << bit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct TestEvictionContext {
+        evicted: Vec<Id>,
+    }
+
+    impl EvictionContext for TestEvictionContext {
+        fn last_verified_at(&mut self, _id: Id) -> Option<crate::Revision> {
+            None
+        }
+
+        fn evict_value(&mut self, id: Id) {
+            self.evicted.push(id);
+        }
+    }
+
+    fn id(index: u32) -> Id {
+        // SAFETY: Test indices are within `Id`'s valid range.
+        unsafe { Id::from_index(index) }
+    }
+
+    #[test]
+    fn all_marked_residents_evict_the_initial_hand() {
+        let page_states = PageStates::new();
+        let mut state = State::default();
+        let oldest = id(0);
+        let middle = id(1);
+        let newest = id(2);
+
+        for id in [oldest, middle, newest] {
+            let (page, slot) = page_and_slot_or_alloc(&page_states, id);
+            state.insert(id, page, slot, 3, &page_states);
+            assert!(page.record_use(slot));
+        }
+
+        assert_eq!(
+            state.select_victim(&page_states).map(|victim| victim.id),
+            Some(oldest)
+        );
+        assert_eq!(state.residents.id(state.hand), middle);
+        assert_eq!(
+            state.residents.resident_ids().collect::<Vec<_>>(),
+            [newest, middle]
+        );
+        let (page, slot) = page_and_slot(&page_states, oldest);
+        assert!(!page.is_resident(slot));
+    }
+
+    #[test]
+    fn insertion_selects_a_victim_before_admitting() {
+        let page_states = PageStates::new();
+        let mut state = State::default();
+        let oldest = id(0);
+        let newest = id(1);
+        let incoming = id(2);
+
+        for id in [oldest, newest] {
+            let (page, slot) = page_and_slot_or_alloc(&page_states, id);
+            state.insert(id, page, slot, 2, &page_states);
+            assert!(page.record_use(slot));
+        }
+
+        let (page, slot) = page_and_slot_or_alloc(&page_states, incoming);
+        state.insert(incoming, page, slot, 2, &page_states);
+
+        assert_eq!(state.pending_evictions, [oldest]);
+        assert_eq!(state.residents.nodes.len(), 3);
+        assert!(page.is_resident(slot));
+    }
+
+    #[test]
+    fn pending_evictions_are_deduplicated_until_reset() {
+        let mut sieve = Sieve::new(1);
+        let first = id(0);
+        let second = id(1);
+
+        for _ in 0..100 {
+            sieve.record_use(first);
+            sieve.record_use(second);
+        }
+
+        assert_eq!(sieve.state.lock().pending_evictions, [first, second]);
+
+        let mut context = TestEvictionContext::default();
+        sieve.start_new_revision(&mut context);
+
+        assert_eq!(context.evicted, [first]);
+        assert!(sieve.state.get_mut().pending_evictions.is_empty());
+
+        sieve.record_use(first);
+        assert_eq!(sieve.state.lock().pending_evictions, [second]);
+    }
 }

--- a/src/function/eviction/volatile.rs
+++ b/src/function/eviction/volatile.rs
@@ -1,0 +1,73 @@
+//! Immediate SIEVE eviction for volatile query values.
+
+use arc_swap::ArcSwapOption;
+
+use crate::Id;
+
+use super::{EvictionPolicy, Sieve};
+
+/// A SIEVE policy that returns victims for immediate value reclamation.
+///
+/// Volatile callers own their result handles, so they can clear a selected
+/// victim within the current revision. The resident order, moving hand, and
+/// visited-bit behavior are shared with [`Sieve`].
+pub struct Volatile {
+    sieve: Sieve,
+}
+
+impl EvictionPolicy for Volatile {
+    type Value<T: Send + Sync> = ArcSwapOption<T>;
+
+    const STORES_VALUE_INLINE: bool = false;
+    const RETIRES_VALUES: bool = true;
+
+    fn new(capacity: usize) -> Self {
+        Self {
+            sieve: Sieve::new(capacity),
+        }
+    }
+
+    #[inline]
+    fn record_volatile_use(&self, id: Id) -> Option<Id> {
+        self.sieve.record_immediate_use(id)
+    }
+
+    fn set_tuning(&mut self, _capacity: usize) {}
+
+    fn for_each_evicted(&mut self, _evict: impl FnMut(Id)) {}
+}
+
+#[cfg(all(test, not(feature = "shuttle")))]
+mod tests {
+    use super::*;
+
+    fn id(index: u32) -> Id {
+        // SAFETY: Test indices are within `Id`'s valid range.
+        unsafe { Id::from_index(index) }
+    }
+
+    #[test]
+    fn returns_sieve_victims_immediately() {
+        let volatile = Volatile::new(3);
+        let oldest = id(0);
+        let middle = id(1);
+        let newest = id(2);
+
+        assert_eq!(volatile.record_volatile_use(oldest), None);
+        assert_eq!(volatile.record_volatile_use(middle), None);
+        assert_eq!(volatile.record_volatile_use(newest), None);
+
+        assert_eq!(volatile.record_volatile_use(oldest), None);
+        assert_eq!(volatile.record_volatile_use(id(3)), Some(middle));
+    }
+
+    #[test]
+    fn does_not_defer_victims_to_revision_boundaries() {
+        let mut volatile = Volatile::new(1);
+
+        assert_eq!(volatile.record_volatile_use(id(0)), None);
+        assert_eq!(volatile.record_volatile_use(id(1)), Some(id(0)));
+
+        volatile.for_each_evicted(|_| panic!("volatile victim should already be returned"));
+    }
+}

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -2,6 +2,7 @@ use smallvec::SmallVec;
 
 use crate::active_query::CompletedQuery;
 use crate::cycle::{CycleHeads, CycleRecoveryStrategy, IterationStamp};
+use crate::function::eviction::MemoValue;
 use crate::function::memo::{Memo, MemoHeader};
 use crate::function::sync::ReleaseMode;
 use crate::function::{ClaimGuard, Configuration, IngredientImpl};
@@ -60,7 +61,7 @@ where
                     db,
                     zalsa,
                     claim_guard.zalsa_local().push_query(database_key_index),
-                    opt_old_memo.map(|memo| &memo.header),
+                    opt_old_memo.map(|memo| (&memo.header, memo.value.is_some())),
                 );
 
                 // Ordinary queries don't need a cycle iteration stamp. Keeping the default avoids
@@ -173,7 +174,7 @@ where
                 active_query,
                 last_provisional_memo_opt
                     .or(opt_old_memo)
-                    .map(|memo| &memo.header),
+                    .map(|memo| (&memo.header, memo.value.is_some())),
             );
 
             let (mut active_query, cycle_heads, outer_cycle, cycle_iteration) =
@@ -230,7 +231,7 @@ where
                 memo
             });
 
-            let last_provisional_value = last_provisional_memo.value.as_ref();
+            let last_provisional_value = last_provisional_memo.value.load();
 
             let last_provisional_value = last_provisional_value.expect(
                 "`fetch_cold_cycle` should have inserted a provisional memo with Cycle::initial",
@@ -258,12 +259,12 @@ where
                 new_value = C::recover_from_cycle(
                     db,
                     &cycle,
-                    last_provisional_value,
+                    &last_provisional_value,
                     new_value,
                     C::id_to_input(zalsa, id),
                 );
 
-                C::values_equal(&new_value, last_provisional_value)
+                C::values_equal(&new_value, &last_provisional_value)
             };
 
             let new_cycle_heads = active_query.take_cycle_heads();
@@ -319,10 +320,10 @@ where
         db: &'db C::DbView,
         zalsa: &'db Zalsa,
         active_query: ActiveQueryGuard<'db>,
-        opt_old_header: Option<&MemoHeader>,
+        opt_old_header: Option<(&MemoHeader, bool)>,
     ) -> (C::Output<'db>, ActiveQueryGuard<'db>) {
-        if let Some(old_header) = opt_old_header {
-            old_header.seed_active_query(zalsa, &active_query);
+        if let Some((old_header, has_value)) = opt_old_header {
+            old_header.seed_active_query(zalsa, &active_query, has_value);
         }
 
         // Query was not previously executed, or value is potentially
@@ -378,11 +379,15 @@ impl MemoHeader {
         //    (we can't rely on `iteration` being updated for nested cycles because the nested cycles may have completed successfully).
         // b) It's guaranteed that this query will panic again anyway.
         // That's why we simply propagate the panic here. It simplifies our lives and it also avoids duplicate panic messages.
-        if !has_value {
+        if self.revisions.poisoned() {
             tracing::warn!(
                 "Propagating panic for cycle head that panicked in an earlier execution in that revision"
             );
             Cancelled::PropagatedPanic.throw();
+        }
+
+        if !has_value {
+            return None;
         }
 
         Some(PreviousIteration {
@@ -393,7 +398,12 @@ impl MemoHeader {
         })
     }
 
-    fn seed_active_query(&self, zalsa: &Zalsa, active_query: &ActiveQueryGuard<'_>) {
+    fn seed_active_query(
+        &self,
+        zalsa: &Zalsa,
+        active_query: &ActiveQueryGuard<'_>,
+        has_value: bool,
+    ) {
         // If we already executed this query once, then use the tracked-struct ids from the
         // previous execution as the starting point for the new one.
         active_query.seed_tracked_struct_ids(self.revisions.tracked_struct_ids());
@@ -403,7 +413,10 @@ impl MemoHeader {
         // * ensure that tracked struct created during the previous iteration
         //   (and are owned by the query) are alive even if the query in this iteration no longer creates them.
         // * ensure the final returned memo depends on all inputs from all iterations.
-        if self.may_be_provisional() && self.verified_at.load() == zalsa.current_revision() {
+        if self.may_be_provisional()
+            && self.verified_at.load() == zalsa.current_revision()
+            && has_value
+        {
             active_query.seed_iteration(&self.revisions);
         }
     }
@@ -552,7 +565,7 @@ impl<C: Configuration> Drop for PoisonProvisionalIfPanicking<'_, C> {
                 IterationStamp::initial(self.zalsa.runtime().cancellation_count()),
             );
 
-            let memo = Memo::new(None, self.zalsa.current_revision(), revisions);
+            let memo = Memo::poisoned(self.zalsa.current_revision(), revisions);
             self.ingredient
                 .insert_memo(self.zalsa, self.id, memo, self.memo_ingredient_index);
         }
@@ -818,6 +831,7 @@ fn try_complete_cycle_head(
             ingredient.finalize_cycle_head(zalsa, head.database_key_index.key_index());
         }
 
+        completed_query.revisions.mark_participated_in_cycle();
         *completed_query.revisions.verified_final.get_mut() = true;
 
         zalsa.event(&|| {

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -1,5 +1,5 @@
 use crate::cycle::{CycleRecoveryStrategy, IterationStamp};
-use crate::function::eviction::EvictionPolicy;
+use crate::function::eviction::{EvictionPolicy, MemoValue};
 use crate::function::memo::Memo;
 use crate::function::sync::ClaimResult;
 use crate::function::{Configuration, IngredientImpl, Reentrancy};
@@ -19,17 +19,21 @@ where
         zalsa_local: &'db ZalsaLocal,
         id: Id,
     ) -> &'db C::Output<'db> {
+        assert!(
+            !C::Eviction::RETIRES_VALUES,
+            "retiring eviction policies must use `fetch_volatile`"
+        );
         zalsa.unwind_if_revision_cancelled(zalsa_local);
-
         let database_key_index = self.database_key_index(id);
 
         #[cfg(feature = "detailed-trace")]
         let _span = crate::tracing::debug_span!("fetch", query = ?database_key_index).entered();
 
         let memo = self.refresh_memo(db, zalsa, zalsa_local, id);
-
-        // SAFETY: We just refreshed the memo so it is guaranteed to contain a value now.
-        let memo_value = unsafe { memo.value.as_ref().unwrap_unchecked() };
+        let memo_value = memo
+            .value
+            .borrow_inline()
+            .expect("a refreshed memo must contain a value");
 
         self.eviction.record_use(id);
 
@@ -46,6 +50,49 @@ where
         );
 
         memo_value
+    }
+
+    /// Fetches an owned handle to a volatile memoized value.
+    #[inline]
+    pub fn fetch_volatile<'db>(
+        &'db self,
+        db: &'db C::DbView,
+        zalsa: &'db Zalsa,
+        zalsa_local: &'db ZalsaLocal,
+        id: Id,
+    ) -> crate::Volatile<C::Output<'db>> {
+        assert!(
+            C::Eviction::RETIRES_VALUES,
+            "non-retiring eviction policies must use `fetch`"
+        );
+
+        zalsa.unwind_if_revision_cancelled(zalsa_local);
+        let _guard = zalsa.memo_read_guard();
+        let database_key_index = self.database_key_index(id);
+
+        loop {
+            let memo = self.refresh_memo(db, zalsa, zalsa_local, id);
+            let Some(value) = memo.value.load_volatile() else {
+                continue;
+            };
+
+            if let Some(evict) = self.eviction.record_volatile_use(id) {
+                self.evict_value_from_memo(zalsa, evict);
+            }
+
+            zalsa_local.report_tracked_read(
+                database_key_index,
+                memo.header.revisions.durability,
+                memo.header.revisions.changed_at,
+                memo.header.cycle_heads(),
+                #[cfg(feature = "accumulator")]
+                memo.header.revisions.accumulated().is_some(),
+                #[cfg(feature = "accumulator")]
+                &memo.header.revisions.accumulated_inputs,
+            );
+
+            return crate::Volatile(value);
+        }
     }
 
     #[inline(always)]
@@ -81,7 +128,9 @@ where
     ) -> Option<&'db Memo<'db, C>> {
         let memo = self.get_memo_from_table_for(zalsa, id, memo_ingredient_index)?;
 
-        memo.value.as_ref()?;
+        if !memo.value.is_some() {
+            return None;
+        }
 
         let database_key_index = self.database_key_index(id);
 

--- a/src/function/inputs.rs
+++ b/src/function/inputs.rs
@@ -1,15 +1,25 @@
-use crate::Id;
+use crate::function::EvictionPolicy;
 use crate::function::{Configuration, IngredientImpl};
 use crate::zalsa::Zalsa;
-use crate::zalsa_local::QueryOriginRef;
+use crate::{DatabaseKeyIndex, Id};
 
 impl<C> IngredientImpl<C>
 where
     C: Configuration,
 {
-    pub(super) fn origin<'db>(&self, zalsa: &'db Zalsa, key: Id) -> Option<QueryOriginRef<'db>> {
+    pub(super) fn extend_origin_inputs(
+        &self,
+        zalsa: &Zalsa,
+        key: Id,
+        inputs: &mut Vec<DatabaseKeyIndex>,
+    ) {
+        let _guard = C::Eviction::RETIRES_VALUES.then(|| zalsa.memo_read_guard());
         let memo_ingredient_index = self.memo_ingredient_index(zalsa, key);
-        self.get_memo_from_table_for(zalsa, key, memo_ingredient_index)
-            .map(|m| m.header.origin())
+        let Some(memo) = self.get_memo_from_table_for(zalsa, key, memo_ingredient_index) else {
+            return;
+        };
+        let origin = memo.header.origin();
+        inputs.reserve(origin.edges().iter().len());
+        inputs.extend(origin.inputs().rev());
     }
 }

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -1,9 +1,10 @@
 #[cfg(feature = "accumulator")]
 use crate::accumulator::accumulated_map::InputAccumulatedValues;
 use crate::cycle::{CycleHeads, CycleRecoveryStrategy, ProvisionalStatus};
+use crate::function::eviction::MemoValue;
 use crate::function::memo::{MemoHeader, TryClaimCycleHeadsIter, TryClaimHeadsResult};
 use crate::function::sync::{ClaimGuard, ClaimResult};
-use crate::function::{Configuration, IngredientImpl, Reentrancy};
+use crate::function::{Configuration, EvictionPolicy, IngredientImpl, Reentrancy};
 use std::sync::atomic::Ordering;
 
 use crate::key::DatabaseKeyIndex;
@@ -91,6 +92,7 @@ where
         revision: Revision,
     ) -> VerifyResult {
         let (zalsa, zalsa_local) = db.zalsas();
+        let _guard = C::Eviction::RETIRES_VALUES.then(|| zalsa.memo_read_guard());
         let memo_ingredient_index = self.memo_ingredient_index(zalsa, id);
         zalsa.unwind_if_revision_cancelled(zalsa_local);
 
@@ -365,6 +367,13 @@ impl MemoHeader {
 
         if cycle_heads.is_empty() {
             return true;
+        }
+
+        // Volatile eviction can keep same-revision cycle metadata after discarding
+        // the provisional value. That metadata is still useful for dependency
+        // tracking, but it must not validate as same-iteration cycle state.
+        if !has_value {
+            return false;
         }
 
         crate::tracing::trace!(

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -72,20 +72,6 @@ impl<C: Configuration> IngredientImpl<C> {
 
         table.map_memo(memo_ingredient_index, map)
     }
-
-    /// Returns when the resident value was last verified.
-    pub(super) fn last_verified_at_for(
-        table: MemoTableWithTypesMut<'_>,
-        memo_ingredient_index: MemoIngredientIndex,
-    ) -> Option<Revision> {
-        let mut last_verified_at = None;
-        table.map_memo(memo_ingredient_index, |memo: &mut Memo<'static, C>| {
-            if memo.value.is_some() {
-                last_verified_at = Some(memo.header.verified_at.load());
-            }
-        });
-        last_verified_at
-    }
 }
 
 #[derive(Debug)]

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -56,9 +56,9 @@ impl<C: Configuration> IngredientImpl<C> {
         Some(unsafe { transmute::<&Memo<'static, C>, &'db Memo<'db, C>>(static_memo.as_ref()) })
     }
 
-    /// Evicts the existing memo for the given key, replacing it
-    /// with an equivalent memo that has no value. If the memo is untracked
-    /// or has values assigned as output of another query, this has no effect.
+    /// Evicts the value from the existing memo for the given key.
+    /// If the memo is untracked or has values assigned as output of another query,
+    /// this has no effect.
     pub(super) fn evict_value_from_memo_for(
         table: MemoTableWithTypesMut<'_>,
         memo_ingredient_index: MemoIngredientIndex,
@@ -71,6 +71,20 @@ impl<C: Configuration> IngredientImpl<C> {
         };
 
         table.map_memo(memo_ingredient_index, map)
+    }
+
+    /// Returns when the resident value was last verified.
+    pub(super) fn last_verified_at_for(
+        table: MemoTableWithTypesMut<'_>,
+        memo_ingredient_index: MemoIngredientIndex,
+    ) -> Option<Revision> {
+        let mut last_verified_at = None;
+        table.map_memo(memo_ingredient_index, |memo: &mut Memo<'static, C>| {
+            if memo.value.is_some() {
+                last_verified_at = Some(memo.header.verified_at.load());
+            }
+        });
+        last_verified_at
     }
 }
 

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -6,6 +6,7 @@ use std::ptr::NonNull;
 use crate::cycle::{
     CycleHeads, CycleHeadsIterator, IterationStamp, ProvisionalStatus, empty_cycle_heads,
 };
+use crate::function::eviction::{EvictionPolicy, MemoValue};
 use crate::function::{Configuration, IngredientImpl};
 use crate::ingredient::WaitForResult;
 use crate::key::DatabaseKeyIndex;
@@ -29,9 +30,11 @@ impl<C: Configuration> IngredientImpl<C> {
         // for `'db` though as we delay their dropping to the end of a revision.
         let static_memo =
             unsafe { transmute::<NonNull<Memo<'db, C>>, NonNull<Memo<'static, C>>>(memo) };
-        let old_static_memo = zalsa
-            .memo_table_for::<C::SalsaStruct<'_>>(id)
-            .insert(memo_ingredient_index, static_memo)?;
+        let old_static_memo = zalsa.memo_table_for::<C::SalsaStruct<'_>>(id).insert(
+            memo_ingredient_index,
+            static_memo,
+            C::Eviction::RETIRES_VALUES,
+        )?;
         // SAFETY: The table stores 'static memos (to support `Any`), the memos are in fact valid
         // for `'db` though as we delay their dropping to the end of a revision.
         Some(unsafe {
@@ -50,7 +53,7 @@ impl<C: Configuration> IngredientImpl<C> {
     ) -> Option<&'db Memo<'db, C>> {
         let static_memo = zalsa
             .memo_table_for::<C::SalsaStruct<'_>>(id)
-            .get(memo_ingredient_index)?;
+            .get(memo_ingredient_index, C::Eviction::RETIRES_VALUES)?;
         // SAFETY: The table stores 'static memos (to support `Any`), the memos are in fact valid
         // for `'db` though as we delay their dropping to the end of a revision.
         Some(unsafe { transmute::<&Memo<'static, C>, &'db Memo<'db, C>>(static_memo.as_ref()) })
@@ -66,21 +69,50 @@ impl<C: Configuration> IngredientImpl<C> {
         let map = |memo: &mut Memo<'static, C>| {
             if memo.header.can_evict_value() {
                 // Set the memo value to `None`.
-                memo.value = None;
+                memo.value = <C::Eviction as EvictionPolicy>::Value::new(None);
             }
         };
 
         table.map_memo(memo_ingredient_index, map)
     }
+
+    /// Atomically clears the current memo's value while retaining its metadata.
+    pub(super) fn evict_value_from_memo(&self, zalsa: &Zalsa, id: Id) -> bool {
+        let _guard = zalsa.memo_read_guard();
+        let memo_ingredient_index = self.memo_ingredient_index(zalsa, id);
+        let Some(old_memo) = self.get_memo_from_table_for(zalsa, id, memo_ingredient_index) else {
+            return false;
+        };
+
+        if !old_memo.value.is_some() {
+            return false;
+        }
+
+        if !matches!(old_memo.header.origin(), QueryOriginRef::Derived(_)) {
+            return false;
+        }
+
+        if !old_memo.can_evict_volatile() {
+            return false;
+        }
+
+        // Cycle participation is fixed when a memo is published. An execution
+        // that newly enters a cycle publishes a different provisional memo, so
+        // concurrently clearing this value cannot erase its cycle state.
+        if old_memo.header.was_cycle_participant() {
+            return false;
+        }
+
+        old_memo.value.clear()
+    }
 }
 
-#[derive(Debug)]
 pub struct Memo<'db, C: Configuration> {
     /// Configuration-independent state used to validate and manage this memo.
     pub(super) header: MemoHeader,
 
     /// The result of the query, if we decide to memoize it.
-    pub(super) value: Option<C::Output<'db>>,
+    pub(super) value: <C::Eviction as EvictionPolicy>::Value<C::Output<'db>>,
 }
 
 #[derive(Debug)]
@@ -141,7 +173,7 @@ impl MemoHeader {
     /// Returns `true` if this memo was part of a cycle in it's last iteration.
     #[inline(always)]
     pub(super) fn was_cycle_participant(&self) -> bool {
-        !self.revisions.cycle_heads().is_empty()
+        self.revisions.participated_in_cycle()
     }
 
     /// Mark memo as having been verified in the `revision_now`, which should
@@ -186,6 +218,7 @@ impl MemoHeader {
                             &"None"
                         },
                     )
+                    .field("poisoned", &self.header.revisions.poisoned())
                     .field("verified_at", &self.header.verified_at)
                     .field("revisions", &self.header.revisions)
                     .finish()
@@ -217,9 +250,28 @@ impl<'db, C: Configuration> Memo<'db, C> {
         revisions: QueryRevisions,
     ) -> Self {
         Self {
-            value,
+            value: <C::Eviction as EvictionPolicy>::Value::new(value),
             header: MemoHeader::new(revision_now, revisions),
         }
+    }
+
+    pub(super) fn poisoned(revision_now: Revision, mut revisions: QueryRevisions) -> Self {
+        revisions.set_poisoned();
+
+        Self::new(None, revision_now, revisions)
+    }
+
+    /// Returns whether this memo supports within-revision volatile eviction.
+    ///
+    /// Accumulated values escape by reference and recomputing would duplicate
+    /// those side-channel results.
+    pub(super) fn can_evict_volatile(&self) -> bool {
+        #[cfg(feature = "accumulator")]
+        if self.header.revisions.accumulated().is_some() {
+            return false;
+        }
+
+        true
     }
 
     /// Returns `true` if this memo should be serialized.
@@ -245,19 +297,26 @@ where
     #[cfg(feature = "salsa_unstable")]
     fn memory_usage(&self) -> crate::database::MemoInfo {
         let size_of = std::mem::size_of::<Memo<C>>() + self.header.revisions.allocation_size();
-        let heap_size = if let Some(value) = self.value.as_ref() {
-            C::heap_size(value)
-        } else {
-            Some(0)
-        };
+        let output_size = std::mem::size_of::<C::Output<'static>>();
+        let (size_of_metadata, size_of_fields, heap_size_of_fields) =
+            if let Some(value) = self.value.load() {
+                let metadata = if C::Eviction::STORES_VALUE_INLINE {
+                    size_of - output_size
+                } else {
+                    size_of
+                };
+                (metadata, output_size, C::heap_size(&value))
+            } else {
+                (size_of, 0, Some(0))
+            };
 
         crate::database::MemoInfo {
             debug_name: C::DEBUG_NAME,
             output: crate::database::SlotInfo {
-                size_of_metadata: size_of - std::mem::size_of::<C::Output<'static>>(),
+                size_of_metadata,
                 debug_name: std::any::type_name::<C::Output<'static>>(),
-                size_of_fields: std::mem::size_of::<C::Output<'static>>(),
-                heap_size_of_fields: heap_size,
+                size_of_fields,
+                heap_size_of_fields,
                 memos: Vec::new(),
             },
         }
@@ -267,7 +326,8 @@ where
 #[cfg(feature = "persistence")]
 mod persistence {
     use crate::function::Configuration;
-    use crate::function::memo::{Memo, MemoHeader};
+    use crate::function::eviction::{EvictionPolicy, MemoValue};
+    use crate::function::memo::Memo;
     use crate::revision::AtomicRevision;
     use crate::zalsa_local::QueryRevisions;
     use crate::zalsa_local::persistence::{MappedQueryRevisions, PersistentQueryOrigin};
@@ -275,9 +335,18 @@ mod persistence {
     use serde::Deserialize;
     use serde::ser::SerializeStruct;
 
-    /// A reference to the fields of a [`Memo`], with its [`QueryRevisions`] transformed.
-    pub(crate) struct MappedMemo<'memo, 'db, C: Configuration> {
-        pub(crate) value: Option<&'memo C::Output<'db>>,
+    type ValueStorage<'db, C> = <<C as Configuration>::Eviction as EvictionPolicy>::Value<
+        <C as Configuration>::Output<'db>,
+    >;
+    type ValueGuard<'memo, 'db, C> =
+        <ValueStorage<'db, C> as MemoValue<<C as Configuration>::Output<'db>>>::Guard<'memo>;
+
+    /// A view of the fields of a [`Memo`], with its [`QueryRevisions`] transformed.
+    pub(crate) struct MappedMemo<'memo, 'db, C: Configuration>
+    where
+        ValueStorage<'db, C>: 'memo,
+    {
+        pub(crate) value: Option<ValueGuard<'memo, 'db, C>>,
         pub(crate) verified_at: AtomicRevision,
         pub(crate) revisions: MappedQueryRevisions<'memo>,
     }
@@ -287,26 +356,18 @@ mod persistence {
             &self,
             serialized_origin: PersistentQueryOrigin,
         ) -> MappedMemo<'_, 'db, C> {
-            let Memo {
-                ref value,
-                ref header,
-            } = *self;
-            let MemoHeader {
-                ref verified_at,
-                ref revisions,
-            } = *header;
-
             MappedMemo {
-                value: value.as_ref(),
-                verified_at: AtomicRevision::from(verified_at.load()),
-                revisions: revisions.with_origin(serialized_origin),
+                value: self.value.load(),
+                verified_at: AtomicRevision::from(self.header.verified_at.load()),
+                revisions: self.header.revisions.with_origin(serialized_origin),
             }
         }
     }
 
-    impl<C> serde::Serialize for MappedMemo<'_, '_, C>
+    impl<'memo, 'db, C> serde::Serialize for MappedMemo<'memo, 'db, C>
     where
         C: Configuration,
+        ValueStorage<'db, C>: 'memo,
     {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
@@ -332,9 +393,10 @@ mod persistence {
                 revisions,
             } = self;
 
-            let value = value.expect(
+            let value = value.as_ref().expect(
                 "attempted to serialize memo where `Memo::should_serialize` returned `false`",
             );
+            let value: &C::Output<'db> = std::ops::Deref::deref(value);
 
             let mut s = serializer.serialize_struct("Memo", 3)?;
             s.serialize_field("value", &SerializeValue::<C>(value))?;
@@ -379,13 +441,11 @@ mod persistence {
 
             let memo = DeserializeMemo::<C>::deserialize(deserializer)?;
 
-            Ok(Memo {
-                value: Some(memo.value.0),
-                header: MemoHeader {
-                    verified_at: memo.verified_at,
-                    revisions: memo.revisions,
-                },
-            })
+            Ok(Memo::new(
+                Some(memo.value.0),
+                memo.verified_at.load(),
+                memo.revisions,
+            ))
         }
     }
 }

--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -1,10 +1,11 @@
 #[cfg(feature = "accumulator")]
 use crate::accumulator::accumulated_map::InputAccumulatedValues;
 use crate::active_query::CompletedQuery;
-use crate::function::memo::{Memo, MemoHeader};
+use crate::function::EvictionPolicy;
+use crate::function::eviction::MemoValue;
+use crate::function::memo::Memo;
 use crate::function::sync::{ClaimResult, Reentrancy};
 use crate::function::{Configuration, IngredientImpl};
-use crate::revision::AtomicRevision;
 use crate::sync::atomic::AtomicBool;
 use crate::tracked_struct::TrackedStructInDb;
 use crate::zalsa::{Zalsa, ZalsaDatabase};
@@ -22,6 +23,7 @@ where
         C::Input<'db>: TrackedStructInDb,
     {
         let (zalsa, zalsa_local) = db.zalsas();
+        let _guard = C::Eviction::RETIRES_VALUES.then(|| zalsa.memo_read_guard());
 
         let (active_query_key, current_deps, cycle_heads) =
             match zalsa_local.active_query_with_cycle_heads() {
@@ -140,13 +142,7 @@ where
                 .diff_outputs(zalsa, database_key_index, &completed_query);
         }
 
-        let memo = Memo {
-            value: Some(value),
-            header: MemoHeader {
-                verified_at: AtomicRevision::from(revision),
-                revisions: completed_query.revisions,
-            },
-        };
+        let memo = Memo::new(Some(value), revision, completed_query.revisions);
 
         crate::tracing::debug!(
             "specify: about to add memo {:#?} for key {:?}",
@@ -169,6 +165,7 @@ where
         executor: DatabaseKeyIndex,
         key: Id,
     ) {
+        let _guard = C::Eviction::RETIRES_VALUES.then(|| zalsa.memo_read_guard());
         let memo_ingredient_index = self.memo_ingredient_index(zalsa, key);
 
         let memo = match self.get_memo_from_table_for(zalsa, key, memo_ingredient_index) {

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -10,7 +10,7 @@ use crate::sync::Arc;
 use crate::table::Table;
 use crate::table::memo::MemoTableTypes;
 use crate::zalsa::{IngredientIndex, JarKind, Zalsa, transmute_data_mut_ptr, transmute_data_ptr};
-use crate::zalsa_local::{QueryEdge, QueryOriginRef};
+use crate::zalsa_local::QueryEdge;
 use crate::{DatabaseKeyIndex, Id, Revision};
 
 /// A "jar" is a group of ingredients that are added atomically.
@@ -73,11 +73,7 @@ pub trait Ingredient: Any + fmt::Debug + Send + Sync {
     /// Is it a provisional value or has it been finalized and in which iteration.
     ///
     /// Returns `None` if `input` doesn't exist.
-    fn provisional_status<'db>(
-        &self,
-        _zalsa: &'db Zalsa,
-        _input: Id,
-    ) -> Option<ProvisionalStatus<'db>> {
+    fn provisional_status(&self, _zalsa: &Zalsa, _input: Id) -> Option<ProvisionalStatus> {
         unreachable!(
             "provisional_status should only be called on cycle heads and only functions can be cycle heads"
         );
@@ -204,9 +200,14 @@ pub trait Ingredient: Any + fmt::Debug + Send + Sync {
         seen: &mut FxHashSet<DatabaseKeyIndex>,
     );
 
-    /// What were the inputs (if any) that were used to create the value at `key_index`.
-    fn origin<'db>(&self, zalsa: &'db Zalsa, key_index: Id) -> Option<QueryOriginRef<'db>> {
-        let _ = (zalsa, key_index);
+    /// Appends the inputs (if any) that were used to create the value at `key_index`.
+    fn extend_origin_inputs(
+        &self,
+        zalsa: &Zalsa,
+        key_index: Id,
+        inputs: &mut Vec<DatabaseKeyIndex>,
+    ) {
+        let _ = (zalsa, key_index, inputs);
         unreachable!("only function ingredients have origins")
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -356,11 +356,13 @@ impl<C: Configuration> Ingredient for IngredientImpl<C> {
     /// Returns memory usage information about any inputs.
     #[cfg(feature = "salsa_unstable")]
     fn memory_usage(&self, db: &dyn crate::Database) -> Option<Vec<crate::database::SlotInfo>> {
+        let zalsa = db.zalsa();
+        let guard = zalsa.memo_read_guard();
         let memory_usage = self
-            .entries(db.zalsa())
+            .entries(zalsa)
             // SAFETY: The memo table belongs to a value that we allocated, so it
             // has the correct type.
-            .map(|entry| unsafe { entry.value.memory_usage(&self.memo_table_types) })
+            .map(|entry| unsafe { entry.value.memory_usage(&self.memo_table_types, &guard) })
             .collect();
 
         Some(memory_usage)
@@ -449,7 +451,11 @@ where
     ///
     /// The `MemoTable` must belong to a `Value` of the correct type.
     #[cfg(feature = "salsa_unstable")]
-    unsafe fn memory_usage(&self, memo_table_types: &MemoTableTypes) -> crate::database::SlotInfo {
+    unsafe fn memory_usage(
+        &self,
+        memo_table_types: &MemoTableTypes,
+        guard: &crate::zalsa::MemoReadGuard<'_>,
+    ) -> crate::database::SlotInfo {
         let heap_size = C::heap_size(&self.fields);
         // SAFETY: The caller guarantees this is the correct types table.
         let memos = unsafe { memo_table_types.attach_memos(&self.memos) };
@@ -459,7 +465,7 @@ where
             size_of_metadata: std::mem::size_of::<Self>() - std::mem::size_of::<C::Fields>(),
             size_of_fields: std::mem::size_of::<C::Fields>(),
             heap_size_of_fields: heap_size,
-            memos: memos.memory_usage(),
+            memos: memos.memory_usage(guard),
         }
     }
 }

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -248,7 +248,11 @@ where
     /// The `MemoTable` must belong to a `Value` of the correct type. Additionally, the
     /// lock must be held for the shard containing the value.
     #[cfg(all(not(feature = "shuttle"), feature = "salsa_unstable"))]
-    unsafe fn memory_usage(&self, memo_table_types: &MemoTableTypes) -> crate::database::SlotInfo {
+    unsafe fn memory_usage(
+        &self,
+        memo_table_types: &MemoTableTypes,
+        guard: &crate::zalsa::MemoReadGuard<'_>,
+    ) -> crate::database::SlotInfo {
         let heap_size = C::heap_size(self.fields());
         // SAFETY: The caller guarantees we hold the lock for the shard containing the value, so we
         // have at-least read-only access to the value's memos.
@@ -261,7 +265,7 @@ where
             size_of_metadata: std::mem::size_of::<Self>() - std::mem::size_of::<C::Fields<'_>>(),
             size_of_fields: std::mem::size_of::<C::Fields<'_>>(),
             heap_size_of_fields: heap_size,
-            memos: memos.memory_usage(),
+            memos: memos.memory_usage(guard),
         }
     }
 }
@@ -1023,18 +1027,21 @@ where
     fn memory_usage(&self, db: &dyn crate::Database) -> Option<Vec<crate::database::SlotInfo>> {
         use parking_lot::lock_api::RawMutex;
 
+        let zalsa = db.zalsa();
+        let guard = zalsa.memo_read_guard();
+
         for shard in self.shards.iter() {
             // SAFETY: We do not hold any active mutex guards.
             unsafe { shard.raw().lock() };
         }
 
         // SAFETY: We hold the locks for all shards.
-        let entries = unsafe { self.entries_inner(false, db.zalsa()) };
+        let entries = unsafe { self.entries_inner(false, zalsa) };
 
         let memory_usage = entries
             // SAFETY: The memo table belongs to a value that we allocated, so it
             // has the correct type. Additionally, we are holding the locks for all shards.
-            .map(|entry| unsafe { entry.value.memory_usage(&self.memo_table_types) })
+            .map(|entry| unsafe { entry.value.memory_usage(&self.memo_table_types, &guard) })
             .collect();
 
         for shard in self.shards.iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,9 +401,7 @@ pub mod plumbing {
         pub use crate::function::Configuration;
         pub use crate::function::IngredientImpl;
         pub use crate::function::Memo;
-        pub use crate::function::{
-            EvictionContext, EvictionPolicy, HasCapacity, Lru, NoopEviction, Sieve,
-        };
+        pub use crate::function::{EvictionPolicy, HasCapacity, Lru, NoopEviction, Sieve};
         pub use crate::table::memo::MemoEntryType;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,7 +402,7 @@ pub mod plumbing {
         pub use crate::function::IngredientImpl;
         pub use crate::function::Memo;
         pub use crate::function::{
-            EvictionContext, EvictionPolicy, HasCapacity, Lru, NoopEviction,
+            EvictionContext, EvictionPolicy, HasCapacity, Lru, NoopEviction, Sieve,
         };
         pub use crate::table::memo::MemoEntryType;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,6 +270,7 @@ mod tracing;
 mod tracked_struct;
 mod update;
 mod views;
+mod volatile;
 mod zalsa;
 mod zalsa_local;
 
@@ -301,6 +302,7 @@ pub use self::revision::Revision;
 pub use self::runtime::Runtime;
 pub use self::storage::{Storage, StorageHandle};
 pub use self::update::{Update, update_fallback};
+pub use self::volatile::Volatile;
 pub use self::zalsa::IngredientIndex;
 pub use self::zalsa_local::CancellationToken;
 pub use crate::attach::{attach, attach_allow_change, with_attached_database};
@@ -401,7 +403,9 @@ pub mod plumbing {
         pub use crate::function::Configuration;
         pub use crate::function::IngredientImpl;
         pub use crate::function::Memo;
-        pub use crate::function::{EvictionPolicy, HasCapacity, Lru, NoopEviction, Sieve};
+        pub use crate::function::{
+            EvictionPolicy, HasCapacity, Lru, MemoValue, NoopEviction, Sieve, Volatile,
+        };
         pub use crate::table::memo::MemoEntryType;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,7 +401,9 @@ pub mod plumbing {
         pub use crate::function::Configuration;
         pub use crate::function::IngredientImpl;
         pub use crate::function::Memo;
-        pub use crate::function::{EvictionPolicy, HasCapacity, Lru, NoopEviction};
+        pub use crate::function::{
+            EvictionContext, EvictionPolicy, HasCapacity, Lru, NoopEviction,
+        };
         pub use crate::table::memo::MemoEntryType;
     }
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -152,10 +152,6 @@ impl SlotIndex {
         debug_assert!(idx < PAGE_LEN);
         Self(idx)
     }
-
-    pub(crate) fn as_usize(&self) -> usize {
-        self.0
-    }
 }
 
 impl Default for Table {

--- a/src/table.rs
+++ b/src/table.rs
@@ -16,9 +16,9 @@ use crate::{Id, IngredientIndex, Revision};
 
 pub(crate) mod memo;
 
-const PAGE_LEN_BITS: usize = 7;
+pub(crate) const PAGE_LEN_BITS: usize = 7;
 const PAGE_LEN_MASK: usize = PAGE_LEN - 1;
-const PAGE_LEN: usize = 1 << PAGE_LEN_BITS;
+pub(crate) const PAGE_LEN: usize = 1 << PAGE_LEN_BITS;
 const MAX_PAGES: usize = Id::MAX_USIZE / PAGE_LEN;
 
 /// A typed [`Page`] view.
@@ -151,6 +151,10 @@ impl SlotIndex {
     fn new(idx: usize) -> Self {
         debug_assert!(idx < PAGE_LEN);
         Self(idx)
+    }
+
+    pub(crate) fn as_usize(&self) -> usize {
+        self.0
     }
 }
 

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -5,8 +5,7 @@ use std::ptr::{self, NonNull};
 
 use crate::DatabaseKeyIndex;
 use crate::sync::atomic::{AtomicPtr, Ordering};
-use crate::zalsa::MemoIngredientIndex;
-use crate::zalsa::Zalsa;
+use crate::zalsa::{MemoIngredientIndex, MemoReadGuard, Zalsa};
 
 /// The "memo table" stores the memoized results of tracked function calls.
 /// Every tracked function must take a salsa struct as its first argument
@@ -301,6 +300,7 @@ impl MemoTableWithTypes<'_> {
         self,
         memo_ingredient_index: MemoIngredientIndex,
         memo: NonNull<M>,
+        retiring: bool,
     ) -> Option<NonNull<M>> {
         let MemoEntry { atomic_memo } = self
             .memos
@@ -320,7 +320,12 @@ impl MemoTableWithTypes<'_> {
             type_assert_failed(memo_ingredient_index);
         }
 
-        let old_memo = atomic_memo.swap(MemoEntryType::to_dummy(memo).as_ptr(), Ordering::AcqRel);
+        let ordering = if retiring {
+            Ordering::SeqCst
+        } else {
+            Ordering::AcqRel
+        };
+        let old_memo = atomic_memo.swap(MemoEntryType::to_dummy(memo).as_ptr(), ordering);
 
         // SAFETY: We asserted that the type is correct above.
         NonNull::new(old_memo).map(|old_memo| unsafe { MemoEntryType::from_dummy(old_memo) })
@@ -331,6 +336,7 @@ impl MemoTableWithTypes<'_> {
     pub(crate) fn get<M: Memo>(
         self,
         memo_ingredient_index: MemoIngredientIndex,
+        retiring: bool,
     ) -> Option<NonNull<M>> {
         let MemoEntry { atomic_memo } = self.memos.memos.get(memo_ingredient_index.as_usize())?;
 
@@ -347,16 +353,24 @@ impl MemoTableWithTypes<'_> {
             type_assert_failed(memo_ingredient_index);
         }
 
-        NonNull::new(atomic_memo.load(Ordering::Acquire))
+        let ordering = if retiring {
+            Ordering::SeqCst
+        } else {
+            Ordering::Acquire
+        };
+        NonNull::new(atomic_memo.load(ordering))
             // SAFETY: We asserted that the type is correct above.
             .map(|memo| unsafe { MemoEntryType::from_dummy(memo) })
     }
 
     #[cfg(feature = "salsa_unstable")]
-    pub(crate) fn memory_usage(&self) -> Vec<crate::database::MemoInfo> {
+    pub(crate) fn memory_usage(
+        &self,
+        _guard: &MemoReadGuard<'_>,
+    ) -> Vec<crate::database::MemoInfo> {
         let mut memory_usage = Vec::new();
         for (index, memo) in self.memos.memos.iter().enumerate() {
-            let Some(memo) = NonNull::new(memo.atomic_memo.load(Ordering::Acquire)) else {
+            let Some(memo) = NonNull::new(memo.atomic_memo.load(Ordering::SeqCst)) else {
                 continue;
             };
 

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -1049,11 +1049,13 @@ where
     /// Returns memory usage information about any tracked structs.
     #[cfg(feature = "salsa_unstable")]
     fn memory_usage(&self, db: &dyn crate::Database) -> Option<Vec<crate::database::SlotInfo>> {
+        let zalsa = db.zalsa();
+        let guard = zalsa.memo_read_guard();
         let memory_usage = self
-            .entries(db.zalsa())
+            .entries(zalsa)
             // SAFETY: The memo table belongs to a value that we allocated, so it
             // has the correct type.
-            .map(|entry| unsafe { entry.value.memory_usage(&self.memo_table_types) })
+            .map(|entry| unsafe { entry.value.memory_usage(&self.memo_table_types, &guard) })
             .collect();
 
         Some(memory_usage)
@@ -1156,7 +1158,11 @@ where
     /// # Safety
     ///
     /// The `MemoTable` must belong to a `Value` of the correct type.
-    unsafe fn memory_usage(&self, memo_table_types: &MemoTableTypes) -> crate::database::SlotInfo {
+    unsafe fn memory_usage(
+        &self,
+        memo_table_types: &MemoTableTypes,
+        guard: &crate::zalsa::MemoReadGuard<'_>,
+    ) -> crate::database::SlotInfo {
         let heap_size = C::heap_size(self.fields());
         // SAFETY: The caller guarantees this is the correct types table.
         let memos = unsafe { memo_table_types.attach_memos(&self.memos) };
@@ -1166,7 +1172,7 @@ where
             size_of_metadata: mem::size_of::<Self>() - mem::size_of::<C::Fields<'_>>(),
             size_of_fields: mem::size_of::<C::Fields<'_>>(),
             heap_size_of_fields: heap_size,
-            memos: memos.memory_usage(),
+            memos: memos.memory_usage(guard),
         }
     }
 }

--- a/src/volatile.rs
+++ b/src/volatile.rs
@@ -1,0 +1,30 @@
+use std::ops::Deref;
+use std::sync::Arc;
+
+/// An owned handle to a volatile query result.
+///
+/// Eviction removes the result from Salsa's memo immediately, while existing
+/// handles keep the value alive until their last clone is dropped.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Volatile<T>(pub(crate) Arc<T>);
+
+impl<T> Clone for Volatile<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T> Volatile<T> {
+    /// Converts this handle into the shared value it owns.
+    pub fn into_arc(self) -> Arc<T> {
+        self.0
+    }
+}
+
+impl<T> Deref for Volatile<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -138,6 +138,12 @@ impl MemoIngredientIndex {
     }
 }
 
+#[cfg(not(feature = "shuttle"))]
+pub(crate) type MemoReadGuard<'a> = seize::LocalGuard<'a>;
+
+#[cfg(feature = "shuttle")]
+pub(crate) type MemoReadGuard<'a> = ();
+
 /// The "plumbing interface" to the Salsa database. Stores all the ingredients and other data.
 ///
 /// **NOT SEMVER STABLE.**
@@ -171,6 +177,9 @@ pub struct Zalsa {
     runtime: Runtime,
 
     event_callback: Option<Box<dyn Fn(crate::Event) + Send + Sync>>,
+
+    #[cfg(not(feature = "shuttle"))]
+    memo_collector: Box<seize::Collector>,
 }
 
 /// All fields on Zalsa are locked behind [`Mutex`]es and [`RwLock`]s and cannot enter
@@ -194,6 +203,8 @@ impl Zalsa {
             runtime: Runtime::default(),
             memo_ingredient_indices: Default::default(),
             event_callback,
+            #[cfg(not(feature = "shuttle"))]
+            memo_collector: Box::new(seize::Collector::new()),
             #[cfg(not(feature = "inventory"))]
             nonce: NONCE.nonce(),
         };
@@ -233,6 +244,14 @@ impl Zalsa {
     pub(crate) fn runtime_mut(&mut self) -> &mut Runtime {
         &mut self.runtime
     }
+
+    #[cfg(not(feature = "shuttle"))]
+    pub(crate) fn memo_read_guard(&self) -> MemoReadGuard<'_> {
+        self.memo_collector.enter()
+    }
+
+    #[cfg(feature = "shuttle")]
+    pub(crate) fn memo_read_guard(&self) -> MemoReadGuard<'_> {}
 
     /// Returns the [`Table`] used to store the value of salsa structs
     #[inline]

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -609,6 +609,7 @@ impl QueryRevisionsExtra {
             None
         } else {
             tracked_struct_ids.shrink_to_fit();
+            let participated_in_cycle = !cycle_heads.is_empty();
 
             Some(QueryRevisionsExtraInner {
                 #[cfg(feature = "accumulator")]
@@ -617,6 +618,8 @@ impl QueryRevisionsExtra {
                 tracked_struct_ids,
                 iteration: iteration.into(),
                 cycle_converged: false,
+                participated_in_cycle,
+                poisoned: false,
             })
         };
 
@@ -670,6 +673,23 @@ struct QueryRevisionsExtraInner {
     /// This value is always `false` for other queries.
     #[cfg_attr(feature = "persistence", serde(skip))]
     cycle_converged: bool,
+
+    /// Whether this memo has ever participated in a cycle.
+    #[cfg_attr(
+        feature = "persistence",
+        serde(default, skip_serializing_if = "is_false")
+    )]
+    participated_in_cycle: bool,
+
+    /// True if the memo is a poison marker for a provisional cycle result
+    /// that panicked while computing.
+    #[cfg_attr(feature = "persistence", serde(skip))]
+    poisoned: bool,
+}
+
+#[cfg(feature = "persistence")]
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 impl QueryRevisionsExtraInner {
@@ -681,6 +701,8 @@ impl QueryRevisionsExtraInner {
             cycle_heads: empty_cycle_heads().clone(),
             iteration: IterationStamp::default().into(),
             cycle_converged: false,
+            participated_in_cycle: false,
+            poisoned: false,
         }
     }
 
@@ -693,6 +715,8 @@ impl QueryRevisionsExtraInner {
             cycle_heads,
             iteration: _,
             cycle_converged: _,
+            participated_in_cycle: _,
+            poisoned: _,
         } = self;
 
         #[cfg(feature = "accumulator")]
@@ -725,7 +749,8 @@ impl fmt::Debug for QueryRevisionsExtraInner {
 
         f.field("cycle_heads", &self.cycle_heads)
             .field("iteration", &self.iteration)
-            .field("cycle_converged", &self.cycle_converged);
+            .field("cycle_converged", &self.cycle_converged)
+            .field("poisoned", &self.poisoned);
 
         #[cfg(feature = "accumulator")]
         {
@@ -792,8 +817,20 @@ impl QueryRevisions {
     /// Sets the `CycleHeads` for this query.
     pub(crate) fn set_cycle_heads(&mut self, cycle_heads: CycleHeads, iteration: IterationStamp) {
         let extra = self.origin_and_extra.get_or_insert_extra();
+        extra.participated_in_cycle |= !cycle_heads.is_empty();
         extra.cycle_heads = cycle_heads;
         extra.iteration = iteration.into();
+    }
+
+    pub(crate) fn participated_in_cycle(&self) -> bool {
+        self.extra()
+            .is_some_and(|extra| extra.participated_in_cycle)
+    }
+
+    pub(crate) fn mark_participated_in_cycle(&mut self) {
+        self.origin_and_extra
+            .get_or_insert_extra()
+            .participated_in_cycle = true;
     }
 
     pub(crate) const fn cycle_converged(&self) -> bool {
@@ -807,6 +844,14 @@ impl QueryRevisions {
         if let Some(extra) = self.origin_and_extra.extra_mut() {
             extra.cycle_converged = cycle_converged
         }
+    }
+
+    pub(crate) fn poisoned(&self) -> bool {
+        self.extra().is_some_and(|extra| extra.poisoned)
+    }
+
+    pub(crate) fn set_poisoned(&mut self) {
+        self.origin_and_extra.get_or_insert_extra().poisoned = true;
     }
 
     pub(crate) fn iteration(&self) -> IterationStamp {
@@ -1767,14 +1812,6 @@ impl<'a> QueryEdges<'a> {
     const fn wide(edges: &'a [QueryEdge]) -> Self {
         QueryEdges {
             data: QueryEdgesData::Wide(edges),
-        }
-    }
-
-    #[cfg(feature = "accumulator")]
-    pub(crate) const fn len(self) -> usize {
-        match self.data {
-            QueryEdgesData::Packed(edges) => edges.len(),
-            QueryEdgesData::Wide(edges) => edges.len(),
         }
     }
 

--- a/tests/compile-fail/volatile_incompatibles.rs
+++ b/tests/compile-fail/volatile_incompatibles.rs
@@ -1,0 +1,42 @@
+use salsa::Database as Db;
+
+#[salsa::input]
+struct MyInput {
+    #[returns(copy)]
+    field: u32,
+}
+
+#[derive(Clone)]
+struct NotUpdate;
+
+#[salsa::tracked(volatile = 3, returns(clone))]
+fn volatile_requires_update(_db: &dyn Db, _input: MyInput) -> NotUpdate {
+    unreachable!()
+}
+
+#[salsa::tracked(volatile = 3, lru = 3)]
+fn volatile_with_lru(db: &dyn Db, input: MyInput) -> u32 {
+    input.field(db)
+}
+
+#[salsa::tracked(volatile = 3, sieve = 3)]
+fn volatile_with_sieve(db: &dyn Db, input: MyInput) -> u32 {
+    input.field(db)
+}
+
+#[salsa::tracked(volatile = 3, specify)]
+fn volatile_with_specify(db: &dyn Db, input: MyInput) -> u32 {
+    input.field(db)
+}
+
+#[salsa::tracked(volatile = 3, unsafe(non_update_types))]
+fn volatile_with_non_update(db: &dyn Db, input: MyInput) -> u32 {
+    input.field(db)
+}
+
+#[salsa::tracked(volatile = 3, returns(ref))]
+fn volatile_with_ref(db: &dyn Db, input: MyInput) -> String {
+    input.field(db).to_string()
+}
+
+fn main() {}

--- a/tests/compile-fail/volatile_incompatibles.stderr
+++ b/tests/compile-fail/volatile_incompatibles.stderr
@@ -1,0 +1,76 @@
+error: the `volatile` and `lru` options cannot be used together
+  --> tests/compile-fail/volatile_incompatibles.rs:17:18
+   |
+17 | #[salsa::tracked(volatile = 3, lru = 3)]
+   |                  ^^^^^^^^
+
+error: the `volatile` and `sieve` options cannot be used together
+  --> tests/compile-fail/volatile_incompatibles.rs:22:18
+   |
+22 | #[salsa::tracked(volatile = 3, sieve = 3)]
+   |                  ^^^^^^^^
+
+error: the `volatile` and `specify` options cannot be used together
+  --> tests/compile-fail/volatile_incompatibles.rs:27:32
+   |
+27 | #[salsa::tracked(volatile = 3, specify)]
+   |                                ^^^^^^^
+
+error: the `volatile` and `unsafe(non_update_types)` options cannot be used together
+  --> tests/compile-fail/volatile_incompatibles.rs:32:39
+   |
+32 | #[salsa::tracked(volatile = 3, unsafe(non_update_types))]
+   |                                       ^^^^^^^^^^^^^^^^
+
+error: the `volatile` option cannot be used with reference return modes
+  --> tests/compile-fail/volatile_incompatibles.rs:37:40
+   |
+37 | #[salsa::tracked(volatile = 3, returns(ref))]
+   |                                        ^^^
+
+error[E0369]: binary operation `==` cannot be applied to type `&NotUpdate`
+  --> tests/compile-fail/volatile_incompatibles.rs:13:63
+   |
+13 | fn volatile_requires_update(_db: &dyn Db, _input: MyInput) -> NotUpdate {
+   |                                                               ^^^^^^^^^
+   |
+note: an implementation of `PartialEq` might be missing for `NotUpdate`
+  --> tests/compile-fail/volatile_incompatibles.rs:10:1
+   |
+10 | struct NotUpdate;
+   | ^^^^^^^^^^^^^^^^ must implement `PartialEq`
+help: consider annotating `NotUpdate` with `#[derive(PartialEq)]`
+   |
+10 + #[derive(PartialEq)]
+11 | struct NotUpdate;
+   |
+
+error[E0277]: the trait bound `NotUpdate: Update` is not satisfied
+  --> tests/compile-fail/volatile_incompatibles.rs:13:63
+   |
+13 | fn volatile_requires_update(_db: &dyn Db, _input: MyInput) -> NotUpdate {
+   |                                                               ^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `Update` is not implemented for `NotUpdate`
+  --> tests/compile-fail/volatile_incompatibles.rs:10:1
+   |
+10 | struct NotUpdate;
+   | ^^^^^^^^^^^^^^^^
+   = help: the following other types implement trait `Update`:
+             ()
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
+           and $N others
+note: required by a bound in `assert_update`
+  --> tests/compile-fail/volatile_incompatibles.rs:12:1
+   |
+12 | #[salsa::tracked(volatile = 3, returns(clone))]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_update`
+13 | fn volatile_requires_update(_db: &dyn Db, _input: MyInput) -> NotUpdate {
+   |                                                               --------- required by a bound in this function
+   = note: this error originates in the macro `salsa::plumbing::setup_tracked_fn` which comes from the expansion of the attribute macro `salsa::tracked` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/memory-usage.rs
+++ b/tests/memory-usage.rs
@@ -46,6 +46,11 @@ fn input_to_string_get_size(_db: &dyn salsa::Database) -> String {
     "a".repeat(1000)
 }
 
+#[salsa::tracked(volatile = 1, returns(clone), heap_size = string_size_of)]
+fn volatile_input_to_string(db: &dyn salsa::Database, input: MyInput) -> String {
+    input.field(db).clone()
+}
+
 #[salsa::tracked(returns(copy))]
 fn input_to_length(db: &dyn salsa::Database, input: MyInput) -> usize {
     input.field(db).len()
@@ -397,4 +402,20 @@ fn page_info_tracks_allocated_slots_after_tracked_struct_deletion() {
     assert_eq!(pages.p75_fill(), 1);
     assert_eq!(pages.p90_fill(), 1);
     assert_eq!(pages.p99_fill(), 1);
+}
+
+#[test]
+fn volatile_collected_values_report_only_metadata() {
+    let db = salsa::DatabaseImpl::new();
+
+    for _ in 0..1_024 {
+        let input = MyInput::new(&db, "a".to_owned());
+        assert_eq!(volatile_input_to_string(&db, input).len(), 1);
+    }
+
+    let memory_usage = <dyn salsa::Database>::memory_usage(&db);
+    let query = &memory_usage.queries["volatile_input_to_string"];
+    assert_eq!(query.count(), 1_024);
+    assert_eq!(query.size_of_fields(), std::mem::size_of::<String>());
+    assert_eq!(query.heap_size_of_fields(), Some(1));
 }

--- a/tests/sieve.rs
+++ b/tests/sieve.rs
@@ -1,0 +1,102 @@
+#![cfg(feature = "inventory")]
+
+//! Tests for the SIEVE eviction policy.
+
+mod common;
+use common::LogDatabase;
+
+use salsa::Database as _;
+use test_log::test;
+
+#[salsa::input]
+struct MyInput {
+    #[returns(copy)]
+    field: u32,
+}
+
+#[salsa::tracked(returns(copy), sieve = 2)]
+fn sieve_value(db: &dyn LogDatabase, input: MyInput) -> u32 {
+    db.push_log(format!("sieve_value({:?})", input.field(db)));
+    input.field(db)
+}
+
+#[test]
+fn sieve_gives_visited_values_a_second_chance() {
+    let mut db = common::LoggerDatabase::default();
+
+    let inputs: Vec<MyInput> = (0..3).map(|field| MyInput::new(&db, field)).collect();
+
+    assert_eq!(sieve_value(&db, inputs[0]), 0);
+    assert_eq!(sieve_value(&db, inputs[1]), 1);
+
+    // Touch `0` again after admission. SIEVE should set its visited bit without
+    // moving it out of its old FIFO position.
+    assert_eq!(sieve_value(&db, inputs[0]), 0);
+
+    assert_eq!(sieve_value(&db, inputs[2]), 2);
+    db.assert_logs_len(3);
+
+    db.synthetic_write(salsa::Durability::HIGH);
+
+    assert_eq!(sieve_value(&db, inputs[0]), 0);
+    db.assert_logs_len(0);
+
+    assert_eq!(sieve_value(&db, inputs[1]), 1);
+    db.assert_logs(expect_test::expect![[r#"
+        [
+            "sieve_value(1)",
+        ]"#]]);
+}
+
+#[test]
+fn sieve_readmits_evicted_values() {
+    let mut db = common::LoggerDatabase::default();
+
+    let inputs: Vec<MyInput> = (0..3).map(|field| MyInput::new(&db, field)).collect();
+
+    assert_eq!(sieve_value(&db, inputs[0]), 0);
+    assert_eq!(sieve_value(&db, inputs[1]), 1);
+    assert_eq!(sieve_value(&db, inputs[2]), 2);
+    db.assert_logs_len(3);
+
+    db.synthetic_write(salsa::Durability::HIGH);
+
+    assert_eq!(sieve_value(&db, inputs[0]), 0);
+    db.assert_logs(expect_test::expect![[r#"
+        [
+            "sieve_value(0)",
+        ]"#]]);
+
+    db.synthetic_write(salsa::Durability::HIGH);
+
+    assert_eq!(sieve_value(&db, inputs[0]), 0);
+    db.assert_logs_len(0);
+
+    assert_eq!(sieve_value(&db, inputs[1]), 1);
+    db.assert_logs(expect_test::expect![[r#"
+        [
+            "sieve_value(1)",
+        ]"#]]);
+}
+
+#[test]
+fn sieve_skips_stale_pending_evictions() {
+    let mut db = common::LoggerDatabase::default();
+
+    let inputs: Vec<MyInput> = (0..3).map(|field| MyInput::new(&db, field)).collect();
+
+    assert_eq!(sieve_value(&db, inputs[0]), 0);
+    assert_eq!(sieve_value(&db, inputs[1]), 1);
+    assert_eq!(sieve_value(&db, inputs[2]), 2);
+
+    // `0` has been selected for eviction but the value is still present until
+    // the next revision starts. Fetching it again must re-admit it and make the
+    // pending eviction stale.
+    assert_eq!(sieve_value(&db, inputs[0]), 0);
+    db.assert_logs_len(3);
+
+    db.synthetic_write(salsa::Durability::HIGH);
+
+    assert_eq!(sieve_value(&db, inputs[0]), 0);
+    db.assert_logs_len(0);
+}

--- a/tests/volatile.rs
+++ b/tests/volatile.rs
@@ -1,0 +1,374 @@
+#![cfg(feature = "inventory")]
+
+//! Tests for volatile tracked functions.
+
+use std::sync::Arc;
+#[cfg(feature = "salsa_unstable")]
+use std::sync::Barrier;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[cfg(feature = "accumulator")]
+use salsa::Accumulator;
+use salsa::{Database as _, Durability};
+use test_log::test;
+
+const FILL_FIELDS: std::ops::Range<u32> = 100..1_124;
+
+#[salsa::input]
+struct MyInput {
+    #[returns(copy)]
+    field: u32,
+}
+
+#[salsa::tracked]
+struct CreatedByVolatile<'db> {
+    #[returns(copy)]
+    field: u32,
+}
+
+#[derive(Clone, salsa::Update)]
+struct TrackedReference<'db>(CreatedByVolatile<'db>);
+
+#[salsa::tracked(returns(copy))]
+fn create_tracked(db: &dyn salsa::Database, input: MyInput) -> CreatedByVolatile<'_> {
+    CreatedByVolatile::new(db, input.field(db))
+}
+
+thread_local! {
+    static VOLATILE_EXECUTIONS: AtomicUsize = const { AtomicUsize::new(0) };
+    static OUTER_EXECUTIONS: AtomicUsize = const { AtomicUsize::new(0) };
+    static CYCLE_EXECUTIONS: AtomicUsize = const { AtomicUsize::new(0) };
+    static TRACKED_EXECUTIONS: AtomicUsize = const { AtomicUsize::new(0) };
+    static ACCUMULATE_EXECUTIONS: AtomicUsize = const { AtomicUsize::new(0) };
+    static LIVE_VALUES: AtomicUsize = const { AtomicUsize::new(0) };
+}
+
+fn reset_counts() {
+    VOLATILE_EXECUTIONS.with(|n| n.store(0, Ordering::SeqCst));
+    OUTER_EXECUTIONS.with(|n| n.store(0, Ordering::SeqCst));
+    CYCLE_EXECUTIONS.with(|n| n.store(0, Ordering::SeqCst));
+    TRACKED_EXECUTIONS.with(|n| n.store(0, Ordering::SeqCst));
+    ACCUMULATE_EXECUTIONS.with(|n| n.store(0, Ordering::SeqCst));
+}
+
+fn volatile_executions() -> usize {
+    VOLATILE_EXECUTIONS.with(|n| n.load(Ordering::SeqCst))
+}
+
+fn outer_executions() -> usize {
+    OUTER_EXECUTIONS.with(|n| n.load(Ordering::SeqCst))
+}
+
+fn cycle_executions() -> usize {
+    CYCLE_EXECUTIONS.with(|n| n.load(Ordering::SeqCst))
+}
+
+#[cfg(feature = "accumulator")]
+fn accumulate_executions() -> usize {
+    ACCUMULATE_EXECUTIONS.with(|n| n.load(Ordering::SeqCst))
+}
+
+#[derive(PartialEq, Eq, salsa::Update)]
+struct LiveValue;
+
+impl LiveValue {
+    fn new() -> Self {
+        LIVE_VALUES.with(|n| n.fetch_add(1, Ordering::SeqCst));
+        Self
+    }
+}
+
+impl Drop for LiveValue {
+    fn drop(&mut self) {
+        LIVE_VALUES.with(|n| n.fetch_sub(1, Ordering::SeqCst));
+    }
+}
+
+fn live_values() -> usize {
+    LIVE_VALUES.with(|n| n.load(Ordering::SeqCst))
+}
+
+#[salsa::tracked(volatile = 2, returns(copy))]
+fn volatile_value(db: &dyn salsa::Database, input: MyInput) -> u32 {
+    VOLATILE_EXECUTIONS.with(|n| n.fetch_add(1, Ordering::SeqCst));
+    input.field(db)
+}
+
+#[salsa::tracked(volatile = 2, returns(copy))]
+fn volatile_copy(db: &dyn salsa::Database, input: MyInput) -> u32 {
+    input.field(db)
+}
+
+#[salsa::tracked(volatile = 2, returns(clone))]
+fn volatile_arc(_db: &dyn salsa::Database, _input: MyInput) -> Arc<LiveValue> {
+    Arc::new(LiveValue::new())
+}
+
+#[salsa::tracked(volatile = 2, returns(clone), no_eq)]
+fn volatile_tracked_reference<'db>(
+    _db: &'db dyn salsa::Database,
+    value: CreatedByVolatile<'db>,
+) -> TrackedReference<'db> {
+    TrackedReference(value)
+}
+
+#[salsa::tracked(volatile = 2, returns(copy))]
+fn volatile_creates_tracked_struct(
+    db: &dyn salsa::Database,
+    input: MyInput,
+) -> CreatedByVolatile<'_> {
+    TRACKED_EXECUTIONS.with(|n| n.fetch_add(1, Ordering::SeqCst));
+    CreatedByVolatile::new(db, input.field(db))
+}
+
+#[cfg(feature = "accumulator")]
+#[salsa::accumulator]
+struct VolatileLog(u32);
+
+#[cfg(feature = "accumulator")]
+#[salsa::tracked(volatile = 2, returns(copy))]
+fn volatile_accumulate(db: &dyn salsa::Database, input: MyInput) -> u32 {
+    ACCUMULATE_EXECUTIONS.with(|n| n.fetch_add(1, Ordering::SeqCst));
+    let field = input.field(db);
+    VolatileLog(field).accumulate(db);
+    field
+}
+
+#[salsa::tracked(returns(copy))]
+fn outer_value(db: &dyn salsa::Database, input: MyInput) -> u32 {
+    OUTER_EXECUTIONS.with(|n| n.fetch_add(1, Ordering::SeqCst));
+    *volatile_value(db, input) + 1
+}
+
+#[salsa::tracked(volatile = 2, returns(copy), cycle_initial=cycle_initial)]
+fn volatile_cycle_value(db: &dyn salsa::Database, input: MyInput) -> u32 {
+    CYCLE_EXECUTIONS.with(|n| n.fetch_add(1, Ordering::SeqCst));
+
+    if input.field(db) != 0 {
+        volatile_cycle_value(db, input);
+    }
+
+    input.field(db)
+}
+
+fn cycle_initial(_db: &dyn salsa::Database, _id: salsa::Id, _input: MyInput) -> u32 {
+    0
+}
+
+fn fill_volatile_cache(db: &salsa::DatabaseImpl) {
+    for field in FILL_FIELDS {
+        let input = MyInput::new(db, field);
+        assert_eq!(*volatile_value(db, input), field);
+    }
+}
+
+fn fill_volatile_cycle_cache(db: &salsa::DatabaseImpl) {
+    for field in FILL_FIELDS {
+        let input = MyInput::new(db, field);
+        assert_eq!(*volatile_cycle_value(db, input), field);
+    }
+}
+
+#[test]
+fn volatile_evicts_automatically_without_new_revision() {
+    reset_counts();
+    let db = salsa::DatabaseImpl::new();
+    let input = MyInput::new(&db, 22);
+
+    assert_eq!(*volatile_value(&db, input), 22);
+    assert_eq!(*volatile_value(&db, input), 22);
+    assert_eq!(volatile_executions(), 1);
+
+    fill_volatile_cache(&db);
+
+    let executions_before_refetch = volatile_executions();
+    assert_eq!(*volatile_value(&db, input), 22);
+    assert_eq!(volatile_executions(), executions_before_refetch + 1);
+}
+
+#[test]
+fn volatile_supports_copy_return_mode() {
+    let db = salsa::DatabaseImpl::new();
+    let input = MyInput::new(&db, 22);
+
+    assert_eq!(*volatile_copy(&db, input), 22);
+}
+
+#[test]
+fn volatile_supports_non_static_update_output() {
+    let db = salsa::DatabaseImpl::new();
+    let input = MyInput::new(&db, 22);
+    let value = create_tracked(&db, input);
+
+    assert_eq!(volatile_tracked_reference(&db, value).0.field(&db), 22);
+}
+
+#[test]
+fn volatile_reuses_tracked_struct_ids_after_eviction() {
+    reset_counts();
+    let db = salsa::DatabaseImpl::new();
+    let inputs = (0..3)
+        .map(|field| MyInput::new(&db, field))
+        .collect::<Vec<_>>();
+    let original = inputs
+        .iter()
+        .map(|input| volatile_creates_tracked_struct(&db, *input))
+        .collect::<Vec<_>>();
+
+    for (input, expected) in inputs.iter().zip(original) {
+        assert!(volatile_creates_tracked_struct(&db, *input) == expected);
+    }
+
+    TRACKED_EXECUTIONS.with(|n| assert!(n.load(Ordering::SeqCst) > 3));
+}
+
+#[test]
+fn volatile_drops_values_without_new_revision() {
+    assert_eq!(live_values(), 0);
+    let db = salsa::DatabaseImpl::new();
+
+    for field in 0..1_024 {
+        let input = MyInput::new(&db, field);
+        drop(volatile_arc(&db, input));
+    }
+
+    assert!(live_values() < 1_024);
+}
+
+#[test]
+fn volatile_handle_keeps_an_evicted_value_alive() {
+    assert_eq!(live_values(), 0);
+    let db = salsa::DatabaseImpl::new();
+    let input = MyInput::new(&db, 22);
+    let original = volatile_arc(&db, input);
+
+    for field in FILL_FIELDS {
+        let input = MyInput::new(&db, field);
+        drop(volatile_arc(&db, input));
+    }
+
+    let replacement = volatile_arc(&db, input);
+    assert!(!Arc::ptr_eq(&original, &replacement));
+
+    let before_drop = live_values();
+    drop(original);
+    assert_eq!(live_values(), before_drop - 1);
+}
+
+#[cfg(feature = "accumulator")]
+#[test]
+fn volatile_keeps_escaped_accumulated_values_alive() {
+    reset_counts();
+    let db = salsa::DatabaseImpl::new();
+    let input = MyInput::new(&db, 22);
+
+    let logs = volatile_accumulate::accumulated::<VolatileLog>(&db, input);
+    assert_eq!(logs[0].0, 22);
+
+    for field in FILL_FIELDS {
+        let input = MyInput::new(&db, field);
+        assert_eq!(*volatile_accumulate(&db, input), field);
+    }
+
+    let executions_before_refetch = accumulate_executions();
+    assert_eq!(*volatile_accumulate(&db, input), 22);
+    assert_eq!(accumulate_executions(), executions_before_refetch);
+    assert_eq!(logs[0].0, 22);
+}
+
+#[test]
+fn volatile_eviction_is_safe_with_parallel_reads() {
+    let db = salsa::DatabaseImpl::new();
+    let inputs = (0..256)
+        .map(|field| MyInput::new(&db, field))
+        .collect::<Vec<_>>();
+
+    let threads = (0..4)
+        .map(|_| {
+            let db = db.clone();
+            let inputs = inputs.clone();
+            std::thread::spawn(move || {
+                for _ in 0..10 {
+                    for input in &inputs {
+                        assert!(**volatile_arc(&db, *input) == LiveValue);
+                    }
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+
+    for thread in threads {
+        thread.join().unwrap();
+    }
+}
+
+#[cfg(feature = "salsa_unstable")]
+#[test]
+fn volatile_eviction_is_safe_with_memory_usage() {
+    let db = salsa::DatabaseImpl::new();
+    let inputs = (0..256)
+        .map(|field| MyInput::new(&db, field))
+        .collect::<Vec<_>>();
+    let barrier = Arc::new(Barrier::new(2));
+
+    let worker = {
+        let db = db.clone();
+        let barrier = Arc::clone(&barrier);
+        std::thread::spawn(move || {
+            barrier.wait();
+            for _ in 0..10 {
+                for input in &inputs {
+                    assert!(**volatile_arc(&db, *input) == LiveValue);
+                }
+            }
+        })
+    };
+
+    barrier.wait();
+    for _ in 0..100 {
+        let _ = <dyn salsa::Database>::memory_usage(&db);
+    }
+
+    worker.join().unwrap();
+}
+
+#[test]
+fn volatile_eviction_retains_dependency_info() {
+    reset_counts();
+    let mut db = salsa::DatabaseImpl::new();
+    let input = MyInput::new(&db, 22);
+
+    assert_eq!(outer_value(&db, input), 23);
+    assert_eq!(volatile_executions(), 1);
+    assert_eq!(outer_executions(), 1);
+
+    fill_volatile_cache(&db);
+    let volatile_after_fill = volatile_executions();
+    db.synthetic_write(Durability::HIGH);
+
+    assert_eq!(outer_value(&db, input), 23);
+    assert_eq!(volatile_executions(), volatile_after_fill);
+    assert_eq!(outer_executions(), 1);
+}
+
+#[test]
+fn volatile_does_not_evict_cycle_participants() {
+    reset_counts();
+    let db = salsa::DatabaseImpl::new();
+    let input = MyInput::new(&db, 22);
+
+    assert_eq!(*volatile_value(&db, input), 22);
+    let cycle_value = volatile_cycle_value(&db, input);
+
+    fill_volatile_cache(&db);
+    fill_volatile_cycle_cache(&db);
+
+    let volatile_before = volatile_executions();
+    let cycle_before = cycle_executions();
+
+    assert_eq!(*volatile_value(&db, input), 22);
+    assert_eq!(volatile_cycle_value(&db, input), cycle_value);
+
+    assert!(volatile_executions() > volatile_before);
+    assert_eq!(cycle_executions(), cycle_before);
+}


### PR DESCRIPTION
Add an opt-in volatile capacity for tracked queries so large, short-lived values can be collected within a revision.

Volatile queries reuse SIEVE victim selection from #1226 but reclaim selected memo values immediately; owned handles keep concurrent readers safe while metadata remains available for validation and tracked-ID reuse.

Testing: Passed Clippy, workspace, persistence, manual-registration, Shuttle, documentation, and targeted Miri checks.