### PR TITLE
fix: reject singleton on non-input structs

### DIFF
--- a/components/salsa-macros/src/interned.rs
+++ b/components/salsa-macros/src/interned.rs
@@ -45,7 +45,7 @@ impl AllowedOptions for InternedStruct {
 
     const NON_UPDATE_TYPES: bool = true;
 
-    const SINGLETON: bool = true;
+    const SINGLETON: bool = false;
 
     const DATA: bool = true;
 

--- a/components/salsa-macros/src/tracked_struct.rs
+++ b/components/salsa-macros/src/tracked_struct.rs
@@ -41,7 +41,7 @@ impl AllowedOptions for TrackedStruct {
 
     const NON_UPDATE_TYPES: bool = false;
 
-    const SINGLETON: bool = true;
+    const SINGLETON: bool = false;
 
     const DATA: bool = true;
 

--- a/tests/compile-fail/singleton_only_for_input.rs
+++ b/tests/compile-fail/singleton_only_for_input.rs
@@ -9,14 +9,17 @@ struct MyInput {
 
 #[salsa::tracked(singleton)]
 struct MyTracked<'db> {
-    field: u32,
+    field: &'db str,
+}
+
+#[salsa::interned(singleton)]
+struct MyInterned<'db> {
+    field: &'db str,
 }
 
 #[salsa::tracked(singleton)]
-fn create_tracked_structs(db: &dyn salsa::Database, input: MyInput) -> Vec<MyTracked> {
-    (0..input.field(db))
-        .map(|i| MyTracked::new(db, i))
-        .collect()
+fn tracked_fn(db: &dyn salsa::Database, input: MyInput) -> u32 {
+    input.field(db)
 }
 
 #[salsa::accumulator(singleton)]

--- a/tests/compile-fail/singleton_only_for_input.stderr
+++ b/tests/compile-fail/singleton_only_for_input.stderr
@@ -1,11 +1,23 @@
 error: `singleton` option not allowed here
-  --> tests/compile-fail/singleton_only_for_input.rs:15:18
+  --> tests/compile-fail/singleton_only_for_input.rs:10:18
    |
-15 | #[salsa::tracked(singleton)]
+10 | #[salsa::tracked(singleton)]
    |                  ^^^^^^^^^
 
 error: `singleton` option not allowed here
-  --> tests/compile-fail/singleton_only_for_input.rs:22:22
+  --> tests/compile-fail/singleton_only_for_input.rs:15:19
    |
-22 | #[salsa::accumulator(singleton)]
+15 | #[salsa::interned(singleton)]
+   |                   ^^^^^^^^^
+
+error: `singleton` option not allowed here
+  --> tests/compile-fail/singleton_only_for_input.rs:20:18
+   |
+20 | #[salsa::tracked(singleton)]
+   |                  ^^^^^^^^^
+
+error: `singleton` option not allowed here
+  --> tests/compile-fail/singleton_only_for_input.rs:25:22
+   |
+25 | #[salsa::accumulator(singleton)]
    |                      ^^^^^^^^^


### PR DESCRIPTION
The singleton option was silently accepted and ignored on tracked and interned structs. Reject it consistently outside input structs.

Testing: Updated and ran the compile-fail suite.