### PR TITLE
fix: avoid redundant captures in input setters

### DIFF
--- a/components/salsa-macro-rules/src/setup_input_struct.rs
+++ b/components/salsa-macro-rules/src/setup_input_struct.rs
@@ -299,7 +299,7 @@ macro_rules! setup_input_struct {
 
                 $(
                     #[must_use]
-                    $field_setter_vis fn $field_setter_id<'db, $Db>(self, db: &'db mut $Db) -> impl salsa::Setter<FieldTy = $field_ty> + use<'db, $Db>
+                    $field_setter_vis fn $field_setter_id<'db, $Db>(self, db: &'db mut $Db) -> impl salsa::Setter<FieldTy = $field_ty>
                     where
                         // FIXME(rust-lang/rust#65991): The `db` argument *should* have the type `dyn Database`
                         $Db: ?Sized + $zalsa::Database,

--- a/tests/compile-pass/input-impl-trait-redundant-captures.rs
+++ b/tests/compile-pass/input-impl-trait-redundant-captures.rs
@@ -1,0 +1,8 @@
+#![deny(impl_trait_redundant_captures)]
+
+#[salsa::input]
+struct Input {
+    field: u32,
+}
+
+fn main() {}


### PR DESCRIPTION
Rust 2024 captures all in-scope parameters for input setter `impl Trait` return types, making the generated precise capture list redundant and triggering `impl_trait_redundant_captures`.

Remove the redundant capture list while retaining Rust 2021 downstream compatibility, and add compile-pass coverage. Fixes #1143.

Testing: Added regression coverage and ran the full test and lint suites.
