### PR TITLE
fix: release tracked struct lock after panic

### DIFF
--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -428,30 +428,6 @@ where
     memos: MemoTable,
 }
 
-#[must_use]
-struct WriteGuard<'a> {
-    updated_at: &'a OptionalAtomicRevision,
-    restore_to: Option<Revision>,
-    id: Id,
-}
-
-impl WriteGuard<'_> {
-    fn release(mut self, revision: Revision) {
-        self.restore_to = Some(revision);
-    }
-}
-
-impl Drop for WriteGuard<'_> {
-    fn drop(&mut self) {
-        let swapped_out = self.updated_at.swap(self.restore_to);
-        assert!(
-            swapped_out.is_none(),
-            "two concurrent writers to {:?}, should not be possible",
-            self.id
-        );
-    }
-}
-
 // ANCHOR_END: ValueStruct
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
@@ -951,6 +927,30 @@ where
                 value,
                 key: self.database_key_index(id),
             })
+    }
+}
+
+#[must_use]
+struct WriteGuard<'a> {
+    updated_at: &'a OptionalAtomicRevision,
+    restore_to: Option<Revision>,
+    id: Id,
+}
+
+impl WriteGuard<'_> {
+    fn release(mut self, revision: Revision) {
+        self.restore_to = Some(revision);
+    }
+}
+
+impl Drop for WriteGuard<'_> {
+    fn drop(&mut self) {
+        let swapped_out = self.updated_at.swap(self.restore_to);
+        assert!(
+            swapped_out.is_none(),
+            "two concurrent writers to {:?}, should not be possible",
+            self.id
+        );
     }
 }
 

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -20,7 +20,7 @@ use crate::plumbing::{self, ZalsaLocal};
 use crate::revision::{AtomicRevision, OptionalAtomicRevision};
 use crate::runtime::Stamp;
 use crate::salsa_struct::SalsaStructInDb;
-use crate::sync::Arc;
+use crate::sync::{Arc, Mutex};
 use crate::table::memo::{MemoTable, MemoTableTypes, MemoTableWithTypesMut};
 use crate::table::{Slot, Table};
 use crate::zalsa::{IngredientIndex, JarKind, Zalsa};
@@ -198,6 +198,12 @@ where
 
     /// Store freed ids
     free_list: SegQueue<Id>,
+
+    /// IDs whose update unwound after acquiring the write lock.
+    ///
+    /// Their slots remain write-locked and are never reused. Keeping this state out-of-band avoids
+    /// increasing the size of every tracked value or reserving an `updated_at` revision.
+    poisoned_ids: Mutex<Option<FxHashSet<Id>>>,
 
     memo_table_types: Arc<MemoTableTypes>,
 }
@@ -489,6 +495,7 @@ where
             ingredient_index: index,
             phantom: PhantomData,
             free_list: Default::default(),
+            poisoned_ids: Default::default(),
             memo_table_types: Arc::new(MemoTableTypes::default()),
         }
     }
@@ -627,9 +634,10 @@ where
         // * When we begin updating, we store `None` in the `updated_at` field
         // * When completed, we store `Some(current_revision)` in `updated_at`
         //
-        // No matter what mischief users get up to, it should be impossible for us to
-        // observe `None` in `updated_at`. The `id` should only be associated with one
-        // query and that query can only be running in one thread at a time.
+        // Outside an active writer, we can only observe `None` if a previous update unwound.
+        // `poisoned_ids` records that case. Observing `None` for an ID that is not poisoned means
+        // there are two concurrent writers: the `id` should only be associated with one query and
+        // that query can only be running in one thread at a time.
         //
         // We *can* observe `Some(current_revision)` however, which means that this
         // tracked struct is already updated for this revision in two ways.
