### PR TITLE
Fix default interned GC configuration

### DIFF
--- a/src/interned.rs
+++ b/src/interned.rs
@@ -37,10 +37,10 @@ pub trait Configuration: Sized + 'static {
     const PERSIST: bool;
 
     // The minimum number of revisions that must pass before a stale value is garbage collected.
-    #[cfg(test)]
+    #[cfg(not(test))]
     const REVISIONS: NonZeroUsize = NonZeroUsize::new(3).unwrap();
 
-    #[cfg(not(test))] // More aggressive garbage collection by default when testing.
+    #[cfg(test)] // More aggressive garbage collection by default when testing.
     const REVISIONS: NonZeroUsize = NonZeroUsize::new(1).unwrap();
 
     /// The fields of the struct being interned.


### PR DESCRIPTION
It looks like this has been incorrect since it was introduced, meaning the default interned GC configuration is very aggressive. Note that the interned tests hardcode `revisions = 3` so this doesn't affect any of the snapshots, the `cfg(test)` override was mostly meant to make it more likely to catch bugs for users of Salsa.