### PR TITLE
Add realistic workload benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,19 @@ name = "lru"
 harness = false
 required-features = ["rayon"]
 
+[[bench]]
+name = "workspace"
+harness = false
+required-features = ["accumulator"]
+
+[[bench]]
+name = "graph_shapes"
+harness = false
+
+[[bench]]
+name = "revision_churn"
+harness = false
+
 [[example]]
 name = "lazy-input"
 required-features = ["accumulator"]

--- a/benches/graph_shapes.rs
+++ b/benches/graph_shapes.rs
@@ -1,0 +1,170 @@
+//! Incremental validation across common dependency graph shapes.
+
+use std::hint::black_box;
+
+use codspeed_criterion_compat::{
+    BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main,
+};
+use salsa::Setter;
+
+const GRAPH_SIZE: usize = 1_024;
+
+#[salsa::input]
+struct Node {
+    value: usize,
+
+    #[returns(ref)]
+    dependencies: Vec<Node>,
+}
+
+#[salsa::tracked]
+#[inline(never)]
+fn evaluate(db: &dyn salsa::Database, node: Node) -> usize {
+    node.dependencies(db)
+        .iter()
+        .fold(node.value(db) / 2, |result, &dependency| {
+            result.wrapping_add(evaluate(db, dependency))
+        })
+}
+
+fn new_nodes(db: &salsa::DatabaseImpl) -> Vec<Node> {
+    (0..GRAPH_SIZE)
+        .map(|index| Node::new(db, if index + 1 == GRAPH_SIZE { 2 } else { 0 }, Vec::new()))
+        .collect()
+}
+
+#[derive(Clone, Copy)]
+enum Shape {
+    Chain,
+    Fanout,
+    Diamond,
+}
+
+impl Shape {
+    fn name(self) -> &'static str {
+        match self {
+            Shape::Chain => "chain",
+            Shape::Fanout => "fanout",
+            Shape::Diamond => "diamond",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Revision {
+    Unrelated,
+    Backdated,
+    Changed,
+}
+
+impl Revision {
+    fn name(self) -> &'static str {
+        match self {
+            Revision::Unrelated => "unrelated_revision",
+            Revision::Backdated => "backdated_leaf",
+            Revision::Changed => "changed_leaf",
+        }
+    }
+}
+
+struct GraphFixture {
+    db: salsa::DatabaseImpl,
+    root: Node,
+    leaf: Node,
+    unrelated: Node,
+    initial_result: usize,
+}
+
+impl GraphFixture {
+    fn new(shape: Shape) -> Self {
+        let mut db = salsa::DatabaseImpl::new();
+
+        let (root, leaf) = match shape {
+            Shape::Chain => {
+                let nodes = new_nodes(&db);
+                for index in 0..GRAPH_SIZE - 1 {
+                    nodes[index]
+                        .set_dependencies(&mut db)
+                        .to(vec![nodes[index + 1]]);
+                }
+                (nodes[0], nodes[GRAPH_SIZE - 1])
+            }
+            Shape::Fanout => {
+                let leaves = new_nodes(&db);
+                let root = Node::new(&db, 0, leaves.clone());
+                (root, leaves[GRAPH_SIZE - 1])
+            }
+            Shape::Diamond => {
+                let leaf = Node::new(&db, 2, Vec::new());
+                let branches: Vec<_> = (0..GRAPH_SIZE)
+                    .map(|_| Node::new(&db, 0, vec![leaf]))
+                    .collect();
+                (Node::new(&db, 0, branches), leaf)
+            }
+        };
+
+        let unrelated = Node::new(&db, 0, Vec::new());
+        let initial_result = evaluate(&db, root);
+
+        Self {
+            db,
+            root,
+            leaf,
+            unrelated,
+            initial_result,
+        }
+    }
+
+    fn run(&mut self, revision: Revision) {
+        match revision {
+            Revision::Unrelated => {
+                self.unrelated
+                    .set_value(black_box(&mut self.db))
+                    .to(black_box(1));
+            }
+            Revision::Backdated => {
+                // `evaluate` divides the value by two, so 2 -> 3 preserves the result.
+                self.leaf
+                    .set_value(black_box(&mut self.db))
+                    .to(black_box(3));
+            }
+            Revision::Changed => {
+                self.leaf
+                    .set_value(black_box(&mut self.db))
+                    .to(black_box(4));
+            }
+        }
+
+        let result = evaluate(black_box(&self.db), black_box(self.root));
+        match revision {
+            Revision::Unrelated | Revision::Backdated => {
+                assert_eq!(black_box(result), self.initial_result);
+            }
+            Revision::Changed => assert_ne!(black_box(result), self.initial_result),
+        }
+    }
+}
+
+fn graph_shapes(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("Graph shapes");
+
+    for shape in [Shape::Chain, Shape::Fanout, Shape::Diamond] {
+        for revision in [Revision::Unrelated, Revision::Backdated, Revision::Changed] {
+            group.bench_function(
+                BenchmarkId::new(format!("{}/{}", shape.name(), revision.name()), GRAPH_SIZE),
+                move |b| {
+                    b.iter_batched_ref(
+                        || GraphFixture::new(shape),
+                        |fixture| fixture.run(revision),
+                        BatchSize::LargeInput,
+                    );
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, graph_shapes);
+criterion_main!(benches);

--- a/benches/revision_churn.rs
+++ b/benches/revision_churn.rs
@@ -1,0 +1,149 @@
+//! A long-lived database that repeatedly creates, updates, and deletes entities.
+
+use std::hint::black_box;
+
+use codspeed_criterion_compat::{
+    BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main,
+};
+use salsa::Setter;
+
+const REVISIONS: usize = 128;
+const STABLE_ITEMS: usize = 1_024;
+const SMALL_LIVE_SET: usize = 1_536;
+const LARGE_LIVE_SET: usize = 2_048;
+
+#[salsa::input]
+struct Session {
+    generation: usize,
+}
+
+#[salsa::interned(revisions = 3)]
+struct Symbol<'db> {
+    name: usize,
+}
+
+#[salsa::tracked]
+struct Item<'db> {
+    /// Stable items retain their symbol across revisions; volatile items receive a new symbol.
+    symbol: Symbol<'db>,
+
+    #[tracked]
+    payload: usize,
+}
+
+#[salsa::tracked(returns(ref))]
+#[inline(never)]
+fn lower_items(db: &dyn salsa::Database, session: Session) -> Vec<Item<'_>> {
+    let generation = session.generation(db);
+    let live_items = if generation % 2 == 0 {
+        LARGE_LIVE_SET
+    } else {
+        SMALL_LIVE_SET
+    };
+
+    (0..live_items)
+        .map(|index| {
+            let stable = index < STABLE_ITEMS;
+            let name = if stable {
+                index
+            } else {
+                generation.wrapping_mul(LARGE_LIVE_SET).wrapping_add(index)
+            };
+            let payload = if stable {
+                index
+            } else {
+                generation.wrapping_add(index)
+            };
+            Item::new(db, Symbol::new(db, name), payload)
+        })
+        .collect()
+}
+
+#[salsa::tracked]
+#[inline(never)]
+fn analyze_item<'db>(db: &'db dyn salsa::Database, item: Item<'db>) -> usize {
+    item.symbol(db)
+        .name(db)
+        .wrapping_mul(31)
+        .wrapping_add(item.payload(db))
+}
+
+#[salsa::tracked]
+#[inline(never)]
+fn analyze_session(db: &dyn salsa::Database, session: Session) -> usize {
+    lower_items(db, session)
+        .iter()
+        .fold(0usize, |checksum, &item| {
+            checksum.wrapping_add(analyze_item(db, item))
+        })
+}
+
+struct ChurnFixture {
+    db: salsa::DatabaseImpl,
+    session: Session,
+    generation: usize,
+}
+
+impl ChurnFixture {
+    fn new() -> Self {
+        let db = salsa::DatabaseImpl::new();
+        let session = Session::new(&db, 0);
+        assert_ne!(analyze_session(&db, session), 0);
+        Self {
+            db,
+            session,
+            generation: 0,
+        }
+    }
+
+    fn advance(&mut self) -> usize {
+        self.generation += 1;
+        self.session
+            .set_generation(black_box(&mut self.db))
+            .to(black_box(self.generation));
+        analyze_session(black_box(&self.db), black_box(self.session))
+    }
+
+    fn advance_by(&mut self, revisions: usize) {
+        for _ in 0..revisions {
+            black_box(self.advance());
+        }
+    }
+}
+
+fn revision_churn(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("Revision churn");
+
+    group.bench_function(
+        BenchmarkId::new("session", format!("{REVISIONS}x{LARGE_LIVE_SET}")),
+        |b| {
+            b.iter_batched_ref(
+                ChurnFixture::new,
+                |fixture| fixture.advance_by(REVISIONS),
+                BatchSize::LargeInput,
+            );
+        },
+    );
+
+    group.bench_function(
+        BenchmarkId::new("aged_edit", format!("after_{REVISIONS}_revisions")),
+        |b| {
+            b.iter_batched_ref(
+                || {
+                    let mut fixture = ChurnFixture::new();
+                    fixture.advance_by(REVISIONS);
+                    fixture
+                },
+                |fixture| {
+                    assert_ne!(black_box(fixture.advance()), 0);
+                },
+                BatchSize::LargeInput,
+            );
+        },
+    );
+
+    group.finish();
+}
+
+criterion_group!(benches, revision_churn);
+criterion_main!(benches);

--- a/benches/workspace.rs
+++ b/benches/workspace.rs
@@ -1,0 +1,185 @@
+//! A compiler/IDE-shaped benchmark with many files, tracked declarations, and diagnostics.
+//!
+//! Every non-root file imports the root file. A private edit changes declaration bodies while
+//! preserving their signatures; a public edit changes signatures and invalidates every importer.
+
+use std::hint::black_box;
+
+use codspeed_criterion_compat::{
+    BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main,
+};
+use salsa::{Accumulator, Setter};
+
+const FILES: usize = 1_024;
+const DECLARATIONS_PER_FILE: usize = 16;
+const DIAGNOSTIC_INTERVAL: usize = 128;
+const DIAGNOSTICS: usize = FILES / DIAGNOSTIC_INTERVAL;
+
+#[salsa::input]
+struct SourceFile {
+    module: usize,
+
+    #[returns(ref)]
+    text: String,
+
+    #[returns(ref)]
+    dependencies: Vec<SourceFile>,
+}
+
+#[salsa::input]
+struct Workspace {
+    #[returns(ref)]
+    files: Vec<SourceFile>,
+}
+
+#[salsa::tracked]
+struct Declaration<'db> {
+    /// Stable identity within a file.
+    name: usize,
+
+    #[tracked]
+    signature: usize,
+
+    #[tracked]
+    body: usize,
+}
+
+#[salsa::accumulator]
+struct Diagnostic(#[allow(dead_code)] usize);
+
+#[salsa::tracked(returns(ref))]
+#[inline(never)]
+fn parse_file(db: &dyn salsa::Database, file: SourceFile) -> Vec<Declaration<'_>> {
+    let (api_seed, body_seed, declarations) = parse_source(file.text(db));
+    (0..declarations)
+        .map(|name| Declaration::new(db, name, mix(api_seed, name), mix(body_seed, name)))
+        .collect()
+}
+
+#[salsa::tracked]
+#[inline(never)]
+fn public_api(db: &dyn salsa::Database, file: SourceFile) -> usize {
+    parse_file(db, file)
+        .iter()
+        .fold(0usize, |checksum, &declaration| {
+            checksum.wrapping_add(declaration.signature(db))
+        })
+}
+
+#[salsa::tracked]
+#[inline(never)]
+fn check_file(db: &dyn salsa::Database, file: SourceFile) -> usize {
+    let mut checksum = public_api(db, file);
+    for &declaration in parse_file(db, file) {
+        checksum = checksum.wrapping_add(declaration.body(db));
+    }
+    for &dependency in file.dependencies(db) {
+        checksum = checksum.wrapping_add(public_api(db, dependency));
+    }
+
+    let module = file.module(db);
+    if module % DIAGNOSTIC_INTERVAL == 0 {
+        Diagnostic(module).accumulate(db);
+    }
+
+    checksum
+}
+
+#[salsa::tracked]
+#[inline(never)]
+fn check_workspace(db: &dyn salsa::Database, workspace: Workspace) -> usize {
+    workspace.files(db).iter().fold(0usize, |checksum, &file| {
+        checksum.wrapping_add(check_file(db, file))
+    })
+}
+
+fn parse_source(source: &str) -> (usize, usize, usize) {
+    let mut fields = source.split(':');
+    let api = fields.next().unwrap().parse().unwrap();
+    let body = fields.next().unwrap().parse().unwrap();
+    let declarations = fields.next().unwrap().parse().unwrap();
+    assert!(fields.next().is_none());
+    (api, body, declarations)
+}
+
+fn source_text(api: usize, body: usize) -> String {
+    format!("{api}:{body}:{DECLARATIONS_PER_FILE}")
+}
+
+fn mix(seed: usize, index: usize) -> usize {
+    seed.wrapping_mul(1_664_525)
+        .wrapping_add(index)
+        .wrapping_add(1_013_904_223)
+}
+
+struct WorkspaceFixture {
+    db: salsa::DatabaseImpl,
+    workspace: Workspace,
+    edited_file: SourceFile,
+    initial_checksum: usize,
+}
+
+impl WorkspaceFixture {
+    fn new() -> Self {
+        let db = salsa::DatabaseImpl::new();
+        let root = SourceFile::new(&db, 0, source_text(1, 100), Vec::new());
+
+        let mut files = Vec::with_capacity(FILES);
+        files.push(root);
+        for module in 1..FILES {
+            files.push(SourceFile::new(
+                &db,
+                module,
+                source_text(module + 1, module + 100),
+                vec![root],
+            ));
+        }
+
+        let workspace = Workspace::new(&db, files);
+        let initial_checksum = check_workspace(&db, workspace);
+        assert_ne!(initial_checksum, 0);
+        let diagnostics = check_workspace::accumulated::<Diagnostic>(&db, workspace);
+        assert_eq!(diagnostics.len(), DIAGNOSTICS);
+
+        Self {
+            db,
+            workspace,
+            edited_file: root,
+            initial_checksum,
+        }
+    }
+
+    fn run(&mut self, api: usize, body: usize) {
+        self.edited_file
+            .set_text(black_box(&mut self.db))
+            .to(black_box(source_text(api, body)));
+
+        let checksum = check_workspace(black_box(&self.db), black_box(self.workspace));
+        assert_ne!(black_box(checksum), self.initial_checksum);
+
+        let diagnostics = check_workspace::accumulated::<Diagnostic>(
+            black_box(&self.db),
+            black_box(self.workspace),
+        );
+        assert_eq!(black_box(diagnostics.len()), DIAGNOSTICS);
+    }
+}
+
+fn workspace_edits(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("Workspace");
+
+    for (name, api, body) in [("private_edit", 1, 101), ("public_api_edit", 2, 100)] {
+        group.bench_function(BenchmarkId::new(name, FILES), move |b| {
+            b.iter_batched_ref(
+                WorkspaceFixture::new,
+                |fixture| fixture.run(api, body),
+                BatchSize::LargeInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, workspace_edits);
+criterion_main!(benches);


### PR DESCRIPTION
Adds workspace-edit, dependency-graph, and revision-churn benchmarks to cover more realistic incremental workloads.

Validated with Clippy and optimized smoke runs of all new benchmarks.
