### PR TITLE
refactor: erase configuration from storage bookkeeping

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -5,7 +5,6 @@ use std::any::Any;
 use std::fmt;
 use std::ptr::NonNull;
 use std::sync::OnceLock;
-use std::sync::atomic::Ordering;
 
 use crate::cycle::{CycleRecoveryStrategy, IterationStamp, ProvisionalStatus};
 use crate::database::RawDatabase;
@@ -269,7 +268,7 @@ where
         mut memo: memo::Memo<'db, C>,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> &'db memo::Memo<'db, C> {
-        if let Some(tracked_struct_ids) = memo.revisions.tracked_struct_ids_mut() {
+        if let Some(tracked_struct_ids) = memo.header.revisions.tracked_struct_ids_mut() {
             tracked_struct_ids.shrink_to_fit();
         }
 
@@ -343,30 +342,8 @@ where
             return;
         };
 
-        let origin = memo.revisions.origin();
-
-        visited_edges.insert(edge);
-
-        // Collect the minimum dependency tree.
-        for edge in origin.edges() {
-            // Avoid forming cycles.
-            if visited_edges.contains(&edge) {
-                continue;
-            }
-
-            // Avoid flattening edges that we're going to serialize directly.
-            if serialized_edges.contains(&edge) {
-                continue;
-            }
-
-            let dependency = zalsa.lookup_ingredient(edge.key().ingredient_index());
-            dependency.collect_minimum_serialized_edges(
-                zalsa,
-                edge,
-                serialized_edges,
-                visited_edges,
-            )
-        }
+        memo.header
+            .collect_minimum_serialized_edges(zalsa, edge, serialized_edges, visited_edges);
     }
 
     /// Returns `final` if the memo has the `verified_final` flag set.
@@ -381,21 +358,7 @@ where
         let memo =
             self.get_memo_from_table_for(zalsa, input, self.memo_ingredient_index(zalsa, input))?;
 
-        let iteration = memo.revisions.iteration();
-        let verified_final = memo.revisions.verified_final.load(Ordering::Relaxed);
-
-        Some(if verified_final {
-            ProvisionalStatus::Final {
-                iteration,
-                verified_at: memo.verified_at.load(),
-            }
-        } else {
-            ProvisionalStatus::Provisional {
-                iteration,
-                verified_at: memo.verified_at.load(),
-                cycle_heads: memo.cycle_heads(),
-            }
-        })
+        Some(memo.header.provisional_status())
     }
 
     fn set_cycle_iteration_count(&self, zalsa: &Zalsa, input: Id, iteration: IterationStamp) {
@@ -405,8 +368,8 @@ where
             return;
         };
 
-        memo.revisions
-            .set_iteration_count(Self::database_key_index(self, input), iteration);
+        memo.header
+            .set_cycle_iteration_count(self.database_key_index(input), iteration);
     }
 
     fn finalize_cycle_head(&self, zalsa: &Zalsa, input: Id) {
@@ -416,7 +379,7 @@ where
             return;
         };
 
-        memo.revisions.verified_final.store(true, Ordering::Release);
+        memo.header.finalize_cycle_head();
     }
 
     fn flatten_cycle_head_dependencies(
@@ -431,41 +394,13 @@ where
             return;
         };
 
-        let database_key_index = self.database_key_index(id);
-
-        // Only flatten dependencies of provisional queries, because only those
-        // contain cyclic dependencies.
-        if !memo.may_be_provisional() {
-            flattened_input_outputs.insert(QueryEdge::input(database_key_index));
-            return;
-        }
-
-        // There's nothing to do if we've visited this query before.
-        if !seen.insert(database_key_index) {
-            return;
-        }
-
-        let inputs = memo.revisions.origin().inputs();
-
-        match C::CYCLE_STRATEGY {
-            // For queries with cycle handling, simply extend the input/outputs, because
-            // they already flattened their own dependencies when completing the query.
-            CycleRecoveryStrategy::FallbackImmediate | CycleRecoveryStrategy::Fixpoint => {
-                flattened_input_outputs.extend(inputs.map(QueryEdge::input));
-            }
-            // For regular queries, recurse
-            CycleRecoveryStrategy::Panic => {
-                for input in inputs {
-                    let ingredient = zalsa.lookup_ingredient(input.ingredient_index());
-                    ingredient.flatten_cycle_head_dependencies(
-                        zalsa,
-                        input.key_index(),
-                        flattened_input_outputs,
-                        seen,
-                    );
-                }
-            }
-        }
+        memo.header.flatten_cycle_head_dependencies(
+            zalsa,
+            self.database_key_index(id),
+            C::CYCLE_STRATEGY,
+            flattened_input_outputs,
+            seen,
+        );
     }
 
     fn cycle_converged(&self, zalsa: &Zalsa, input: Id) -> bool {
@@ -475,7 +410,7 @@ where
             return true;
         };
 
-        memo.revisions.cycle_converged()
+        memo.header.cycle_converged()
     }
 
     fn mark_as_transfer_target(&self, key_index: Id) -> Option<SyncOwner> {
@@ -699,7 +634,7 @@ mod persistence {
 
                 if let Some(memo) = memo.filter(|memo| memo.should_serialize()) {
                     // Flatten the dependencies of this query down to the base inputs.
-                    let flattened_origin = match memo.revisions.origin() {
+                    let flattened_origin = match memo.header.origin() {
                         QueryOriginRef::Derived(edges) => {
                             collect_minimum_serialized_edges(
                                 zalsa,

--- a/src/function/accumulated.rs
+++ b/src/function/accumulated.rs
@@ -96,8 +96,8 @@ where
         // NEXT STEP: stash and refactor `fetch` to return an `&Memo` so we can make this work
         let memo = self.refresh_memo(db, zalsa, zalsa_local, key);
         (
-            memo.revisions.accumulated(),
-            memo.revisions.accumulated_inputs.load(),
+            memo.header.revisions.accumulated(),
+            memo.header.revisions.accumulated_inputs.load(),
         )
     }
 }

--- a/src/function/backdate.rs
+++ b/src/function/backdate.rs
@@ -24,7 +24,7 @@ where
         // right now whether backdating could be made safe for queries participating in queries.
         // TODO: Write a test that demonstrates that backdating queries participating in a cycle isn't safe
         // OR write many tests showing that it is (and fixing the case where it didn't correctly account for today).
-        if !revisions.cycle_heads().is_empty() || old_memo.may_be_provisional() {
+        if !revisions.cycle_heads().is_empty() || old_memo.header.may_be_provisional() {
             return;
         }
 
@@ -33,23 +33,23 @@ where
             // used to be, that is a "breaking change" that our
             // consumers must be aware of. Becoming *more* durable
             // is not. See the test `durable_to_less_durable`.
-            if revisions.durability >= old_memo.revisions.durability
+            if revisions.durability >= old_memo.header.revisions.durability
                 && C::values_equal(old_value, value)
             {
                 crate::tracing::debug!(
                     "{index:?} value is equal, back-dating to {:?}",
-                    old_memo.revisions.changed_at,
+                    old_memo.header.revisions.changed_at,
                 );
 
-                if old_memo.revisions.changed_at > revisions.changed_at {
+                if old_memo.header.revisions.changed_at > revisions.changed_at {
                     report_backdate_violation(
                         index,
-                        old_memo.revisions.changed_at,
+                        old_memo.header.revisions.changed_at,
                         revisions.changed_at,
                     );
                 }
 
-                revisions.changed_at = old_memo.revisions.changed_at;
+                revisions.changed_at = old_memo.header.revisions.changed_at;
             }
         }
     }

--- a/src/function/diff_outputs.rs
+++ b/src/function/diff_outputs.rs
@@ -19,7 +19,7 @@ where
         old_memo: &Memo<'_, C>,
         completed_query: &CompletedQuery,
     ) {
-        diff_outputs_on_revision(zalsa, key, &old_memo.revisions, completed_query);
+        diff_outputs_on_revision(zalsa, key, &old_memo.header.revisions, completed_query);
     }
 }
 

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -138,8 +138,8 @@ where
         let mut iteration = IterationStamp::initial(cancellation_count);
 
         if let Some(old_memo) = opt_old_memo {
-            if old_memo.verified_at.load() == zalsa.current_revision()
-                && old_memo.revisions.iteration().cancellation_count() == cancellation_count
+            if old_memo.header.verified_at.load() == zalsa.current_revision()
+                && old_memo.header.revisions.iteration().cancellation_count() == cancellation_count
             {
                 // The `DependencyGraph` locking propagates panics when another thread is blocked on a panicking query.
                 // However, the locking doesn't handle the case where a thread fetches the result of a panicking
@@ -158,11 +158,11 @@ where
 
                 // Only use the last provisional memo if it was a cycle head in the last iteration. This is to
                 // force at least two executions.
-                if old_memo.cycle_heads().contains(&database_key_index) {
+                if old_memo.header.cycle_heads().contains(&database_key_index) {
                     last_provisional_memo_opt = Some(old_memo);
                 }
 
-                iteration = old_memo.revisions.iteration();
+                iteration = old_memo.header.revisions.iteration();
             }
         }
 
@@ -261,7 +261,7 @@ where
                         )
                     });
 
-                debug_assert!(memo.may_be_provisional());
+                debug_assert!(memo.header.may_be_provisional());
                 memo
             });
 
