### PR TITLE
fix: make interned slot reuse unwind-safe

### DIFF
--- a/src/interned.rs
+++ b/src/interned.rs
@@ -512,14 +512,21 @@ where
                 continue;
             };
 
-            // Mark the slot as reused.
-            *value_shared = ValueShared {
-                id: new_id,
-                durability,
-                last_interned_at,
-            };
+            // Assemble and hash the replacement before mutating the existing slot. Both operations
+            // can invoke user code and panic.
+            // SAFETY: We call `from_internal_data` to restore the correct lifetime before access.
+            let new_fields = unsafe { self.to_internal_data(assemble(new_id, key)) };
 
-            let index = self.database_key_index(value_shared.id);
+            // SAFETY: We hold the lock for the shard containing the value.
+            let old_hash = self.hasher.hash_one(unsafe { &*value.fields.get() });
+
+            // Ensure inserting the replacement cannot invoke user hashing after the slot has been
+            // modified.
+            // SAFETY: We hold the lock for the shard containing every value passed to `hasher`.
+            let hasher = |id: &_| unsafe { self.value_hash(*id, zalsa) };
+            shard.key_map.reserve(1, hasher);
+
+            let index = self.database_key_index(new_id);
 
             // Record a dependency on the new value if its slot can be reused.
             //
@@ -528,25 +535,13 @@ where
                 zalsa_local,
                 index,
                 current_revision,
-                value_shared.durability,
+                durability,
             );
-
-            zalsa.event(&|| {
-                Event::new(EventKind::DidReuseInternedValue {
-                    key: index,
-                    revision: current_revision,
-                })
-            });
 
             // Remove the value from the LRU list.
             //
             // SAFETY: The value pointer is valid for the lifetime of the database.
             let value = unsafe { &*UnsafeRef::into_raw(cursor.remove().unwrap()) };
-
-            // SAFETY: We hold the lock for the shard containing the value, and the
-            // value has not been interned in the current revision, so no references to
-            // it can exist.
-            let old_fields = unsafe { &mut *value.fields.get() };
 
             // Remove the previous value from the ID map.
             //
@@ -555,23 +550,38 @@ where
             // map. Crucially, we know that the hashes for the old and new fields both map
             // to the same shard, because we determined the initial shard based on the new
             // fields and only accessed the LRU list for that shard.
-            let old_hash = self.hasher.hash_one(&*old_fields);
             shard
                 .key_map
                 .find_entry(old_hash, |found_id: &Id| *found_id == old_id)
                 .expect("interned value in LRU so must be in key_map")
                 .remove();
 
-            // Update the fields.
+            // Replace the fields without dropping the previous value until the slot is consistent.
             //
-            // SAFETY: We call `from_internal_data` to restore the correct lifetime before access.
-            *old_fields = unsafe { self.to_internal_data(assemble(new_id, key)) };
-
-            // SAFETY: We hold the lock for the shard containing the value.
-            let hasher = |id: &_| unsafe { self.value_hash(*id, zalsa) };
+            // SAFETY: We hold the lock for the shard containing the value, and the
+            // value has not been interned in the current revision, so no references to
+            // it can exist. This mutable reference must be created after `reserve`, whose
+            // hasher can read the fields of this value.
+            let old_fields = unsafe { &mut *value.fields.get() };
+            let old_fields = std::mem::replace(old_fields, new_fields);
 
             // Insert the new value into the ID map.
             shard.key_map.insert_unique(hash, new_id, hasher);
+
+            // Mark the slot as reused.
+            *value_shared = ValueShared {
+                id: new_id,
+                durability,
+                last_interned_at,
+            };
+
+            if value_shared.is_reusable::<C>() {
+                // Move the value to the front of the LRU list.
+                //
+                // SAFETY: The value pointer is valid for the lifetime of the database.
+                // and never accessed mutably directly.
+                shard.lru.push_front(unsafe { UnsafeRef::from_raw(value) });
+            }
 
             // SAFETY: We hold the lock for the shard containing the value, and the
             // value has not been interned in the current revision, so no references to
@@ -582,15 +592,16 @@ where
             //
             // SAFETY: The memo table belongs to a value that we allocated, so it has the
             // correct type.
-            unsafe { self.clear_memos(zalsa, memo_table, new_id) };
+            unsafe { self.clear_memos(zalsa, memo_table, old_id) };
 
-            if value_shared.is_reusable::<C>() {
-                // Move the value to the front of the LRU list.
-                //
-                // SAFETY: The value pointer is valid for the lifetime of the database.
-                // and never accessed mutably directly.
-                shard.lru.push_front(unsafe { UnsafeRef::from_raw(value) });
-            }
+            drop(old_fields);
+
+            zalsa.event(&|| {
+                Event::new(EventKind::DidReuseInternedValue {
+                    key: index,
+                    revision: current_revision,
+                })
+            });
 
             return new_id;
         }

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -520,12 +520,6 @@ where
             // SAFETY: We hold the lock for the shard containing the value.
             let old_hash = self.hasher.hash_one(unsafe { &*value.fields.get() });
 
