### PR TITLE
refactor: Introduce `MemoHeader` to reduce monomorphization

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -269,7 +269,7 @@ where
         mut memo: memo::Memo<'db, C>,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> &'db memo::Memo<'db, C> {
-        if let Some(tracked_struct_ids) = memo.revisions.tracked_struct_ids_mut() {
+        if let Some(tracked_struct_ids) = memo.header.revisions.tracked_struct_ids_mut() {
             tracked_struct_ids.shrink_to_fit();
         }
 
@@ -343,30 +343,8 @@ where
             return;
         };
 
-        let origin = memo.revisions.origin();
-
-        visited_edges.insert(edge);
-
-        // Collect the minimum dependency tree.
-        for edge in origin.edges() {
-            // Avoid forming cycles.
-            if visited_edges.contains(&edge) {
-                continue;
-            }
-
-            // Avoid flattening edges that we're going to serialize directly.
-            if serialized_edges.contains(&edge) {
-                continue;
-            }
-
-            let dependency = zalsa.lookup_ingredient(edge.key().ingredient_index());
-            dependency.collect_minimum_serialized_edges(
-                zalsa,
-                edge,
-                serialized_edges,
-                visited_edges,
-            )
-        }
+        memo.header
+            .collect_minimum_serialized_edges(zalsa, edge, serialized_edges, visited_edges);
     }
 
     /// Returns `final` if the memo has the `verified_final` flag set.
@@ -381,21 +359,7 @@ where
         let memo =
             self.get_memo_from_table_for(zalsa, input, self.memo_ingredient_index(zalsa, input))?;
 
-        let iteration = memo.revisions.iteration();
-        let verified_final = memo.revisions.verified_final.load(Ordering::Relaxed);
-
-        Some(if verified_final {
-            ProvisionalStatus::Final {
-                iteration,
-                verified_at: memo.verified_at.load(),
-            }
-        } else {
-            ProvisionalStatus::Provisional {
-                iteration,
-                verified_at: memo.verified_at.load(),
-                cycle_heads: memo.cycle_heads(),
-            }
-        })
+        Some(memo.header.provisional_status())
     }
 
     fn set_cycle_iteration_count(&self, zalsa: &Zalsa, input: Id, iteration: IterationStamp) {
@@ -405,8 +369,8 @@ where
             return;
         };
 
-        memo.revisions
-            .set_iteration_count(Self::database_key_index(self, input), iteration);
+        memo.header
+            .set_cycle_iteration_count(self.database_key_index(input), iteration);
     }
 
     fn finalize_cycle_head(&self, zalsa: &Zalsa, input: Id) {
@@ -416,7 +380,7 @@ where
             return;
         };
 
-        memo.revisions.verified_final.store(true, Ordering::Release);
+        memo.header.finalize_cycle_head();
     }
 
     fn flatten_cycle_head_dependencies(
@@ -431,41 +395,13 @@ where
             return;
         };
 
-        let database_key_index = self.database_key_index(id);
-
-        // Only flatten dependencies of provisional queries, because only those
-        // contain cyclic dependencies.
-        if !memo.may_be_provisional() {
-            flattened_input_outputs.insert(QueryEdge::input(database_key_index));
-            return;
-        }
-
-        // There's nothing to do if we've visited this query before.
-        if !seen.insert(database_key_index) {
-            return;
-        }
-
-        let inputs = memo.revisions.origin().inputs();
-
-        match C::CYCLE_STRATEGY {
-            // For queries with cycle handling, simply extend the input/outputs, because
-            // they already flattened their own dependencies when completing the query.
-            CycleRecoveryStrategy::FallbackImmediate | CycleRecoveryStrategy::Fixpoint => {
-                flattened_input_outputs.extend(inputs.map(QueryEdge::input));
-            }
-            // For regular queries, recurse
-            CycleRecoveryStrategy::Panic => {
-                for input in inputs {
-                    let ingredient = zalsa.lookup_ingredient(input.ingredient_index());
-                    ingredient.flatten_cycle_head_dependencies(
-                        zalsa,
-                        input.key_index(),
-                        flattened_input_outputs,
-                        seen,
-                    );
-                }
-            }
-        }
+        memo.header.flatten_cycle_head_dependencies(
+            zalsa,
+            self.database_key_index(id),
+            C::CYCLE_STRATEGY,
+            flattened_input_outputs,
+            seen,
+        );
     }
 
     fn cycle_converged(&self, zalsa: &Zalsa, input: Id) -> bool {
@@ -475,7 +411,7 @@ where
             return true;
         };
 
-        memo.revisions.cycle_converged()
+        memo.header.cycle_converged()
     }
 
     fn mark_as_transfer_target(&self, key_index: Id) -> Option<SyncOwner> {
@@ -621,6 +557,117 @@ where
     }
 }
 
+impl memo::MemoHeader {
+    fn collect_minimum_serialized_edges(
+        &self,
+        zalsa: &Zalsa,
+        edge: QueryEdge,
+        serialized_edges: &mut FxIndexSet<QueryEdge>,
+        visited_edges: &mut FxHashSet<QueryEdge>,
+    ) {
+        visited_edges.insert(edge);
+
+        // Collect the minimum dependency tree.
+        for edge in self.origin().edges() {
+            // Avoid forming cycles.
+            if visited_edges.contains(&edge) {
+                continue;
+            }
+
+            // Avoid flattening edges that we're going to serialize directly.
+            if serialized_edges.contains(&edge) {
+                continue;
+            }
+
+            let dependency = zalsa.lookup_ingredient(edge.key().ingredient_index());
+            dependency.collect_minimum_serialized_edges(
+                zalsa,
+                edge,
+                serialized_edges,
+                visited_edges,
+            );
+        }
+    }
+
+    fn provisional_status(&self) -> ProvisionalStatus<'_> {
+        let iteration = self.revisions.iteration();
+        let verified_at = self.verified_at.load();
+
+        if self.revisions.verified_final.load(Ordering::Relaxed) {
+            ProvisionalStatus::Final {
+                iteration,
+                verified_at,
+            }
+        } else {
+            ProvisionalStatus::Provisional {
+                iteration,
+                verified_at,
+                cycle_heads: self.cycle_heads(),
+            }
+        }
+    }
+
+    fn set_cycle_iteration_count(
+        &self,
+        database_key_index: DatabaseKeyIndex,
+        iteration: IterationStamp,
+    ) {
+        self.revisions
+            .set_iteration_count(database_key_index, iteration);
+    }
+
+    fn finalize_cycle_head(&self) {
+        self.revisions.verified_final.store(true, Ordering::Release);
+    }
+
+    fn flatten_cycle_head_dependencies(
+        &self,
+        zalsa: &Zalsa,
+        database_key_index: DatabaseKeyIndex,
+        cycle_recovery_strategy: CycleRecoveryStrategy,
+        flattened_input_outputs: &mut FxIndexSet<QueryEdge>,
+        seen: &mut FxHashSet<DatabaseKeyIndex>,
+    ) {
+        // Only flatten dependencies of provisional queries, because only those
+        // contain cyclic dependencies.
+        if !self.may_be_provisional() {
+            flattened_input_outputs.insert(QueryEdge::input(database_key_index));
+            return;
+        }
+
+        // There's nothing to do if we've visited this query before.
+        if !seen.insert(database_key_index) {
+            return;
+        }
+
+        let inputs = self.origin().inputs();
+
+        match cycle_recovery_strategy {
+            // For queries with cycle handling, simply extend the input/outputs, because
+            // they already flattened their own dependencies when completing the query.
+            CycleRecoveryStrategy::FallbackImmediate | CycleRecoveryStrategy::Fixpoint => {
+                flattened_input_outputs.extend(inputs.map(QueryEdge::input));
+            }
+            // For regular queries, recurse.
+            CycleRecoveryStrategy::Panic => {
+                for input in inputs {
+                    let ingredient = zalsa.lookup_ingredient(input.ingredient_index());
+                    ingredient.flatten_cycle_head_dependencies(
+                        zalsa,
+                        input.key_index(),
+                        flattened_input_outputs,
+                        seen,
+                    );
+                }
+            }
+        }
+    }
+
+    fn cycle_converged(&self) -> bool {
+        self.revisions.cycle_converged()
+    }
+}
+
 impl<C> std::fmt::Debug for IngredientImpl<C>
 where
     C: Configuration,
