### PR TITLE
fix: reset cancellation after event panic

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -254,8 +254,8 @@ impl Runtime {
         self.revision_cancelled.store(true, Ordering::Release);
     }
 
-    pub(crate) fn reset_cancellation_flag(&mut self) {
-        *self.revision_cancelled.get_mut() = false;
+    pub(crate) fn reset_cancellation_flag(&self) {
+        self.revision_cancelled.store(false, Ordering::Release);
     }
 
     pub(crate) fn bump_cancellation_count(&mut self) -> bool {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -101,6 +101,22 @@ struct Coordinate {
     cvar: Condvar,
 }
 
+#[must_use]
+struct CancellationFlagGuard<'a>(&'a Zalsa);
+
+impl<'a> CancellationFlagGuard<'a> {
+    fn new(zalsa: &'a Zalsa) -> Self {
+        zalsa.runtime().set_cancellation_flag();
+        Self(zalsa)
+    }
+}
+
+impl Drop for CancellationFlagGuard<'_> {
+    fn drop(&mut self) {
+        self.0.runtime().reset_cancellation_flag();
+    }
+}
+
 // We cannot panic while holding a lock to `clones: Mutex<usize>` and therefore we cannot enter an
 // inconsistent state.
 impl RefUnwindSafe for Coordinate {}
@@ -164,20 +180,21 @@ impl<Db: Database> Storage<Db> {
                 == Some(true),
             "attempted to cancel within query computation, this is a deadlock"
         );
-        self.handle.zalsa_impl.runtime().set_cancellation_flag();
+        {
+            let _cancellation_flag = CancellationFlagGuard::new(&self.handle.zalsa_impl);
 
-        self.handle
-            .zalsa_impl
-            .event(&|| Event::new(EventKind::DidSetCancellationFlag));
+            self.handle
+                .zalsa_impl
+                .event(&|| Event::new(EventKind::DidSetCancellationFlag));
 
-        let mut clones = self.handle.coordinate.clones.lock();
-        while *clones != 1 {
-            clones = self.handle.coordinate.cvar.wait(clones);
+            let mut clones = self.handle.coordinate.clones.lock();
+            while *clones != 1 {
+                clones = self.handle.coordinate.cvar.wait(clones);
+            }
         }
+
         // The ref count on the `Arc` should now be 1
         let zalsa = Arc::get_mut(&mut self.handle.zalsa_impl).unwrap();
-        // cancellation is done, so reset the flag
-        zalsa.runtime_mut().reset_cancellation_flag();
         // Advance the epoch only after cancelled workers have dropped their handles. Otherwise,
         // a worker unwinding from cancellation could insert a provisional memo with the new epoch.
         let overflow = zalsa.runtime_mut().bump_cancellation_count();

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -101,22 +101,6 @@ struct Coordinate {
     cvar: Condvar,
 }
 
-#[must_use]
-struct CancellationFlagGuard<'a>(&'a Zalsa);
-
-impl<'a> CancellationFlagGuard<'a> {
-    fn new(zalsa: &'a Zalsa) -> Self {
-        zalsa.runtime().set_cancellation_flag();
-        Self(zalsa)
-    }
-}
-
-impl Drop for CancellationFlagGuard<'_> {
-    fn drop(&mut self) {
-        self.0.runtime().reset_cancellation_flag();
-    }
-}
-
 // We cannot panic while holding a lock to `clones: Mutex<usize>` and therefore we cannot enter an
 // inconsistent state.
 impl RefUnwindSafe for Coordinate {}
@@ -294,5 +278,21 @@ impl Drop for CoordinateDrop {
     fn drop(&mut self) {
         *self.0.clones.lock() -= 1;
         self.0.cvar.notify_all();
+    }
+}
+
+#[must_use]
+struct CancellationFlagGuard<'a>(&'a Zalsa);
+
+impl<'a> CancellationFlagGuard<'a> {
+    fn new(zalsa: &'a Zalsa) -> Self {
+        zalsa.runtime().set_cancellation_flag();
+        Self(zalsa)
+    }
+}
+
+impl Drop for CancellationFlagGuard<'_> {
+    fn drop(&mut self) {
+        self.0.runtime().reset_cancellation_flag();
     }
 }

--- a/tests/cancellation-event-panic.rs
+++ b/tests/cancellation-event-panic.rs
@@ -1,0 +1,51 @@
+#![cfg(feature = "inventory")]
+
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use salsa::{Database, Setter, Storage};
+
+#[salsa::db]
+struct TestDatabase {
+    storage: Storage<Self>,
+}
+
+impl Default for TestDatabase {
+    fn default() -> Self {
+        let did_panic = Arc::new(AtomicBool::new(false));
+        Self {
+            storage: Storage::new(Some(Box::new(move |event| {
+                if matches!(event.kind, salsa::EventKind::DidSetCancellationFlag)
+                    && !did_panic.swap(true, Ordering::Relaxed)
+                {
+                    panic!("event callback panic");
+                }
+            }))),
+        }
+    }
+}
+
+#[salsa::db]
+impl Database for TestDatabase {}
+
+#[salsa::input]
+struct Input {
+    value: u32,
+}
+
+#[salsa::tracked]
+fn read(db: &dyn Database, input: Input) -> u32 {
+    input.value(db)
+}
+
+#[test]
+fn event_panic_does_not_leave_database_cancelled() {
+    let mut db = TestDatabase::default();
+    let input = Input::new(&db, 1);
+
+    let result = catch_unwind(AssertUnwindSafe(|| input.set_value(&mut db).to(2)));
+    assert!(result.is_err());
+
+    assert_eq!(read(&db, input), 1);
+}


### PR DESCRIPTION
A panic from the cancellation event callback could leave the global cancellation flag set and break later reads. Reset the flag on every exit path.

Testing: Added a regression test and ran the cancellation tests.