-            // Ensure inserting the replacement cannot invoke user hashing after the slot has been
-            // modified.
-            // SAFETY: We hold the lock for the shard containing every value passed to `hasher`.
-            let hasher = |id: &_| unsafe { self.value_hash(*id, zalsa) };
-            shard.key_map.reserve(1, hasher);
-
             let index = self.database_key_index(new_id);
 
             // Record a dependency on the new value if its slot can be reused.
@@ -537,6 +531,13 @@ where
                 current_revision,
                 durability,
             );
+
+            // Insert the replacement while the old slot is still intact. `insert_unique`
+            // currently performs any rehashing before inserting, so a panic in user hashing
+            // leaves the old value reachable. Revisit this assumption when updating hashbrown.
+            // SAFETY: We hold the lock for the shard containing every value passed to `hasher`.
+            let hasher = |id: &_| unsafe { self.value_hash(*id, zalsa) };
+            shard.key_map.insert_unique(hash, new_id, hasher);
 
             // Remove the value from the LRU list.
             //
@@ -562,9 +563,6 @@ where
             // value has not been interned in the current revision, so no references to
             // it can exist.
             let old_fields = unsafe { std::mem::replace(&mut *value.fields.get(), new_fields) };
-
-            // Insert the new value into the ID map.
-            shard.key_map.insert_unique(hash, new_id, hasher);
 
             // Mark the slot as reused.
             *value_shared = ValueShared {

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -560,10 +560,8 @@ where
             //
             // SAFETY: We hold the lock for the shard containing the value, and the
             // value has not been interned in the current revision, so no references to
-            // it can exist. This mutable reference must be created after `reserve`, whose
-            // hasher can read the fields of this value.
-            let old_fields = unsafe { &mut *value.fields.get() };
-            let old_fields = std::mem::replace(old_fields, new_fields);
+            // it can exist.
+            let old_fields = unsafe { std::mem::replace(&mut *value.fields.get(), new_fields) };
 
             // Insert the new value into the ID map.
             shard.key_map.insert_unique(hash, new_id, hasher);

--- a/tests/interned-revisions.rs
+++ b/tests/interned-revisions.rs
@@ -6,7 +6,7 @@
 mod common;
 use common::LogDatabase;
 use expect_test::expect;
-use salsa::{Database, Durability, Setter};
+use salsa::{Database, Durability, HashEqLike, Lookup, Setter};
 use test_log::test;
 
 #[salsa::input]
@@ -28,6 +28,81 @@ impl std::hash::Hash for BadHash {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         state.write_i16(0);
     }
+}
+
+#[derive(Debug)]
+struct PanickingLookup {
+    value: usize,
+    should_panic: bool,
+}
+
+impl std::hash::Hash for PanickingLookup {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        state.write_i16(0);
+    }
+}
+
+impl Lookup<BadHash> for PanickingLookup {
+    fn into_owned(self) -> BadHash {
+        assert!(!self.should_panic, "lookup panic");
+        BadHash(self.value)
+    }
+}
+
+impl HashEqLike<PanickingLookup> for BadHash {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        state.write_i16(0);
+    }
+
+    fn eq(&self, data: &PanickingLookup) -> bool {
+        self.0 == data.value
+    }
+}
+
+#[salsa::input]
+struct PanickingInput {
+    value: usize,
+    should_panic: bool,
+}
+
+#[salsa::interned(revisions = 1)]
+struct PanickingInterned<'db> {
+    value: BadHash,
+}
+
+#[salsa::tracked]
+fn intern_panicking(db: &dyn Database, input: PanickingInput) -> PanickingInterned<'_> {
+    PanickingInterned::new(
+        db,
+        PanickingLookup {
+            value: input.value(db),
+            should_panic: input.should_panic(db),
+        },
+    )
+}
+
+#[test]
+fn panic_during_reuse_does_not_orphan_slot() {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    use salsa::plumbing::AsId;
+
+    let mut db = common::LoggerDatabase::default();
+    let input = PanickingInput::new(&db, 0, false);
+
+    let first_id = intern_panicking(&db, input).as_id();
+    input.set_value(&mut db).to(1);
+    let second_id = intern_panicking(&db, input).as_id();
+    assert_eq!(second_id, first_id.next_generation().unwrap());
+
+    input.set_value(&mut db).to(2);
+    input.set_should_panic(&mut db).to(true);
+    let result = catch_unwind(AssertUnwindSafe(|| intern_panicking(&db, input)));
+    assert!(result.is_err());
+
+    input.set_should_panic(&mut db).to(false);
+    let recovered_id = intern_panicking(&db, input).as_id();
+    assert_eq!(recovered_id, second_id.next_generation().unwrap());
 }
 
 #[salsa::interned]