@@ -699,7 +746,7 @@ mod persistence {
 
                 if let Some(memo) = memo.filter(|memo| memo.should_serialize()) {
                     // Flatten the dependencies of this query down to the base inputs.
-                    let flattened_origin = match memo.revisions.origin() {
+                    let flattened_origin = match memo.header.origin() {
                         QueryOriginRef::Derived(edges) => {
                             collect_minimum_serialized_edges(
                                 zalsa,

--- a/src/function.rs
+++ b/src/function.rs
@@ -648,7 +648,7 @@ impl memo::MemoHeader {
             CycleRecoveryStrategy::FallbackImmediate | CycleRecoveryStrategy::Fixpoint => {
                 flattened_input_outputs.extend(inputs.map(QueryEdge::input));
             }
-            // For regular queries, recurse.
+            // For regular queries, recurse
             CycleRecoveryStrategy::Panic => {
                 for input in inputs {
                     let ingredient = zalsa.lookup_ingredient(input.ingredient_index());

--- a/src/function/accumulated.rs
+++ b/src/function/accumulated.rs
@@ -96,8 +96,8 @@ where
         // NEXT STEP: stash and refactor `fetch` to return an `&Memo` so we can make this work
         let memo = self.refresh_memo(db, zalsa, zalsa_local, key);
         (
-            memo.revisions.accumulated(),
-            memo.revisions.accumulated_inputs.load(),
+            memo.revision().accumulated(),
+            memo.revision().accumulated_inputs.load(),
         )
     }
 }

--- a/src/function/accumulated.rs
+++ b/src/function/accumulated.rs
@@ -96,8 +96,8 @@ where
         // NEXT STEP: stash and refactor `fetch` to return an `&Memo` so we can make this work
         let memo = self.refresh_memo(db, zalsa, zalsa_local, key);
         (
-            memo.revision().accumulated(),
-            memo.revision().accumulated_inputs.load(),
+            memo.header.revisions.accumulated(),
+            memo.header.revisions.accumulated_inputs.load(),
         )
     }
 }

--- a/src/function/backdate.rs
+++ b/src/function/backdate.rs
@@ -1,6 +1,6 @@
 use crate::Backtrace;
 use crate::DatabaseKeyIndex;
-use crate::function::memo::Memo;
+use crate::function::memo::{Memo, MemoHeader};
 use crate::function::{Configuration, IngredientImpl};
 use crate::zalsa_local::QueryRevisions;
 use std::fmt;
@@ -19,39 +19,44 @@ where
         revisions: &mut QueryRevisions,
         value: &C::Output<'db>,
     ) {
+        if old_memo.header.can_backdate(revisions)
+            && old_memo
+                .value
+                .as_ref()
+                .is_some_and(|old_value| C::values_equal(old_value, value))
+        {
+            old_memo.header.backdate(index, revisions);
+        }
+    }
+}
+
+impl MemoHeader {
+    fn can_backdate(&self, revisions: &QueryRevisions) -> bool {
         // We've seen issues where queries weren't re-validated when backdating provisional values
         // in ty. This is more of a bandaid because we're close to a release and don't have the time to prove
         // right now whether backdating could be made safe for queries participating in queries.
         // TODO: Write a test that demonstrates that backdating queries participating in a cycle isn't safe
         // OR write many tests showing that it is (and fixing the case where it didn't correctly account for today).
-        if !revisions.cycle_heads().is_empty() || old_memo.may_be_provisional() {
-            return;
-        }
-
-        if let Some(old_value) = &old_memo.value {
+        revisions.cycle_heads().is_empty()
+            && !self.may_be_provisional()
             // Careful: if the value became less durable than it
             // used to be, that is a "breaking change" that our
             // consumers must be aware of. Becoming *more* durable
             // is not. See the test `durable_to_less_durable`.
-            if revisions.durability >= old_memo.revisions.durability
-                && C::values_equal(old_value, value)
-            {
-                crate::tracing::debug!(
-                    "{index:?} value is equal, back-dating to {:?}",
-                    old_memo.revisions.changed_at,
-                );
+            && revisions.durability >= self.revisions.durability
+    }
 
-                if old_memo.revisions.changed_at > revisions.changed_at {
-                    report_backdate_violation(
-                        index,
-                        old_memo.revisions.changed_at,
-                        revisions.changed_at,
-                    );
-                }
+    fn backdate(&self, index: DatabaseKeyIndex, revisions: &mut QueryRevisions) {
+        crate::tracing::debug!(
+            "{index:?} value is equal, back-dating to {:?}",
+            self.revisions.changed_at,
+        );
 
-                revisions.changed_at = old_memo.revisions.changed_at;
-            }
+        if self.revisions.changed_at > revisions.changed_at {
+            report_backdate_violation(index, self.revisions.changed_at, revisions.changed_at);
         }
+
+        revisions.changed_at = self.revisions.changed_at;
     }
 }
 

--- a/src/function/diff_outputs.rs
+++ b/src/function/diff_outputs.rs
@@ -1,61 +1,47 @@
 use crate::active_query::CompletedQuery;
-use crate::function::memo::Memo;
-use crate::function::{Configuration, IngredientImpl};
+use crate::function::memo::MemoHeader;
 use crate::hash::FxIndexSet;
 use crate::zalsa::Zalsa;
-use crate::zalsa_local::{QueryOriginRef, QueryRevisions, output_edges};
+use crate::zalsa_local::{QueryOriginRef, output_edges};
 use crate::{DatabaseKeyIndex, Event, EventKind};
 
-impl<C> IngredientImpl<C>
-where
-    C: Configuration,
-{
+impl MemoHeader {
     /// Compute the old and new outputs and invoke `remove_stale_output` for each output that
     /// was generated before but is not generated now.
     pub(super) fn diff_outputs(
         &self,
         zalsa: &Zalsa,
         key: DatabaseKeyIndex,
-        old_memo: &Memo<'_, C>,
         completed_query: &CompletedQuery,
     ) {
-        diff_outputs_on_revision(zalsa, key, &old_memo.revisions, completed_query);
-    }
-}
+        let (QueryOriginRef::Derived(edges) | QueryOriginRef::DerivedUntracked(edges)) =
+            self.origin()
+        else {
+            return;
+        };
 
-fn diff_outputs_on_revision(
-    zalsa: &Zalsa,
-    key: DatabaseKeyIndex,
-    old_revisions: &QueryRevisions,
-    completed_query: &CompletedQuery,
-) {
-    let (QueryOriginRef::Derived(edges) | QueryOriginRef::DerivedUntracked(edges)) =
-        old_revisions.origin()
-    else {
-        return;
-    };
+        // Note that tracked structs are not stored as direct query outputs, but they are still outputs
+        // that need to be reported as stale.
+        for (identity, id) in &completed_query.stale_tracked_structs {
+            let output = DatabaseKeyIndex::new(identity.ingredient_index(), *id);
+            report_stale_output(zalsa, key, output);
+        }
 
-    // Note that tracked structs are not stored as direct query outputs, but they are still outputs
-    // that need to be reported as stale.
-    for (identity, id) in &completed_query.stale_tracked_structs {
-        let output = DatabaseKeyIndex::new(identity.ingredient_index(), *id);
-        report_stale_output(zalsa, key, output);
-    }
+        let mut stale_outputs = output_edges(edges).collect::<FxIndexSet<_>>();
 
-    let mut stale_outputs = output_edges(edges).collect::<FxIndexSet<_>>();
+        if stale_outputs.is_empty() {
+            return;
+        }
 
-    if stale_outputs.is_empty() {
-        return;
-    }
+        // Preserve any outputs that were recreated in the current revision.
+        for new_output in completed_query.revisions.origin().outputs() {
+            stale_outputs.swap_remove(&new_output);
+        }
 
-    // Preserve any outputs that were recreated in the current revision.
-    for new_output in completed_query.revisions.origin().outputs() {
-        stale_outputs.swap_remove(&new_output);
-    }
-
-    // Any outputs that were created in a previous revision but not the current one are stale.
-    for output in stale_outputs {
-        report_stale_output(zalsa, key, output);
+        // Any outputs that were created in a previous revision but not the current one are stale.
+        for output in stale_outputs {
+            report_stale_output(zalsa, key, output);
+        }
     }
 }
 

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -63,7 +63,7 @@ where
                     opt_old_memo.map(|memo| &memo.header),
                 );
 
-                // Ordinary queries don't need an epoch stamp. Keeping the default avoids
+                // Ordinary queries don't need a cycle iteration stamp. Keeping the default avoids
                 // allocating `QueryRevisionsExtra` after a revision-preserving cancellation.
                 (new_value, active_query.pop(IterationStamp::default()))
             }
@@ -174,14 +174,14 @@ where
             );
 
             let (mut active_query, cycle_heads, outer_cycle, cycle_iteration) =
-                match prepare_cycle_step(
+                match try_complete_query(
                     zalsa,
                     active_query,
                     claim_guard,
                     C::CYCLE_STRATEGY,
                     iteration,
                 ) {
-                    CycleStep::Complete {
+                    QueryExecutionOutcome::Completed {
                         completed_query,
                         requires_initial_value,
                     } => {
@@ -195,7 +195,7 @@ where
 
                         break (new_value, completed_query);
                     }
-                    CycleStep::CycleHead {
+                    QueryExecutionOutcome::CycleHead {
                         active_query,
                         cycle_heads,
                         outer_cycle,
@@ -333,8 +333,8 @@ struct PreviousIteration {
     reuse_as_provisional: bool,
 }
 
-enum CycleStep<'db> {
-    Complete {
+enum QueryExecutionOutcome<'db> {
+    Completed {
         completed_query: CompletedQuery,
         requires_initial_value: bool,
     },
@@ -404,20 +404,20 @@ impl MemoHeader {
     }
 }
 
-fn prepare_cycle_step<'db>(
+fn try_complete_query<'db>(
     zalsa: &Zalsa,
     mut active_query: ActiveQueryGuard<'db>,
     claim_guard: &mut ClaimGuard<'db>,
     cycle_recovery_strategy: CycleRecoveryStrategy,
     iteration: IterationStamp,
-) -> CycleStep<'db> {
+) -> QueryExecutionOutcome<'db> {
     let database_key_index = active_query.database_key_index;
 
     // Take the cycle heads to not fight Rust's borrow checker.
     let mut cycle_heads = active_query.take_cycle_heads();
 
     if cycle_heads.is_empty() {
-        // There's no cycle state whose epoch needs to be preserved.
+        // There's no cycle iteration state to preserve.
         let iteration = if iteration.is_initial_iteration() {
             IterationStamp::default()
         } else {
@@ -427,7 +427,7 @@ fn prepare_cycle_step<'db>(
             })
         };
 
-        return CycleStep::Complete {
+        return QueryExecutionOutcome::Completed {
             completed_query: active_query.pop(iteration),
             requires_initial_value: false,
         };
@@ -452,7 +452,7 @@ fn prepare_cycle_step<'db>(
             );
         };
 
-        return CycleStep::Complete {
+        return QueryExecutionOutcome::Completed {
             completed_query: complete_cycle_participant(
                 active_query,
                 claim_guard,
@@ -478,7 +478,7 @@ fn prepare_cycle_step<'db>(
         iteration
     };
 
-    CycleStep::CycleHead {
+    QueryExecutionOutcome::CycleHead {
         active_query,
         cycle_heads,
         outer_cycle,

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -264,7 +264,7 @@ where
                 active_query,
                 claim_guard,
                 cycle_heads,
-                last_provisional_memo.revision(),
+                &last_provisional_memo.header.revisions,
                 outer_cycle,
                 iteration,
                 cycle_iteration,

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -13,7 +13,7 @@ use crate::tracked_struct::Identity;
 use crate::zalsa::{MemoIngredientIndex, Zalsa};
 use crate::zalsa_local::{ActiveQueryGuard, QueryEdge, QueryEdgeKind, QueryRevisions};
 use crate::{Cancelled, Cycle, tracing};
-use crate::{DatabaseKeyIndex, Event, EventKind, Id, Revision};
+use crate::{DatabaseKeyIndex, Event, EventKind, Id};
 
 impl<C> IngredientImpl<C>
 where
@@ -178,13 +178,25 @@ where
                     QueryExecutionOutcome::Completed(completed_query) => {
                         break (new_value, completed_query);
                     }
-                    QueryExecutionOutcome::Participant(completed_query) => {
+                    QueryExecutionOutcome::Participant {
+                        active_query,
+                        cycle_heads,
+                        outer_cycle,
+                    } => {
                         // For FallbackImmediate, use the fallback value instead of the computed value
                         // for all cycle participants. This ensures that the results don't depend on the query call order, see
                         // https://github.com/salsa-rs/salsa/pull/798#issuecomment-2812855285.
                         if C::CYCLE_STRATEGY == CycleRecoveryStrategy::FallbackImmediate {
                             new_value = C::cycle_initial(db, id, C::id_to_input(zalsa, id));
                         }
+
+                        let completed_query = complete_cycle_participant(
+                            active_query,
+                            claim_guard,
+                            cycle_heads,
+                            outer_cycle,
+                            iteration,
+                        );
 
                         break (new_value, completed_query);
                     }
@@ -307,7 +319,7 @@ where
         opt_old_header: Option<&MemoHeader>,
     ) -> (C::Output<'db>, ActiveQueryGuard<'db>) {
         if let Some(old_header) = opt_old_header {
-            old_header.seed_active_query(zalsa.current_revision(), &active_query);
+            old_header.seed_active_query(zalsa, &active_query);
         }
 
         // Query was not previously executed, or value is potentially
@@ -328,7 +340,11 @@ struct PreviousIteration {
 
 enum QueryExecutionOutcome<'db> {
     Completed(CompletedQuery),
-    Participant(CompletedQuery),
+    Participant {
+        active_query: ActiveQueryGuard<'db>,
+        cycle_heads: CycleHeads,
+        outer_cycle: DatabaseKeyIndex,
+    },
     CycleHead {
         active_query: ActiveQueryGuard<'db>,
         cycle_heads: CycleHeads,
@@ -374,7 +390,7 @@ impl MemoHeader {
         })
     }
 
-    fn seed_active_query(&self, revision_now: Revision, active_query: &ActiveQueryGuard<'_>) {
+    fn seed_active_query(&self, zalsa: &Zalsa, active_query: &ActiveQueryGuard<'_>) {
         // If we already executed this query once, then use the tracked-struct ids from the
         // previous execution as the starting point for the new one.
         active_query.seed_tracked_struct_ids(self.revisions.tracked_struct_ids());
@@ -384,7 +400,7 @@ impl MemoHeader {
         // * ensure that tracked struct created during the previous iteration
         //   (and are owned by the query) are alive even if the query in this iteration no longer creates them.
         // * ensure the final returned memo depends on all inputs from all iterations.
-        if self.may_be_provisional() && self.verified_at.load() == revision_now {
+        if self.may_be_provisional() && self.verified_at.load() == zalsa.current_revision() {
             active_query.seed_iteration(&self.revisions);
         }
     }
@@ -435,13 +451,11 @@ fn try_complete_query<'db>(
             );
         };
 
-        return QueryExecutionOutcome::Participant(complete_cycle_participant(
+        return QueryExecutionOutcome::Participant {
             active_query,
-            claim_guard,
             cycle_heads,
             outer_cycle,
-            iteration,
-        ));
+        };
     }
 
     // If this is the outermost cycle, use the maximum iteration count of all cycles.

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -2,7 +2,7 @@ use smallvec::SmallVec;
 
 use crate::active_query::CompletedQuery;
 use crate::cycle::{CycleHeads, CycleRecoveryStrategy, IterationStamp};
-use crate::function::memo::Memo;
+use crate::function::memo::{Memo, MemoHeader};
 use crate::function::sync::ReleaseMode;
 use crate::function::{ClaimGuard, Configuration, IngredientImpl};
 use crate::hash::{FxHashSet, FxIndexSet};
@@ -13,7 +13,7 @@ use crate::tracked_struct::Identity;
 use crate::zalsa::{MemoIngredientIndex, Zalsa};
 use crate::zalsa_local::{ActiveQueryGuard, QueryEdge, QueryEdgeKind, QueryRevisions};
 use crate::{Cancelled, Cycle, tracing};
-use crate::{DatabaseKeyIndex, Event, EventKind, Id};
+use crate::{DatabaseKeyIndex, Event, EventKind, Id, Revision};
 
 impl<C> IngredientImpl<C>
 where
@@ -60,7 +60,7 @@ where
                     db,
                     zalsa,
                     claim_guard.zalsa_local().push_query(database_key_index),
-                    opt_old_memo,
+                    opt_old_memo.map(|memo| &memo.header),
                 );
 
                 // Ordinary queries don't need an epoch stamp. Keeping the default avoids
@@ -94,7 +94,9 @@ where
 
             // Diff the new outputs with the old, to discard any no-longer-emitted
             // outputs and update the tracked struct IDs for seeding the next revision.
-            self.diff_outputs(zalsa, database_key_index, old_memo, &completed_query);
+            old_memo
+                .header
+                .diff_outputs(zalsa, database_key_index, &completed_query);
         }
 
         let memo = self.insert_memo(
@@ -134,31 +136,17 @@ where
         let mut iteration = IterationStamp::initial(cancellation_count);
 
         if let Some(old_memo) = opt_old_memo {
-            if old_memo.verified_at.load() == zalsa.current_revision()
-                && old_memo.revisions.iteration().cancellation_count() == cancellation_count
-            {
-                // The `DependencyGraph` locking propagates panics when another thread is blocked on a panicking query.
-                // However, the locking doesn't handle the case where a thread fetches the result of a panicking
-                // cycle head query **after** all locks were released. That's what we do here.
-                // We could consider re-executing the entire cycle but:
-                // a) It's tricky to ensure that all queries participating in the cycle will re-execute
-                //    (we can't rely on `iteration` being updated for nested cycles because the nested cycles may have completed successfully).
-                // b) It's guaranteed that this query will panic again anyway.
-                // That's why we simply propagate the panic here. It simplifies our lives and it also avoids duplicate panic messages.
-                if old_memo.value.is_none() {
-                    tracing::warn!(
-                        "Propagating panic for cycle head that panicked in an earlier execution in that revision"
-                    );
-                    Cancelled::PropagatedPanic.throw();
-                }
-
-                // Only use the last provisional memo if it was a cycle head in the last iteration. This is to
-                // force at least two executions.
-                if old_memo.cycle_heads().contains(&database_key_index) {
+            if let Some(previous_iteration) = old_memo.header.previous_iteration(
+                zalsa,
+                database_key_index,
+                cancellation_count,
+                old_memo.value.is_some(),
+            ) {
+                if previous_iteration.reuse_as_provisional {
                     last_provisional_memo_opt = Some(old_memo);
                 }
 
-                iteration = old_memo.revisions.iteration();
+                iteration = previous_iteration.iteration;
             }
         }
 
@@ -176,71 +164,44 @@ where
             // if they aren't recreated when reaching the final iteration.
             active_query.seed_tracked_struct_ids(&last_stale_tracked_ids);
 
-            let (mut new_value, mut active_query) = Self::execute_query(
+            let (mut new_value, active_query) = Self::execute_query(
                 db,
                 zalsa,
                 active_query,
-                last_provisional_memo_opt.or(opt_old_memo),
+                last_provisional_memo_opt
+                    .or(opt_old_memo)
+                    .map(|memo| &memo.header),
             );
 
-            // Take the cycle heads to not-fight-rust's-borrow-checker.
-            let mut cycle_heads = active_query.take_cycle_heads();
-
-            // If there are no cycle heads, break out of the loop.
-            if cycle_heads.is_empty() {
-                // There's no cycle state whose epoch needs to be preserved.
-                let iteration = if iteration.is_initial_iteration() {
-                    IterationStamp::default()
-                } else {
-                    iteration.increment_iteration().unwrap_or_else(|| {
-                        tracing::warn!(
-                            "{database_key_index:?}: execute: too many cycle iterations"
-                        );
-                        panic!("{database_key_index:?}: execute: too many cycle iterations")
-                    })
-                };
-
-                break (new_value, active_query.pop(iteration));
-            }
-
-            let (max_iteration, depends_on_self) =
-                collect_all_cycle_heads(zalsa, &mut cycle_heads, database_key_index, iteration);
-
-            let outer_cycle = outer_cycle(
-                zalsa,
-                claim_guard.zalsa_local(),
-                &cycle_heads,
-                database_key_index,
-            );
-
-            // Did the new result we got depend on our own provisional value, in a cycle?
-            // If not, return because this query is not a cycle head.
-            if !depends_on_self {
-                let Some(outer_cycle) = outer_cycle else {
-                    panic!(
-                        "cycle participant with non-empty cycle heads and that doesn't depend on itself must have an outer cycle responsible to finalize the query later (query: {database_key_index:?}, cycle heads: {cycle_heads:?})."
-                    );
-                };
-
-                // For FallbackImmediate, use the fallback value instead of the computed value
-                // for all cycle participants. This ensures that the results don't depend on the query call order, see
-                // https://github.com/salsa-rs/salsa/pull/798#issuecomment-2812855285.
-                let new_value = if C::CYCLE_STRATEGY == CycleRecoveryStrategy::FallbackImmediate {
-                    C::cycle_initial(db, id, C::id_to_input(zalsa, id))
-                } else {
-                    new_value
-                };
-
-                let completed_query = complete_cycle_participant(
+            let (mut active_query, cycle_heads, outer_cycle, cycle_iteration) =
+                match prepare_cycle_step(
+                    zalsa,
                     active_query,
                     claim_guard,
-                    cycle_heads,
-                    outer_cycle,
+                    C::CYCLE_STRATEGY,
                     iteration,
-                );
+                ) {
+                    CycleStep::Complete {
+                        completed_query,
+                        requires_initial_value,
+                    } => {
+                        // For FallbackImmediate, use the fallback value instead of the computed
+                        // value for all cycle participants. This ensures that the results don't
+                        // depend on the query call order, see
+                        // https://github.com/salsa-rs/salsa/pull/798#issuecomment-2812855285.
+                        if requires_initial_value {
+                            new_value = C::cycle_initial(db, id, C::id_to_input(zalsa, id));
+                        }
 
-                break (new_value, completed_query);
-            }
+                        break (new_value, completed_query);
+                    }
+                    CycleStep::CycleHead {
+                        active_query,
+                        cycle_heads,
+                        outer_cycle,
+                        cycle_iteration,
+                    } => (active_query, cycle_heads, outer_cycle, cycle_iteration),
+                };
 
             // Get the last provisional value for this query so that we can compare it with the new value
             // to test if the cycle converged.
@@ -257,7 +218,7 @@ where
                         )
                     });
 
-                debug_assert!(memo.may_be_provisional());
+                debug_assert!(memo.header.may_be_provisional());
                 memo
             });
 
@@ -270,20 +231,6 @@ where
                 "{database_key_index:?}: execute: \
                 I am a cycle head, comparing last provisional value with new value"
             );
-
-            // If this is the outermost cycle, use the maximum iteration count of all cycles.
-            // This is important for when later iterations introduce new cycle heads (that then
-            // become the outermost cycle). We want to ensure that the iteration count keeps increasing
-            // for all queries or they won't be re-executed because `validate_same_iteration` would
-            // pass when we go from 1 -> 0 and then increment by 1 to 1).
-            let cycle_iteration = if outer_cycle.is_none() {
-                max_iteration
-            } else {
-                // Otherwise keep the iteration count because outer cycles
-                // already have a cycle head with this exact iteration count (and we don't allow
-                // heads from different iterations).
-                iteration
-            };
 
             // For FallbackImmediate, the value always converges immediately (we use the
             // fallback directly). We still iterate if metadata hasn't converged.
@@ -318,7 +265,7 @@ where
                 active_query,
                 claim_guard,
                 cycle_heads,
-                &last_provisional_memo.revisions,
+                last_provisional_memo.revision(),
                 outer_cycle,
                 iteration,
                 cycle_iteration,
@@ -364,23 +311,10 @@ where
         db: &'db C::DbView,
         zalsa: &'db Zalsa,
         active_query: ActiveQueryGuard<'db>,
-        opt_old_memo: Option<&Memo<'db, C>>,
+        opt_old_header: Option<&MemoHeader>,
     ) -> (C::Output<'db>, ActiveQueryGuard<'db>) {
-        if let Some(old_memo) = opt_old_memo {
-            // If we already executed this query once, then use the tracked-struct ids from the
-            // previous execution as the starting point for the new one.
-            active_query.seed_tracked_struct_ids(old_memo.revisions.tracked_struct_ids());
-
-            // Copy over all inputs and outputs from a previous iteration.
-            // This is necessary to:
-            // * ensure that tracked struct created during the previous iteration
-            //   (and are owned by the query) are alive even if the query in this iteration no longer creates them.
-            // * ensure the final returned memo depends on all inputs from all iterations.
-            if old_memo.may_be_provisional()
-                && old_memo.verified_at.load() == zalsa.current_revision()
-            {
-                active_query.seed_iteration(&old_memo.revisions);
-            }
+        if let Some(old_header) = opt_old_header {
+            old_header.seed_active_query(zalsa.current_revision(), &active_query);
         }
 
         // Query was not previously executed, or value is potentially
@@ -391,6 +325,164 @@ where
         );
 
         (new_value, active_query)
+    }
+}
+
+struct PreviousIteration {
+    iteration: IterationStamp,
+    reuse_as_provisional: bool,
+}
+
+enum CycleStep<'db> {
+    Complete {
+        completed_query: CompletedQuery,
+        requires_initial_value: bool,
+    },
+    CycleHead {
+        active_query: ActiveQueryGuard<'db>,
+        cycle_heads: CycleHeads,
+        outer_cycle: Option<DatabaseKeyIndex>,
+        cycle_iteration: IterationStamp,
+    },
+}
+
+impl MemoHeader {
+    fn previous_iteration(
+        &self,
+        zalsa: &Zalsa,
+        database_key_index: DatabaseKeyIndex,
+        cancellation_count: u8,
+        has_value: bool,
+    ) -> Option<PreviousIteration> {
+        if self.verified_at.load() != zalsa.current_revision()
+            || self.revisions.iteration().cancellation_count() != cancellation_count
+        {
+            return None;
+        }
+
+        // The `DependencyGraph` locking propagates panics when another thread is blocked on a
+        // panicking query. However, the locking doesn't handle the case where a thread fetches
+        // the result of a panicking cycle head query after all locks were released. That's what
+        // we do here.
+        //
+        // We could consider re-executing the entire cycle but:
+        // a) It's tricky to ensure that all queries participating in the cycle will re-execute
+        //    (we can't rely on `iteration` being updated for nested cycles because the nested
+        //    cycles may have completed successfully).
+        // b) It's guaranteed that this query will panic again anyway.
+        //
+        // That's why we simply propagate the panic here. It simplifies our lives and avoids
+        // duplicate panic messages.
+        if !has_value {
+            tracing::warn!(
+                "Propagating panic for cycle head that panicked in an earlier execution in that revision"
+            );
+            Cancelled::PropagatedPanic.throw();
+        }
+
+        Some(PreviousIteration {
+            iteration: self.revisions.iteration(),
+            // Only use the last provisional memo if it was a cycle head in the last iteration.
+            // This forces at least two executions.
+            reuse_as_provisional: self.cycle_heads().contains(&database_key_index),
+        })
+    }
+
+    fn seed_active_query(&self, revision_now: Revision, active_query: &ActiveQueryGuard<'_>) {
+        // If we already executed this query once, then use the tracked-struct ids from the
+        // previous execution as the starting point for the new one.
+        active_query.seed_tracked_struct_ids(self.revisions.tracked_struct_ids());
+
+        // Copy over all inputs and outputs from a previous iteration.
+        // This is necessary to:
+        // * ensure that tracked struct created during the previous iteration
+        //   (and are owned by the query) are alive even if the query in this iteration no longer creates them.
+        // * ensure the final returned memo depends on all inputs from all iterations.
+        if self.may_be_provisional() && self.verified_at.load() == revision_now {
+            active_query.seed_iteration(&self.revisions);
+        }
+    }
+}
+
+fn prepare_cycle_step<'db>(
+    zalsa: &Zalsa,
+    mut active_query: ActiveQueryGuard<'db>,
+    claim_guard: &mut ClaimGuard<'db>,
+    cycle_recovery_strategy: CycleRecoveryStrategy,
+    iteration: IterationStamp,
+) -> CycleStep<'db> {
+    let database_key_index = active_query.database_key_index;
+
+    // Take the cycle heads to not fight Rust's borrow checker.
+    let mut cycle_heads = active_query.take_cycle_heads();
+
+    if cycle_heads.is_empty() {
+        // There's no cycle state whose epoch needs to be preserved.
+        let iteration = if iteration.is_initial_iteration() {
+            IterationStamp::default()
+        } else {
+            iteration.increment_iteration().unwrap_or_else(|| {
+                tracing::warn!("{database_key_index:?}: execute: too many cycle iterations");
+                panic!("{database_key_index:?}: execute: too many cycle iterations")
+            })
+        };
+
+        return CycleStep::Complete {
+            completed_query: active_query.pop(iteration),
+            requires_initial_value: false,
+        };
+    }
+
+    let (max_iteration, depends_on_self) =
+        collect_all_cycle_heads(zalsa, &mut cycle_heads, database_key_index, iteration);
+
+    let outer_cycle = outer_cycle(
+        zalsa,
+        claim_guard.zalsa_local(),
+        &cycle_heads,
+        database_key_index,
+    );
+
+    // Did the new result depend on our own provisional value, in a cycle? If not, this query
+    // is only a participant in an outer cycle.
+    if !depends_on_self {
+        let Some(outer_cycle) = outer_cycle else {
+            panic!(
+                "cycle participant with non-empty cycle heads and that doesn't depend on itself must have an outer cycle responsible to finalize the query later (query: {database_key_index:?}, cycle heads: {cycle_heads:?})."
+            );
+        };
+
+        return CycleStep::Complete {
+            completed_query: complete_cycle_participant(
+                active_query,
+                claim_guard,
+                cycle_heads,
+                outer_cycle,
+                iteration,
+            ),
+            requires_initial_value: cycle_recovery_strategy
+                == CycleRecoveryStrategy::FallbackImmediate,
+        };
+    }
+
+    // If this is the outermost cycle, use the maximum iteration count of all cycles. This is
+    // important for when later iterations introduce new cycle heads that then become the
+    // outermost cycle. We want to ensure that the iteration count keeps increasing for all
+    // queries or they won't be re-executed because `validate_same_iteration` would pass when we
+    // go from 1 -> 0 and then increment by 1 to 1.
+    let cycle_iteration = if outer_cycle.is_none() {
+        max_iteration
+    } else {
+        // Otherwise keep the iteration count because outer cycles already have a cycle head with
+        // this exact iteration count (and we don't allow heads from different iterations).
+        iteration
+    };
+
+    CycleStep::CycleHead {
+        active_query,
+        cycle_heads,
+        outer_cycle,
+        cycle_iteration,
     }
 }
 

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -174,21 +174,15 @@ where
             );
 
             let (mut active_query, cycle_heads, outer_cycle, cycle_iteration) =