@@ -660,14 +668,22 @@ where
         let write_guard = {
             // SAFETY: `updated_at` is never exclusively borrowed, so borrowing it is sound
             let updated_at = unsafe { &(*data_raw).updated_at };
-            let last_updated_at = updated_at.load();
-            assert!(
-                last_updated_at.is_some(),
-                "two concurrent writers to {id:?}, should not be possible"
-            );
+            let Some(last_updated_at) = updated_at.load() else {
+                assert!(
+                    self.poisoned_ids
+                        .lock()
+                        .as_ref()
+                        .is_some_and(|poisoned_ids| poisoned_ids.contains(&id)),
+                    "two concurrent writers to {id:?}, should not be possible"
+                );
+
+                // A previous update unwound after partially updating this value. Leave its slot
+                // permanently write-locked and allocate a fully initialized replacement instead.
+                return Err(fields);
+            };
 
             // The value is already read-locked, but we can reuse it safely as per above.
-            if last_updated_at == Some(zalsa.current_revision()) {
+            if last_updated_at == zalsa.current_revision() {
                 return Ok(id);
             }
 
@@ -686,20 +702,25 @@ where
             // Acquire the write-lock. This can only fail if there is a parallel thread
             // reading from this same `id`, which can only happen if the user has leaked it.
             // Tsk tsk.
-            // SAFETY: `updated_at` is never exclusively borrowed, so borrowing it is sound
-            let swapped = updated_at.swap(None);
-            let write_guard = WriteGuard {
-                updated_at,
-                restore_to: swapped,
-                id,
-            };
-            if last_updated_at != swapped {
+            // Use compare-exchange so a failed acquisition does not modify the lock. This lets us
+            // arm the guard only after successfully claiming the value; dropping an armed guard
+            // without releasing it marks the ID as poisoned.
+            if updated_at
+                .compare_exchange(Some(last_updated_at), None)
+                .is_err()
+            {
                 panic!(
                     "failed to acquire write lock, id `{id:?}` \
                     must have been leaked across threads"
                 );
             }
-            write_guard
+
+            WriteGuard {
+                updated_at,
+                poisoned_ids: &self.poisoned_ids,
+                publish_revision: None,
+                id,
+            }
         };
 
         // SAFETY: We have now *claimed* mutable access to the `value` field by swapping in `None`,
@@ -933,19 +954,28 @@ where
 #[must_use]
 struct WriteGuard<'a> {
     updated_at: &'a OptionalAtomicRevision,
-    restore_to: Option<Revision>,
+    poisoned_ids: &'a Mutex<Option<FxHashSet<Id>>>,
+    publish_revision: Option<Revision>,
     id: Id,
 }
 
 impl WriteGuard<'_> {
     fn release(mut self, revision: Revision) {
-        self.restore_to = Some(revision);
+        self.publish_revision = Some(revision);
     }
 }
 
 impl Drop for WriteGuard<'_> {
     fn drop(&mut self) {
-        let swapped_out = self.updated_at.swap(self.restore_to);
+        let Some(revision) = self.publish_revision else {
+            self.poisoned_ids
+                .lock()
+                .get_or_insert_default()
+                .insert(self.id);
+            return;
+        };
+
+        let swapped_out = self.updated_at.swap(Some(revision));
         assert!(
             swapped_out.is_none(),
             "two concurrent writers to {:?}, should not be possible",

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -428,6 +428,30 @@ where
     memos: MemoTable,
 }
 
+#[must_use]
+struct WriteGuard<'a> {
+    updated_at: &'a OptionalAtomicRevision,
+    restore_to: Option<Revision>,
+    id: Id,
+}
+
+impl WriteGuard<'_> {
+    fn release(mut self, revision: Revision) {
+        self.restore_to = Some(revision);
+    }
+}
+
+impl Drop for WriteGuard<'_> {
+    fn drop(&mut self) {
+        let swapped_out = self.updated_at.swap(self.restore_to);
+        assert!(
+            swapped_out.is_none(),
+            "two concurrent writers to {:?}, should not be possible",
+            self.id
+        );
+    }
+}
+
 // ANCHOR_END: ValueStruct
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
@@ -657,9 +681,10 @@ where
         // during the current revision and thus obtained an `&` reference to those fields
         // that is still live.
 
-        {
+        let write_guard = {
             // SAFETY: `updated_at` is never exclusively borrowed, so borrowing it is sound
-            let last_updated_at = unsafe { (*data_raw).updated_at.load() };
+            let updated_at = unsafe { &(*data_raw).updated_at };
+            let last_updated_at = updated_at.load();
             assert!(
                 last_updated_at.is_some(),
                 "two concurrent writers to {id:?}, should not be possible"
@@ -686,14 +711,20 @@ where
             // reading from this same `id`, which can only happen if the user has leaked it.
             // Tsk tsk.
             // SAFETY: `updated_at` is never exclusively borrowed, so borrowing it is sound
-            let swapped = unsafe { (*data_raw).updated_at.swap(None) };
+            let swapped = updated_at.swap(None);
+            let write_guard = WriteGuard {
+                updated_at,
+                restore_to: swapped,
+                id,
+            };
             if last_updated_at != swapped {
                 panic!(
                     "failed to acquire write lock, id `{id:?}` \
                     must have been leaked across threads"
                 );
             }
-        }
+            write_guard
+        };
 
         // SAFETY: We have now *claimed* mutable access to the `value` field by swapping in `None`,
         // any attempt to read concurrently will panic so it is safe to take exclusive references.
@@ -738,13 +769,7 @@ where
             }
         }
         *durability = current_deps.durability;
-        // SAFETY: `updated_at` is never exclusively borrowed, so borrowing it is sound
-        // release the lock
-        let swapped_out = unsafe { (*data_raw).updated_at.swap(Some(zalsa.current_revision())) };
-        assert!(
-            swapped_out.is_none(),
-            "two concurrent writers to {id:?}, should not be possible"
-        );
+        write_guard.release(zalsa.current_revision());
 
         Ok(id)
     }

