### PR TITLE
fix: exclude deleted tracked structs from enumeration

### DIFF
--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -922,6 +922,10 @@ where
         zalsa
             .table()
             .slots_of::<Value<C>>()
+            .filter(|(_, value)| {
+                // Deleted values remain allocated for reuse with `updated_at == None`.
+                value.updated_at.load().is_some()
+            })
             .map(|(id, value)| StructEntry {
                 value,
                 key: self.database_key_index(id),
@@ -1056,7 +1060,13 @@ where
     }
 
     fn should_serialize(&self, zalsa: &Zalsa) -> bool {
-        C::PERSIST && self.entries(zalsa).next().is_some()
+        C::PERSIST
+            && zalsa
+                .table()
+                .slots_of::<Value<C>>()
+                // Serialization has exclusive database access, so any value that is not
+                // write-locked is live, even if it has not been verified in this revision.
+                .any(|(_, value)| value.updated_at.load().is_some())
     }
 
     #[cfg(feature = "persistence")]
@@ -1315,10 +1325,19 @@ mod persistence {
         {
             let Self { zalsa, .. } = self;
 
-            let count = zalsa.table().slots_of::<Value<C>>().count();
+            let count = zalsa
+                .table()
+                .slots_of::<Value<C>>()
+                // Deleted values remain allocated for reuse with `updated_at == None`.
+                .filter(|(_, value)| value.updated_at.load().is_some())
+                .count();
             let mut map = serializer.serialize_map(Some(count))?;
 
-            for (id, value) in zalsa.table().slots_of::<Value<C>>() {
+            for (id, value) in zalsa
+                .table()
+                .slots_of::<Value<C>>()
+                .filter(|(_, value)| value.updated_at.load().is_some())
+            {
                 map.serialize_entry(&id.as_bits(), value)?;
             }
 

--- a/tests/tracked-struct-entries-persistence.rs
+++ b/tests/tracked-struct-entries-persistence.rs
@@ -1,0 +1,40 @@
+#![cfg(all(feature = "inventory", feature = "persistence"))]
+
+use salsa::Setter;
+
+const DELETED_VALUE: &str = "deleted tracked entry sentinel";
+
+#[salsa::input(persist)]
+struct Input {
+    enabled: bool,
+}
+
+#[salsa::tracked(persist)]
+struct Entity<'db> {
+    value: String,
+}
+
+#[salsa::tracked(persist)]
+fn maybe_entity(db: &dyn salsa::Database, input: Input) -> Option<Entity<'_>> {
+    input
+        .enabled(db)
+        .then(|| Entity::new(db, DELETED_VALUE.to_owned()))
+}
+
+#[salsa::tracked(persist)]
+fn consume(db: &dyn salsa::Database, entity: Entity<'_>) -> usize {
+    entity.value(db).len()
+}
+
+#[test]
+fn deleted_tracked_structs_are_not_persisted() {
+    let mut db = salsa::DatabaseImpl::default();
+    let input = Input::new(&db, true);
+    assert!(maybe_entity(&db, input).is_some());
+
+    input.set_enabled(&mut db).to(false);
+    assert!(maybe_entity(&db, input).is_none());
+
+    let serialized = serde_json::to_string(&<dyn salsa::Database>::as_serialize(&mut db)).unwrap();
+    assert!(!serialized.contains(DELETED_VALUE));
+}

--- a/tests/tracked-struct-entries.rs
+++ b/tests/tracked-struct-entries.rs
@@ -1,0 +1,66 @@
+#![cfg(feature = "inventory")]
+
+use salsa::Setter;
+use salsa::plumbing::ZalsaDatabase;
+
+mod deleted {
+    use super::*;
+
+    #[salsa::input]
+    struct Input {
+        enabled: bool,
+    }
+
+    #[salsa::tracked]
+    struct Entity<'db> {
+        value: u32,
+    }
+
+    #[salsa::tracked]
+    fn maybe_entity(db: &dyn salsa::Database, input: Input) -> Option<Entity<'_>> {
+        input.enabled(db).then(|| Entity::new(db, 22))
+    }
+
+    #[test]
+    fn deleted_tracked_structs_are_not_enumerated() {
+        let mut db = salsa::DatabaseImpl::default();
+        let input = Input::new(&db, true);
+        assert!(maybe_entity(&db, input).is_some());
+
+        input.set_enabled(&mut db).to(false);
+        assert!(maybe_entity(&db, input).is_none());
+
+        assert_eq!(Entity::ingredient(&db).entries(db.zalsa()).count(), 0);
+    }
+}
+
+mod stale {
+    use super::*;
+
+    #[salsa::input]
+    struct Input {
+        value: u32,
+    }
+
+    #[salsa::tracked]
+    struct Entity<'db> {
+        value: u32,
+    }
+
+    #[salsa::tracked]
+    fn make_entity(db: &dyn salsa::Database, input: Input) -> Entity<'_> {
+        Entity::new(db, input.value(db))
+    }
+
+    #[test]
+    fn stale_tracked_structs_remain_enumerated() {
+        let mut db = salsa::DatabaseImpl::default();
+        let input = Input::new(&db, 1);
+        assert_eq!(make_entity(&db, input).value(&db), 1);
+
+        input.set_value(&mut db).to(2);
+
+        assert_eq!(Entity::ingredient(&db).entries(db.zalsa()).count(), 1);
+        assert_eq!(make_entity(&db, input).value(&db), 2);
+    }
+}


### PR DESCRIPTION
Deleted tracked structs remain allocated for reuse with `updated_at = None`. This change excludes those tombstones from enumeration and persistence while keeping stale-but-live values visible.

Concurrent observation of stale tracked values remains a separate follow-up.