-                match try_complete_query(
-                    zalsa,
-                    active_query,
-                    claim_guard,
-                    C::CYCLE_STRATEGY,
-                    iteration,
-                ) {
-                    QueryExecutionOutcome::Completed {
-                        completed_query,
-                        requires_initial_value,
-                    } => {
+                match try_complete_query(zalsa, active_query, claim_guard, iteration) {
+                    QueryExecutionOutcome::Completed(completed_query) => {
+                        break (new_value, completed_query);
+                    }
+                    QueryExecutionOutcome::Participant(completed_query) => {
                         // For FallbackImmediate, use the fallback value instead of the computed value
                         // for all cycle participants. This ensures that the results don't depend on the query call order, see
                         // https://github.com/salsa-rs/salsa/pull/798#issuecomment-2812855285.
-                        if requires_initial_value {
+                        if C::CYCLE_STRATEGY == CycleRecoveryStrategy::FallbackImmediate {
                             new_value = C::cycle_initial(db, id, C::id_to_input(zalsa, id));
                         }
 
@@ -333,10 +327,8 @@ struct PreviousIteration {
 }
 
 enum QueryExecutionOutcome<'db> {
-    Completed {
-        completed_query: CompletedQuery,
-        requires_initial_value: bool,
-    },
+    Completed(CompletedQuery),
+    Participant(CompletedQuery),
     CycleHead {
         active_query: ActiveQueryGuard<'db>,
         cycle_heads: CycleHeads,
@@ -402,7 +394,6 @@ fn try_complete_query<'db>(
     zalsa: &Zalsa,
     mut active_query: ActiveQueryGuard<'db>,
     claim_guard: &mut ClaimGuard<'db>,
-    cycle_recovery_strategy: CycleRecoveryStrategy,
     iteration: IterationStamp,
 ) -> QueryExecutionOutcome<'db> {
     let database_key_index = active_query.database_key_index;
@@ -422,10 +413,7 @@ fn try_complete_query<'db>(
             })
         };
 
-        return QueryExecutionOutcome::Completed {
-            completed_query: active_query.pop(iteration),
-            requires_initial_value: false,
-        };
+        return QueryExecutionOutcome::Completed(active_query.pop(iteration));
     }
 
     let (max_iteration, depends_on_self) =
@@ -447,17 +435,13 @@ fn try_complete_query<'db>(
             );
         };
 
