### PR TITLE
fix: guarantee RawDatabase ABI transparency

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -7,6 +7,7 @@ use crate::zalsa_local::CancellationToken;
 use crate::{Durability, Revision};
 
 #[derive(Copy, Clone)]
+#[repr(transparent)]
 pub struct RawDatabase<'db> {
     pub(crate) ptr: NonNull<()>,
     _marker: std::marker::PhantomData<&'db dyn Database>,


### PR DESCRIPTION
RawDatabase is now explicitly transparent over its pointer, matching the ABI assumed by database view caster function-pointer erasure.

https://github.com/salsa-rs/salsa/blob/03500ac605dfa07b950765fd991c5c31d67c3c68/src/views.rs#L128-L132


https://github.com/salsa-rs/salsa/blob/03500ac605dfa07b950765fd991c5c31d67c3c68/src/views.rs#L47-L48