### PR TITLE
fix: restore tracked struct state after deletion panic

### DIFF
--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -788,16 +788,28 @@ where
 
         let data = Self::data_raw(zalsa.table(), id);
 
+        struct RestoreRevisionOnPanic<'a>(&'a OptionalAtomicRevision, Revision);
+
+        impl Drop for RestoreRevisionOnPanic<'_> {
+            fn drop(&mut self) {
+                let _ = self.0.swap(Some(self.1));
+            }
+        }
+
         // We want to set `updated_at` to `None`, signalling that other field values
         // cannot be read. The current value should be `Some(R0)` for some older revision.
-        match unsafe { (*data).updated_at.swap(None) } {
-            None => {
-                panic!("cannot delete write-locked id `{id:?}`; value leaked across threads");
-            }
-            Some(r) if r == zalsa.current_revision() => panic!(
+        let Some(previous_revision) = (unsafe { (*data).updated_at.swap(None) }) else {
+            panic!("cannot delete write-locked id `{id:?}`; value leaked across threads");
+        };
+        let restore_revision = RestoreRevisionOnPanic(
+            // SAFETY: `data` is a valid pointer acquired from the table.
+            unsafe { &(*data).updated_at },
+            previous_revision,
+        );
+        if previous_revision == zalsa.current_revision() {
+            panic!(
                 "cannot delete read-locked id `{id:?}`; value leaked across threads or user functions not deterministic"
-            ),
-            Some(_) => (),
+            );
         }
 
         // SAFETY: We have acquired the write lock by swapping `None` into `updated_at`
@@ -809,6 +821,7 @@ where
 
         // now that all cleanup has occurred, make available for re-use
         self.free_list.push(id);
+        mem::forget(restore_revision);
     }
 
     /// Clears the given memo table.

--- a/tests/deletion-event-panic.rs
+++ b/tests/deletion-event-panic.rs
@@ -1,0 +1,66 @@
+#![cfg(feature = "inventory")]
+
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use salsa::{Database, Setter, Storage};
+
+#[salsa::db]
+struct TestDatabase {
+    storage: Storage<Self>,
+}
+
+impl Default for TestDatabase {
+    fn default() -> Self {
+        let discards = Arc::new(AtomicUsize::new(0));
+        Self {
+            storage: Storage::new(Some(Box::new(move |event| {
+                if matches!(event.kind, salsa::EventKind::DidDiscard { .. })
+                    && discards.fetch_add(1, Ordering::Relaxed) == 1
+                {
+                    panic!("discard callback panic");
+                }
+            }))),
+        }
+    }
+}
+
+#[salsa::db]
+impl Database for TestDatabase {}
+
+#[salsa::input]
+struct Input {
+    keep: bool,
+}
+
+#[salsa::tracked]
+struct Entity<'db> {
+    value: u32,
+}
+
+#[salsa::tracked]
+fn create(db: &dyn Database, input: Input) -> Option<Entity<'_>> {
+    input.keep(db).then(|| Entity::new(db, 1))
+}
+
+#[salsa::tracked]
+fn read_entity(db: &dyn Database, entity: Entity<'_>) -> u32 {
+    entity.value(db)
+}
+
+#[test]
+fn deletion_can_be_retried_after_event_callback_panics() {
+    let mut db = TestDatabase::default();
+    let input = Input::new(&db, true);
+    let entity = create(&db, input).unwrap();
+    assert_eq!(read_entity(&db, entity), 1);
+
+    input.set_keep(&mut db).to(false);
+
+    let first = catch_unwind(AssertUnwindSafe(|| create(&db, input)));
+    assert!(first.is_err());
+
+    let retry = catch_unwind(AssertUnwindSafe(|| create(&db, input)));
+    assert!(retry.unwrap().is_none());
+}


### PR DESCRIPTION
A panic from a discard callback could leave a tracked struct's revision set to the write-lock sentinel. Restore the previous revision during unwinding so deletion can be retried instead of permanently poisoning the slot.

Testing: Added regression coverage and ran the inventory-enabled test suite.
