### PR TITLE
fix: preserve order when updating OrderMap

### DIFF
--- a/src/update.rs
+++ b/src/update.rs
@@ -346,7 +346,14 @@ where
     S: BuildHasher,
 {
     unsafe fn maybe_update(old_pointer: *mut Self, new_map: Self) -> bool {
-        maybe_update_map!(old_pointer, new_map)
+        let old_map = unsafe { &mut *old_pointer };
+
+        if old_map.keys().ne(new_map.keys()) {
+            *old_map = new_map;
+            true
+        } else {
+            maybe_update_map!(old_pointer, new_map)
+        }
     }
 }
 
@@ -570,5 +577,22 @@ where
 unsafe impl<T> Update for PhantomData<T> {
     unsafe fn maybe_update(_old_pointer: *mut Self, _new_value: Self) -> bool {
         false
+    }
+}
+
+#[cfg(all(test, feature = "ordermap"))]
+mod tests {
+    use super::Update;
+
+    #[test]
+    fn update_order_map_reorders_entries() {
+        let mut old = ordermap::OrderMap::from([(1_u32, 10_u32), (2, 20)]);
+        let new = ordermap::OrderMap::from([(2_u32, 20_u32), (1, 10)]);
+
+        // SAFETY: `old` is valid for reads and writes for the duration of this call.
+        let changed = unsafe { Update::maybe_update(&mut old, new.clone()) };
+
+        assert!(changed);
+        assert_eq!(old, new);
     }
 }


### PR DESCRIPTION
Treat `OrderMap` key reordering as a change so Salsa stores the new iteration order instead of retaining stale results.

Testing: Added regression coverage and ran the optional-feature workspace test suite.