--- a/tests/tracked-struct-update-panic.rs
+++ b/tests/tracked-struct-update-panic.rs
@@ -3,11 +3,12 @@
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use salsa::plumbing::AsId;
 use salsa::{Database, Setter};
 
 static PANIC_ON_CHANGE: AtomicBool = AtomicBool::new(true);
 
-#[derive(Clone, Debug, Hash)]
+#[derive(Clone, Debug)]
 struct PanicsOnce(u32);
 
 impl PartialEq for PanicsOnce {
@@ -52,4 +53,67 @@ fn tracked_struct_can_be_updated_after_panic() {
 
     let tracked = make_tracked(&db, input);
     assert_eq!(tracked.value(&db).0, 2);
+}
+
+static PANIC_AFTER_PARTIAL_UPDATE: AtomicBool = AtomicBool::new(false);
+
+#[derive(Clone, Debug)]
+struct PanicsWhileEqual(u32);
+
+impl PartialEq for PanicsWhileEqual {
+    fn eq(&self, other: &Self) -> bool {
+        if PANIC_AFTER_PARTIAL_UPDATE.swap(false, Ordering::Relaxed) {
+            panic!("equality panic after an earlier field was updated");
+        }
+        self.0 == other.0
+    }
+}
+
+impl Eq for PanicsWhileEqual {}
+
+#[derive(Clone, Debug, salsa::Update)]
+struct PartiallyPanickingValue {
+    first: u32,
+    second: PanicsWhileEqual,
+}
+
+#[salsa::tracked]
+struct PartiallyUpdated<'db> {
+    #[tracked]
+    value: PartiallyPanickingValue,
+}
+
+#[salsa::tracked]
+fn make_partially_updated(db: &dyn Database, input: Input) -> PartiallyUpdated<'_> {
+    PartiallyUpdated::new(
+        db,
+        PartiallyPanickingValue {
+            first: input.value(db),
+            second: PanicsWhileEqual(0),
+        },
+    )
+}
+
+#[salsa::tracked]
+fn read_first<'db>(db: &'db dyn Database, tracked: PartiallyUpdated<'db>) -> u32 {
+    tracked.value(db).first
+}
+
+#[test]
+fn partially_updated_struct_uses_fresh_slot_after_panic() {
+    let mut db = salsa::DatabaseImpl::default();
+    let input = Input::new(&db, 1);
+    let tracked = make_partially_updated(&db, input);
+    let old_id = tracked.as_id();
+    assert_eq!(read_first(&db, tracked), 1);
+
+    input.set_value(&mut db).to(2);
+    PANIC_AFTER_PARTIAL_UPDATE.store(true, Ordering::Relaxed);
+    let result = catch_unwind(AssertUnwindSafe(|| make_partially_updated(&db, input)));
+    assert!(result.is_err());
+
+    let tracked = make_partially_updated(&db, input);
+    assert_ne!(tracked.as_id(), old_id);
+    assert_eq!(tracked.value(&db).first, 2);
+    assert_eq!(read_first(&db, tracked), 2);
 }

--- a/tests/tracked-struct-update-panic.rs
+++ b/tests/tracked-struct-update-panic.rs
@@ -1,0 +1,55 @@
+#![cfg(feature = "inventory")]
+
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use salsa::{Database, Setter};
+
+static PANIC_ON_CHANGE: AtomicBool = AtomicBool::new(true);
+
+#[derive(Clone, Debug, Hash)]
+struct PanicsOnce(u32);
+
+impl PartialEq for PanicsOnce {
+    fn eq(&self, other: &Self) -> bool {
+        if self.0 != other.0 && PANIC_ON_CHANGE.swap(false, Ordering::Relaxed) {
+            panic!("equality panic");
+        }
+        self.0 == other.0
+    }
+}
+
+impl Eq for PanicsOnce {}
+
+#[salsa::input]
+struct Input {
+    value: u32,
+}
+
+#[salsa::tracked]
+struct Tracked<'db> {
+    #[tracked]
+    value: PanicsOnce,
+}
+
+#[salsa::tracked]
+fn make_tracked(db: &dyn Database, input: Input) -> Tracked<'_> {
+    Tracked::new(db, PanicsOnce(input.value(db)))
+}
+
+#[test]
+fn tracked_struct_can_be_updated_after_panic() {
+    PANIC_ON_CHANGE.store(true, Ordering::Relaxed);
+
+    let mut db = salsa::DatabaseImpl::default();
+    let input = Input::new(&db, 1);
+    let tracked = make_tracked(&db, input);
+    assert_eq!(tracked.value(&db).0, 1);
+
+    input.set_value(&mut db).to(2);
+    let result = catch_unwind(AssertUnwindSafe(|| make_tracked(&db, input)));
+    assert!(result.is_err());
+
+    let tracked = make_tracked(&db, input);
+    assert_eq!(tracked.value(&db).0, 2);
+}


### PR DESCRIPTION
A panic while updating tracked fields could leave the struct permanently write-locked. Restore its previous update revision during unwinding so a later execution can retry.

Testing: Added a regression test and ran the related tracked-struct tests.