-        return QueryExecutionOutcome::Completed {
-            completed_query: complete_cycle_participant(
-                active_query,
-                claim_guard,
-                cycle_heads,
-                outer_cycle,
-                iteration,
-            ),
-            requires_initial_value: cycle_recovery_strategy
-                == CycleRecoveryStrategy::FallbackImmediate,
-        };
+        return QueryExecutionOutcome::Participant(complete_cycle_participant(
+            active_query,
+            claim_guard,
+            cycle_heads,
+            outer_cycle,
+            iteration,
+        ));
     }
 
     // If this is the outermost cycle, use the maximum iteration count of all cycles.

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -185,9 +185,8 @@ where
                         completed_query,
                         requires_initial_value,
                     } => {
-                        // For FallbackImmediate, use the fallback value instead of the computed
-                        // value for all cycle participants. This ensures that the results don't
-                        // depend on the query call order, see
+                        // For FallbackImmediate, use the fallback value instead of the computed value
+                        // for all cycle participants. This ensures that the results don't depend on the query call order, see
                         // https://github.com/salsa-rs/salsa/pull/798#issuecomment-2812855285.
                         if requires_initial_value {
                             new_value = C::cycle_initial(db, id, C::id_to_input(zalsa, id));
@@ -360,19 +359,14 @@ impl MemoHeader {
             return None;
         }
 
-        // The `DependencyGraph` locking propagates panics when another thread is blocked on a
-        // panicking query. However, the locking doesn't handle the case where a thread fetches
-        // the result of a panicking cycle head query after all locks were released. That's what
-        // we do here.
-        //
+        // The `DependencyGraph` locking propagates panics when another thread is blocked on a panicking query.
+        // However, the locking doesn't handle the case where a thread fetches the result of a panicking
+        // cycle head query **after** all locks were released. That's what we do here.
         // We could consider re-executing the entire cycle but:
         // a) It's tricky to ensure that all queries participating in the cycle will re-execute
-        //    (we can't rely on `iteration` being updated for nested cycles because the nested
-        //    cycles may have completed successfully).
+        //    (we can't rely on `iteration` being updated for nested cycles because the nested cycles may have completed successfully).
         // b) It's guaranteed that this query will panic again anyway.
-        //
-        // That's why we simply propagate the panic here. It simplifies our lives and avoids
-        // duplicate panic messages.
+        // That's why we simply propagate the panic here. It simplifies our lives and it also avoids duplicate panic messages.
         if !has_value {
             tracing::warn!(
                 "Propagating panic for cycle head that panicked in an earlier execution in that revision"
@@ -382,8 +376,8 @@ impl MemoHeader {
 
         Some(PreviousIteration {
             iteration: self.revisions.iteration(),
-            // Only use the last provisional memo if it was a cycle head in the last iteration.
-            // This forces at least two executions.
+            // Only use the last provisional memo if it was a cycle head in the last iteration. This is to
+            // force at least two executions.
             reuse_as_provisional: self.cycle_heads().contains(&database_key_index),
         })
     }
@@ -413,9 +407,10 @@ fn try_complete_query<'db>(
 ) -> QueryExecutionOutcome<'db> {
     let database_key_index = active_query.database_key_index;
 
-    // Take the cycle heads to not fight Rust's borrow checker.
+    // Take the cycle heads to not-fight-rust's-borrow-checker.
     let mut cycle_heads = active_query.take_cycle_heads();
 
+    // If there are no cycle heads, break out of the loop.
     if cycle_heads.is_empty() {
         // There's no cycle iteration state to preserve.
         let iteration = if iteration.is_initial_iteration() {
@@ -443,8 +438,8 @@ fn try_complete_query<'db>(
         database_key_index,
     );
 
-    // Did the new result depend on our own provisional value, in a cycle? If not, this query
-    // is only a participant in an outer cycle.
+    // Did the new result we got depend on our own provisional value, in a cycle?
+    // If not, return because this query is not a cycle head.
     if !depends_on_self {
         let Some(outer_cycle) = outer_cycle else {
             panic!(
@@ -465,16 +460,17 @@ fn try_complete_query<'db>(
         };
     }
 
-    // If this is the outermost cycle, use the maximum iteration count of all cycles. This is
-    // important for when later iterations introduce new cycle heads that then become the
-    // outermost cycle. We want to ensure that the iteration count keeps increasing for all
-    // queries or they won't be re-executed because `validate_same_iteration` would pass when we
-    // go from 1 -> 0 and then increment by 1 to 1.
+    // If this is the outermost cycle, use the maximum iteration count of all cycles.
+    // This is important for when later iterations introduce new cycle heads (that then
+    // become the outermost cycle). We want to ensure that the iteration count keeps increasing
+    // for all queries or they won't be re-executed because `validate_same_iteration` would
+    // pass when we go from 1 -> 0 and then increment by 1 to 1).
     let cycle_iteration = if outer_cycle.is_none() {
         max_iteration
     } else {
-        // Otherwise keep the iteration count because outer cycles already have a cycle head with
-        // this exact iteration count (and we don't allow heads from different iterations).
+        // Otherwise keep the iteration count because outer cycles
+        // already have a cycle head with this exact iteration count (and we don't allow
+        // heads from different iterations).
         iteration
     };
 

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -135,14 +135,7 @@ where
             if old_memo.value.is_some()
                 && old_memo
                     .header
-                    .maybe_changed_after_cold(
-                        db.into(),
-                        &claim_guard,
-                        zalsa.current_revision(),
-                        C::CYCLE_STRATEGY,
-                        true,
-                    )
-                    .is_some_and(|result| result.is_unchanged())
+                    .verify_memo(db.into(), &claim_guard, C::CYCLE_STRATEGY, true)
             {
                 // SAFETY: memo is present in memo_map and we have verified that it is
                 // still valid for the current revision.

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -137,9 +137,7 @@ where
                     .header
                     .maybe_changed_after_cold(
                         db.into(),
-                        zalsa,
-                        zalsa_local,
-                        database_key_index,
+                        &claim_guard,
                         zalsa.current_revision(),
                         C::CYCLE_STRATEGY,
                         true,

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -33,15 +33,16 @@ where
 
         self.eviction.record_use(id);
 
+        let revisions = &memo.header.revisions;
         zalsa_local.report_tracked_read(
             database_key_index,
-            memo.revision().durability,
-            memo.revision().changed_at,
+            revisions.durability,
+            revisions.changed_at,
             memo.header.cycle_heads(),
             #[cfg(feature = "accumulator")]
-            memo.revision().accumulated().is_some(),
+            revisions.accumulated().is_some(),
             #[cfg(feature = "accumulator")]
-            &memo.revision().accumulated_inputs,
+            &revisions.accumulated_inputs,
         );
 
         memo_value
@@ -184,22 +185,23 @@ where
                 // existing provisional memo if it exists
                 let memo_guard = self.get_memo_from_table_for(zalsa, id, memo_ingredient_index);
                 if let Some(memo) = &memo_guard {
+                    let revisions = &memo.header.revisions;
                     // Ideally, we'd use the last provisional memo even if it wasn't a cycle head in the last iteration
                     // but that would require inserting itself as a cycle head, which either requires clone
                     // on the value OR a concurrent `Vec` for cycle heads.
                     if memo.header.verified_at.load() == zalsa.current_revision()
                         && memo.value.is_some()
-                        && memo.revision().iteration().cancellation_count() == cancellation_count
-                        && memo.revision().cycle_heads().contains(&database_key_index)
+                        && revisions.iteration().cancellation_count() == cancellation_count
+                        && revisions.cycle_heads().contains(&database_key_index)
                     {
-                        memo.revision()
+                        revisions
                             .cycle_heads()
                             .remove_all_except(database_key_index);
 
                         crate::tracing::debug!(
                             "hit cycle at {database_key_index:#?}, \
                                 returning last provisional value: {:#?}",
-                            memo.revision()
+                            revisions
                         );
 
                         // SAFETY: memo is present in memo_map.
@@ -214,12 +216,12 @@ where
 
                 let iteration = memo_guard
                     .and_then(|old_memo| {
+                        let revisions = &old_memo.header.revisions;
                         if old_memo.header.verified_at.load() == zalsa.current_revision()
                             && old_memo.value.is_some()
-                            && old_memo.revision().iteration().cancellation_count()
-                                == cancellation_count
+                            && revisions.iteration().cancellation_count() == cancellation_count
                         {
-                            Some(old_memo.revision().iteration())
+                            Some(revisions.iteration())
                         } else {
                             None
                         }

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -35,13 +35,13 @@ where
 
         zalsa_local.report_tracked_read(
             database_key_index,
-            memo.revisions.durability,
-            memo.revisions.changed_at,
-            memo.cycle_heads(),
+            memo.revision().durability,
+            memo.revision().changed_at,
+            memo.header.cycle_heads(),
             #[cfg(feature = "accumulator")]
-            memo.revisions.accumulated().is_some(),
+            memo.revision().accumulated().is_some(),
             #[cfg(feature = "accumulator")]
-            &memo.revisions.accumulated_inputs,
+            &memo.revision().accumulated_inputs,
         );
 
         memo_value
@@ -80,10 +80,13 @@ where
 
         let database_key_index = self.database_key_index(id);
 
-        let can_shallow_update = self.shallow_verify_memo(zalsa, database_key_index, memo);
+        let can_shallow_update = memo
+            .header
+            .shallow_verify_memo(zalsa, database_key_index, true);
 
-        if can_shallow_update.yes() && !memo.may_be_provisional() {
-            self.update_shallow(zalsa, database_key_index, memo, can_shallow_update);
+        if can_shallow_update.yes() && !memo.header.may_be_provisional() {
+            memo.header
+                .update_shallow(zalsa, database_key_index, can_shallow_update);
 
             // SAFETY: memo is present in memo_map and we have verified that it is
             // still valid for the current revision.
@@ -128,31 +131,23 @@ where
         let opt_old_memo = self.get_memo_from_table_for(zalsa, id, memo_ingredient_index);
 
         if let Some(old_memo) = opt_old_memo {
-            if old_memo.value.is_some() {
-                let can_shallow_update =
-                    self.shallow_verify_memo(zalsa, database_key_index, old_memo);
-                if can_shallow_update.yes()
-                    && self.validate_may_be_provisional(
+            if old_memo.value.is_some()
+                && old_memo
+                    .header
+                    .maybe_changed_after_cold(
+                        db.into(),
                         zalsa,
                         zalsa_local,
                         database_key_index,
-                        old_memo,
+                        zalsa.current_revision(),
+                        C::CYCLE_STRATEGY,
+                        true,
                     )
-                {
-                    self.update_shallow(zalsa, database_key_index, old_memo, can_shallow_update);
-
-                    // SAFETY: memo is present in memo_map and we have verified that it is
-                    // still valid for the current revision.
-                    return unsafe { Some(self.extend_memo_lifetime(old_memo)) };
-                }
-
-                let verify_result = self.deep_verify_memo(db, zalsa, old_memo, database_key_index);
-
-                if verify_result.is_unchanged() {
-                    // SAFETY: memo is present in memo_map and we have verified that it is
-                    // still valid for the current revision.
-                    return unsafe { Some(self.extend_memo_lifetime(old_memo)) };
-                }
+                    .is_some_and(|result| result.is_unchanged())
+            {
+                // SAFETY: memo is present in memo_map and we have verified that it is
+                // still valid for the current revision.
+                return unsafe { Some(self.extend_memo_lifetime(old_memo)) };
             }
         }
 
@@ -192,19 +187,19 @@ where
                     // Ideally, we'd use the last provisional memo even if it wasn't a cycle head in the last iteration
                     // but that would require inserting itself as a cycle head, which either requires clone
                     // on the value OR a concurrent `Vec` for cycle heads.
-                    if memo.verified_at.load() == zalsa.current_revision()
+                    if memo.header.verified_at.load() == zalsa.current_revision()
                         && memo.value.is_some()
-                        && memo.revisions.iteration().cancellation_count() == cancellation_count
-                        && memo.revisions.cycle_heads().contains(&database_key_index)
+                        && memo.revision().iteration().cancellation_count() == cancellation_count
+                        && memo.revision().cycle_heads().contains(&database_key_index)
                     {
-                        memo.revisions
+                        memo.revision()
                             .cycle_heads()
                             .remove_all_except(database_key_index);
 
                         crate::tracing::debug!(
                             "hit cycle at {database_key_index:#?}, \
                                 returning last provisional value: {:#?}",
-                            memo.revisions
+                            memo.revision()
                         );
 
                         // SAFETY: memo is present in memo_map.
@@ -219,12 +214,12 @@ where
 
                 let iteration = memo_guard
                     .and_then(|old_memo| {
-                        if old_memo.verified_at.load() == zalsa.current_revision()
+                        if old_memo.header.verified_at.load() == zalsa.current_revision()
                             && old_memo.value.is_some()
-                            && old_memo.revisions.iteration().cancellation_count()
+                            && old_memo.revision().iteration().cancellation_count()
                                 == cancellation_count
                         {
-                            Some(old_memo.revisions.iteration())
+                            Some(old_memo.revision().iteration())
                         } else {
                             None
                         }

--- a/src/function/inputs.rs
+++ b/src/function/inputs.rs
@@ -10,6 +10,6 @@ where
     pub(super) fn origin<'db>(&self, zalsa: &'db Zalsa, key: Id) -> Option<QueryOriginRef<'db>> {
         let memo_ingredient_index = self.memo_ingredient_index(zalsa, key);
         self.get_memo_from_table_for(zalsa, key, memo_ingredient_index)
-            .map(|m| m.revisions.origin())
+            .map(|m| m.header.origin())
     }
 }

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -258,6 +258,7 @@ impl MemoHeader {
         };
 
         if verified {
+            // Check if the inputs are still valid. We can just compare `changed_at`.
             Some(if self.revisions.changed_at > revision {
                 VerifyResult::changed()
             } else {
@@ -266,6 +267,7 @@ impl MemoHeader {
         } else if has_value && !self.may_be_provisional() {
             None
         } else {
+            // Otherwise, nothing for it: have to consider the value to have changed.
             Some(VerifyResult::changed())
         }
     }

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "accumulator")]
 use crate::accumulator::accumulated_map::InputAccumulatedValues;
 use crate::cycle::{CycleHeads, CycleRecoveryStrategy, ProvisionalStatus};
-use crate::function::memo::{Memo, TryClaimCycleHeadsIter, TryClaimHeadsResult};
+use crate::function::memo::{MemoHeader, TryClaimCycleHeadsIter, TryClaimHeadsResult};
 use crate::function::sync::ClaimResult;
 use crate::function::{Configuration, IngredientImpl, Reentrancy};
 use std::sync::atomic::Ordering;
@@ -108,15 +108,13 @@ where
                 return VerifyResult::changed();
             };
 
-            let can_shallow_update = self.shallow_verify_memo(zalsa, database_key_index, memo);
-            if can_shallow_update.yes() && !memo.may_be_provisional() {
-                self.update_shallow(zalsa, database_key_index, memo, can_shallow_update);
-
-                return if memo.revisions.changed_at > revision {
-                    VerifyResult::changed()
-                } else {
-                    VerifyResult::unchanged_for_memo(&memo.revisions)
-                };
+            if let Some(result) = memo.header.maybe_changed_after_hot(
+                zalsa,
+                database_key_index,
+                revision,
+                memo.value.is_some(),
+            ) {
+                return result;
             }
 
             if let Some(mcs) = self.maybe_changed_after_cold(
@@ -170,57 +168,106 @@ where
             return Some(VerifyResult::changed());
         };
 
-        crate::tracing::debug!(
-            "{database_key_index:?}: maybe_changed_after_cold, successful claim, \
-                revision = {revision:?}, old_memo = {old_memo:#?}",
-            old_memo = old_memo.tracing_debug()
-        );
-
-        let can_shallow_update = self.shallow_verify_memo(zalsa, database_key_index, old_memo);
-        if can_shallow_update.yes()
-            && self.validate_may_be_provisional(zalsa, zalsa_local, database_key_index, old_memo)
-        {
-            self.update_shallow(zalsa, database_key_index, old_memo, can_shallow_update);
-
-            return Some(if old_memo.revisions.changed_at > revision {
-                VerifyResult::changed()
-            } else {
-                VerifyResult::unchanged_for_memo(&old_memo.revisions)
-            });
-        }
-
-        let deep_verify = self.deep_verify_memo(db, zalsa, old_memo, database_key_index);
-
-        if deep_verify.is_unchanged() {
-            // Check if the inputs are still valid. We can just compare `changed_at`.
-            return Some(if old_memo.revisions.changed_at > revision {
-                VerifyResult::changed()
-            } else {
-                VerifyResult::unchanged_for_memo(&old_memo.revisions)
-            });
+        if let Some(result) = old_memo.header.maybe_changed_after_cold(
+            db.into(),
+            zalsa,
+            zalsa_local,
+            database_key_index,
+            revision,
+            C::CYCLE_STRATEGY,
+            old_memo.value.is_some(),
+        ) {
+            return Some(result);
         }
 
         // If inputs have changed, but we have an old value, we can re-execute.
         // It is possible the result will be equal to the old value and hence
         // backdated. In that case, although we will have computed a new memo,
         // the value has not logically changed.
-        if old_memo.value.is_some() && !old_memo.may_be_provisional() {
-            let memo = self.execute(db, claim_guard, Some(old_memo))?;
-            let changed_at = memo.revisions.changed_at;
+        let memo = self.execute(db, claim_guard, Some(old_memo))?;
+        let changed_at = memo.revision().changed_at;
 
-            // Always assume that a provisional value has changed.
-            //
-            // We don't know if a provisional value has actually changed. To determine whether a provisional
-            // value has changed, we need to iterate the outer cycle, which cannot be done here.
-            return Some(if changed_at > revision || memo.may_be_provisional() {
+        // Always assume that a provisional value has changed.
+        //
+        // We don't know if a provisional value has actually changed. To determine whether a provisional
+        // value has changed, we need to iterate the outer cycle, which cannot be done here.
+        Some(
+            if changed_at > revision || memo.header.may_be_provisional() {
                 VerifyResult::changed()
             } else {
-                VerifyResult::unchanged_for_memo(&memo.revisions)
-            });
-        }
+                VerifyResult::unchanged_for_memo(memo.revision())
+            },
+        )
+    }
+}
 
-        // Otherwise, nothing for it: have to consider the value to have changed.
-        Some(VerifyResult::changed())
+impl MemoHeader {
+    fn maybe_changed_after_hot(
+        &self,
+        zalsa: &Zalsa,
+        database_key_index: DatabaseKeyIndex,
+        revision: Revision,
+        has_value: bool,
+    ) -> Option<VerifyResult> {
+        let can_shallow_update = self.shallow_verify_memo(zalsa, database_key_index, has_value);
+        if can_shallow_update.yes() && !self.may_be_provisional() {
+            self.update_shallow(zalsa, database_key_index, can_shallow_update);
+
+            Some(if self.revisions.changed_at > revision {
+                VerifyResult::changed()
+            } else {
+                VerifyResult::unchanged_for_memo(&self.revisions)
+            })
+        } else {
+            None
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn maybe_changed_after_cold(
+        &self,
+        db: crate::database::RawDatabase<'_>,
+        zalsa: &Zalsa,
+        zalsa_local: &ZalsaLocal,
+        database_key_index: DatabaseKeyIndex,
+        revision: Revision,
+        cycle_recovery_strategy: CycleRecoveryStrategy,
+        has_value: bool,
+    ) -> Option<VerifyResult> {
+        crate::tracing::debug!(
+            "{database_key_index:?}: maybe_changed_after_cold, successful claim, \
+                revision = {revision:?}, old_memo = {old_memo:#?}",
+            old_memo = self.tracing_debug(has_value)
+        );
+
+        let can_shallow_update = self.shallow_verify_memo(zalsa, database_key_index, has_value);
+        let verified = if can_shallow_update.yes()
+            && self.validate_may_be_provisional(zalsa, zalsa_local, database_key_index, has_value)
+        {
+            self.update_shallow(zalsa, database_key_index, can_shallow_update);
+            true
+        } else {
+            self.deep_verify_memo(
+                db,
+                zalsa,
+                database_key_index,
+                cycle_recovery_strategy,
+                has_value,
+            )
+            .is_unchanged()
+        };
+
+        if verified {
+            Some(if self.revisions.changed_at > revision {
+                VerifyResult::changed()
+            } else {
+                VerifyResult::unchanged_for_memo(&self.revisions)
+            })
+        } else if has_value && !self.may_be_provisional() {
+            None
+        } else {
+            Some(VerifyResult::changed())
+        }
     }
 
     /// `Some` if the memo's value and `changed_at` time is still valid in this revision.
@@ -235,13 +282,13 @@ where
         &self,
         zalsa: &Zalsa,
         database_key_index: DatabaseKeyIndex,
-        memo: &Memo<'_, C>,
+        has_value: bool,
     ) -> ShallowUpdate {
         crate::tracing::debug!(
             "{database_key_index:?}: shallow_verify_memo(memo = {memo:#?})",
-            memo = memo.tracing_debug()
+            memo = self.tracing_debug(has_value)
         );
-        let verified_at = memo.verified_at.load();
+        let verified_at = self.verified_at.load();
         let revision_now = zalsa.current_revision();
 
         if verified_at == revision_now {
@@ -249,7 +296,7 @@ where
             return ShallowUpdate::Verified;
         }
 
-        let last_changed = zalsa.last_changed_revision(memo.revisions.durability);
+        let last_changed = zalsa.last_changed_revision(self.revisions.durability);
         crate::tracing::trace!(
             "{database_key_index:?}: check_durability({database_key_index:#?}, last_changed={:?} <= verified_at={:?}) = {:?}",
             last_changed,
@@ -269,12 +316,11 @@ where
         &self,
         zalsa: &Zalsa,
         database_key_index: DatabaseKeyIndex,
-        memo: &Memo<'_, C>,
         update: ShallowUpdate,
     ) {
         if let ShallowUpdate::HigherDurability = update {
-            memo.mark_as_verified(zalsa, database_key_index);
-            memo.mark_outputs_as_verified(zalsa, database_key_index);
+            self.mark_as_verified(zalsa, database_key_index);
+            self.mark_outputs_as_verified(zalsa, database_key_index);
         }
     }
 
@@ -284,18 +330,18 @@ where
     ///   cycle heads have all been finalized.
     /// * provisional memos that have been created in the same revision and iteration and are part of the same cycle.
     #[inline]
-    pub(super) fn validate_may_be_provisional(
+    fn validate_may_be_provisional(
         &self,
         zalsa: &Zalsa,
         zalsa_local: &ZalsaLocal,
         database_key_index: DatabaseKeyIndex,
-        memo: &Memo<'_, C>,
+        has_value: bool,
     ) -> bool {
-        if !memo.may_be_provisional() {
+        if !self.may_be_provisional() {
             return true;
         }
 
-        let cycle_heads = memo.cycle_heads();
+        let cycle_heads = self.cycle_heads();
 
         if cycle_heads.is_empty() {
             return true;
@@ -303,14 +349,14 @@ where
 
         crate::tracing::trace!(
             "{database_key_index:?}: validate_may_be_provisional(memo = {memo:#?})",
-            memo = memo.tracing_debug()
+            memo = self.tracing_debug(has_value)
         );
 
-        let verified_at = memo.verified_at.load();
+        let verified_at = self.verified_at.load();
         validate_provisional(
             zalsa,
             database_key_index,
-            &memo.revisions,
+            &self.revisions,
             verified_at,
             cycle_heads,
         ) || validate_same_iteration(
@@ -329,21 +375,22 @@ where
     /// Takes an [`ActiveQueryGuard`] argument because this function recursively
     /// walks dependencies of `old_memo` and may even execute them to see if their
     /// outputs have changed.
-    pub(super) fn deep_verify_memo(
+    fn deep_verify_memo(
         &self,
-        db: &C::DbView,
+        db: crate::database::RawDatabase<'_>,
         zalsa: &Zalsa,
-        old_memo: &Memo<'_, C>,
         database_key_index: DatabaseKeyIndex,
+        cycle_recovery_strategy: CycleRecoveryStrategy,
+        has_value: bool,
     ) -> VerifyResult {
-        match old_memo.revisions.origin() {
+        match self.origin() {
             QueryOriginRef::Derived(edges) => {
                 crate::tracing::debug!(
                     "{database_key_index:?}: deep_verify_memo(old_memo = {old_memo:#?})",
-                    old_memo = old_memo.tracing_debug()
+                    old_memo = self.tracing_debug(has_value)
                 );
 
-                let is_provisional = old_memo.may_be_provisional();
+                let is_provisional = self.may_be_provisional();
 
                 // If the value is from the same revision but is still provisional, consider it changed
                 // because we're now in a new iteration.
@@ -365,25 +412,25 @@ where
                 //
                 // For queries with cycle handling, verify the flattened
                 // dependencies of the cycle head instead.
-                if C::CYCLE_STRATEGY == CycleRecoveryStrategy::Panic
-                    && old_memo.was_cycle_participant()
+                if cycle_recovery_strategy == CycleRecoveryStrategy::Panic
+                    && self.was_cycle_participant()
                 {
                     return VerifyResult::changed();
                 }
 
-                let verified_at = old_memo.verified_at.load();
+                let verified_at = self.verified_at.load();
 
                 let result = deep_verify_edges(
-                    db.into(),
+                    db,
                     zalsa,
-                    &old_memo.revisions,
+                    &self.revisions,
                     verified_at,
                     edges,
                     database_key_index,
                 );
 
                 if result.is_unchanged() {
-                    old_memo.mark_as_verified(zalsa, database_key_index);
+                    self.mark_as_verified(zalsa, database_key_index);
                 }
 
                 result

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -291,6 +291,17 @@ impl MemoHeader {
             return ShallowUpdate::Verified;
         }
 
+        self.shallow_verify_memo_cold(zalsa, database_key_index, verified_at)
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn shallow_verify_memo_cold(
+        &self,
+        zalsa: &Zalsa,
+        database_key_index: DatabaseKeyIndex,
+        verified_at: Revision,
+    ) -> ShallowUpdate {
         let last_changed = zalsa.last_changed_revision(self.revisions.durability);
         crate::tracing::trace!(
             "{database_key_index:?}: check_durability({database_key_index:#?}, last_changed={:?} <= verified_at={:?}) = {:?}",

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -185,7 +185,7 @@ where
         // backdated. In that case, although we will have computed a new memo,
         // the value has not logically changed.
         let memo = self.execute(db, claim_guard, Some(old_memo))?;
-        let changed_at = memo.revision().changed_at;
+        let changed_at = memo.header.revisions.changed_at;
 
         // Always assume that a provisional value has changed.
         //
@@ -195,7 +195,7 @@ where
             if changed_at > revision || memo.header.may_be_provisional() {
                 VerifyResult::changed()
             } else {
-                VerifyResult::unchanged_for_memo(memo.revision())
+                VerifyResult::unchanged_for_memo(&memo.header.revisions)
             },
         )
     }

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -182,20 +182,25 @@ where
         // It is possible the result will be equal to the old value and hence
         // backdated. In that case, although we will have computed a new memo,
         // the value has not logically changed.
-        let memo = self.execute(db, claim_guard, Some(old_memo))?;
-        let changed_at = memo.header.revisions.changed_at;
+        if old_memo.value.is_some() && !old_memo.header.may_be_provisional() {
+            let memo = self.execute(db, claim_guard, Some(old_memo))?;
+            let changed_at = memo.header.revisions.changed_at;
 
-        // Always assume that a provisional value has changed.
-        //
-        // We don't know if a provisional value has actually changed. To determine whether a provisional
-        // value has changed, we need to iterate the outer cycle, which cannot be done here.
-        Some(
-            if changed_at > revision || memo.header.may_be_provisional() {
-                VerifyResult::changed()
-            } else {
-                VerifyResult::unchanged_for_memo(&memo.header.revisions)
-            },
-        )
+            // Always assume that a provisional value has changed.
+            //
+            // We don't know if a provisional value has actually changed. To determine whether a provisional
+            // value has changed, we need to iterate the outer cycle, which cannot be done here.
+            return Some(
+                if changed_at > revision || memo.header.may_be_provisional() {
+                    VerifyResult::changed()
+                } else {
+                    VerifyResult::unchanged_for_memo(&memo.header.revisions)
+                },
+            );
+        }
+
+        // Otherwise, nothing for it: have to consider the value to have changed.
+        Some(VerifyResult::changed())
     }
 }
 
@@ -221,6 +226,30 @@ impl MemoHeader {
         }
     }
 
+    /// Returns whether this memo is still valid in the current revision.
+    pub(super) fn verify_memo(
+        &self,
+        db: crate::database::RawDatabase<'_>,
+        claim_guard: &ClaimGuard<'_>,
+        cycle_recovery_strategy: CycleRecoveryStrategy,
+        has_value: bool,
+    ) -> bool {
+        let zalsa = claim_guard.zalsa();
+        let zalsa_local = claim_guard.zalsa_local();
+        let database_key_index = claim_guard.database_key_index();
+
+        let can_shallow_update = self.shallow_verify_memo(zalsa, database_key_index, has_value);
+        if can_shallow_update.yes()
+            && self.validate_may_be_provisional(zalsa, zalsa_local, database_key_index, has_value)
+        {
+            self.update_shallow(zalsa, database_key_index, can_shallow_update);
+            true
+        } else {
+            self.deep_verify_memo(db, claim_guard, cycle_recovery_strategy, has_value)
+                .is_unchanged()
+        }
+    }
+
     pub(super) fn maybe_changed_after_cold(
         &self,
         db: crate::database::RawDatabase<'_>,
@@ -229,8 +258,6 @@ impl MemoHeader {
         cycle_recovery_strategy: CycleRecoveryStrategy,
         has_value: bool,
     ) -> Option<VerifyResult> {
-        let zalsa = claim_guard.zalsa();
-        let zalsa_local = claim_guard.zalsa_local();
         let database_key_index = claim_guard.database_key_index();
 
         crate::tracing::debug!(
@@ -239,16 +266,7 @@ impl MemoHeader {
             old_memo = self.tracing_debug(has_value)
         );
 
-        let can_shallow_update = self.shallow_verify_memo(zalsa, database_key_index, has_value);
-        let verified = if can_shallow_update.yes()
-            && self.validate_may_be_provisional(zalsa, zalsa_local, database_key_index, has_value)
-        {
-            self.update_shallow(zalsa, database_key_index, can_shallow_update);
-            true
-        } else {
-            self.deep_verify_memo(db, claim_guard, cycle_recovery_strategy, has_value)
-                .is_unchanged()
-        };
+        let verified = self.verify_memo(db, claim_guard, cycle_recovery_strategy, has_value);
 
         if verified {
             // Check if the inputs are still valid. We can just compare `changed_at`.
@@ -257,11 +275,8 @@ impl MemoHeader {
             } else {
                 VerifyResult::unchanged_for_memo(&self.revisions)
             })
-        } else if has_value && !self.may_be_provisional() {
-            None
         } else {
-            // Otherwise, nothing for it: have to consider the value to have changed.
-            Some(VerifyResult::changed())
+            None
         }
     }
 

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -2,7 +2,7 @@
 use crate::accumulator::accumulated_map::InputAccumulatedValues;
 use crate::cycle::{CycleHeads, CycleRecoveryStrategy, ProvisionalStatus};
 use crate::function::memo::{MemoHeader, TryClaimCycleHeadsIter, TryClaimHeadsResult};
-use crate::function::sync::ClaimResult;
+use crate::function::sync::{ClaimGuard, ClaimResult};
 use crate::function::{Configuration, IngredientImpl, Reentrancy};
 use std::sync::atomic::Ordering;
 
@@ -170,9 +170,7 @@ where
 
         if let Some(result) = old_memo.header.maybe_changed_after_cold(
             db.into(),
-            zalsa,
-            zalsa_local,
-            database_key_index,
+            &claim_guard,
             revision,
             C::CYCLE_STRATEGY,
             old_memo.value.is_some(),
@@ -223,17 +221,18 @@ impl MemoHeader {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub(super) fn maybe_changed_after_cold(
         &self,
         db: crate::database::RawDatabase<'_>,
-        zalsa: &Zalsa,
-        zalsa_local: &ZalsaLocal,
-        database_key_index: DatabaseKeyIndex,
+        claim_guard: &ClaimGuard<'_>,
         revision: Revision,
         cycle_recovery_strategy: CycleRecoveryStrategy,
         has_value: bool,
     ) -> Option<VerifyResult> {
+        let zalsa = claim_guard.zalsa();
+        let zalsa_local = claim_guard.zalsa_local();
+        let database_key_index = claim_guard.database_key_index();
+
         crate::tracing::debug!(
             "{database_key_index:?}: maybe_changed_after_cold, successful claim, \
                 revision = {revision:?}, old_memo = {old_memo:#?}",
@@ -247,14 +246,8 @@ impl MemoHeader {
             self.update_shallow(zalsa, database_key_index, can_shallow_update);
             true
         } else {
-            self.deep_verify_memo(
-                db,
-                zalsa,
-                database_key_index,
-                cycle_recovery_strategy,
-                has_value,
-            )
-            .is_unchanged()
+            self.deep_verify_memo(db, claim_guard, cycle_recovery_strategy, has_value)
+                .is_unchanged()
         };
 
         if verified {
@@ -374,17 +367,19 @@ impl MemoHeader {
     /// current revision. When this returns Unchanged with no cycle heads, it also updates the
     /// memo's `verified_at` field if needed to make future calls cheaper.
     ///
-    /// Takes an [`ActiveQueryGuard`] argument because this function recursively
+    /// Takes a [`ClaimGuard`] argument because this function recursively
     /// walks dependencies of `old_memo` and may even execute them to see if their
     /// outputs have changed.
     fn deep_verify_memo(
         &self,
         db: crate::database::RawDatabase<'_>,
-        zalsa: &Zalsa,
-        database_key_index: DatabaseKeyIndex,
+        claim_guard: &ClaimGuard<'_>,
         cycle_recovery_strategy: CycleRecoveryStrategy,
         has_value: bool,
     ) -> VerifyResult {
+        let zalsa = claim_guard.zalsa();
+        let database_key_index = claim_guard.database_key_index();
+
         match self.origin() {
             QueryOriginRef::Derived(edges) => {
                 crate::tracing::debug!(

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -64,17 +64,8 @@ impl<C: Configuration> IngredientImpl<C> {
         memo_ingredient_index: MemoIngredientIndex,
     ) {
         let map = |memo: &mut Memo<'static, C>| {
-            match memo.revisions.origin() {
-                QueryOriginRef::Assigned(_) | QueryOriginRef::DerivedUntracked(_) => {
-                    // Careful: Cannot evict memos whose values were
-                    // assigned as output of another query
-                    // or those with untracked inputs
-                    // as their values cannot be reconstructed.
-                }
-                QueryOriginRef::Derived(_) => {
-                    // Set the memo value to `None`.
-                    memo.value = None;
-                }
+            if memo.header.can_evict_value() {
+                memo.value = None;
             }
         };
 
@@ -84,9 +75,15 @@ impl<C: Configuration> IngredientImpl<C> {
 
 #[derive(Debug)]
 pub struct Memo<'db, C: Configuration> {
+    /// Configuration-independent state used to validate and manage this memo.
+    pub(super) header: MemoHeader,
+
     /// The result of the query, if we decide to memoize it.
     pub(super) value: Option<C::Output<'db>>,
+}
 
+#[derive(Debug)]
+pub(super) struct MemoHeader {
     /// Last revision when this memo was verified; this begins
     /// as the current revision.
     pub(super) verified_at: AtomicRevision,
@@ -95,28 +92,26 @@ pub struct Memo<'db, C: Configuration> {
     pub(super) revisions: QueryRevisions,
 }
 
-impl<'db, C: Configuration> Memo<'db, C> {
-    pub(super) fn new(
-        value: Option<C::Output<'db>>,
-        revision_now: Revision,
-        revisions: QueryRevisions,
-    ) -> Self {
+impl MemoHeader {
+    fn new(revision_now: Revision, revisions: QueryRevisions) -> Self {
         debug_assert!(
             !revisions.verified_final.load(Ordering::Relaxed) || revisions.cycle_heads().is_empty(),
             "Memo must be finalized if it has no cycle heads"
         );
-        Memo {
-            value,
+        Self {
             verified_at: AtomicRevision::from(revision_now),
             revisions,
         }
     }
 
-    /// Returns `true` if this memo should be serialized.
-    pub(super) fn should_serialize(&self) -> bool {
-        // TODO: Serialization is a good opportunity to prune old query results based on
-        // the `verified_at` revision.
-        self.value.is_some() && !self.may_be_provisional()
+    #[inline]
+    pub(super) fn origin(&self) -> QueryOriginRef<'_> {
+        self.revisions.origin()
+    }
+
+    fn can_evict_value(&self) -> bool {
+        // Assigned values and values with untracked inputs cannot be reconstructed.
+        matches!(self.origin(), QueryOriginRef::Derived(_))
     }
 
     /// True if this may be a provisional cycle-iteration result.
@@ -170,37 +165,36 @@ impl<'db, C: Configuration> Memo<'db, C> {
         }
     }
 
-    pub(super) fn tracing_debug(&self) -> impl std::fmt::Debug + use<'_, 'db, C> {
-        struct TracingDebug<'memo, 'db, C: Configuration> {
-            memo: &'memo Memo<'db, C>,
+    pub(super) fn tracing_debug(&self, has_value: bool) -> impl std::fmt::Debug + use<'_> {
+        struct TracingDebug<'memo> {
+            header: &'memo MemoHeader,
+            has_value: bool,
         }
 
-        impl<C: Configuration> std::fmt::Debug for TracingDebug<'_, '_, C> {
+        impl std::fmt::Debug for TracingDebug<'_> {
             fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
                 f.debug_struct("Memo")
                     .field(
                         "value",
-                        if self.memo.value.is_some() {
+                        if self.has_value {
                             &"Some(<value>)"
                         } else {
                             &"None"
                         },
                     )
-                    .field("verified_at", &self.memo.verified_at)
-                    .field("revisions", &self.memo.revisions)
+                    .field("verified_at", &self.header.verified_at)
+                    .field("revisions", &self.header.revisions)
                     .finish()
             }
         }
 
-        TracingDebug { memo: self }
+        TracingDebug {
+            header: self,
+            has_value,
+        }
     }
-}
 
-impl<C: Configuration> crate::table::memo::Memo for Memo<'static, C>
-where
-    C::Output<'static>: Send + Sync + Any,
-{
-    fn remove_outputs(&self, zalsa: &Zalsa, executor: DatabaseKeyIndex) {
+    pub(super) fn remove_outputs(&self, zalsa: &Zalsa, executor: DatabaseKeyIndex) {
         for stale_output in self.revisions.origin().outputs() {
             stale_output.remove_stale_output(zalsa, executor);
         }
@@ -210,10 +204,48 @@ where
             key.remove_stale_output(zalsa, executor);
         }
     }
+}
+
+impl<'db, C: Configuration> Memo<'db, C> {
+    pub(super) fn new(
+        value: Option<C::Output<'db>>,
+        revision_now: Revision,
+        revisions: QueryRevisions,
+    ) -> Self {
+        Self {
+            value,
+            header: MemoHeader::new(revision_now, revisions),
+        }
+    }
+
+    #[inline]
+    pub(super) fn revision(&self) -> &QueryRevisions {
+        &self.header.revisions
+    }
+
+    /// Returns `true` if this memo should be serialized.
+    pub(super) fn should_serialize(&self) -> bool {
+        // TODO: Serialization is a good opportunity to prune old query results based on
+        // the `verified_at` revision.
+        self.value.is_some() && !self.header.may_be_provisional()
+    }
+
+    pub(super) fn tracing_debug(&self) -> impl std::fmt::Debug + use<'_, 'db, C> {
+        self.header.tracing_debug(self.value.is_some())
+    }
+}
+
+impl<C: Configuration> crate::table::memo::Memo for Memo<'static, C>
+where
+    C::Output<'static>: Send + Sync + Any,
+{
+    fn remove_outputs(&self, zalsa: &Zalsa, executor: DatabaseKeyIndex) {
+        self.header.remove_outputs(zalsa, executor);
+    }
 
     #[cfg(feature = "salsa_unstable")]
     fn memory_usage(&self) -> crate::database::MemoInfo {
-        let size_of = std::mem::size_of::<Memo<C>>() + self.revisions.allocation_size();
+        let size_of = std::mem::size_of::<Memo<C>>() + self.revision().allocation_size();
         let heap_size = if let Some(value) = self.value.as_ref() {
             C::heap_size(value)
         } else {
@@ -236,7 +268,7 @@ where
 #[cfg(feature = "persistence")]
 mod persistence {
     use crate::function::Configuration;
-    use crate::function::memo::Memo;
+    use crate::function::memo::{Memo, MemoHeader};
     use crate::revision::AtomicRevision;
     use crate::zalsa_local::QueryRevisions;
     use crate::zalsa_local::persistence::{MappedQueryRevisions, PersistentQueryOrigin};
@@ -257,10 +289,13 @@ mod persistence {
             serialized_origin: PersistentQueryOrigin,
         ) -> MappedMemo<'_, 'db, C> {
             let Memo {
-                ref verified_at,
                 ref value,
-                ref revisions,
+                ref header,
             } = *self;
+            let MemoHeader {
+                ref verified_at,
+                ref revisions,
+            } = *header;
 
             MappedMemo {
                 value: value.as_ref(),
@@ -347,8 +382,10 @@ mod persistence {
 
             Ok(Memo {
                 value: Some(memo.value.0),
-                verified_at: memo.verified_at,
-                revisions: memo.revisions,
+                header: MemoHeader {
+                    verified_at: memo.verified_at,
+                    revisions: memo.revisions,
+                },
             })
         }
     }
@@ -448,6 +485,8 @@ mod _memory_usage {
     use std::num::NonZeroUsize;
 
     // Memo's are stored a lot, make sure their size doesn't randomly increase.
+    const _: [(); std::mem::size_of::<super::MemoHeader>()] =
+        [(); std::mem::size_of::<[usize; 4]>()];
     const _: [(); std::mem::size_of::<super::Memo<DummyConfiguration>>()] =
         [(); std::mem::size_of::<[usize; 5]>()];
 

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -65,6 +65,7 @@ impl<C: Configuration> IngredientImpl<C> {
     ) {
         let map = |memo: &mut Memo<'static, C>| {
             if memo.header.can_evict_value() {
+                // Set the memo value to `None`.
                 memo.value = None;
             }
         };
@@ -110,7 +111,10 @@ impl MemoHeader {
     }
 
     fn can_evict_value(&self) -> bool {
-        // Assigned values and values with untracked inputs cannot be reconstructed.
+        // Careful: Cannot evict memos whose values were
+        // assigned as output of another query
+        // or those with untracked inputs
+        // as their values cannot be reconstructed.
         matches!(self.origin(), QueryOriginRef::Derived(_))
     }
 

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -222,11 +222,6 @@ impl<'db, C: Configuration> Memo<'db, C> {
         }
     }
 
-    #[inline]
-    pub(super) fn revision(&self) -> &QueryRevisions {
-        &self.header.revisions
-    }
-
     /// Returns `true` if this memo should be serialized.
     pub(super) fn should_serialize(&self) -> bool {
         // TODO: Serialization is a good opportunity to prune old query results based on
@@ -249,7 +244,7 @@ where
 
     #[cfg(feature = "salsa_unstable")]
     fn memory_usage(&self) -> crate::database::MemoInfo {
-        let size_of = std::mem::size_of::<Memo<C>>() + self.revision().allocation_size();
+        let size_of = std::mem::size_of::<Memo<C>>() + self.header.revisions.allocation_size();
         let heap_size = if let Some(value) = self.value.as_ref() {
             C::heap_size(value)
         } else {

--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "accumulator")]
 use crate::accumulator::accumulated_map::InputAccumulatedValues;
 use crate::active_query::CompletedQuery;
-use crate::function::memo::Memo;
+use crate::function::memo::{Memo, MemoHeader};
 use crate::function::{Configuration, IngredientImpl};
 use crate::revision::AtomicRevision;
 use crate::sync::atomic::AtomicBool;
@@ -81,20 +81,24 @@ where
         if let Some(old_memo) = self.get_memo_from_table_for(zalsa, key, memo_ingredient_index) {
             completed_query
                 .stale_tracked_structs
-                .extend_from_slice(old_memo.revisions.tracked_struct_ids());
+                .extend_from_slice(old_memo.header.revisions.tracked_struct_ids());
             self.backdate_if_appropriate(
                 old_memo,
                 database_key_index,
                 &mut completed_query.revisions,
                 &value,
             );
-            self.diff_outputs(zalsa, database_key_index, old_memo, &completed_query);
+            old_memo
+                .header
+                .diff_outputs(zalsa, database_key_index, &completed_query);
         }
 
         let memo = Memo {
             value: Some(value),
-            verified_at: AtomicRevision::from(revision),
-            revisions: completed_query.revisions,
+            header: MemoHeader {
+                verified_at: AtomicRevision::from(revision),
+                revisions: completed_query.revisions,
+            },
         };
 
         crate::tracing::debug!(
@@ -127,19 +131,19 @@ where
 
         // If we are marking this as validated, it must be a value that was
         // assigned by `executor`.
-        match memo.revisions.origin() {
+        match memo.header.origin() {
             QueryOriginRef::Assigned(by_query) => assert_eq!(by_query, executor),
             _ => panic!(
                 "expected a query assigned by `{:?}`, not `{:?}`",
                 executor,
-                memo.revisions.origin(),
+                memo.header.origin(),
             ),
         }
 
         let database_key_index = self.database_key_index(key);
-        memo.mark_as_verified(zalsa, database_key_index);
+        memo.header.mark_as_verified(zalsa, database_key_index);
         #[cfg(feature = "accumulator")]
-        memo.revisions
+        memo.revision()
             .accumulated_inputs
             .store(InputAccumulatedValues::Empty);
     }

--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -143,7 +143,8 @@ where
         let database_key_index = self.database_key_index(key);
         memo.header.mark_as_verified(zalsa, database_key_index);
         #[cfg(feature = "accumulator")]
-        memo.revision()
+        memo.header
+            .revisions
             .accumulated_inputs
             .store(InputAccumulatedValues::Empty);
     }

--- a/src/revision.rs
+++ b/src/revision.rs
@@ -128,6 +128,7 @@ impl AtomicRevision {
         }
     }
 
+    #[inline]
     pub fn load(&self) -> Revision {
         Revision {
             // SAFETY: We know that the value is non-zero because we only ever store `START` which 1, or a

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -179,8 +179,9 @@ impl<Db: Database> Storage<Db> {
 
         // The ref count on the `Arc` should now be 1
         let zalsa = Arc::get_mut(&mut self.handle.zalsa_impl).unwrap();
-        // Advance the epoch only after cancelled workers have dropped their handles. Otherwise,
-        // a worker unwinding from cancellation could insert a provisional memo with the new epoch.
+        // Increment the cancellation count only after cancelled workers have dropped their
+        // handles. Otherwise, a worker unwinding from cancellation could insert a provisional
+        // memo with the new cancellation count.
         let overflow = zalsa.runtime_mut().bump_cancellation_count();
         if overflow {
             zalsa.new_revision();


### PR DESCRIPTION
Moves configuration-independent memo validation and cycle metadata into `MemoHeader` to avoid monomorphization. 

This does not change the size of `Memo` because `MemoHeader` has no padding (it's always 32 bytes).


**Release Binary size**

Metric | Base | Branch | Difference
-- | -- | -- | --
Stripped binary | 23,189,920 B | 22,430,096 B | −759,824 B / −3.28%
Unstripped binary | 26,479,232 B | 25,674,128 B | −805,104 B / −3.04%
Mach-O __text | 16,110,760 B | 15,403,432 B | −707,328 B / −4.39%


**LLVM IR**

Scope | Base | Branch | Difference
-- | -- | -- | --
ty_python_semantic | 12,484,695 lines | 11,096,129 lines | −1,388,566 / −11.12%
Entire ty build | 35,139,488 lines | 33,380,017 lines | −1,759,471 / −5.01%


Testing: Passed local validation and GitHub CI.