@@ -322,7 +322,7 @@ where
                 active_query,
                 claim_guard,
                 cycle_heads,
-                &last_provisional_memo.revisions,
+                &last_provisional_memo.header.revisions,
                 outer_cycle,
                 iteration,
                 cycle_iteration,
@@ -373,17 +373,17 @@ where
         if let Some(old_memo) = opt_old_memo {
             // If we already executed this query once, then use the tracked-struct ids from the
             // previous execution as the starting point for the new one.
-            active_query.seed_tracked_struct_ids(old_memo.revisions.tracked_struct_ids());
+            active_query.seed_tracked_struct_ids(old_memo.header.revisions.tracked_struct_ids());
 
             // Copy over all inputs and outputs from a previous iteration.
             // This is necessary to:
             // * ensure that tracked struct created during the previous iteration
             //   (and are owned by the query) are alive even if the query in this iteration no longer creates them.
             // * ensure the final returned memo depends on all inputs from all iterations.
-            if old_memo.may_be_provisional()
-                && old_memo.verified_at.load() == zalsa.current_revision()
+            if old_memo.header.may_be_provisional()
+                && old_memo.header.verified_at.load() == zalsa.current_revision()
             {
-                active_query.seed_iteration(&old_memo.revisions);
+                active_query.seed_iteration(&old_memo.header.revisions);
             }
         }
 

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -35,13 +35,13 @@ where
 
         zalsa_local.report_tracked_read(
             database_key_index,
-            memo.revisions.durability,
-            memo.revisions.changed_at,
-            memo.cycle_heads(),
+            memo.header.revisions.durability,
+            memo.header.revisions.changed_at,
+            memo.header.cycle_heads(),
             #[cfg(feature = "accumulator")]
-            memo.revisions.accumulated().is_some(),
+            memo.header.revisions.accumulated().is_some(),
             #[cfg(feature = "accumulator")]
-            &memo.revisions.accumulated_inputs,
+            &memo.header.revisions.accumulated_inputs,
         );
 
         memo_value
@@ -80,10 +80,13 @@ where
 
         let database_key_index = self.database_key_index(id);
 
-        let can_shallow_update = self.shallow_verify_memo(zalsa, database_key_index, memo);
+        let can_shallow_update = memo
+            .header
+            .shallow_verify_memo(zalsa, database_key_index, true);
 
