### PR TITLE
feat: use generational tracked function eviction

### DIFF
--- a/book/src/tuning.md
+++ b/book/src/tuning.md
@@ -1,10 +1,9 @@
 # Tuning Salsa
 
-## Cache Eviction (LRU)
+## Cache Eviction
 
-Salsa supports Least Recently Used (LRU) cache eviction for tracked functions.
-By default, memoized values are never evicted (unbounded cache). You can enable
-LRU eviction by specifying a capacity at compile time:
+By default, memoized values are never evicted. You can enable adaptive,
+generational eviction with the existing `lru` option:
 
 ```rust
 #[salsa::tracked(lru = 128)]
@@ -13,9 +12,11 @@ fn parse(db: &dyn Db, input: SourceFile) -> Ast {
 }
 ```
 
-With `lru = 128`, Salsa will keep at most 128 memoized values for this function.
-When the cache exceeds this capacity, the least recently used values are evicted
-at the start of each new revision.
+The value is currently a minimum collection-growth threshold, not a hard
+capacity. New values receive multiple collection epochs of grace. Values that
+are reused across epochs move into older generations, while values that remain
+cold across repeated inspections are evicted. Collection epochs advance only
+after sufficient resident growth and only inspect the due generation.
 
 ### Zero-Cost When Disabled
 
@@ -23,9 +24,10 @@ When no `lru` capacity is specified (the default), Salsa uses a no-op eviction
 policy that is completely optimized away by the compiler. This means there is
 zero runtime overhead for functions that don't need cache eviction.
 
-### Runtime Capacity Adjustment
+### Runtime Threshold Adjustment
 
-For functions with LRU enabled, you can adjust the capacity at runtime:
+For functions with eviction enabled, the existing method adjusts the minimum
+growth threshold at runtime:
 
 ```rust
 #[salsa::tracked(lru = 128)]
@@ -33,18 +35,19 @@ fn my_query(db: &dyn Db, input: MyInput) -> Output {
     // ...
 }
 
-// Later, adjust the capacity:
+// Later, adjust the collection threshold:
 my_query::set_lru_capacity(db, 256);
 ```
 
-**Note:** The `set_lru_capacity` method is only generated for functions that have
-an `lru` attribute. Functions without LRU enabled do not have this method.
+The method retains its existing name while the eviction API is being evaluated.
+It is only generated for functions that have an `lru` attribute.
 
 ### Memory Management
 
-There is no garbage collection for keys and results of old queries, so LRU caches
-are currently the primary mechanism for avoiding unbounded memory usage in
-long-running applications built on Salsa.
+Eviction drops memoized values but retains their dependency information. The
+collector does not enforce an absolute memory bound: its goal is to prevent
+unused values from accumulating indefinitely while avoiding synchronization on
+query fetches.
 
 ## Intern Queries
 

--- a/book/src/tuning.md
+++ b/book/src/tuning.md
@@ -13,10 +13,11 @@ fn parse(db: &dyn Db, input: SourceFile) -> Ast {
 ```
 
 The value is currently a minimum per-revision inspection budget, not a hard
-capacity. New values receive multiple revisions of grace. Values that are reused
-across revisions move into older generations, while values that remain cold
-across repeated inspections are evicted. Large due cohorts are processed
-incrementally across revisions to limit maintenance pauses.
+capacity. New values enter a compact probation cohort for 16 revisions. Values
+reused during probation become full residents and can move through warm, hot,
+and tenured generations; one-shot values are evicted directly when probation
+expires. Large due cohorts are processed incrementally across revisions to limit
+maintenance pauses.
 
 ### Zero-Cost When Disabled
 

--- a/book/src/tuning.md
+++ b/book/src/tuning.md
@@ -12,11 +12,11 @@ fn parse(db: &dyn Db, input: SourceFile) -> Ast {
 }
 ```
 
-The value is currently a minimum collection-growth threshold, not a hard
-capacity. New values receive multiple collection epochs of grace. Values that
-are reused across epochs move into older generations, while values that remain
-cold across repeated inspections are evicted. Collection epochs advance only
-after sufficient resident growth and only inspect the due generation.
+The value is currently a minimum per-revision inspection budget, not a hard
+capacity. New values receive multiple revisions of grace. Values that are reused
+across revisions move into older generations, while values that remain cold
+across repeated inspections are evicted. Large due cohorts are processed
+incrementally across revisions to limit maintenance pauses.
 
 ### Zero-Cost When Disabled
 
@@ -27,7 +27,7 @@ zero runtime overhead for functions that don't need cache eviction.
 ### Runtime Threshold Adjustment
 
 For functions with eviction enabled, the existing method adjusts the minimum
-growth threshold at runtime:
+per-revision inspection budget at runtime:
 
 ```rust
 #[salsa::tracked(lru = 128)]
@@ -35,7 +35,7 @@ fn my_query(db: &dyn Db, input: MyInput) -> Output {
     // ...
 }
 
-// Later, adjust the collection threshold:
+// Later, adjust the maintenance budget:
 my_query::set_lru_capacity(db, 256);
 ```
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -239,7 +239,7 @@ where
         DatabaseKeyIndex::new(self.index, key)
     }
 
-    /// Set eviction capacity. Only available when eviction policy supports it.
+    /// Set the eviction threshold. Only available when the policy supports it.
     pub fn set_capacity(&mut self, capacity: usize)
     where
         C::Eviction: HasCapacity,
@@ -540,13 +540,21 @@ where
     }
 
     fn reset_for_new_revision(&mut self, table: &mut Table) {
-        self.eviction.for_each_evicted(|evict| {
+        let evicted = self.eviction.evict(|id| {
+            let ingredient_index = table.ingredient_index(id);
+            Self::verified_at_for(
+                table.memos_mut(id),
+                self.memo_ingredient_indices.get(ingredient_index),
+            )
+        });
+
+        for evict in evicted {
             let ingredient_index = table.ingredient_index(evict);
             Self::evict_value_from_memo_for(
                 table.memos_mut(evict),
                 self.memo_ingredient_indices.get(ingredient_index),
             )
-        });
+        }
 
         self.deleted_entries.clear();
     }

--- a/src/function.rs
+++ b/src/function.rs
@@ -269,6 +269,8 @@ where
         mut memo: memo::Memo<'db, C>,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> &'db memo::Memo<'db, C> {
+        let has_value = memo.value.is_some();
+
         if let Some(tracked_struct_ids) = memo.revisions.tracked_struct_ids_mut() {
             tracked_struct_ids.shrink_to_fit();
         }
@@ -278,15 +280,24 @@ where
         // FIXME: Use `Box::into_non_null` once stable
         let memo = NonNull::from(Box::leak(Box::new(memo)));
 
