### PR TITLE
fix: restore cancellation state after cycle panic

### DIFF
--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -68,7 +68,8 @@ where
                 (new_value, active_query.pop(IterationStamp::default()))
             }
             CycleRecoveryStrategy::FallbackImmediate | CycleRecoveryStrategy::Fixpoint => {
-                let _cancellation_guard = CancellationGuard::new(claim_guard.zalsa_local());
+                let _cancellation_guard =
+                    DisableLocalCancellationGuard::new(claim_guard.zalsa_local());
 
                 self.execute_maybe_iterate(
                     db,
@@ -394,12 +395,12 @@ where
 }
 
 #[must_use]
-struct CancellationGuard<'a> {
+struct DisableLocalCancellationGuard<'a> {
     zalsa_local: &'a ZalsaLocal,
     was_disabled: bool,
 }
 
-impl<'a> CancellationGuard<'a> {
+impl<'a> DisableLocalCancellationGuard<'a> {
     fn new(zalsa_local: &'a ZalsaLocal) -> Self {
         Self {
             zalsa_local,
@@ -408,7 +409,7 @@ impl<'a> CancellationGuard<'a> {
     }
 }
 
-impl Drop for CancellationGuard<'_> {
+impl Drop for DisableLocalCancellationGuard<'_> {
     fn drop(&mut self) {
         self.zalsa_local
             .set_cancellation_disabled(self.was_disabled);

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -15,28 +15,6 @@ use crate::zalsa_local::{ActiveQueryGuard, QueryEdge, QueryEdgeKind, QueryRevisi
 use crate::{Cancelled, Cycle, tracing};
 use crate::{DatabaseKeyIndex, Event, EventKind, Id};
 
-#[must_use]
-struct CancellationGuard<'a> {
-    zalsa_local: &'a ZalsaLocal,
-    was_disabled: bool,
-}
-
-impl<'a> CancellationGuard<'a> {
-    fn new(zalsa_local: &'a ZalsaLocal) -> Self {
-        Self {
-            zalsa_local,
-            was_disabled: zalsa_local.set_cancellation_disabled(true),
-        }
-    }
-}
-
-impl Drop for CancellationGuard<'_> {
-    fn drop(&mut self) {
-        self.zalsa_local
-            .set_cancellation_disabled(self.was_disabled);
-    }
-}
-
 impl<C> IngredientImpl<C>
 where
     C: Configuration,
@@ -412,6 +390,28 @@ where
         );
 
         (new_value, active_query)
+    }
+}
+
+#[must_use]
+struct CancellationGuard<'a> {
+    zalsa_local: &'a ZalsaLocal,
+    was_disabled: bool,
+}
+
+impl<'a> CancellationGuard<'a> {
+    fn new(zalsa_local: &'a ZalsaLocal) -> Self {
+        Self {
+            zalsa_local,
+            was_disabled: zalsa_local.set_cancellation_disabled(true),
+        }
+    }
+}
+
+impl Drop for CancellationGuard<'_> {
+    fn drop(&mut self) {
+        self.zalsa_local
+            .set_cancellation_disabled(self.was_disabled);
     }
 }
 

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -15,6 +15,28 @@ use crate::zalsa_local::{ActiveQueryGuard, QueryEdge, QueryEdgeKind, QueryRevisi
 use crate::{Cancelled, Cycle, tracing};
 use crate::{DatabaseKeyIndex, Event, EventKind, Id};
 
+#[must_use]
+struct CancellationGuard<'a> {
+    zalsa_local: &'a ZalsaLocal,
+    was_disabled: bool,
+}
+
+impl<'a> CancellationGuard<'a> {
+    fn new(zalsa_local: &'a ZalsaLocal) -> Self {
+        Self {
+            zalsa_local,
+            was_disabled: zalsa_local.set_cancellation_disabled(true),
+        }
+    }
+}
+
+impl Drop for CancellationGuard<'_> {
+    fn drop(&mut self) {
+        self.zalsa_local
+            .set_cancellation_disabled(self.was_disabled);
+    }
+}
+
 impl<C> IngredientImpl<C>
 where
     C: Configuration,
@@ -68,19 +90,14 @@ where
                 (new_value, active_query.pop(IterationStamp::default()))
             }
             CycleRecoveryStrategy::FallbackImmediate | CycleRecoveryStrategy::Fixpoint => {
-                let zalsa_local = claim_guard.zalsa_local();
-                let was_disabled = zalsa_local.set_cancellation_disabled(true);
+                let _cancellation_guard = CancellationGuard::new(claim_guard.zalsa_local());
 
-                let res = self.execute_maybe_iterate(
+                self.execute_maybe_iterate(
                     db,
                     opt_old_memo,
                     &mut claim_guard,
                     memo_ingredient_index,
-                );
-
-                zalsa_local.set_cancellation_disabled(was_disabled);
-
-                res
+                )
             }
         };
 

--- a/tests/cancellation_token.rs
+++ b/tests/cancellation_token.rs
@@ -3,7 +3,11 @@
 
 mod common;
 
-use std::{sync::Barrier, thread};
+use std::{
+    panic::{AssertUnwindSafe, catch_unwind},
+    sync::Barrier,
+    thread,
+};
 
 use expect_test::expect;
 use salsa::{Cancelled, Database};
@@ -24,6 +28,23 @@ fn a(db: &dyn Database, input: MyInput) -> u32 {
 #[salsa::tracked]
 fn b(db: &dyn Database, input: MyInput) -> u32 {
     input.field(db)
+}
+
+#[salsa::tracked(cycle_initial = |_, _| 0)]
+fn panicking_cycle_query(_db: &dyn Database) -> u32 {
+    panic!("boom")
+}
+
+#[salsa::tracked]
+fn uncancelled_query(_db: &dyn Database) -> u32 {
+    1
+}
+
+#[salsa::tracked]
+fn cancel_after_cycle_panic(db: &dyn Database) -> u32 {
+    assert!(catch_unwind(AssertUnwindSafe(|| panicking_cycle_query(db))).is_err());
+    db.cancellation_token().cancel();
+    uncancelled_query(db)
 }
 
 static BARRIER: Barrier = Barrier::new(2);
@@ -64,4 +85,11 @@ fn cancellation_token() {
             "WillCheckCancellation",
             "WillExecute { database_key: b(Id(0)) }",
         ]"#]]);
+}
+
+#[test]
+fn cancellation_is_restored_after_cycle_panic() {
+    let db = common::LoggerDatabase::default();
+    let result = Cancelled::catch(|| cancel_after_cycle_panic(&db));
+    assert!(matches!(result, Err(Cancelled::Local)), "{result:?}");
 }


### PR DESCRIPTION
A panic during cycle recovery could leave local cancellation disabled, causing later cancellation requests to be ignored. Restore the previous state with an unwind-safe guard.

Testing: Added a regression test and ran the cancellation and cycle-recovery tests.