-        if can_shallow_update.yes() && !memo.may_be_provisional() {
-            self.update_shallow(zalsa, database_key_index, memo, can_shallow_update);
+        if can_shallow_update.yes() && !memo.header.may_be_provisional() {
+            memo.header
+                .update_shallow(zalsa, database_key_index, can_shallow_update);
 
             // SAFETY: memo is present in memo_map and we have verified that it is
             // still valid for the current revision.
@@ -130,23 +133,33 @@ where
         if let Some(old_memo) = opt_old_memo {
             if old_memo.value.is_some() {
                 let can_shallow_update =
-                    self.shallow_verify_memo(zalsa, database_key_index, old_memo);
+                    old_memo
+                        .header
+                        .shallow_verify_memo(zalsa, database_key_index, true);
                 if can_shallow_update.yes()
-                    && self.validate_may_be_provisional(
+                    && old_memo.header.validate_may_be_provisional(
                         zalsa,
                         zalsa_local,
                         database_key_index,
-                        old_memo,
+                        true,
                     )
                 {
-                    self.update_shallow(zalsa, database_key_index, old_memo, can_shallow_update);
+                    old_memo
+                        .header
+                        .update_shallow(zalsa, database_key_index, can_shallow_update);
 
                     // SAFETY: memo is present in memo_map and we have verified that it is
                     // still valid for the current revision.
                     return unsafe { Some(self.extend_memo_lifetime(old_memo)) };
                 }
 
-                let verify_result = self.deep_verify_memo(db, zalsa, old_memo, database_key_index);
+                let verify_result = old_memo.header.deep_verify_memo(
+                    db.into(),
+                    zalsa,
+                    database_key_index,
+                    C::CYCLE_STRATEGY,
+                    true,
+                );
 
                 if verify_result.is_unchanged() {
                     // SAFETY: memo is present in memo_map and we have verified that it is
@@ -192,19 +205,25 @@ where
                     // Ideally, we'd use the last provisional memo even if it wasn't a cycle head in the last iteration
                     // but that would require inserting itself as a cycle head, which either requires clone
                     // on the value OR a concurrent `Vec` for cycle heads.
-                    if memo.verified_at.load() == zalsa.current_revision()
+                    if memo.header.verified_at.load() == zalsa.current_revision()
                         && memo.value.is_some()
-                        && memo.revisions.iteration().cancellation_count() == cancellation_count
-                        && memo.revisions.cycle_heads().contains(&database_key_index)
+                        && memo.header.revisions.iteration().cancellation_count()
+                            == cancellation_count
+                        && memo
+                            .header
+                            .revisions
+                            .cycle_heads()
+                            .contains(&database_key_index)
                     {
-                        memo.revisions
+                        memo.header
+                            .revisions
                             .cycle_heads()
                             .remove_all_except(database_key_index);
 
                         crate::tracing::debug!(
                             "hit cycle at {database_key_index:#?}, \
                                 returning last provisional value: {:#?}",
-                            memo.revisions
+                            memo.header.revisions
                         );
 
                         // SAFETY: memo is present in memo_map.
@@ -219,12 +238,12 @@ where
 
                 let iteration = memo_guard
                     .and_then(|old_memo| {
-                        if old_memo.verified_at.load() == zalsa.current_revision()
+                        if old_memo.header.verified_at.load() == zalsa.current_revision()
                             && old_memo.value.is_some()
-                            && old_memo.revisions.iteration().cancellation_count()
+                            && old_memo.header.revisions.iteration().cancellation_count()
                                 == cancellation_count
                         {
-                            Some(old_memo.revisions.iteration())
+                            Some(old_memo.header.revisions.iteration())
                         } else {
                             None
                         }

--- a/src/function/inputs.rs
+++ b/src/function/inputs.rs
@@ -10,6 +10,6 @@ where
     pub(super) fn origin<'db>(&self, zalsa: &'db Zalsa, key: Id) -> Option<QueryOriginRef<'db>> {
         let memo_ingredient_index = self.memo_ingredient_index(zalsa, key);
         self.get_memo_from_table_for(zalsa, key, memo_ingredient_index)
-            .map(|m| m.revisions.origin())
+            .map(|m| m.header.origin())
     }
 }

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "accumulator")]
 use crate::accumulator::accumulated_map::InputAccumulatedValues;
 use crate::cycle::{CycleHeads, CycleRecoveryStrategy, ProvisionalStatus};
-use crate::function::memo::{Memo, TryClaimCycleHeadsIter, TryClaimHeadsResult};
+use crate::function::memo::{MemoHeader, TryClaimCycleHeadsIter, TryClaimHeadsResult};
 use crate::function::sync::ClaimResult;
 use crate::function::{Configuration, IngredientImpl, Reentrancy};
 use std::sync::atomic::Ordering;
@@ -92,17 +92,20 @@ where
                 return VerifyResult::changed();
             };
 
-            let can_shallow_update = self.shallow_verify_memo(zalsa, database_key_index, memo);
-            if can_shallow_update.yes() && !memo.may_be_provisional() {
-                self.update_shallow(zalsa, database_key_index, memo, can_shallow_update);
+            let can_shallow_update =
+                memo.header
+                    .shallow_verify_memo(zalsa, database_key_index, memo.value.is_some());
+            if can_shallow_update.yes() && !memo.header.may_be_provisional() {
+                memo.header
+                    .update_shallow(zalsa, database_key_index, can_shallow_update);
 
-                return if memo.revisions.changed_at > revision {
+                return if memo.header.revisions.changed_at > revision {
                     VerifyResult::changed()
                 } else {
                     VerifyResult::unchanged_with_accumulated(
                         #[cfg(feature = "accumulator")]
                         {
-                            memo.revisions.accumulated_inputs.load()
+                            memo.header.revisions.accumulated_inputs.load()
                         },
                     )
                 };
@@ -165,25 +168,42 @@ where
             old_memo = old_memo.tracing_debug()
         );
 
-        let can_shallow_update = self.shallow_verify_memo(zalsa, database_key_index, old_memo);
+        let can_shallow_update = old_memo.header.shallow_verify_memo(
+            zalsa,
+            database_key_index,
+            old_memo.value.is_some(),
+        );
         if can_shallow_update.yes()
-            && self.validate_may_be_provisional(zalsa, zalsa_local, database_key_index, old_memo)
+            && old_memo.header.validate_may_be_provisional(
+                zalsa,
+                zalsa_local,
+                database_key_index,
+                old_memo.value.is_some(),
+            )
         {
-            self.update_shallow(zalsa, database_key_index, old_memo, can_shallow_update);
+            old_memo
+                .header
+                .update_shallow(zalsa, database_key_index, can_shallow_update);
 
-            return Some(if old_memo.revisions.changed_at > revision {
+            return Some(if old_memo.header.revisions.changed_at > revision {
                 VerifyResult::changed()
             } else {
                 VerifyResult::unchanged_with_accumulated(
                     #[cfg(feature = "accumulator")]
                     {
-                        old_memo.revisions.accumulated_inputs.load()
+                        old_memo.header.revisions.accumulated_inputs.load()
                     },
                 )
             });
         }
 
-        let deep_verify = self.deep_verify_memo(db, zalsa, old_memo, database_key_index);
+        let deep_verify = old_memo.header.deep_verify_memo(
+            db.into(),
+            zalsa,
+            database_key_index,
+            C::CYCLE_STRATEGY,
+            old_memo.value.is_some(),
+        );
 
         if let VerifyResult::Unchanged {
             #[cfg(feature = "accumulator")]
@@ -191,7 +211,7 @@ where
         } = deep_verify
         {
             // Check if the inputs are still valid. We can just compare `changed_at`.
-            return Some(if old_memo.revisions.changed_at > revision {
+            return Some(if old_memo.header.revisions.changed_at > revision {
                 VerifyResult::changed()
             } else {
                 // Propagate accumulated values from inputs *and* from this memo itself.
@@ -201,7 +221,7 @@ where
                 VerifyResult::unchanged_with_accumulated(
                     #[cfg(feature = "accumulator")]
                     {
-                        if old_memo.revisions.accumulated().is_some() {
+                        if old_memo.header.revisions.accumulated().is_some() {
                             InputAccumulatedValues::Any
                         } else {
                             accumulated
@@ -215,31 +235,35 @@ where
         // It is possible the result will be equal to the old value and hence
         // backdated. In that case, although we will have computed a new memo,
         // the value has not logically changed.
-        if old_memo.value.is_some() && !old_memo.may_be_provisional() {
+        if old_memo.value.is_some() && !old_memo.header.may_be_provisional() {
             let memo = self.execute(db, claim_guard, Some(old_memo))?;
-            let changed_at = memo.revisions.changed_at;
+            let changed_at = memo.header.revisions.changed_at;
 
             // Always assume that a provisional value has changed.
             //
             // We don't know if a provisional value has actually changed. To determine whether a provisional
             // value has changed, we need to iterate the outer cycle, which cannot be done here.
-            return Some(if changed_at > revision || memo.may_be_provisional() {
-                VerifyResult::changed()
-            } else {
-                VerifyResult::unchanged_with_accumulated(
-                    #[cfg(feature = "accumulator")]
-                    match memo.revisions.accumulated() {
-                        Some(_) => InputAccumulatedValues::Any,
-                        None => memo.revisions.accumulated_inputs.load(),
-                    },
-                )
-            });
+            return Some(
+                if changed_at > revision || memo.header.may_be_provisional() {
+                    VerifyResult::changed()
+                } else {
+                    VerifyResult::unchanged_with_accumulated(
+                        #[cfg(feature = "accumulator")]
+                        match memo.header.revisions.accumulated() {
+                            Some(_) => InputAccumulatedValues::Any,
+                            None => memo.header.revisions.accumulated_inputs.load(),
+                        },
+                    )
+                },
+            );
         }
 
         // Otherwise, nothing for it: have to consider the value to have changed.
         Some(VerifyResult::changed())
     }
+}
 
+impl MemoHeader {
     /// `Some` if the memo's value and `changed_at` time is still valid in this revision.
     /// Does only a shallow O(1) check, doesn't walk the dependencies.
     ///
@@ -252,13 +276,13 @@ where
         &self,
         zalsa: &Zalsa,
         database_key_index: DatabaseKeyIndex,
-        memo: &Memo<'_, C>,
+        has_value: bool,
     ) -> ShallowUpdate {
         crate::tracing::debug!(
             "{database_key_index:?}: shallow_verify_memo(memo = {memo:#?})",
-            memo = memo.tracing_debug()
+            memo = self.tracing_debug(has_value)
         );
-        let verified_at = memo.verified_at.load();
+        let verified_at = self.verified_at.load();
         let revision_now = zalsa.current_revision();
 
         if verified_at == revision_now {
@@ -266,7 +290,7 @@ where
             return ShallowUpdate::Verified;
         }
 
-        let last_changed = zalsa.last_changed_revision(memo.revisions.durability);
+        let last_changed = zalsa.last_changed_revision(self.revisions.durability);
         crate::tracing::trace!(
             "{database_key_index:?}: check_durability({database_key_index:#?}, last_changed={:?} <= verified_at={:?}) = {:?}",
             last_changed,
@@ -286,12 +310,11 @@ where
         &self,
         zalsa: &Zalsa,
         database_key_index: DatabaseKeyIndex,
-        memo: &Memo<'_, C>,
         update: ShallowUpdate,
     ) {
         if let ShallowUpdate::HigherDurability = update {
-            memo.mark_as_verified(zalsa, database_key_index);
-            memo.mark_outputs_as_verified(zalsa, database_key_index);
+            self.mark_as_verified(zalsa, database_key_index);
+            self.mark_outputs_as_verified(zalsa, database_key_index);
         }
     }
 
@@ -306,13 +329,13 @@ where
         zalsa: &Zalsa,
         zalsa_local: &ZalsaLocal,
         database_key_index: DatabaseKeyIndex,
-        memo: &Memo<'_, C>,
+        has_value: bool,
     ) -> bool {
-        if !memo.may_be_provisional() {
+        if !self.may_be_provisional() {
             return true;
         }
 
-        let cycle_heads = memo.cycle_heads();
+        let cycle_heads = self.cycle_heads();
 
         if cycle_heads.is_empty() {
             return true;
@@ -320,14 +343,14 @@ where
 
         crate::tracing::trace!(
             "{database_key_index:?}: validate_may_be_provisional(memo = {memo:#?})",
-            memo = memo.tracing_debug()
+            memo = self.tracing_debug(has_value)
         );
 
-        let verified_at = memo.verified_at.load();
+        let verified_at = self.verified_at.load();
         validate_provisional(
             zalsa,
             database_key_index,
-            &memo.revisions,
+            &self.revisions,
             verified_at,
             cycle_heads,
         ) || validate_same_iteration(
@@ -348,19 +371,20 @@ where
     /// outputs have changed.
     pub(super) fn deep_verify_memo(
         &self,
-        db: &C::DbView,
+        db: crate::database::RawDatabase<'_>,
         zalsa: &Zalsa,
-        old_memo: &Memo<'_, C>,
         database_key_index: DatabaseKeyIndex,
+        cycle_recovery_strategy: CycleRecoveryStrategy,
+        has_value: bool,
     ) -> VerifyResult {
-        match old_memo.revisions.origin() {
+        match self.origin() {
             QueryOriginRef::Derived(edges) => {
                 crate::tracing::debug!(
                     "{database_key_index:?}: deep_verify_memo(old_memo = {old_memo:#?})",
-                    old_memo = old_memo.tracing_debug()
+                    old_memo = self.tracing_debug(has_value)
                 );
 
-                let is_provisional = old_memo.may_be_provisional();
+                let is_provisional = self.may_be_provisional();
 
                 // If the value is from the same revision but is still provisional, consider it changed
                 // because we're now in a new iteration.
@@ -382,25 +406,25 @@ where
                 //
                 // For queries with cycle handling, verify the flattened
                 // dependencies of the cycle head instead.
-                if C::CYCLE_STRATEGY == CycleRecoveryStrategy::Panic
-                    && old_memo.was_cycle_participant()
+                if cycle_recovery_strategy == CycleRecoveryStrategy::Panic
+                    && self.was_cycle_participant()
                 {
                     return VerifyResult::changed();
                 }
 
-                let verified_at = old_memo.verified_at.load();
+                let verified_at = self.verified_at.load();
 
                 let result = deep_verify_edges(
-                    db.into(),
+                    db,
                     zalsa,
-                    &old_memo.revisions,
+                    &self.revisions,
                     verified_at,
                     edges,
                     database_key_index,
                 );
 
                 if result.is_unchanged() {
-                    old_memo.mark_as_verified(zalsa, database_key_index);
+                    self.mark_as_verified(zalsa, database_key_index);
                 }
 
                 result

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -4,16 +4,18 @@ use std::mem::transmute;
 use std::ptr::NonNull;
 
 use crate::cycle::{
-    CycleHeads, CycleHeadsIterator, IterationStamp, ProvisionalStatus, empty_cycle_heads,
+    CycleHeads, CycleHeadsIterator, CycleRecoveryStrategy, IterationStamp, ProvisionalStatus,
+    empty_cycle_heads,
 };
 use crate::function::{Configuration, IngredientImpl};
+use crate::hash::{FxHashSet, FxIndexSet};
 use crate::ingredient::WaitForResult;
 use crate::key::DatabaseKeyIndex;
 use crate::revision::AtomicRevision;
 use crate::sync::atomic::Ordering;
 use crate::table::memo::MemoTableWithTypesMut;
 use crate::zalsa::{MemoIngredientIndex, Zalsa};
-use crate::zalsa_local::{QueryOriginRef, QueryRevisions};
+use crate::zalsa_local::{QueryEdge, QueryOriginRef, QueryRevisions};
 use crate::{Event, EventKind, Id, Revision};
 
 impl<C: Configuration> IngredientImpl<C> {
@@ -64,17 +66,8 @@ impl<C: Configuration> IngredientImpl<C> {
         memo_ingredient_index: MemoIngredientIndex,
     ) {
         let map = |memo: &mut Memo<'static, C>| {
-            match memo.revisions.origin() {
-                QueryOriginRef::Assigned(_) | QueryOriginRef::DerivedUntracked(_) => {
-                    // Careful: Cannot evict memos whose values were
-                    // assigned as output of another query
-                    // or those with untracked inputs
-                    // as their values cannot be reconstructed.
-                }
-                QueryOriginRef::Derived(_) => {
-                    // Set the memo value to `None`.
-                    memo.value = None;
-                }
+            if memo.header.can_evict_value() {
+                memo.value = None;
             }
         };
 
@@ -84,9 +77,15 @@ impl<C: Configuration> IngredientImpl<C> {
 
 #[derive(Debug)]
 pub struct Memo<'db, C: Configuration> {
+    /// Configuration-independent state used to validate and manage this memo.
+    pub(super) header: MemoHeader,
+
     /// The result of the query, if we decide to memoize it.
     pub(super) value: Option<C::Output<'db>>,
+}
 
+#[derive(Debug)]
+pub(super) struct MemoHeader {
     /// Last revision when this memo was verified; this begins
     /// as the current revision.
     pub(super) verified_at: AtomicRevision,
@@ -95,28 +94,26 @@ pub struct Memo<'db, C: Configuration> {
     pub(super) revisions: QueryRevisions,
 }
 
-impl<'db, C: Configuration> Memo<'db, C> {
-    pub(super) fn new(
-        value: Option<C::Output<'db>>,
-        revision_now: Revision,
-        revisions: QueryRevisions,
-    ) -> Self {
+impl MemoHeader {
+    fn new(revision_now: Revision, revisions: QueryRevisions) -> Self {
         debug_assert!(
             !revisions.verified_final.load(Ordering::Relaxed) || revisions.cycle_heads().is_empty(),
             "Memo must be finalized if it has no cycle heads"
         );
-        Memo {
-            value,
+        Self {
             verified_at: AtomicRevision::from(revision_now),
             revisions,
         }
     }
 
-    /// Returns `true` if this memo should be serialized.
-    pub(super) fn should_serialize(&self) -> bool {
-        // TODO: Serialization is a good opportunity to prune old query results based on
-        // the `verified_at` revision.
-        self.value.is_some() && !self.may_be_provisional()
+    #[inline]
+    pub(super) fn origin(&self) -> QueryOriginRef<'_> {
+        self.revisions.origin()
+    }
+
+    fn can_evict_value(&self) -> bool {
+        // Assigned values and values with untracked inputs cannot be reconstructed.
+        matches!(self.origin(), QueryOriginRef::Derived(_))
     }
 
     /// True if this may be a provisional cycle-iteration result.
@@ -170,37 +167,36 @@ impl<'db, C: Configuration> Memo<'db, C> {
         }
     }
 
-    pub(super) fn tracing_debug(&self) -> impl std::fmt::Debug + use<'_, 'db, C> {
-        struct TracingDebug<'memo, 'db, C: Configuration> {
-            memo: &'memo Memo<'db, C>,
+    pub(super) fn tracing_debug(&self, has_value: bool) -> impl std::fmt::Debug + use<'_> {
+        struct TracingDebug<'memo> {
+            header: &'memo MemoHeader,
+            has_value: bool,
         }
 
-        impl<C: Configuration> std::fmt::Debug for TracingDebug<'_, '_, C> {
+        impl std::fmt::Debug for TracingDebug<'_> {
             fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
                 f.debug_struct("Memo")
                     .field(
                         "value",
-                        if self.memo.value.is_some() {
+                        if self.has_value {
                             &"Some(<value>)"
                         } else {
                             &"None"
                         },
                     )
-                    .field("verified_at", &self.memo.verified_at)
-                    .field("revisions", &self.memo.revisions)
+                    .field("verified_at", &self.header.verified_at)
+                    .field("revisions", &self.header.revisions)
                     .finish()
             }
         }
 
-        TracingDebug { memo: self }
+        TracingDebug {
+            header: self,
+            has_value,
+        }
     }
-}
 
-impl<C: Configuration> crate::table::memo::Memo for Memo<'static, C>
-where
-    C::Output<'static>: Send + Sync + Any,
-{
-    fn remove_outputs(&self, zalsa: &Zalsa, executor: DatabaseKeyIndex) {
+    pub(super) fn remove_outputs(&self, zalsa: &Zalsa, executor: DatabaseKeyIndex) {
         for stale_output in self.revisions.origin().outputs() {
             stale_output.remove_stale_output(zalsa, executor);
         }
@@ -211,9 +207,151 @@ where
         }
     }
 
+    pub(super) fn collect_minimum_serialized_edges(
+        &self,
+        zalsa: &Zalsa,
+        edge: QueryEdge,
+        serialized_edges: &mut FxIndexSet<QueryEdge>,
+        visited_edges: &mut FxHashSet<QueryEdge>,
+    ) {
+        visited_edges.insert(edge);
+
+        // Collect the minimum dependency tree.
+        for edge in self.origin().edges() {
+            // Avoid forming cycles.
+            if visited_edges.contains(&edge) {
+                continue;
+            }
+
+            // Avoid flattening edges that we're going to serialize directly.
+            if serialized_edges.contains(&edge) {
+                continue;
+            }
+
+            let dependency = zalsa.lookup_ingredient(edge.key().ingredient_index());
+            dependency.collect_minimum_serialized_edges(
+                zalsa,
+                edge,
+                serialized_edges,
+                visited_edges,
+            );
+        }
+    }
+
+    pub(super) fn provisional_status(&self) -> ProvisionalStatus<'_> {
+        let iteration = self.revisions.iteration();
+        let verified_at = self.verified_at.load();
+
+        if self.revisions.verified_final.load(Ordering::Relaxed) {
+            ProvisionalStatus::Final {
+                iteration,
+                verified_at,
+            }
+        } else {
+            ProvisionalStatus::Provisional {
+                iteration,
+                verified_at,
+                cycle_heads: self.cycle_heads(),
+            }
+        }
+    }
+
+    pub(super) fn set_cycle_iteration_count(
+        &self,
+        database_key_index: DatabaseKeyIndex,
+        iteration: IterationStamp,
+    ) {
+        self.revisions
+            .set_iteration_count(database_key_index, iteration);
+    }
+
+    pub(super) fn finalize_cycle_head(&self) {
+        self.revisions.verified_final.store(true, Ordering::Release);
+    }
+
+    pub(super) fn flatten_cycle_head_dependencies(
+        &self,
+        zalsa: &Zalsa,
+        database_key_index: DatabaseKeyIndex,
+        cycle_recovery_strategy: CycleRecoveryStrategy,
+        flattened_input_outputs: &mut FxIndexSet<QueryEdge>,
+        seen: &mut FxHashSet<DatabaseKeyIndex>,
+    ) {
+        // Only flatten dependencies of provisional queries, because only those
+        // contain cyclic dependencies.
+        if !self.may_be_provisional() {
+            flattened_input_outputs.insert(QueryEdge::input(database_key_index));
+            return;
+        }
+
+        // There's nothing to do if we've visited this query before.
+        if !seen.insert(database_key_index) {
+            return;
+        }
+
+        let inputs = self.origin().inputs();
+
+        match cycle_recovery_strategy {
+            // For queries with cycle handling, simply extend the input/outputs, because
+            // they already flattened their own dependencies when completing the query.
+            CycleRecoveryStrategy::FallbackImmediate | CycleRecoveryStrategy::Fixpoint => {
+                flattened_input_outputs.extend(inputs.map(QueryEdge::input));
+            }
+            // For regular queries, recurse.
+            CycleRecoveryStrategy::Panic => {
+                for input in inputs {
+                    let ingredient = zalsa.lookup_ingredient(input.ingredient_index());
+                    ingredient.flatten_cycle_head_dependencies(
+                        zalsa,
+                        input.key_index(),
+                        flattened_input_outputs,
+                        seen,
+                    );
+                }
+            }
+        }
+    }
+
+    pub(super) fn cycle_converged(&self) -> bool {
+        self.revisions.cycle_converged()
+    }
+}
+
+impl<'db, C: Configuration> Memo<'db, C> {
+    pub(super) fn new(
+        value: Option<C::Output<'db>>,
+        revision_now: Revision,
+        revisions: QueryRevisions,
+    ) -> Self {
+        Self {
+            value,
+            header: MemoHeader::new(revision_now, revisions),
+        }
+    }
+
+    /// Returns `true` if this memo should be serialized.
+    pub(super) fn should_serialize(&self) -> bool {
+        // TODO: Serialization is a good opportunity to prune old query results based on
+        // the `verified_at` revision.
+        self.value.is_some() && !self.header.may_be_provisional()
+    }
+
+    pub(super) fn tracing_debug(&self) -> impl std::fmt::Debug + use<'_, 'db, C> {
+        self.header.tracing_debug(self.value.is_some())
+    }
+}
+
+impl<C: Configuration> crate::table::memo::Memo for Memo<'static, C>
+where
+    C::Output<'static>: Send + Sync + Any,
+{
+    fn remove_outputs(&self, zalsa: &Zalsa, executor: DatabaseKeyIndex) {
+        self.header.remove_outputs(zalsa, executor);
+    }
+
     #[cfg(feature = "salsa_unstable")]
     fn memory_usage(&self) -> crate::database::MemoInfo {
-        let size_of = std::mem::size_of::<Memo<C>>() + self.revisions.allocation_size();
+        let size_of = std::mem::size_of::<Memo<C>>() + self.header.revisions.allocation_size();
         let heap_size = if let Some(value) = self.value.as_ref() {
             C::heap_size(value)
         } else {
@@ -236,7 +374,7 @@ where
 #[cfg(feature = "persistence")]
 mod persistence {
     use crate::function::Configuration;
-    use crate::function::memo::Memo;
+    use crate::function::memo::{Memo, MemoHeader};
     use crate::revision::AtomicRevision;
     use crate::zalsa_local::QueryRevisions;
     use crate::zalsa_local::persistence::{MappedQueryRevisions, PersistentQueryOrigin};
@@ -257,10 +395,13 @@ mod persistence {
             serialized_origin: PersistentQueryOrigin,
         ) -> MappedMemo<'_, 'db, C> {
             let Memo {
-                ref verified_at,
                 ref value,
-                ref revisions,
+                ref header,
             } = *self;
+            let MemoHeader {
+                ref verified_at,
+                ref revisions,
+            } = *header;
 
             MappedMemo {
                 value: value.as_ref(),
@@ -347,8 +488,10 @@ mod persistence {
 
             Ok(Memo {
                 value: Some(memo.value.0),
-                verified_at: memo.verified_at,
-                revisions: memo.revisions,
+                header: MemoHeader {
+                    verified_at: memo.verified_at,
+                    revisions: memo.revisions,
+                },
             })
         }
     }
@@ -448,6 +591,8 @@ mod _memory_usage {
     use std::num::NonZeroUsize;
 
     // Memo's are stored a lot, make sure their size doesn't randomly increase.
+    const _: [(); std::mem::size_of::<super::MemoHeader>()] =
+        [(); std::mem::size_of::<[usize; 4]>()];
     const _: [(); std::mem::size_of::<super::Memo<DummyConfiguration>>()] =
         [(); std::mem::size_of::<[usize; 5]>()];
 

--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "accumulator")]
 use crate::accumulator::accumulated_map::InputAccumulatedValues;
 use crate::active_query::CompletedQuery;
-use crate::function::memo::Memo;
+use crate::function::memo::{Memo, MemoHeader};
 use crate::function::{Configuration, IngredientImpl};
 use crate::revision::AtomicRevision;
 use crate::sync::atomic::AtomicBool;
@@ -89,8 +89,10 @@ where
 
         let memo = Memo {
             value: Some(value),
-            verified_at: AtomicRevision::from(revision),
-            revisions: completed_query.revisions,
+            header: MemoHeader {
+                verified_at: AtomicRevision::from(revision),
+                revisions: completed_query.revisions,
+            },
         };
 
         crate::tracing::debug!(
@@ -124,19 +126,20 @@ where
 
         // If we are marking this as validated, it must be a value that was
         // assigned by `executor`.
-        match memo.revisions.origin() {
+        match memo.header.origin() {
             QueryOriginRef::Assigned(by_query) => assert_eq!(by_query, executor),
             _ => panic!(
                 "expected a query assigned by `{:?}`, not `{:?}`",
                 executor,
-                memo.revisions.origin(),
+                memo.header.origin(),
             ),
         }
 
         let database_key_index = self.database_key_index(key);
-        memo.mark_as_verified(zalsa, database_key_index);
+        memo.header.mark_as_verified(zalsa, database_key_index);
         #[cfg(feature = "accumulator")]
-        memo.revisions
+        memo.header
+            .revisions
             .accumulated_inputs
             .store(InputAccumulatedValues::Empty);
     }

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -91,17 +91,17 @@ pub struct IngredientImpl<C: Configuration> {
     shift: u32,
 
     /// Sharded data that can only be accessed through a lock.
-    shards: Box<[CachePadded<Mutex<IngredientShard<C>>>]>,
+    shards: Box<[CachePadded<Mutex<IngredientShard>>]>,
 
     /// A queue of recent revisions in which values were interned.
-    revision_queue: RevisionQueue<C>,
+    revision_queue: RevisionQueue,
 
     memo_table_types: Arc<MemoTableTypes>,
 
     _marker: PhantomData<fn() -> C>,
 }
 
-struct IngredientShard<C: Configuration> {
+struct IngredientShard {
     /// Maps from data to the existing interned ID for that data.
     ///
     /// This doesn't hold the fields themselves to save memory, instead it points
@@ -109,10 +109,10 @@ struct IngredientShard<C: Configuration> {
     key_map: hashbrown::HashTable<Id>,
 
     /// An intrusive linked list for LRU.
-    lru: LinkedList<ValueAdapter<C>>,
+    lru: LinkedList<ValueHeaderAdapter>,
 }
 
-impl<C: Configuration> Default for IngredientShard<C> {
+impl Default for IngredientShard {
     fn default() -> Self {
         Self {
             lru: LinkedList::default(),
@@ -125,24 +125,33 @@ impl<C: Configuration> Default for IngredientShard<C> {
 // ingredient lock, and values are only ever linked to a single list on the ingredient.
 unsafe impl<C: Configuration> Sync for Value<C> {}
 
-intrusive_adapter!(ValueAdapter<C> = UnsafeRef<Value<C>>: Value<C> { link => LinkedListLink } where C: Configuration);
+// SAFETY: `LinkedListLink`, `memos`, and `shared` are only accessed while holding the
+// ingredient shard lock.
+unsafe impl Sync for ValueHeader {}
+
+intrusive_adapter!(ValueHeaderAdapter = UnsafeRef<ValueHeader>: ValueHeader { link => LinkedListLink });
 
 /// Struct storing the interned fields.
 pub struct Value<C>
 where
     C: Configuration,
 {
-    /// The index of the shard containing this value.
-    shard: u16,
-
-    /// An intrusive linked list for LRU.
-    link: LinkedListLink,
+    /// Configuration-independent state used to manage this value.
+    header: ValueHeader,
 
     /// The interned fields for this value.
     ///
     /// These are valid for read-only access as long as the lock is held
     /// or the value has been validated in the current revision.
     fields: UnsafeCell<C::Fields<'static>>,
+}
+
+struct ValueHeader {
+    /// The index of the shard containing this value.
+    shard: u16,
+
+    /// An intrusive linked list for LRU.
+    link: LinkedListLink,
 
     /// Memos attached to this interned value.
     ///
@@ -155,8 +164,11 @@ where
     shared: UnsafeCell<ValueShared>,
 }
 
+#[cfg(all(not(feature = "shuttle"), target_pointer_width = "64"))]
+const _: [(); std::mem::size_of::<ValueHeader>()] = [(); std::mem::size_of::<[usize; 7]>()];
+
 /// Shared value data can only be read through the lock.
-#[repr(Rust, packed)] // Allow `durability` to be stored in the padding of the outer `Value` struct.
+#[repr(Rust, packed)] // Avoid padding around `durability` inside `ValueHeader`.
 #[derive(Clone, Copy)]
 struct ValueShared {
     /// The interned ID for this value.
@@ -186,9 +198,9 @@ struct ValueShared {
 
 impl ValueShared {
     /// Returns `true` if this value slot can be reused when interning, and should be added to the LRU.
-    fn is_reusable<C: Configuration>(&self) -> bool {
+    fn is_reusable(&self, revisions: NonZeroUsize) -> bool {
         // Garbage collection is disabled.
-        if C::REVISIONS == IMMORTAL {
+        if revisions == IMMORTAL {
             return false;
         }
 
@@ -226,7 +238,7 @@ where
         let heap_size = C::heap_size(self.fields());
         // SAFETY: The caller guarantees we hold the lock for the shard containing the value, so we
         // have at-least read-only access to the value's memos.
-        let memos = unsafe { &*self.memos.get() };
+        let memos = unsafe { &*self.header.memos.get() };
         // SAFETY: The caller guarantees this is the correct types table.
         let memos = unsafe { memo_table_types.attach_memos(memos) };
 
@@ -279,7 +291,7 @@ where
             ingredient_index,
             hasher: FxBuildHasher,
             memo_table_types: Arc::new(MemoTableTypes::default()),
-            revision_queue: RevisionQueue::default(),
+            revision_queue: RevisionQueue::new(C::REVISIONS),
             shift: usize::BITS - shards.trailing_zeros(),
             shards: (0..shards).map(|_| Default::default()).collect(),
             _marker: PhantomData,
@@ -361,7 +373,9 @@ where
     {
         // Record the current revision as active.
         let current_revision = zalsa.current_revision();
-        self.revision_queue.record(current_revision);
+        if C::REVISIONS != IMMORTAL {
+            self.revision_queue.record(current_revision);
+        }
 
         // Hash the value before acquiring the lock.
         let hash = self.hasher.hash_one(&key);
@@ -383,7 +397,7 @@ where
             let index = self.database_key_index(id);
 
             // SAFETY: We hold the lock for the shard containing the value.
-            let value_shared = unsafe { &mut *value.shared.get() };
+            let value_shared = unsafe { &mut *value.header.shared.get() };
 
             // Validate the value in this revision to avoid reuse.
             if { value_shared.last_interned_at } < current_revision {
@@ -396,31 +410,31 @@ where
                     })
                 });
 
-                if value_shared.is_reusable::<C>() {
+                if value_shared.is_reusable(C::REVISIONS) {
                     // Move the value to the front of the LRU list.
                     //
                     // SAFETY: We hold the lock for the shard containing the value, and `value` is
                     // a reusable value that was previously interned, so is in the list.
-                    unsafe { shard.lru.cursor_mut_from_ptr(value).remove() };
+                    unsafe { shard.lru.cursor_mut_from_ptr(&value.header).remove() };
 
                     // SAFETY: The value pointer is valid for the lifetime of the database
                     // and never accessed mutably directly.
-                    unsafe { shard.lru.push_front(UnsafeRef::from_raw(value)) };
+                    unsafe { shard.lru.push_front(UnsafeRef::from_raw(&value.header)) };
                 }
             }
 
             if let Some((_, stamp)) = zalsa_local.active_query() {
-                let was_reusable = value_shared.is_reusable::<C>();
+                let was_reusable = value_shared.is_reusable(C::REVISIONS);
 
                 // Record the maximum durability across all queries that intern this value.
                 value_shared.durability = std::cmp::max(value_shared.durability, stamp.durability);
 
                 // If the value is no longer reusable, i.e. the durability increased, remove it
                 // from the LRU.
-                if was_reusable && !value_shared.is_reusable::<C>() {
+                if was_reusable && !value_shared.is_reusable(C::REVISIONS) {
                     // SAFETY: We hold the lock for the shard containing the value, and `value`
                     // was previously reusable, so is in the list.
-                    unsafe { shard.lru.cursor_mut_from_ptr(value).remove() };
+                    unsafe { shard.lru.cursor_mut_from_ptr(&value.header).remove() };
                 }
             }
 
@@ -454,9 +468,9 @@ where
         // Otherwise, try to reuse a stale slot.
         let mut cursor = shard.lru.back_mut();
 
-        while let Some(value) = cursor.get() {
+        while let Some(header) = cursor.get() {
             // SAFETY: We hold the lock for the shard containing the value.
-            let value_shared = unsafe { &mut *value.shared.get() };
+            let value_shared = unsafe { &mut *header.shared.get() };
 
             // The value must not have been read in the current revision to be collected
             // soundly, but we also do not want to collect values that have been read recently.
@@ -521,8 +535,9 @@ where
 
             // Remove the value from the LRU list.
             //
-            // SAFETY: The value pointer is valid for the lifetime of the database.
-            let value = unsafe { &*UnsafeRef::into_raw(cursor.remove().unwrap()) };
+            let header = UnsafeRef::into_raw(cursor.remove().unwrap());
+            let value = zalsa.table().get::<Value<C>>(new_id);
+            debug_assert!(std::ptr::eq(header, &value.header));
 
             // SAFETY: We hold the lock for the shard containing the value, and the
             // value has not been interned in the current revision, so no references to
@@ -557,7 +572,7 @@ where
             // SAFETY: We hold the lock for the shard containing the value, and the
             // value has not been interned in the current revision, so no references to
             // it can exist.
-            let memo_table = unsafe { &mut *value.memos.get() };
+            let memo_table = unsafe { &mut *value.header.memos.get() };
 
             // Free the memos associated with the previous interned value.
             //
@@ -565,12 +580,14 @@ where
             // correct type.
             unsafe { self.clear_memos(zalsa, memo_table, new_id) };
 
-            if value_shared.is_reusable::<C>() {
+            if value_shared.is_reusable(C::REVISIONS) {
                 // Move the value to the front of the LRU list.
                 //
                 // SAFETY: The value pointer is valid for the lifetime of the database.
                 // and never accessed mutably directly.
-                shard.lru.push_front(unsafe { UnsafeRef::from_raw(value) });
+                shard
+                    .lru
+                    .push_front(unsafe { UnsafeRef::from_raw(&value.header) });
             }
 
             return new_id;
@@ -590,7 +607,7 @@ where
         zalsa: &Zalsa,
         zalsa_local: &ZalsaLocal,
         assemble: impl FnOnce(Id, Key) -> C::Fields<'db>,
-        shard: &mut IngredientShard<C>,
+        shard: &mut IngredientShard,
         shard_index: usize,
         hash: u64,
     ) -> crate::Id
@@ -610,18 +627,20 @@ where
 
         // Allocate the value slot.
         let (id, value) = zalsa_local.allocate(zalsa, self.ingredient_index, |id| Value::<C> {
-            shard: shard_index as u16,
-            link: LinkedListLink::new(),
-            // SAFETY: We only ever access the memos of a value that we allocated through
-            // our `MemoTableTypes`.
-            memos: UnsafeCell::new(unsafe { MemoTable::new(self.memo_table_types()) }),
+            header: ValueHeader {
+                shard: shard_index as u16,
+                link: LinkedListLink::new(),
+                // SAFETY: We only ever access the memos of a value that we allocated through
+                // our `MemoTableTypes`.
+                memos: UnsafeCell::new(unsafe { MemoTable::new(self.memo_table_types()) }),
+                shared: UnsafeCell::new(ValueShared {
+                    id,
+                    durability,
+                    last_interned_at,
+                }),
+            },
             // SAFETY: We call `from_internal_data` to restore the correct lifetime before access.
             fields: UnsafeCell::new(unsafe { self.to_internal_data(assemble(id, key)) }),
-            shared: UnsafeCell::new(ValueShared {
-                id,
-                durability,
-                last_interned_at,
-            }),
         });
 
         // Insert the newly allocated ID.
@@ -654,19 +673,21 @@ where
         &self,
         id: Id,
         zalsa: &Zalsa,
-        shard: &mut IngredientShard<C>,
+        shard: &mut IngredientShard,
         hash: u64,
         value: &Value<C>,
     ) {
         // SAFETY: We hold the lock for the shard containing the value.
-        let value_shared = unsafe { &mut *value.shared.get() };
+        let value_shared = unsafe { &mut *value.header.shared.get() };
 
-        if value_shared.is_reusable::<C>() {
+        if value_shared.is_reusable(C::REVISIONS) {
             // Add the value to the front of the LRU list.
             //
             // SAFETY: The value pointer is valid for the lifetime of the database
             // and never accessed mutably directly.
-            shard.lru.push_front(unsafe { UnsafeRef::from_raw(value) });
+            shard
+                .lru
+                .push_front(unsafe { UnsafeRef::from_raw(&value.header) });
         }
 
         // SAFETY: We hold the lock for the shard containing the value.
@@ -776,10 +797,10 @@ where
 
         debug_assert!(
             {
-                let _shard = self.shards[value.shard as usize].lock();
+                let _shard = self.shards[value.header.shard as usize].lock();
 
                 // SAFETY: We hold the lock for the shard containing the value.
-                let value_shared = unsafe { &mut *value.shared.get() };
+                let value_shared = unsafe { &mut *value.header.shared.get() };
 
                 let last_changed_revision = zalsa.last_changed_revision(value_shared.durability);
                 ({ value_shared.last_interned_at }) >= last_changed_revision
@@ -830,14 +851,15 @@ where
         // TODO: Grab all locks eagerly.
         zalsa.table().slots_of::<Value<C>>().map(move |(_, value)| {
             if should_lock {
-                // SAFETY: `value.shard` is guaranteed to be in-bounds for `self.shards`.
-                let _shard = unsafe { self.shards.get_unchecked(value.shard as usize) }.lock();
+                // SAFETY: `value.header.shard` is guaranteed to be in-bounds for `self.shards`.
+                let _shard =
+                    unsafe { self.shards.get_unchecked(value.header.shard as usize) }.lock();
             }
 
             // SAFETY: The caller guarantees we hold the lock for the shard containing the value.
             //
             // Note that this ID includes the generation, unlike the ID provided by the table.
-            let id = unsafe { (*value.shared.get()).id };
+            let id = unsafe { (*value.header.shared.get()).id };
 
             StructEntry {
                 value,
@@ -898,15 +920,17 @@ where
     ) -> VerifyResult {
         // Record the current revision as active.
         let current_revision = zalsa.current_revision();
-        self.revision_queue.record(current_revision);
+        if C::REVISIONS != IMMORTAL {
+            self.revision_queue.record(current_revision);
+        }
 
         let value = zalsa.table().get::<Value<C>>(input);
 
-        // SAFETY: `value.shard` is guaranteed to be in-bounds for `self.shards`.
-        let _shard = unsafe { self.shards.get_unchecked(value.shard as usize) }.lock();
+        // SAFETY: `value.header.shard` is guaranteed to be in-bounds for `self.shards`.
+        let _shard = unsafe { self.shards.get_unchecked(value.header.shard as usize) }.lock();
 
         // SAFETY: We hold the lock for the shard containing the value.
-        let value_shared = unsafe { &mut *value.shared.get() };
+        let value_shared = unsafe { &mut *value.header.shared.get() };
 
         // The slot was reused.
         if value_shared.id.generation() > input.generation() {
@@ -1060,12 +1084,12 @@ where
         // SAFETY: The fact that we have a pointer to the `Value` means it must
         // have been interned, and thus validated, in the current revision.
         // Caller obligation demands this pointer to be valid.
-        unsafe { (*this).memos.get() }
+        unsafe { (*this).header.memos.get() }
     }
 
     #[inline(always)]
     fn memos_mut(&mut self) -> &mut crate::table::memo::MemoTable {
-        self.memos.get_mut()
+        self.header.memos.get_mut()
     }
 }
 
@@ -1074,42 +1098,35 @@ where
 /// An interned value is considered stale if it has not been read in the past `REVS`
 /// revisions. However, we only consider revisions in which interned values were actually
 /// read, as revisions may be created in bursts.
-struct RevisionQueue<C> {
+struct RevisionQueue {
     lock: Mutex<()>,
     // Once `feature(generic_const_exprs)` is stable this can just be an array.
     revisions: Box<[AtomicRevision]>,
-    _configuration: PhantomData<fn() -> C>,
 }
 
 // `#[salsa::interned(revisions = usize::MAX)]` disables garbage collection.
 const IMMORTAL: NonZeroUsize = NonZeroUsize::MAX;
 
-impl<C: Configuration> Default for RevisionQueue<C> {
-    fn default() -> RevisionQueue<C> {
-        let revisions = if C::REVISIONS == IMMORTAL {
+impl RevisionQueue {
+    fn new(capacity: NonZeroUsize) -> Self {
+        let revisions = if capacity == IMMORTAL {
             Box::default()
         } else {
-            (0..C::REVISIONS.get())
+            (0..capacity.get())
                 .map(|_| AtomicRevision::start())
                 .collect()
         };
 
-        RevisionQueue {
+        Self {
             lock: Mutex::new(()),
             revisions,
-            _configuration: PhantomData,
         }
     }
-}
 
-impl<C: Configuration> RevisionQueue<C> {
     /// Record the given revision as active.
     #[inline]
     fn record(&self, revision: Revision) {
-        // Garbage collection is disabled.
-        if C::REVISIONS == IMMORTAL {
-            return;
-        }
+        debug_assert!(!self.revisions.is_empty());
 
         // Fast-path: We already recorded this revision.
         if self.revisions[0].load() >= revision {
@@ -1126,7 +1143,7 @@ impl<C: Configuration> RevisionQueue<C> {
         // Otherwise, update the queue, maintaining sorted order.
         //
         // Note that this should only happen once per revision.
-        for i in (1..C::REVISIONS.get()).rev() {
+        for i in (1..self.revisions.len()).rev() {
             self.revisions[i].store(self.revisions[i - 1].load());
         }
 
@@ -1136,12 +1153,10 @@ impl<C: Configuration> RevisionQueue<C> {
     /// Returns `true` if the given revision is old enough to be considered stale.
     #[inline]
     fn is_stale(&self, revision: Revision) -> bool {
-        // Garbage collection is disabled.
-        if C::REVISIONS == IMMORTAL {
+        let Some(oldest) = self.revisions.last() else {
             return false;
-        }
-
-        let oldest = self.revisions[C::REVISIONS.get() - 1].load();
+        };
+        let oldest = oldest.load();
 
         // If we have not recorded `REVS` revisions yet, nothing can be stale.
         if oldest == Revision::start() {
@@ -1151,16 +1166,13 @@ impl<C: Configuration> RevisionQueue<C> {
         revision < oldest
     }
 
-    /// Returns `true` if `C::REVISIONS` revisions have been recorded as active,
+    /// Returns `true` if the configured number of revisions have been recorded as active,
     /// i.e. enough data has been recorded to start garbage collection.
     #[inline]
     fn is_primed(&self) -> bool {
-        // Garbage collection is disabled.
-        if C::REVISIONS == IMMORTAL {
-            return false;
-        }
-
-        self.revisions[C::REVISIONS.get() - 1].load() > Revision::start()
+        self.revisions
+            .last()
+            .is_some_and(|oldest| oldest.load() > Revision::start())
     }
 }
 
@@ -1480,7 +1492,7 @@ mod persistence {
     use serde::ser::{SerializeMap, SerializeStruct};
     use serde::{Deserialize, de};
 
-    use super::{Configuration, IngredientImpl, Value, ValueShared};
+    use super::{Configuration, IngredientImpl, Value, ValueHeader, ValueShared};
     use crate::plumbing::Ingredient;
     use crate::table::memo::MemoTable;
     use crate::zalsa::Zalsa;
@@ -1515,7 +1527,7 @@ mod persistence {
             for (_, value) in zalsa.table().slots_of::<Value<C>>() {
                 // SAFETY: The safety invariant of `Ingredient::serialize` ensures we have exclusive access
                 // to the database.
-                let id = unsafe { (*value.shared.get()).id };
+                let id = unsafe { (*value.header.shared.get()).id };
 
                 map.serialize_entry(&id.as_bits(), value)?;
             }
@@ -1534,13 +1546,13 @@ mod persistence {
         {
             let mut value = serializer.serialize_struct("Value,", 3)?;
 
-            let Value {
-                fields,
+            let Value { fields, header } = self;
+            let ValueHeader {
                 shared,
                 shard: _,
                 link: _,
                 memos: _,
-            } = self;
+            } = header;
 
             // SAFETY: The safety invariant of `Ingredient::serialize` ensures we have exclusive access
             // to the database.
@@ -1626,19 +1638,21 @@ mod persistence {
                 let shard = unsafe { &mut *ingredient.shards.get_unchecked(shard_index).lock() };
 
                 let value = Value::<C> {
-                    shard: shard_index as u16,
-                    link: LinkedListLink::new(),
-                    // SAFETY: We only ever access the memos of a value that we allocated through
-                    // our `MemoTableTypes`.
-                    memos: UnsafeCell::new(unsafe {
-                        MemoTable::new(ingredient.memo_table_types())
-                    }),
+                    header: ValueHeader {
+                        shard: shard_index as u16,
+                        link: LinkedListLink::new(),
+                        // SAFETY: We only ever access the memos of a value that we allocated through
+                        // our `MemoTableTypes`.
+                        memos: UnsafeCell::new(unsafe {
+                            MemoTable::new(ingredient.memo_table_types())
+                        }),
+                        shared: UnsafeCell::new(ValueShared {
+                            id,
+                            durability: value.durability,
+                            last_interned_at: value.last_interned_at,
+                        }),
+                    },
                     fields: UnsafeCell::new(value.fields.0),
-                    shared: UnsafeCell::new(ValueShared {
-                        id,
-                        durability: value.durability,
-                        last_interned_at: value.last_interned_at,
-                    }),
                 };
 
                 // Force initialize the relevant page.


### PR DESCRIPTION
Moves memo validation and cycle metadata plus interned shard and LRU bookkeeping into configuration-independent headers while keeping stored values typed.\n\nOn ty_python_semantic, release LLVM output dropped 6.2% and median debug rebuild time improved 3.2%; Salsa callgrind results remained flat.\n\nTesting: Passed the full default test suite, persistence-enabled unit tests, all-feature compilation, and performance comparisons.