-        if let Some(old_value) =
-            self.insert_memo_into_table_for(zalsa, id, memo, memo_ingredient_index)
-        {
+        let old_value = self.insert_memo_into_table_for(zalsa, id, memo, memo_ingredient_index);
+        let became_resident = has_value
+            && old_value.is_none_or(|old_value| {
+                // SAFETY: The old memo remains allocated in `deleted_entries` until the next
+                // revision, so it is valid to inspect here.
+                unsafe { old_value.as_ref().value.is_none() }
+            });
+
+        if let Some(old_value) = old_value {
             // In case there is a reference to the old memo out there, we have to store it
             // in the deleted entries. This will get cleared when a new revision starts.
             //
             // SAFETY: Once the revision starts, there will be no outstanding borrows to the
             // memo contents, and so it will be safe to free.
             unsafe { self.deleted_entries.push(old_value) };
+        }
+        if became_resident {
+            self.eviction.admit(id);
         }
         // SAFETY: memo has been inserted into the table
         unsafe { self.extend_memo_lifetime(memo.as_ref()) }

--- a/src/function/eviction.rs
+++ b/src/function/eviction.rs
@@ -19,8 +19,13 @@ pub trait EvictionPolicy: Send + Sync {
     /// Create a new eviction policy with the given capacity.
     fn new(capacity: usize) -> Self;
 
+    /// Record that an item acquired a memoized value that may need to be evicted.
+    fn admit(&self, id: Id);
+
     /// Record that an item was accessed.
-    fn record_use(&self, id: Id);
+    ///
+    /// Implementations may treat this as a best-effort hint.
+    fn promote(&self, id: Id);
 
     /// Set the maximum capacity.
     fn set_capacity(&mut self, capacity: usize);

--- a/src/function/eviction.rs
+++ b/src/function/eviction.rs
@@ -9,15 +9,15 @@ mod noop;
 pub use lru::Lru;
 pub use noop::NoopEviction;
 
-use crate::Id;
+use crate::{Id, Revision};
 
 /// Trait for cache eviction strategies.
 ///
 /// Implementations control when memoized values are evicted from the cache.
 /// The eviction policy is selected at compile time via the `Configuration` trait.
 pub trait EvictionPolicy: Send + Sync {
-    /// Create a new eviction policy with the given capacity.
-    fn new(capacity: usize) -> Self;
+    /// Create a new eviction policy with the configured `lru` value.
+    fn new(value: usize) -> Self;
 
     /// Record that an item acquired a memoized value that may need to be evicted.
     fn admit(&self, id: Id);
@@ -27,19 +27,20 @@ pub trait EvictionPolicy: Send + Sync {
     /// Implementations may treat this as a best-effort hint.
     fn promote(&self, id: Id);
 
-    /// Set the maximum capacity.
-    fn set_capacity(&mut self, capacity: usize);
+    /// Set the policy's runtime threshold. Zero disables eviction.
+    fn set_capacity(&mut self, value: usize);
 
-    /// Iterate over items that should be evicted.
+    /// Return items that should be evicted.
     ///
     /// Called once per revision during `reset_for_new_revision`.
-    /// The callback `cb` should be invoked for each item to evict.
-    fn for_each_evicted(&mut self, cb: impl FnMut(Id));
+    /// `last_verified_at` returns the last revision in which an item's memoized
+    /// value was verified, or `None` if it no longer has a value.
+    fn evict(&mut self, last_verified_at: impl FnMut(Id) -> Option<Revision>) -> Vec<Id>;
 }
 
-/// Marker trait for eviction policies that have a configurable capacity.
+/// Marker trait for eviction policies that have a configurable threshold.
 ///
 /// This trait is used to conditionally generate the `set_lru_capacity` method
 /// on tracked functions. Only policies that implement this trait will expose
-/// runtime capacity configuration.
+/// runtime eviction configuration.
 pub trait HasCapacity: EvictionPolicy {}

--- a/src/function/eviction/lru.rs
+++ b/src/function/eviction/lru.rs
@@ -37,7 +37,14 @@ impl EvictionPolicy for Lru {
     }
 
     #[inline(always)]
-    fn record_use(&self, id: Id) {
+    fn admit(&self, id: Id) {
+        if self.capacity.is_some() {
+            self.insert(id);
+        }
+    }
+
+    #[inline(always)]
+    fn promote(&self, id: Id) {
         if self.capacity.is_some() {
             self.insert(id);
         }

--- a/src/function/eviction/lru.rs
+++ b/src/function/eviction/lru.rs
@@ -1,73 +1,514 @@
-//! Least Recently Used (LRU) eviction policy.
+//! Adaptive generational eviction for memoized values.
 //!
-//! This policy tracks the most recently accessed items and evicts
-//! the least recently used ones when the cache exceeds its capacity.
+//! Values are tracked outside the memo in a timing wheel. Query fetches do not
+//! touch the policy: reuse is detected lazily from the memo's existing
+//! `verified_at` revision when a resident becomes due for inspection.
 
+use std::hash::BuildHasher;
 use std::num::NonZeroUsize;
 
-use crate::Id;
-use crate::hash::FxLinkedHashSet;
-use crate::sync::Mutex;
+use crossbeam_utils::CachePadded;
+use rustc_hash::FxBuildHasher;
+
+use crate::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use crate::sync::{Mutex, OnceLock};
+use crate::{Id, Revision};
 
 use super::{EvictionPolicy, HasCapacity};
 
-/// Least Recently Used eviction policy.
+const GENERATIONS: u8 = 4;
+const WHEEL_SIZE: usize = 64;
+const GHOST_HORIZON: usize = 8;
+const MIN_ADAPTIVE_SAMPLE: usize = 32;
+
+/// An adaptive generational collector selected by the existing `lru` option.
 ///
-/// When the number of memoized values exceeds the configured capacity,
-/// the least recently accessed values are evicted at the start of each
-/// new revision.
+/// The configured value is an activation and minimum growth threshold, not a
+/// hard resident-value limit.
 pub struct Lru {
-    capacity: Option<NonZeroUsize>,
-    set: Mutex<FxLinkedHashSet<Id>>,
+    activation_floor: Option<NonZeroUsize>,
+    hasher: FxBuildHasher,
+    shift: u32,
+    admissions: Box<[CachePadded<Mutex<Vec<Admission>>>]>,
+    state: State,
+    current_epoch: AtomicUsize,
+    ghosts: GhostSketch,
+    refaults_by_epoch: [AtomicUsize; GHOST_HORIZON],
+}
+
+#[derive(Clone, Copy)]
+struct Admission {
+    id: Id,
+    generation: u8,
+}
+
+struct Resident {
+    id: Id,
+    observed_at: Revision,
+    generation: u8,
+    cold_strikes: u8,
+}
+
+struct State {
+    wheel: [Vec<Resident>; WHEEL_SIZE],
+    epoch: usize,
+    resident_count: usize,
+    next_collection: usize,
+    next_admission_shard: usize,
+    evictions_by_epoch: [usize; GHOST_HORIZON],
+    controller: AdaptiveController,
+}
+
+impl State {
+    fn new(activation_floor: usize) -> Self {
+        Self {
+            wheel: std::array::from_fn(|_| Vec::new()),
+            epoch: 0,
+            resident_count: 0,
+            next_collection: activation_floor,
+            next_admission_shard: 0,
+            evictions_by_epoch: [0; GHOST_HORIZON],
+            controller: AdaptiveController::default(),
+        }
+    }
+
+    fn schedule(&mut self, resident: Resident, delay: usize) {
+        let bucket = self.epoch.wrapping_add(delay) & (WHEEL_SIZE - 1);
+        self.wheel[bucket].push(resident);
+    }
+
+    fn update_collection_target(&mut self, activation_floor: usize) {
+        let growth = (self.resident_count / 2).max(activation_floor);
+        self.next_collection = self.resident_count.saturating_add(growth);
+    }
+}
+
+#[derive(Default)]
+struct AdaptiveController {
+    nursery_grace: u8,
+    cold_strikes: u8,
+    sampled_evictions: usize,
+    sampled_refaults: usize,
+}
+
+impl AdaptiveController {
+    fn initialize(&mut self) {
+        if self.nursery_grace == 0 {
+            self.nursery_grace = 2;
+            self.cold_strikes = 2;
+        }
+    }
+
+    fn observe(&mut self, evictions: usize, refaults: usize) {
+        self.initialize();
+        self.sampled_evictions = self.sampled_evictions.saturating_add(evictions);
+        self.sampled_refaults = self.sampled_refaults.saturating_add(refaults);
+        if self.sampled_evictions < MIN_ADAPTIVE_SAMPLE {
+            return;
+        }
+
+        if self.sampled_refaults.saturating_mul(10) > self.sampled_evictions {
+            self.nursery_grace = self.nursery_grace.saturating_add(1).min(8);
+            self.cold_strikes = self.cold_strikes.saturating_add(1).min(4);
+        } else if self.sampled_refaults.saturating_mul(100) < self.sampled_evictions {
+            self.nursery_grace = self.nursery_grace.saturating_sub(1).max(2);
+            self.cold_strikes = self.cold_strikes.saturating_sub(1).max(2);
+        }
+
+        self.sampled_evictions = 0;
+        self.sampled_refaults = 0;
+    }
+
+    fn inspection_delay(&mut self, generation: u8) -> usize {
+        self.initialize();
+        if generation == 0 {
+            usize::from(self.nursery_grace)
+        } else {
+            usize::from(self.nursery_grace) + (1usize << generation)
+        }
+    }
 }
 
 impl Lru {
-    #[inline(never)]
-    fn insert(&self, id: Id) {
-        self.set.lock().insert(id);
+    fn with_shards(activation_floor: usize, shards: usize) -> Self {
+        assert!(shards > 1 && shards.is_power_of_two());
+
+        Self {
+            activation_floor: NonZeroUsize::new(activation_floor),
+            hasher: FxBuildHasher,
+            shift: usize::BITS - shards.trailing_zeros(),
+            admissions: (0..shards).map(|_| Default::default()).collect(),
+            state: State::new(activation_floor),
+            current_epoch: AtomicUsize::new(0),
+            ghosts: GhostSketch::new(activation_floor),
+            refaults_by_epoch: std::array::from_fn(|_| AtomicUsize::new(0)),
+        }
+    }
+
+    #[inline]
+    fn shard(&self, id: Id) -> usize {
+        let hash = self.hasher.hash_one(id);
+        ((hash as usize) << 7) >> self.shift
+    }
+
+    fn drain_admissions(&mut self, last_verified_at: &mut impl FnMut(Id) -> Option<Revision>) {
+        let admissions: Vec<Vec<Admission>> = self
+            .admissions
+            .iter_mut()
+            .map(|shard| std::mem::take(shard.get_mut()))
+            .collect();
+        let mut cursors = vec![0; admissions.len()];
+        let mut remaining = admissions.iter().map(Vec::len).sum::<usize>();
+
+        while remaining > 0 {
+            for offset in 0..admissions.len() {
+                let shard = (self.state.next_admission_shard + offset) & (admissions.len() - 1);
+                let Some(&admission) = admissions[shard].get(cursors[shard]) else {
+                    continue;
+                };
+
+                cursors[shard] += 1;
+                remaining -= 1;
+                let Some(observed_at) = last_verified_at(admission.id) else {
+                    continue;
+                };
+
+                let delay = self.state.controller.inspection_delay(admission.generation);
+                self.state.schedule(
+                    Resident {
+                        id: admission.id,
+                        observed_at,
+                        generation: admission.generation,
+                        cold_strikes: 0,
+                    },
+                    delay,
+                );
+                self.state.resident_count += 1;
+            }
+            self.state.next_admission_shard =
+                (self.state.next_admission_shard + 1) & (admissions.len() - 1);
+        }
+
+        for (shard, mut admissions) in self.admissions.iter_mut().zip(admissions) {
+            admissions.clear();
+            *shard.get_mut() = admissions;
+        }
+    }
+
+    fn advance_epoch(
+        &mut self,
+        last_verified_at: &mut impl FnMut(Id) -> Option<Revision>,
+        evicted: &mut Vec<Id>,
+    ) {
+        self.state.epoch = self.state.epoch.wrapping_add(1);
+        self.current_epoch
+            .store(self.state.epoch, Ordering::Relaxed);
+
+        if self.state.epoch >= GHOST_HORIZON {
+            let expired_epoch = self.state.epoch - GHOST_HORIZON;
+            let slot = expired_epoch % GHOST_HORIZON;
+            let refaults = self.refaults_by_epoch[slot].swap(0, Ordering::Relaxed);
+            let evictions = std::mem::take(&mut self.state.evictions_by_epoch[slot]);
+            self.state.controller.observe(evictions, refaults);
+        }
+
+        let bucket = self.state.epoch & (WHEEL_SIZE - 1);
+        let due = std::mem::take(&mut self.state.wheel[bucket]);
+        for mut resident in due {
+            let Some(verified_at) = last_verified_at(resident.id) else {
+                self.state.resident_count = self.state.resident_count.saturating_sub(1);
+                continue;
+            };
+
+            if verified_at > resident.observed_at {
+                resident.observed_at = verified_at;
+                resident.generation = resident.generation.saturating_add(1).min(GENERATIONS - 1);
+                resident.cold_strikes = 0;
+                let delay = self.state.controller.inspection_delay(resident.generation);
+                self.state.schedule(resident, delay);
+                continue;
+            }
+
+            if resident.generation > 0 {
+                resident.generation -= 1;
+                resident.cold_strikes = 0;
+                let delay = self.state.controller.inspection_delay(resident.generation);
+                self.state.schedule(resident, delay);
+                continue;
+            }
+
+            resident.cold_strikes += 1;
+            self.state.controller.initialize();
+            if resident.cold_strikes < self.state.controller.cold_strikes {
+                self.state.schedule(resident, 1);
+                continue;
+            }
+
+            self.ghosts
+                .record(resident.id, self.state.epoch, resident.generation);
+            self.state.evictions_by_epoch[self.state.epoch % GHOST_HORIZON] += 1;
+            self.state.resident_count = self.state.resident_count.saturating_sub(1);
+            evicted.push(resident.id);
+        }
     }
 }
 
 impl EvictionPolicy for Lru {
-    fn new(cap: usize) -> Self {
-        Self {
-            capacity: NonZeroUsize::new(cap),
-            set: Mutex::default(),
-        }
+    fn new(activation_floor: usize) -> Self {
+        static SHARDS: OnceLock<usize> = OnceLock::new();
+        let shards = *SHARDS.get_or_init(|| {
+            let parallelism = std::thread::available_parallelism()
+                .map(usize::from)
+                .unwrap_or(1);
+            (parallelism * 4).next_power_of_two()
+        });
+
+        Self::with_shards(activation_floor, shards)
     }
 
     #[inline(always)]
     fn admit(&self, id: Id) {
-        if self.capacity.is_some() {
-            self.insert(id);
+        if self.activation_floor.is_none() {
+            return;
         }
+
+        let epoch = self.current_epoch.load(Ordering::Relaxed);
+        let generation = self
+            .ghosts
+            .refault(id, epoch)
+            .map(|(generation, eviction_epoch)| {
+                self.refaults_by_epoch[eviction_epoch % GHOST_HORIZON]
+                    .fetch_add(1, Ordering::Relaxed);
+                generation.saturating_add(1).min(GENERATIONS - 1)
+            })
+            .unwrap_or(0);
+        self.admissions[self.shard(id)]
+            .lock()
+            .push(Admission { id, generation });
     }
 
     #[inline(always)]
-    fn promote(&self, id: Id) {
-        if self.capacity.is_some() {
-            self.insert(id);
-        }
-    }
+    fn promote(&self, _id: Id) {}
 
-    fn set_capacity(&mut self, capacity: usize) {
-        self.capacity = NonZeroUsize::new(capacity);
-        if self.capacity.is_none() {
-            self.set.get_mut().clear();
-        }
-    }
-
-    fn for_each_evicted(&mut self, mut cb: impl FnMut(Id)) {
-        let Some(cap) = self.capacity else {
-            return;
-        };
-        let set = self.set.get_mut();
-        while set.len() > cap.get() {
-            if let Some(id) = set.pop_front() {
-                cb(id);
+    fn set_capacity(&mut self, activation_floor: usize) {
+        self.activation_floor = NonZeroUsize::new(activation_floor);
+        if self.activation_floor.is_none() {
+            for admissions in &mut self.admissions {
+                admissions.get_mut().clear();
             }
+            self.state = State::new(0);
+            self.current_epoch.store(0, Ordering::Relaxed);
+            self.ghosts.clear();
+            for refaults in &mut self.refaults_by_epoch {
+                *refaults.get_mut() = 0;
+            }
+        } else {
+            self.state.next_collection = activation_floor;
         }
+    }
+
+    fn evict(&mut self, mut last_verified_at: impl FnMut(Id) -> Option<Revision>) -> Vec<Id> {
+        let Some(activation_floor) = self.activation_floor.map(NonZeroUsize::get) else {
+            return Vec::new();
+        };
+
+        self.drain_admissions(&mut last_verified_at);
+        if self.state.resident_count < self.state.next_collection {
+            return Vec::new();
+        }
+
+        let mut evicted = Vec::new();
+        self.advance_epoch(&mut last_verified_at, &mut evicted);
+        self.state.update_collection_target(activation_floor);
+        evicted
     }
 }
 
 impl HasCapacity for Lru {}
+
+struct GhostSketch {
+    slots: Box<[AtomicU64]>,
+}
+
+impl GhostSketch {
+    const VALID: u64 = 1 << 63;
+    const EPOCH_MASK: usize = (1 << 24) - 1;
+
+    fn new(activation_floor: usize) -> Self {
+        let len = activation_floor
+            .saturating_mul(4)
+            .clamp(256, 65_536)
+            .next_power_of_two();
+        Self {
+            slots: (0..len).map(|_| AtomicU64::new(0)).collect(),
+        }
+    }
+
+    fn clear(&mut self) {
+        for slot in &mut self.slots {
+            *slot.get_mut() = 0;
+        }
+    }
+
+    fn record(&self, id: Id, epoch: usize, generation: u8) {
+        let hash = hash(id);
+        let fingerprint = (hash >> 32) as u32 | 1;
+        let packed = Self::VALID
+            | u64::from(fingerprint)
+            | (((epoch & Self::EPOCH_MASK) as u64) << 32)
+            | (u64::from(generation) << 56);
+        self.slots[hash as usize & (self.slots.len() - 1)].store(packed, Ordering::Relaxed);
+    }
+
+    fn refault(&self, id: Id, current_epoch: usize) -> Option<(u8, usize)> {
+        let hash = hash(id);
+        let packed = self.slots[hash as usize & (self.slots.len() - 1)].load(Ordering::Relaxed);
+        let fingerprint = (hash >> 32) as u32 | 1;
+        if packed & Self::VALID == 0 || packed as u32 != fingerprint {
+            return None;
+        }
+
+        let eviction_epoch = ((packed >> 32) as usize) & Self::EPOCH_MASK;
+        let age =
+            (current_epoch & Self::EPOCH_MASK).wrapping_sub(eviction_epoch) & Self::EPOCH_MASK;
+        if age >= GHOST_HORIZON {
+            return None;
+        }
+
+        Some((((packed >> 56) & 0x7f) as u8, eviction_epoch))
+    }
+}
+
+#[inline]
+fn hash(id: Id) -> u64 {
+    let mut value = id.as_bits();
+    value ^= value >> 30;
+    value = value.wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value ^= value >> 27;
+    value = value.wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+#[cfg(all(test, not(feature = "shuttle")))]
+mod tests {
+    use super::*;
+
+    fn id(index: u32) -> Id {
+        // SAFETY: Test indices are all below `Id::MAX_U32`.
+        unsafe { Id::from_index(index) }
+    }
+
+    fn revisions(entries: &[(Id, Revision)]) -> impl FnMut(Id) -> Option<Revision> + '_ {
+        |id| {
+            entries
+                .iter()
+                .find_map(|&(candidate, revision)| (candidate == id).then_some(revision))
+        }
+    }
+
+    #[test]
+    fn cold_resident_requires_multiple_collection_epochs() {
+        let mut lru = Lru::with_shards(1, 2);
+        let cold = id(0);
+        let trigger1 = id(1);
+        let trigger2 = id(2);
+        let revision = Revision::start();
+
+        lru.admit(cold);
+        assert_eq!(lru.evict(revisions(&[(cold, revision)])), []);
+
+        lru.admit(trigger1);
+        assert_eq!(
+            lru.evict(revisions(&[(cold, revision), (trigger1, revision)])),
+            []
+        );
+
+        lru.admit(trigger2);
+        assert_eq!(
+            lru.evict(revisions(&[
+                (cold, revision),
+                (trigger1, revision),
+                (trigger2, revision),
+            ])),
+            [cold]
+        );
+    }
+
+    #[test]
+    fn reuse_promotes_a_resident() {
+        let mut lru = Lru::with_shards(1, 2);
+        let reused = id(0);
+        let trigger1 = id(1);
+        let trigger2 = id(2);
+
+        lru.admit(reused);
+        assert_eq!(lru.evict(revisions(&[(reused, Revision::start())])), []);
+
+        lru.admit(trigger1);
+        assert_eq!(
+            lru.evict(revisions(&[
+                (reused, Revision::from(2)),
+                (trigger1, Revision::start()),
+            ])),
+            []
+        );
+
+        lru.admit(trigger2);
+        assert_eq!(
+            lru.evict(revisions(&[
+                (reused, Revision::from(2)),
+                (trigger1, Revision::start()),
+                (trigger2, Revision::start()),
+            ])),
+            []
+        );
+    }
+
+    #[test]
+    fn refault_feedback_increases_retention() {
+        let mut controller = AdaptiveController::default();
+        controller.observe(100, 20);
+
+        assert_eq!(controller.nursery_grace, 3);
+        assert_eq!(controller.cold_strikes, 3);
+    }
+
+    #[test]
+    fn ghost_sketch_recognizes_recent_eviction() {
+        let ghosts = GhostSketch::new(1);
+        let id = id(0);
+        ghosts.record(id, 4, 2);
+
+        assert_eq!(ghosts.refault(id, 5), Some((2, 4)));
+        assert_eq!(ghosts.refault(id, 12), None);
+    }
+
+    #[test]
+    fn hashes_strided_ids_across_admission_shards() {
+        let lru = Lru::with_shards(1, 64);
+        let mut shard_counts = [0; 64];
+
+        for index in (0..64 * 4096).step_by(64) {
+            shard_counts[lru.shard(id(index))] += 1;
+        }
+
+        let min = shard_counts.into_iter().min().unwrap();
+        let max = shard_counts.into_iter().max().unwrap();
+        assert!(max - min <= 8, "{shard_counts:?}");
+    }
+
+    #[test]
+    fn preserves_admission_capacity_between_revisions() {
+        let mut lru = Lru::with_shards(1, 2);
+        let candidate = id(0);
+        let shard = lru.shard(candidate);
+        let revision = Revision::start();
+
+        lru.admit(candidate);
+        let capacity = lru.admissions[shard].get_mut().capacity();
+        assert!(capacity > 0);
+
+        assert_eq!(lru.evict(revisions(&[(candidate, revision)])), []);
+        assert_eq!(lru.admissions[shard].get_mut().capacity(), capacity);
+    }
+}

--- a/src/function/eviction/lru.rs
+++ b/src/function/eviction/lru.rs
@@ -1,8 +1,8 @@
 //! Adaptive generational eviction for memoized values.
 //!
-//! Values are tracked outside the memo in a timing wheel. Query fetches do not
+//! Values are tracked outside the memo in timing wheels. Query fetches do not
 //! touch the policy: reuse is detected lazily from the memo's existing
-//! `verified_at` revision when a resident becomes due for inspection.
+//! `verified_at` revision when a value becomes due for inspection.
 
 use std::collections::VecDeque;
 use std::hash::BuildHasher;
@@ -17,11 +17,21 @@ use crate::{Id, Revision};
 
 use super::{EvictionPolicy, HasCapacity};
 
-const GENERATIONS: u8 = 4;
+const RESIDENT_GENERATIONS: u8 = 3;
 const WHEEL_SIZE: usize = 64;
-const GHOST_HORIZON: usize = 8;
+const PROBATION_DELAY: usize = 16;
+const RESIDENT_BASE_DELAY: usize = 24;
+const RESIDENT_DELAY_STEP: usize = 16;
+const GHOST_HORIZON: usize = 64;
+const FEEDBACK_HORIZON: usize = 8;
 const MIN_ADAPTIVE_SAMPLE: usize = 32;
 const TARGET_BACKLOG_REVISIONS: usize = 8;
+const PROBATION_ADMISSION: u8 = u8::MAX;
+const _: () = assert!(PROBATION_DELAY < WHEEL_SIZE);
+const _: () = assert!(
+    RESIDENT_BASE_DELAY + (RESIDENT_GENERATIONS as usize - 1) * RESIDENT_DELAY_STEP + 7
+        < WHEEL_SIZE
+);
 
 /// An adaptive generational collector selected by the existing `lru` option.
 ///
@@ -35,13 +45,20 @@ pub struct Lru {
     state: State,
     current_epoch: AtomicUsize,
     ghosts: GhostSketch,
-    refaults_by_epoch: [AtomicUsize; GHOST_HORIZON],
+    refaults_by_epoch: [AtomicUsize; FEEDBACK_HORIZON],
 }
 
 #[derive(Clone, Copy)]
 struct Admission {
     id: Id,
+    /// `PROBATION_ADMISSION` for first-time admissions; otherwise the resident
+    /// generation to restore after a refault.
     generation: u8,
+}
+
+struct Probation {
+    id: Id,
+    observed_at: Revision,
 }
 
 struct Resident {
@@ -52,78 +69,139 @@ struct Resident {
 }
 
 struct State {
-    wheel: [Vec<Resident>; WHEEL_SIZE],
+    probation_cohorts: VecDeque<ProbationCohort>,
+    resident_wheel: [Vec<Resident>; WHEEL_SIZE],
     /// Due buckets detached from the wheel so advancing the clock never has to
     /// process an entire cohort in one revision.
-    due_cohorts: VecDeque<Vec<Resident>>,
+    due_cohorts: VecDeque<DueCohort>,
     /// Empty cohort allocations retained for reuse by wheel buckets.
-    spare_buffers: Vec<Vec<Resident>>,
+    spare_probation_buffers: Vec<Vec<Probation>>,
+    spare_resident_buffers: Vec<Vec<Resident>>,
     due_count: usize,
     epoch: usize,
-    resident_count: usize,
+    entry_count: usize,
     next_admission_shard: usize,
-    evictions_by_epoch: [usize; GHOST_HORIZON],
+    evictions_by_epoch: [usize; FEEDBACK_HORIZON],
     controller: AdaptiveController,
+}
+
+struct ProbationCohort {
+    due_epoch: usize,
+    entries: Vec<Probation>,
+}
+
+enum DueCohort {
+    Probation(Vec<Probation>),
+    Resident(Vec<Resident>),
+}
+
+enum DueEntry {
+    Probation(Probation),
+    Resident(Resident),
 }
 
 impl State {
     fn new() -> Self {
         Self {
-            wheel: std::array::from_fn(|_| Vec::new()),
+            probation_cohorts: VecDeque::new(),
+            resident_wheel: std::array::from_fn(|_| Vec::new()),
             due_cohorts: VecDeque::new(),
-            spare_buffers: Vec::new(),
+            spare_probation_buffers: Vec::new(),
+            spare_resident_buffers: Vec::new(),
             due_count: 0,
             epoch: 0,
-            resident_count: 0,
+            entry_count: 0,
             next_admission_shard: 0,
-            evictions_by_epoch: [0; GHOST_HORIZON],
+            evictions_by_epoch: [0; FEEDBACK_HORIZON],
             controller: AdaptiveController::default(),
         }
     }
 
-    fn schedule(&mut self, resident: Resident, delay: usize) {
-        debug_assert!(delay < WHEEL_SIZE);
-        let bucket = self.epoch.wrapping_add(delay) & (WHEEL_SIZE - 1);
-        if self.wheel[bucket].capacity() == 0 {
-            if let Some(buffer) = self.spare_buffers.pop() {
-                self.wheel[bucket] = buffer;
-            }
-        }
-        self.wheel[bucket].push(resident);
-    }
-
-    fn queue_due_bucket(&mut self) {
-        let bucket = self.epoch & (WHEEL_SIZE - 1);
-        if self.wheel[bucket].is_empty() {
+    fn schedule_probation(&mut self, probation: Probation) {
+        let due_epoch = self.epoch.wrapping_add(PROBATION_DELAY);
+        if let Some(cohort) = self
+            .probation_cohorts
+            .back_mut()
+            .filter(|cohort| cohort.due_epoch == due_epoch)
+        {
+            cohort.entries.push(probation);
             return;
         }
 
-        let due = std::mem::take(&mut self.wheel[bucket]);
-        self.due_count += due.len();
-        self.due_cohorts.push_back(due);
+        let mut entries = self.spare_probation_buffers.pop().unwrap_or_default();
+        entries.push(probation);
+        self.probation_cohorts
+            .push_back(ProbationCohort { due_epoch, entries });
     }
 
-    fn pop_due(&mut self) -> Option<Resident> {
-        loop {
-            if let Some(resident) = self.due_cohorts.front_mut()?.pop() {
-                self.due_count -= 1;
+    fn schedule_resident(&mut self, resident: Resident, delay: usize) {
+        debug_assert!(delay < WHEEL_SIZE);
+        let bucket = self.epoch.wrapping_add(delay) & (WHEEL_SIZE - 1);
+        if self.resident_wheel[bucket].capacity() == 0 {
+            if let Some(buffer) = self.spare_resident_buffers.pop() {
+                self.resident_wheel[bucket] = buffer;
+            }
+        }
+        self.resident_wheel[bucket].push(resident);
+    }
 
-                if self.due_cohorts.front().is_some_and(Vec::is_empty) {
+    fn queue_due_bucket(&mut self) {
+        while self
+            .probation_cohorts
+            .front()
+            .is_some_and(|cohort| cohort.due_epoch == self.epoch)
+        {
+            let cohort = self.probation_cohorts.pop_front().unwrap();
+            self.due_count += cohort.entries.len();
+            self.due_cohorts
+                .push_back(DueCohort::Probation(cohort.entries));
+        }
+
+        let bucket = self.epoch & (WHEEL_SIZE - 1);
+        if !self.resident_wheel[bucket].is_empty() {
+            let due = std::mem::take(&mut self.resident_wheel[bucket]);
+            self.due_count += due.len();
+            self.due_cohorts.push_back(DueCohort::Resident(due));
+        }
+    }
+
+    fn pop_due(&mut self) -> Option<DueEntry> {
+        loop {
+            let entry = match self.due_cohorts.front_mut()? {
+                DueCohort::Probation(probations) => probations.pop().map(DueEntry::Probation),
+                DueCohort::Resident(residents) => residents.pop().map(DueEntry::Resident),
+            };
+
+            if let Some(entry) = entry {
+                self.due_count -= 1;
+                if self.front_cohort_is_empty() {
                     self.recycle_front_cohort();
                 }
-
-                return Some(resident);
+                return Some(entry);
             }
 
             self.recycle_front_cohort();
         }
     }
 
+    fn front_cohort_is_empty(&self) -> bool {
+        self.due_cohorts.front().is_some_and(|cohort| match cohort {
+            DueCohort::Probation(probations) => probations.is_empty(),
+            DueCohort::Resident(residents) => residents.is_empty(),
+        })
+    }
+
     fn recycle_front_cohort(&mut self) {
-        if let Some(buffer) = self.due_cohorts.pop_front() {
-            if self.spare_buffers.len() < WHEEL_SIZE {
-                self.spare_buffers.push(buffer);
+        match self.due_cohorts.pop_front() {
+            Some(DueCohort::Probation(buffer))
+                if self.spare_probation_buffers.len() < WHEEL_SIZE =>
+            {
+                self.spare_probation_buffers.push(buffer);
             }
+            Some(DueCohort::Resident(buffer)) if self.spare_resident_buffers.len() < WHEEL_SIZE => {
+                self.spare_resident_buffers.push(buffer);
+            }
+            _ => {}
         }
     }
 
@@ -136,7 +214,7 @@ impl State {
 
 #[derive(Default)]
 struct AdaptiveController {
-    nursery_grace: u8,
+    retention_bonus: u8,
     cold_strikes: u8,
     sampled_evictions: usize,
     sampled_refaults: usize,
@@ -144,8 +222,7 @@ struct AdaptiveController {
 
 impl AdaptiveController {
     fn initialize(&mut self) {
-        if self.nursery_grace == 0 {
-            self.nursery_grace = 2;
+        if self.cold_strikes == 0 {
             self.cold_strikes = 2;
         }
     }
@@ -159,10 +236,10 @@ impl AdaptiveController {
         }
 
         if self.sampled_refaults.saturating_mul(10) > self.sampled_evictions {
-            self.nursery_grace = self.nursery_grace.saturating_add(1).min(8);
+            self.retention_bonus = self.retention_bonus.saturating_add(1).min(7);
             self.cold_strikes = self.cold_strikes.saturating_add(1).min(4);
         } else if self.sampled_refaults.saturating_mul(100) < self.sampled_evictions {
-            self.nursery_grace = self.nursery_grace.saturating_sub(1).max(2);
+            self.retention_bonus = self.retention_bonus.saturating_sub(1);
             self.cold_strikes = self.cold_strikes.saturating_sub(1).max(2);
         }
 
@@ -172,11 +249,10 @@ impl AdaptiveController {
 
     fn inspection_delay(&mut self, generation: u8) -> usize {
         self.initialize();
-        if generation == 0 {
-            usize::from(self.nursery_grace)
-        } else {
-            usize::from(self.nursery_grace) + (1usize << generation)
-        }
+        debug_assert!(generation < RESIDENT_GENERATIONS);
+        RESIDENT_BASE_DELAY
+            + usize::from(generation) * RESIDENT_DELAY_STEP
+            + usize::from(self.retention_bonus)
     }
 }
 
@@ -224,17 +300,24 @@ impl Lru {
                     continue;
                 };
 
-                let delay = self.state.controller.inspection_delay(admission.generation);
-                self.state.schedule(
-                    Resident {
+                if admission.generation == PROBATION_ADMISSION {
+                    self.state.schedule_probation(Probation {
                         id: admission.id,
                         observed_at,
-                        generation: admission.generation,
-                        cold_strikes: 0,
-                    },
-                    delay,
-                );
-                self.state.resident_count += 1;
+                    });
+                } else {
+                    let delay = self.state.controller.inspection_delay(admission.generation);
+                    self.state.schedule_resident(
+                        Resident {
+                            id: admission.id,
+                            observed_at,
+                            generation: admission.generation,
+                            cold_strikes: 0,
+                        },
+                        delay,
+                    );
+                }
+                self.state.entry_count += 1;
             }
             self.state.next_admission_shard =
                 (self.state.next_admission_shard + 1) & (admissions.len() - 1);
@@ -256,9 +339,9 @@ impl Lru {
         self.current_epoch
             .store(self.state.epoch, Ordering::Relaxed);
 
-        if self.state.epoch >= GHOST_HORIZON {
-            let expired_epoch = self.state.epoch - GHOST_HORIZON;
-            let slot = expired_epoch % GHOST_HORIZON;
+        if self.state.epoch >= FEEDBACK_HORIZON {
+            let expired_epoch = self.state.epoch - FEEDBACK_HORIZON;
+            let slot = expired_epoch % FEEDBACK_HORIZON;
             let refaults = self.refaults_by_epoch[slot].swap(0, Ordering::Relaxed);
             let evictions = std::mem::take(&mut self.state.evictions_by_epoch[slot]);
             self.state.controller.observe(evictions, refaults);
@@ -267,44 +350,95 @@ impl Lru {
         self.state.queue_due_bucket();
         let budget = self.state.maintenance_budget(maintenance_floor);
         for _ in 0..budget {
-            let Some(mut resident) = self.state.pop_due() else {
+            let Some(entry) = self.state.pop_due() else {
                 break;
             };
-            let Some(verified_at) = last_verified_at(resident.id) else {
-                self.state.resident_count = self.state.resident_count.saturating_sub(1);
-                continue;
-            };
-
-            if verified_at > resident.observed_at {
-                resident.observed_at = verified_at;
-                resident.generation = resident.generation.saturating_add(1).min(GENERATIONS - 1);
-                resident.cold_strikes = 0;
-                let delay = self.state.controller.inspection_delay(resident.generation);
-                self.state.schedule(resident, delay);
-                continue;
+            match entry {
+                DueEntry::Probation(probation) => {
+                    self.inspect_probation(probation, last_verified_at, evicted);
+                }
+                DueEntry::Resident(resident) => {
+                    self.inspect_resident(resident, last_verified_at, evicted);
+                }
             }
-
-            if resident.generation > 0 {
-                resident.generation -= 1;
-                resident.cold_strikes = 0;
-                let delay = self.state.controller.inspection_delay(resident.generation);
-                self.state.schedule(resident, delay);
-                continue;
-            }
-
-            resident.cold_strikes += 1;
-            self.state.controller.initialize();
-            if resident.cold_strikes < self.state.controller.cold_strikes {
-                self.state.schedule(resident, 1);
-                continue;
-            }
-
-            self.ghosts
-                .record(resident.id, self.state.epoch, resident.generation);
-            self.state.evictions_by_epoch[self.state.epoch % GHOST_HORIZON] += 1;
-            self.state.resident_count = self.state.resident_count.saturating_sub(1);
-            evicted.push(resident.id);
         }
+    }
+
+    fn inspect_probation(
+        &mut self,
+        probation: Probation,
+        last_verified_at: &mut impl FnMut(Id) -> Option<Revision>,
+        evicted: &mut Vec<Id>,
+    ) {
+        let Some(verified_at) = last_verified_at(probation.id) else {
+            self.state.entry_count = self.state.entry_count.saturating_sub(1);
+            return;
+        };
+
+        if verified_at > probation.observed_at {
+            let generation = 0;
+            let delay = self.state.controller.inspection_delay(generation);
+            self.state.schedule_resident(
+                Resident {
+                    id: probation.id,
+                    observed_at: verified_at,
+                    generation,
+                    cold_strikes: 0,
+                },
+                delay,
+            );
+        } else {
+            self.record_eviction(probation.id, 0, evicted);
+        }
+    }
+
+    fn inspect_resident(
+        &mut self,
+        mut resident: Resident,
+        last_verified_at: &mut impl FnMut(Id) -> Option<Revision>,
+        evicted: &mut Vec<Id>,
+    ) {
+        let Some(verified_at) = last_verified_at(resident.id) else {
+            self.state.entry_count = self.state.entry_count.saturating_sub(1);
+            return;
+        };
+
+        if verified_at > resident.observed_at {
+            resident.observed_at = verified_at;
+            resident.generation = resident
+                .generation
+                .saturating_add(1)
+                .min(RESIDENT_GENERATIONS - 1);
+            resident.cold_strikes = 0;
+            let delay = self.state.controller.inspection_delay(resident.generation);
+            self.state.schedule_resident(resident, delay);
+            return;
+        }
+
+        if resident.generation > 0 {
+            resident.generation -= 1;
+            resident.cold_strikes = 0;
+            let delay = self.state.controller.inspection_delay(resident.generation);
+            self.state.schedule_resident(resident, delay);
+            return;
+        }
+
+        resident.cold_strikes += 1;
+        self.state.controller.initialize();
+        if resident.cold_strikes < self.state.controller.cold_strikes {
+            self.state.schedule_resident(resident, 1);
+            return;
+        }
+
+        self.record_eviction(resident.id, 1, evicted);
+    }
+
+    fn record_eviction(&mut self, id: Id, return_generation: u8, evicted: &mut Vec<Id>) {
+        debug_assert!(return_generation < RESIDENT_GENERATIONS);
+        self.ghosts.record(id, self.state.epoch, return_generation);
+        self.state.evictions_by_epoch[self.state.epoch % FEEDBACK_HORIZON] += 1;
+        self.state.entry_count = self.state.entry_count.saturating_sub(1);
+        evicted.push(id);
     }
 }
 
@@ -331,12 +465,11 @@ impl EvictionPolicy for Lru {
         let generation = self
             .ghosts
             .refault(id, epoch)
-            .map(|(generation, eviction_epoch)| {
-                self.refaults_by_epoch[eviction_epoch % GHOST_HORIZON]
-                    .fetch_add(1, Ordering::Relaxed);
-                generation.saturating_add(1).min(GENERATIONS - 1)
+            .map(|(return_generation, _eviction_epoch)| {
+                self.refaults_by_epoch[epoch % FEEDBACK_HORIZON].fetch_add(1, Ordering::Relaxed);
+                return_generation
             })
-            .unwrap_or(0);
+            .unwrap_or(PROBATION_ADMISSION);
         self.admissions[self.shard(id)]
             .lock()
             .push(Admission { id, generation });
@@ -366,7 +499,7 @@ impl EvictionPolicy for Lru {
         };
 
         self.drain_admissions(&mut last_verified_at);
-        if self.state.resident_count == 0 {
+        if self.state.entry_count == 0 {
             return Vec::new();
         }
 
@@ -402,13 +535,13 @@ impl GhostSketch {
         }
     }
 
-    fn record(&self, id: Id, epoch: usize, generation: u8) {
+    fn record(&self, id: Id, epoch: usize, return_generation: u8) {
         let hash = hash(id);
         let fingerprint = (hash >> 32) as u32 | 1;
         let packed = Self::VALID
             | u64::from(fingerprint)
             | (((epoch & Self::EPOCH_MASK) as u64) << 32)
-            | (u64::from(generation) << 56);
+            | (u64::from(return_generation) << 56);
         self.slots[hash as usize & (self.slots.len() - 1)].store(packed, Ordering::Relaxed);
     }
 
@@ -459,28 +592,87 @@ mod tests {
     }
 
     #[test]
-    fn cold_resident_ages_without_new_admissions() {
+    fn probation_is_more_compact_than_a_resident() {
+        assert!(std::mem::size_of::<Probation>() < std::mem::size_of::<Resident>());
+    }
+
+    #[test]
+    fn cold_probation_ages_without_new_admissions() {
         let mut lru = Lru::with_shards(1, 2);
         let cold = id(0);
         let revision = Revision::start();
 
         lru.admit(cold);
-        assert_eq!(lru.evict(revisions(&[(cold, revision)])), []);
-        assert_eq!(lru.evict(revisions(&[(cold, revision)])), []);
+        for _ in 1..PROBATION_DELAY {
+            assert_eq!(lru.evict(revisions(&[(cold, revision)])), []);
+        }
         assert_eq!(lru.evict(revisions(&[(cold, revision)])), [cold]);
     }
 
     #[test]
-    fn reuse_promotes_a_resident() {
+    fn reused_probation_promotes_through_three_resident_generations() {
         let mut lru = Lru::with_shards(1, 2);
         let reused = id(0);
 
         lru.admit(reused);
         assert_eq!(lru.evict(revisions(&[(reused, Revision::start())])), []);
-        assert_eq!(lru.evict(revisions(&[(reused, Revision::from(2))])), []);
-        for _ in 0..4 {
+        for _ in 1..PROBATION_DELAY {
             assert_eq!(lru.evict(revisions(&[(reused, Revision::from(2))])), []);
         }
+        assert_eq!(scheduled_generation(&lru, reused), Some(0));
+
+        for _ in 0..RESIDENT_BASE_DELAY {
+            assert_eq!(lru.evict(revisions(&[(reused, Revision::from(3))])), []);
+        }
+        assert_eq!(scheduled_generation(&lru, reused), Some(1));
+
+        for _ in 0..RESIDENT_BASE_DELAY + RESIDENT_DELAY_STEP {
+            assert_eq!(lru.evict(revisions(&[(reused, Revision::from(4))])), []);
+        }
+        assert_eq!(scheduled_generation(&lru, reused), Some(2));
+
+        for _ in 0..RESIDENT_BASE_DELAY + 2 * RESIDENT_DELAY_STEP {
+            assert_eq!(lru.evict(revisions(&[(reused, Revision::from(5))])), []);
+        }
+        assert_eq!(scheduled_generation(&lru, reused), Some(2));
+    }
+
+    #[test]
+    fn cold_tenured_resident_demotes_before_eviction() {
+        let mut lru = Lru::with_shards(1, 2);
+        let cold = id(0);
+        let revision = Revision::start();
+        lru.state.schedule_resident(
+            Resident {
+                id: cold,
+                observed_at: revision,
+                generation: 2,
+                cold_strikes: 0,
+            },
+            1,
+        );
+        lru.state.entry_count = 1;
+
+        assert_eq!(lru.evict(revisions(&[(cold, revision)])), []);
+        assert_eq!(scheduled_generation(&lru, cold), Some(1));
+
+        for _ in 0..RESIDENT_BASE_DELAY + RESIDENT_DELAY_STEP {
+            assert_eq!(lru.evict(revisions(&[(cold, revision)])), []);
+        }
+        assert_eq!(scheduled_generation(&lru, cold), Some(0));
+
+        for _ in 0..RESIDENT_BASE_DELAY {
+            assert_eq!(lru.evict(revisions(&[(cold, revision)])), []);
+        }
+        assert_eq!(lru.evict(revisions(&[(cold, revision)])), [cold]);
+    }
+
+    fn scheduled_generation(lru: &Lru, id: Id) -> Option<u8> {
+        lru.state
+            .resident_wheel
+            .iter()
+            .flatten()
+            .find_map(|resident| (resident.id == id).then_some(resident.generation))
     }
 
     #[test]
@@ -494,12 +686,14 @@ mod tests {
             lru.admit(id);
         }
 
-        assert_eq!(lru.evict(revisions(&entries)), []);
-        assert_eq!(lru.state.due_count, 0);
+        for _ in 1..PROBATION_DELAY {
+            assert_eq!(lru.evict(revisions(&entries)), []);
+            assert_eq!(lru.state.due_count, 0);
+        }
 
-        assert_eq!(lru.evict(revisions(&entries)), []);
+        assert_eq!(lru.evict(revisions(&entries)).len(), 4);
         assert_eq!(lru.state.due_count, 28);
-        assert_eq!(lru.state.resident_count, 32);
+        assert_eq!(lru.state.entry_count, 28);
     }
 
     #[test]
@@ -515,9 +709,11 @@ mod tests {
         }
 
         assert!(
-            lru.state.resident_count < ADMISSIONS_PER_REVISION as usize * 32,
-            "cold resident set did not converge: {}",
-            lru.state.resident_count
+            lru.state.entry_count
+                < ADMISSIONS_PER_REVISION as usize
+                    * (PROBATION_DELAY + TARGET_BACKLOG_REVISIONS + 4),
+            "cold entry set did not converge: {}",
+            lru.state.entry_count
         );
     }
 
@@ -526,7 +722,7 @@ mod tests {
         let mut controller = AdaptiveController::default();
         controller.observe(100, 20);
 
-        assert_eq!(controller.nursery_grace, 3);
+        assert_eq!(controller.retention_bonus, 1);
         assert_eq!(controller.cold_strikes, 3);
     }
 
@@ -537,7 +733,31 @@ mod tests {
         ghosts.record(id, 4, 2);
 
         assert_eq!(ghosts.refault(id, 5), Some((2, 4)));
-        assert_eq!(ghosts.refault(id, 12), None);
+        assert_eq!(ghosts.refault(id, 67), Some((2, 4)));
+        assert_eq!(ghosts.refault(id, 68), None);
+    }
+
+    #[test]
+    fn a_probation_refault_bypasses_probation() {
+        let mut lru = Lru::with_shards(1, 2);
+        let candidate = id(0);
+        let revision = Revision::start();
+
+        lru.admit(candidate);
+        for _ in 1..PROBATION_DELAY {
+            assert_eq!(lru.evict(revisions(&[(candidate, revision)])), []);
+        }
+        assert_eq!(lru.evict(revisions(&[(candidate, revision)])), [candidate]);
+
+        lru.admit(candidate);
+        assert_eq!(
+            lru.admissions[lru.shard(candidate)]
+                .get_mut()
+                .last()
+                .unwrap()
+                .generation,
+            0
+        );
     }
 
     #[test]

--- a/src/function/eviction/lru.rs
+++ b/src/function/eviction/lru.rs
@@ -4,6 +4,7 @@
 //! touch the policy: reuse is detected lazily from the memo's existing
 //! `verified_at` revision when a resident becomes due for inspection.
 
+use std::collections::VecDeque;
 use std::hash::BuildHasher;
 use std::num::NonZeroUsize;
 
@@ -20,13 +21,14 @@ const GENERATIONS: u8 = 4;
 const WHEEL_SIZE: usize = 64;
 const GHOST_HORIZON: usize = 8;
 const MIN_ADAPTIVE_SAMPLE: usize = 32;
+const TARGET_BACKLOG_REVISIONS: usize = 8;
 
 /// An adaptive generational collector selected by the existing `lru` option.
 ///
-/// The configured value is an activation and minimum growth threshold, not a
+/// The configured value is a minimum per-revision maintenance budget, not a
 /// hard resident-value limit.
 pub struct Lru {
-    activation_floor: Option<NonZeroUsize>,
+    maintenance_floor: Option<NonZeroUsize>,
     hasher: FxBuildHasher,
     shift: u32,
     admissions: Box<[CachePadded<Mutex<Vec<Admission>>>]>,
@@ -51,21 +53,28 @@ struct Resident {
 
 struct State {
     wheel: [Vec<Resident>; WHEEL_SIZE],
+    /// Due buckets detached from the wheel so advancing the clock never has to
+    /// process an entire cohort in one revision.
+    due_cohorts: VecDeque<Vec<Resident>>,
+    /// Empty cohort allocations retained for reuse by wheel buckets.
+    spare_buffers: Vec<Vec<Resident>>,
+    due_count: usize,
     epoch: usize,
     resident_count: usize,
-    next_collection: usize,
     next_admission_shard: usize,
     evictions_by_epoch: [usize; GHOST_HORIZON],
     controller: AdaptiveController,
 }
 
 impl State {
-    fn new(activation_floor: usize) -> Self {
+    fn new() -> Self {
         Self {
             wheel: std::array::from_fn(|_| Vec::new()),
+            due_cohorts: VecDeque::new(),
+            spare_buffers: Vec::new(),
+            due_count: 0,
             epoch: 0,
             resident_count: 0,
-            next_collection: activation_floor,
             next_admission_shard: 0,
             evictions_by_epoch: [0; GHOST_HORIZON],
             controller: AdaptiveController::default(),
@@ -73,13 +82,55 @@ impl State {
     }
 
     fn schedule(&mut self, resident: Resident, delay: usize) {
+        debug_assert!(delay < WHEEL_SIZE);
         let bucket = self.epoch.wrapping_add(delay) & (WHEEL_SIZE - 1);
+        if self.wheel[bucket].capacity() == 0 {
+            if let Some(buffer) = self.spare_buffers.pop() {
+                self.wheel[bucket] = buffer;
+            }
+        }
         self.wheel[bucket].push(resident);
     }
 
-    fn update_collection_target(&mut self, activation_floor: usize) {
-        let growth = (self.resident_count / 2).max(activation_floor);
-        self.next_collection = self.resident_count.saturating_add(growth);
+    fn queue_due_bucket(&mut self) {
+        let bucket = self.epoch & (WHEEL_SIZE - 1);
+        if self.wheel[bucket].is_empty() {
+            return;
+        }
+
+        let due = std::mem::take(&mut self.wheel[bucket]);
+        self.due_count += due.len();
+        self.due_cohorts.push_back(due);
+    }
+
+    fn pop_due(&mut self) -> Option<Resident> {
+        loop {
+            if let Some(resident) = self.due_cohorts.front_mut()?.pop() {
+                self.due_count -= 1;
+
+                if self.due_cohorts.front().is_some_and(Vec::is_empty) {
+                    self.recycle_front_cohort();
+                }
+
+                return Some(resident);
+            }
+
+            self.recycle_front_cohort();
+        }
+    }
+
+    fn recycle_front_cohort(&mut self) {
+        if let Some(buffer) = self.due_cohorts.pop_front() {
+            if self.spare_buffers.len() < WHEEL_SIZE {
+                self.spare_buffers.push(buffer);
+            }
+        }
+    }
+
+    fn maintenance_budget(&self, maintenance_floor: usize) -> usize {
+        // At this rate, a burst decays geometrically while a continuous stream
+        // reaches a stable backlog instead of growing without bound.
+        maintenance_floor.max(self.due_count.div_ceil(TARGET_BACKLOG_REVISIONS))
     }
 }
 
@@ -130,17 +181,17 @@ impl AdaptiveController {
 }
 
 impl Lru {
-    fn with_shards(activation_floor: usize, shards: usize) -> Self {
+    fn with_shards(maintenance_floor: usize, shards: usize) -> Self {
         assert!(shards > 1 && shards.is_power_of_two());
 
         Self {
-            activation_floor: NonZeroUsize::new(activation_floor),
+            maintenance_floor: NonZeroUsize::new(maintenance_floor),
             hasher: FxBuildHasher,
             shift: usize::BITS - shards.trailing_zeros(),
             admissions: (0..shards).map(|_| Default::default()).collect(),
-            state: State::new(activation_floor),
+            state: State::new(),
             current_epoch: AtomicUsize::new(0),
-            ghosts: GhostSketch::new(activation_floor),
+            ghosts: GhostSketch::new(maintenance_floor),
             refaults_by_epoch: std::array::from_fn(|_| AtomicUsize::new(0)),
         }
     }
@@ -197,6 +248,7 @@ impl Lru {
 
     fn advance_epoch(
         &mut self,
+        maintenance_floor: usize,
         last_verified_at: &mut impl FnMut(Id) -> Option<Revision>,
         evicted: &mut Vec<Id>,
     ) {
@@ -212,9 +264,12 @@ impl Lru {
             self.state.controller.observe(evictions, refaults);
         }
 
-        let bucket = self.state.epoch & (WHEEL_SIZE - 1);
-        let due = std::mem::take(&mut self.state.wheel[bucket]);
-        for mut resident in due {
+        self.state.queue_due_bucket();
+        let budget = self.state.maintenance_budget(maintenance_floor);
+        for _ in 0..budget {
+            let Some(mut resident) = self.state.pop_due() else {
+                break;
+            };
             let Some(verified_at) = last_verified_at(resident.id) else {
                 self.state.resident_count = self.state.resident_count.saturating_sub(1);
                 continue;
@@ -254,7 +309,7 @@ impl Lru {
 }
 
 impl EvictionPolicy for Lru {
-    fn new(activation_floor: usize) -> Self {
+    fn new(maintenance_floor: usize) -> Self {
         static SHARDS: OnceLock<usize> = OnceLock::new();
         let shards = *SHARDS.get_or_init(|| {
             let parallelism = std::thread::available_parallelism()
@@ -263,12 +318,12 @@ impl EvictionPolicy for Lru {
             (parallelism * 4).next_power_of_two()
         });
 
-        Self::with_shards(activation_floor, shards)
+        Self::with_shards(maintenance_floor, shards)
     }
 
     #[inline(always)]
     fn admit(&self, id: Id) {
-        if self.activation_floor.is_none() {
+        if self.maintenance_floor.is_none() {
             return;
         }
 
@@ -290,36 +345,33 @@ impl EvictionPolicy for Lru {
     #[inline(always)]
     fn promote(&self, _id: Id) {}
 
-    fn set_capacity(&mut self, activation_floor: usize) {
-        self.activation_floor = NonZeroUsize::new(activation_floor);
-        if self.activation_floor.is_none() {
+    fn set_capacity(&mut self, maintenance_floor: usize) {
+        self.maintenance_floor = NonZeroUsize::new(maintenance_floor);
+        if self.maintenance_floor.is_none() {
             for admissions in &mut self.admissions {
                 admissions.get_mut().clear();
             }
-            self.state = State::new(0);
+            self.state = State::new();
             self.current_epoch.store(0, Ordering::Relaxed);
             self.ghosts.clear();
             for refaults in &mut self.refaults_by_epoch {
                 *refaults.get_mut() = 0;
             }
-        } else {
-            self.state.next_collection = activation_floor;
         }
     }
 
     fn evict(&mut self, mut last_verified_at: impl FnMut(Id) -> Option<Revision>) -> Vec<Id> {
-        let Some(activation_floor) = self.activation_floor.map(NonZeroUsize::get) else {
+        let Some(maintenance_floor) = self.maintenance_floor.map(NonZeroUsize::get) else {
             return Vec::new();
         };
 
         self.drain_admissions(&mut last_verified_at);
-        if self.state.resident_count < self.state.next_collection {
+        if self.state.resident_count == 0 {
             return Vec::new();
         }
 
         let mut evicted = Vec::new();
-        self.advance_epoch(&mut last_verified_at, &mut evicted);
-        self.state.update_collection_target(activation_floor);
+        self.advance_epoch(maintenance_floor, &mut last_verified_at, &mut evicted);
         evicted
     }
 }
@@ -334,8 +386,8 @@ impl GhostSketch {
     const VALID: u64 = 1 << 63;
     const EPOCH_MASK: usize = (1 << 24) - 1;
 
-    fn new(activation_floor: usize) -> Self {
-        let len = activation_floor
+    fn new(maintenance_floor: usize) -> Self {
+        let len = maintenance_floor
             .saturating_mul(4)
             .clamp(256, 65_536)
             .next_power_of_two();
@@ -407,60 +459,65 @@ mod tests {
     }
 
     #[test]
-    fn cold_resident_requires_multiple_collection_epochs() {
+    fn cold_resident_ages_without_new_admissions() {
         let mut lru = Lru::with_shards(1, 2);
         let cold = id(0);
-        let trigger1 = id(1);
-        let trigger2 = id(2);
         let revision = Revision::start();
 
         lru.admit(cold);
         assert_eq!(lru.evict(revisions(&[(cold, revision)])), []);
-
-        lru.admit(trigger1);
-        assert_eq!(
-            lru.evict(revisions(&[(cold, revision), (trigger1, revision)])),
-            []
-        );
-
-        lru.admit(trigger2);
-        assert_eq!(
-            lru.evict(revisions(&[
-                (cold, revision),
-                (trigger1, revision),
-                (trigger2, revision),
-            ])),
-            [cold]
-        );
+        assert_eq!(lru.evict(revisions(&[(cold, revision)])), []);
+        assert_eq!(lru.evict(revisions(&[(cold, revision)])), [cold]);
     }
 
     #[test]
     fn reuse_promotes_a_resident() {
         let mut lru = Lru::with_shards(1, 2);
         let reused = id(0);
-        let trigger1 = id(1);
-        let trigger2 = id(2);
 
         lru.admit(reused);
         assert_eq!(lru.evict(revisions(&[(reused, Revision::start())])), []);
+        assert_eq!(lru.evict(revisions(&[(reused, Revision::from(2))])), []);
+        for _ in 0..4 {
+            assert_eq!(lru.evict(revisions(&[(reused, Revision::from(2))])), []);
+        }
+    }
 
-        lru.admit(trigger1);
-        assert_eq!(
-            lru.evict(revisions(&[
-                (reused, Revision::from(2)),
-                (trigger1, Revision::start()),
-            ])),
-            []
-        );
+    #[test]
+    fn large_due_cohort_is_processed_incrementally() {
+        let mut lru = Lru::with_shards(1, 2);
+        let entries: Vec<_> = (0..32)
+            .map(|index| (id(index), Revision::start()))
+            .collect();
 
-        lru.admit(trigger2);
-        assert_eq!(
-            lru.evict(revisions(&[
-                (reused, Revision::from(2)),
-                (trigger1, Revision::start()),
-                (trigger2, Revision::start()),
-            ])),
-            []
+        for &(id, _) in &entries {
+            lru.admit(id);
+        }
+
+        assert_eq!(lru.evict(revisions(&entries)), []);
+        assert_eq!(lru.state.due_count, 0);
+
+        assert_eq!(lru.evict(revisions(&entries)), []);
+        assert_eq!(lru.state.due_count, 28);
+        assert_eq!(lru.state.resident_count, 32);
+    }
+
+    #[test]
+    fn continuous_cold_admissions_converge() {
+        const ADMISSIONS_PER_REVISION: u32 = 32;
+
+        let mut lru = Lru::with_shards(1, 2);
+        for revision in 0..256 {
+            for offset in 0..ADMISSIONS_PER_REVISION {
+                lru.admit(id(revision * ADMISSIONS_PER_REVISION + offset));
+            }
+            lru.evict(|_| Some(Revision::start()));
+        }
+
+        assert!(
+            lru.state.resident_count < ADMISSIONS_PER_REVISION as usize * 32,
+            "cold resident set did not converge: {}",
+            lru.state.resident_count
         );
     }
 

--- a/src/function/eviction/noop.rs
+++ b/src/function/eviction/noop.rs
@@ -2,7 +2,7 @@
 //!
 //! This is the default eviction policy when no LRU capacity is specified.
 
-use crate::{Id, function::EvictionPolicy};
+use crate::{Id, Revision, function::EvictionPolicy};
 
 /// No eviction - cache grows unbounded.
 pub struct NoopEviction;
@@ -22,5 +22,7 @@ impl EvictionPolicy for NoopEviction {
     fn set_capacity(&mut self, _capacity: usize) {}
 
     #[inline(always)]
-    fn for_each_evicted(&mut self, _cb: impl FnMut(Id)) {}
+    fn evict(&mut self, _last_verified_at: impl FnMut(Id) -> Option<Revision>) -> Vec<Id> {
+        Vec::new()
+    }
 }

--- a/src/function/eviction/noop.rs
+++ b/src/function/eviction/noop.rs
@@ -13,7 +13,10 @@ impl EvictionPolicy for NoopEviction {
     }
 
     #[inline(always)]
-    fn record_use(&self, _id: Id) {}
+    fn admit(&self, _id: Id) {}
+
+    #[inline(always)]
+    fn promote(&self, _id: Id) {}
 
     #[inline(always)]
     fn set_capacity(&mut self, _capacity: usize) {}

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -31,7 +31,7 @@ where
         // SAFETY: We just refreshed the memo so it is guaranteed to contain a value now.
         let memo_value = unsafe { memo.value.as_ref().unwrap_unchecked() };
 
-        self.eviction.record_use(id);
+        self.eviction.promote(id);
 
         zalsa_local.report_tracked_read(
             database_key_index,

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -80,6 +80,19 @@ impl<C: Configuration> IngredientImpl<C> {
 
         table.map_memo(memo_ingredient_index, map)
     }
+
+    pub(super) fn verified_at_for(
+        table: MemoTableWithTypesMut<'_>,
+        memo_ingredient_index: MemoIngredientIndex,
+    ) -> Option<Revision> {
+        let mut verified_at = None;
+        table.map_memo(memo_ingredient_index, |memo: &mut Memo<'static, C>| {
+            if memo.value.is_some() {
+                verified_at = Some(memo.verified_at.load());
+            }
+        });
+        verified_at
+    }
 }
 
 #[derive(Debug)]

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -2,7 +2,6 @@ use std::hash::{BuildHasher, Hash, Hasher};
 
 pub(crate) type FxHasher = std::hash::BuildHasherDefault<rustc_hash::FxHasher>;
 pub(crate) type FxIndexSet<K> = indexmap::IndexSet<K, FxHasher>;
-pub(crate) type FxLinkedHashSet<K> = hashlink::LinkedHashSet<K, FxHasher>;
 pub(crate) type FxHashSet<K> = std::collections::HashSet<K, FxHasher>;
 
 pub(crate) fn hash<T: Hash>(t: &T) -> u64 {

--- a/tests/lru.rs
+++ b/tests/lru.rs
@@ -65,9 +65,9 @@ fn lru_works() {
     }
 
     assert_eq!(load_n_potatoes(), 32);
-    // Values age without requiring any additional admissions. The maintenance
-    // budget spreads inspection of this cohort across revisions.
-    for _ in 0..5 {
+    // Probation values age without requiring any additional admissions. The
+    // maintenance budget spreads inspection of the due cohort across revisions.
+    for _ in 1..16 {
         db.synthetic_write(salsa::Durability::HIGH);
     }
     assert_eq!(load_n_potatoes(), 32);
@@ -94,16 +94,13 @@ fn lru_maintenance_budget_can_be_changed_at_runtime() {
     }
 
     assert_eq!(load_n_potatoes(), 32);
-    // The first collection gives the cohort grace.
-    db.synthetic_write(salsa::Durability::HIGH);
-    assert_eq!(load_n_potatoes(), 32);
-
-    // Raising the maintenance floor lets each due cohort be inspected in one
-    // revision. The first inspection marks the cohort cold.
+    // Raising the maintenance floor lets the probation cohort be inspected in
+    // one revision once its grace period expires.
     get_hot_potato::set_lru_capacity(&mut db, 32);
-    db.synthetic_write(salsa::Durability::HIGH);
+    for _ in 1..16 {
+        db.synthetic_write(salsa::Durability::HIGH);
+    }
     assert_eq!(load_n_potatoes(), 32);
-
     db.synthetic_write(salsa::Durability::HIGH);
     assert_eq!(load_n_potatoes(), 0);
 
@@ -139,9 +136,9 @@ fn lru_keeps_dependency_info() {
     // Advance enough revisions to evict the inner memo values. Use a maintenance
     // budget large enough to inspect the entire cohort on each due revision.
     get_hot_potato::set_lru_capacity(&mut db, input_count);
-    db.synthetic_write(salsa::Durability::HIGH);
-    db.synthetic_write(salsa::Durability::HIGH);
-    db.synthetic_write(salsa::Durability::HIGH);
+    for _ in 0..16 {
+        db.synthetic_write(salsa::Durability::HIGH);
+    }
     assert_eq!(load_n_potatoes(), 0);
 
     // We want to test that calls to `get_hot_potato2` are still considered

--- a/tests/lru.rs
+++ b/tests/lru.rs
@@ -65,30 +65,24 @@ fn lru_works() {
     }
 
     assert_eq!(load_n_potatoes(), 32);
-    // The first collection epoch gives newly admitted values grace.
-    db.synthetic_write(salsa::Durability::HIGH);
+    // Values age without requiring any additional admissions. The maintenance
+    // budget spreads inspection of this cohort across revisions.
+    for _ in 0..5 {
+        db.synthetic_write(salsa::Durability::HIGH);
+    }
     assert_eq!(load_n_potatoes(), 32);
 
-    // Growing the resident set by 50% advances another collection epoch and
-    // marks the original cohort cold, but does not evict it yet.
-    for i in 32..48u32 {
-        let input = MyInput::new(&db, i);
-        get_hot_potato(&db, input);
-    }
     db.synthetic_write(salsa::Durability::HIGH);
-    assert_eq!(load_n_potatoes(), 48);
+    assert_eq!(load_n_potatoes(), 24);
 
-    // Another 50% growth gives the original cohort its second cold inspection.
-    for i in 48..72u32 {
-        let input = MyInput::new(&db, i);
-        get_hot_potato(&db, input);
+    for _ in 0..3 {
+        db.synthetic_write(salsa::Durability::HIGH);
     }
-    db.synthetic_write(salsa::Durability::HIGH);
-    assert_eq!(load_n_potatoes(), 40);
+    assert_eq!(load_n_potatoes(), 0);
 }
 
 #[test]
-fn lru_growth_floor_can_be_changed_at_runtime() {
+fn lru_maintenance_budget_can_be_changed_at_runtime() {
     let mut db = common::LoggerDatabase::default();
     assert_eq!(load_n_potatoes(), 0);
 
@@ -104,13 +98,12 @@ fn lru_growth_floor_can_be_changed_at_runtime() {
     db.synthetic_write(salsa::Durability::HIGH);
     assert_eq!(load_n_potatoes(), 32);
 
-    // Lowering the growth floor forces two more collection epochs. The first
-    // marks the cohort cold and the second evicts it.
-    get_hot_potato::set_lru_capacity(&mut db, 1);
+    // Raising the maintenance floor lets each due cohort be inspected in one
+    // revision. The first inspection marks the cohort cold.
+    get_hot_potato::set_lru_capacity(&mut db, 32);
     db.synthetic_write(salsa::Durability::HIGH);
     assert_eq!(load_n_potatoes(), 32);
 
-    get_hot_potato::set_lru_capacity(&mut db, 1);
     db.synthetic_write(salsa::Durability::HIGH);
     assert_eq!(load_n_potatoes(), 0);
 
@@ -132,10 +125,9 @@ fn lru_growth_floor_can_be_changed_at_runtime() {
 #[test]
 fn lru_keeps_dependency_info() {
     let mut db = common::LoggerDatabase::default();
-    let activation_floor = 8;
+    let input_count = 9;
 
-    // Invoke `get_hot_potato2` enough times to cross the collection floor.
-    let inputs: Vec<MyInput> = (0..(activation_floor + 1))
+    let inputs: Vec<MyInput> = (0..input_count)
         .map(|i| MyInput::new(&db, i as u32))
         .collect();
 
@@ -144,11 +136,11 @@ fn lru_keeps_dependency_info() {
         assert_eq!(x as usize, i);
     }
 
-    // Advance enough collection epochs to evict the inner memo values.
+    // Advance enough revisions to evict the inner memo values. Use a maintenance
+    // budget large enough to inspect the entire cohort on each due revision.
+    get_hot_potato::set_lru_capacity(&mut db, input_count);
     db.synthetic_write(salsa::Durability::HIGH);
-    get_hot_potato::set_lru_capacity(&mut db, 1);
     db.synthetic_write(salsa::Durability::HIGH);
-    get_hot_potato::set_lru_capacity(&mut db, 1);
     db.synthetic_write(salsa::Durability::HIGH);
     assert_eq!(load_n_potatoes(), 0);
 

--- a/tests/lru.rs
+++ b/tests/lru.rs
@@ -65,13 +65,30 @@ fn lru_works() {
     }
 
     assert_eq!(load_n_potatoes(), 32);
-    // trigger the GC
+    // The first collection epoch gives newly admitted values grace.
     db.synthetic_write(salsa::Durability::HIGH);
-    assert_eq!(load_n_potatoes(), 8);
+    assert_eq!(load_n_potatoes(), 32);
+
+    // Growing the resident set by 50% advances another collection epoch and
+    // marks the original cohort cold, but does not evict it yet.
+    for i in 32..48u32 {
+        let input = MyInput::new(&db, i);
+        get_hot_potato(&db, input);
+    }
+    db.synthetic_write(salsa::Durability::HIGH);
+    assert_eq!(load_n_potatoes(), 48);
+
+    // Another 50% growth gives the original cohort its second cold inspection.
+    for i in 48..72u32 {
+        let input = MyInput::new(&db, i);
+        get_hot_potato(&db, input);
+    }
+    db.synthetic_write(salsa::Durability::HIGH);
+    assert_eq!(load_n_potatoes(), 40);
 }
 
 #[test]
-fn lru_can_be_changed_at_runtime() {
+fn lru_growth_floor_can_be_changed_at_runtime() {
     let mut db = common::LoggerDatabase::default();
     assert_eq!(load_n_potatoes(), 0);
 
@@ -83,32 +100,28 @@ fn lru_can_be_changed_at_runtime() {
     }
 
     assert_eq!(load_n_potatoes(), 32);
-    // trigger the GC
+    // The first collection gives the cohort grace.
     db.synthetic_write(salsa::Durability::HIGH);
-    assert_eq!(load_n_potatoes(), 8);
-
-    get_hot_potato::set_lru_capacity(&mut db, 16);
-    assert_eq!(load_n_potatoes(), 8);
-    for &(i, input) in inputs.iter() {
-        let p = get_hot_potato(&db, input);
-        assert_eq!(p.0, i);
-    }
-
     assert_eq!(load_n_potatoes(), 32);
-    // trigger the GC
-    db.synthetic_write(salsa::Durability::HIGH);
-    assert_eq!(load_n_potatoes(), 16);
 
-    // Special case: setting capacity to zero disables LRU
+    // Lowering the growth floor forces two more collection epochs. The first
+    // marks the cohort cold and the second evicts it.
+    get_hot_potato::set_lru_capacity(&mut db, 1);
+    db.synthetic_write(salsa::Durability::HIGH);
+    assert_eq!(load_n_potatoes(), 32);
+
+    get_hot_potato::set_lru_capacity(&mut db, 1);
+    db.synthetic_write(salsa::Durability::HIGH);
+    assert_eq!(load_n_potatoes(), 0);
+
+    // Setting the value to zero still disables eviction.
     get_hot_potato::set_lru_capacity(&mut db, 0);
-    assert_eq!(load_n_potatoes(), 16);
     for &(i, input) in inputs.iter() {
         let p = get_hot_potato(&db, input);
         assert_eq!(p.0, i);
     }
 
     assert_eq!(load_n_potatoes(), 32);
-    // trigger the GC
     db.synthetic_write(salsa::Durability::HIGH);
     assert_eq!(load_n_potatoes(), 32);
 
@@ -119,11 +132,10 @@ fn lru_can_be_changed_at_runtime() {
 #[test]
 fn lru_keeps_dependency_info() {
     let mut db = common::LoggerDatabase::default();
-    let capacity = 8;
+    let activation_floor = 8;
 
-    // Invoke `get_hot_potato2` 33 times. This will (in turn) invoke
-    // `get_hot_potato`, which will trigger LRU after 8 executions.
-    let inputs: Vec<MyInput> = (0..(capacity + 1))
+    // Invoke `get_hot_potato2` enough times to cross the collection floor.
+    let inputs: Vec<MyInput> = (0..(activation_floor + 1))
         .map(|i| MyInput::new(&db, i as u32))
         .collect();
 
@@ -132,14 +144,20 @@ fn lru_keeps_dependency_info() {
         assert_eq!(x as usize, i);
     }
 
+    // Advance enough collection epochs to evict the inner memo values.
     db.synthetic_write(salsa::Durability::HIGH);
+    get_hot_potato::set_lru_capacity(&mut db, 1);
+    db.synthetic_write(salsa::Durability::HIGH);
+    get_hot_potato::set_lru_capacity(&mut db, 1);
+    db.synthetic_write(salsa::Durability::HIGH);
+    assert_eq!(load_n_potatoes(), 0);
 
     // We want to test that calls to `get_hot_potato2` are still considered
     // clean. Check that no new executions occur as we go here.
-    db.assert_logs_len((capacity + 1) * 2);
+    db.clear_logs();
 
-    // calling `get_hot_potato2(0)` has to check that `get_hot_potato(0)` is still valid;
-    // even though we've evicted it (LRU), we find that it is still good
+    // Calling `get_hot_potato2(0)` has to check that `get_hot_potato(0)` is still valid;
+    // even though we've evicted its value, we find that it is still good.
     let p = get_hot_potato2(&db, *inputs.first().unwrap());
     assert_eq!(p, 0);
     db.assert_logs_len(0);


### PR DESCRIPTION
Replace capacity-driven tracked-function LRU bookkeeping with an off-memo generational collector. First-use values receive 16 revisions of compact probation; reused values promote through warm, hot, and tenured tiers, with revision-driven aging and incremental due-cohort processing.
Home Assistant with semantic-index LRU enabled remains effectively flat against the prior scheduler: 3.627 ± 0.146 s versus 3.613 ± 0.102 s cold, approximately 3.842 GB RSS for both, and 5.079 s versus 4.999 s over 65 edits; main was 4.177 ± 0.283 s cold.
Testing: Added collector coverage, ran the full default Salsa suite and all-feature checks, and benchmarked Home Assistant wall time and RSS.