@@ -317,6 +392,43 @@ fn test_reuse() {
             "DidValidateInternedValue { key: Interned(Id(402g2)), revision: R10 }",
             "WillCheckCancellation",
             "WillExecute { database_key: function(Id(9)) }",
+        ]"#]]);
+}
+
+#[test]
+fn reuse_discards_memos_for_old_generation() {
+    use salsa::plumbing::AsId;
+
+    #[salsa::tracked]
+    fn intern(db: &dyn Database, input: Input) -> Interned<'_> {
+        Interned::new(db, BadHash(input.field1(db)))
+    }
+
+    #[salsa::tracked]
+    fn read(db: &dyn Database, interned: Interned<'_>) -> usize {
+        interned.field1(db).0
+    }
+
+    let mut db = common::DiscardLoggerDatabase::default();
+    let input = Input::new(&db, 0);
+    let first = intern(&db, input);
+    let first_id = first.as_id();
+    assert_eq!(read(&db, first), 0);
+    db.clear_logs();
+
+    let mut reused = false;
+    for value in 1..10 {
+        input.set_field1(&mut db).to(value);
+        if intern(&db, input).as_id().index() == first_id.index() {
+            reused = true;
+            break;
+        }
+    }
+    assert!(reused);
+
+    db.assert_logs(expect![[r#"
+        [
+            "salsa_event(DidDiscard { key: read(Id(400)) })",
         ]"#]]);
 }
 

--- a/tests/interned-revisions.rs
+++ b/tests/interned-revisions.rs
@@ -31,10 +31,7 @@ impl std::hash::Hash for BadHash {
 }
 
 #[derive(Debug)]
-struct PanickingLookup {
-    value: usize,
-    should_panic: bool,
-}
+struct PanickingLookup(usize);
 
 impl std::hash::Hash for PanickingLookup {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
@@ -44,8 +41,8 @@ impl std::hash::Hash for PanickingLookup {
 
 impl Lookup<BadHash> for PanickingLookup {
     fn into_owned(self) -> BadHash {
-        assert!(!self.should_panic, "lookup panic");
-        BadHash(self.value)
+        assert_ne!(self.0, 2, "lookup panic");
+        BadHash(self.0)
     }
 }
 
@@ -55,14 +52,8 @@ impl HashEqLike<PanickingLookup> for BadHash {
     }
 
     fn eq(&self, data: &PanickingLookup) -> bool {
-        self.0 == data.value
+        self.0 == data.0
     }
-}
-
-#[salsa::input]
-struct PanickingInput {
-    value: usize,
-    should_panic: bool,
 }
 
 #[salsa::interned(revisions = 1)]
@@ -71,14 +62,8 @@ struct PanickingInterned<'db> {
 }
 
 #[salsa::tracked]
-fn intern_panicking(db: &dyn Database, input: PanickingInput) -> PanickingInterned<'_> {
-    PanickingInterned::new(
-        db,
-        PanickingLookup {
-            value: input.value(db),
-            should_panic: input.should_panic(db),
-        },
-    )
+fn intern_panicking(db: &dyn Database, input: Input) -> PanickingInterned<'_> {
+    PanickingInterned::new(db, PanickingLookup(input.field1(db)))
 }
 
 #[test]
@@ -88,19 +73,18 @@ fn panic_during_reuse_does_not_orphan_slot() {
     use salsa::plumbing::AsId;
 
     let mut db = common::LoggerDatabase::default();
-    let input = PanickingInput::new(&db, 0, false);
+    let input = Input::new(&db, 0);
 
     let first_id = intern_panicking(&db, input).as_id();
-    input.set_value(&mut db).to(1);
+    input.set_field1(&mut db).to(1);
     let second_id = intern_panicking(&db, input).as_id();
     assert_eq!(second_id, first_id.next_generation().unwrap());
 
-    input.set_value(&mut db).to(2);
-    input.set_should_panic(&mut db).to(true);
+    input.set_field1(&mut db).to(2);
     let result = catch_unwind(AssertUnwindSafe(|| intern_panicking(&db, input)));
     assert!(result.is_err());
 
-    input.set_should_panic(&mut db).to(false);
+    input.set_field1(&mut db).to(3);
     let recovered_id = intern_panicking(&db, input).as_id();
     assert_eq!(recovered_id, second_id.next_generation().unwrap());
 }


### PR DESCRIPTION
A panic while assembling a reused interned value could orphan its slot after removing the old key and LRU entry. Run user-controlled work before mutation and finish the structural commit before callbacks or drops can unwind.

Testing: Added a regression test and ran the interned-revision, interned-struct, and LRU tests.