### PR TITLE
fix: discard tracked outputs overwritten by specify

### DIFF
--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -39,8 +39,8 @@ where
         // * Q4 invokes Q2 and then Q1
         //
         // Now, if We invoke Q3 first, We get one result for Q2, but if We invoke Q4 first, We get a different value. That's no good.
-        let database_key_index = <C::Input<'db>>::database_key_index(zalsa, key);
-        if !zalsa_local.is_tracked_struct_of_active_query(database_key_index) {
+        let input_key = <C::Input<'db>>::database_key_index(zalsa, key);
+        if !zalsa_local.is_tracked_struct_of_active_query(input_key) {
             panic!("can only use `specify` on salsa structs created during the current tracked fn");
         }
 
@@ -76,8 +76,12 @@ where
             stale_tracked_structs: Vec::new(),
         };
 
+        let database_key_index = self.database_key_index(key);
         let memo_ingredient_index = self.memo_ingredient_index(zalsa, key);
         if let Some(old_memo) = self.get_memo_from_table_for(zalsa, key, memo_ingredient_index) {
+            completed_query
+                .stale_tracked_structs
+                .extend_from_slice(old_memo.revisions.tracked_struct_ids());
             self.backdate_if_appropriate(
                 old_memo,
                 database_key_index,
@@ -101,7 +105,6 @@ where
         self.insert_memo(zalsa, key, memo, memo_ingredient_index);
 
         // Record that the current query *specified* a value for this cell.
-        let database_key_index = self.database_key_index(key);
         zalsa_local.add_output(database_key_index);
     }
 

--- a/tests/specify-discards-derived-tracked-outputs.rs
+++ b/tests/specify-discards-derived-tracked-outputs.rs
@@ -1,0 +1,88 @@
+#![cfg(feature = "inventory")]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use salsa::{Database, EventKind, Setter, Storage};
+
+#[salsa::db]
+struct EventDatabase {
+    storage: Storage<Self>,
+    will_discard: Arc<AtomicUsize>,
+    did_discard: Arc<AtomicUsize>,
+}
+
+impl Default for EventDatabase {
+    fn default() -> Self {
+        let will_discard = Arc::new(AtomicUsize::new(0));
+        let did_discard = Arc::new(AtomicUsize::new(0));
+        Self {
+            storage: Storage::new(Some(Box::new({
+                let will_discard = Arc::clone(&will_discard);
+                let did_discard = Arc::clone(&did_discard);
+                move |event| match event.kind {
+                    EventKind::WillDiscardStaleOutput { .. } => {
+                        will_discard.fetch_add(1, Ordering::Relaxed);
+                    }
+                    EventKind::DidDiscard { .. } => {
+                        did_discard.fetch_add(1, Ordering::Relaxed);
+                    }
+                    _ => {}
+                }
+            }))),
+            will_discard,
+            did_discard,
+        }
+    }
+}
+
+#[salsa::db]
+impl Database for EventDatabase {}
+
+#[salsa::tracked]
+struct Owner<'db> {
+    value: u32,
+}
+
+#[salsa::input]
+struct Input {
+    specify: bool,
+}
+
+#[salsa::tracked]
+struct Child<'db> {
+    value: u32,
+}
+
+#[salsa::tracked(specify)]
+fn overridable<'db>(db: &'db dyn Database, owner: Owner<'db>) -> Child<'db> {
+    Child::new(db, owner.value(db) + 10)
+}
+
+#[salsa::tracked]
+fn specify_over_derived_memo(db: &dyn Database, input: Input) -> Child<'_> {
+    let owner = Owner::new(db, 1);
+    if input.specify(db) {
+        let replacement = Child::new(db, 99);
+        overridable::specify(db, owner, replacement);
+        replacement
+    } else {
+        overridable(db, owner)
+    }
+}
+
+#[test]
+fn specify_discards_tracked_outputs_of_derived_memo() {
+    let mut db = EventDatabase::default();
+    let input = Input::new(&db, false);
+
+    assert_eq!(specify_over_derived_memo(&db, input).value(&db), 11);
+    assert_eq!(db.will_discard.load(Ordering::Relaxed), 0);
+    assert_eq!(db.did_discard.load(Ordering::Relaxed), 0);
+
+    input.set_specify(&mut db).to(true);
+
+    assert_eq!(specify_over_derived_memo(&db, input).value(&db), 99);
+    assert_eq!(db.will_discard.load(Ordering::Relaxed), 1);
+    assert_eq!(db.did_discard.load(Ordering::Relaxed), 1);
+}


### PR DESCRIPTION
`specify` could replace a derived memo without discarding tracked structs owned by the old execution. Carry those tracked IDs into output diffing and use the function key when reporting their removal.

Testing: Added regression coverage and ran the inventory-enabled test suite.
