### PR TITLE
fix: preserve custom interned ID auto traits

### DIFF
--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -223,10 +223,6 @@ macro_rules! setup_interned_struct {
                 }
             }
 
-            unsafe impl< $($db_lt_arg)? > Send for $Struct< $($db_lt_arg)? > {}
-
-            unsafe impl< $($db_lt_arg)? > Sync for $Struct< $($db_lt_arg)? > {}
-
             $zalsa::macro_if! { $generate_debug_impl =>
                 impl< $($db_lt_arg)? > ::std::fmt::Debug for $Struct< $($db_lt_arg)? > {
                     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {

--- a/tests/compile-fail/interned_custom_id_not_send.rs
+++ b/tests/compile-fail/interned_custom_id_not_send.rs
@@ -1,12 +1,9 @@
-use std::marker::PhantomData;
-use std::rc::Rc;
-
 use salsa::plumbing::{AsId, FromId};
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 struct LocalId {
     id: salsa::Id,
-    not_send_or_sync: PhantomData<Rc<()>>,
+    not_send_or_sync: *const (),
 }
 
 impl AsId for LocalId {
@@ -19,7 +16,7 @@ impl FromId for LocalId {
     fn from_id(id: salsa::Id) -> Self {
         Self {
             id,
-            not_send_or_sync: PhantomData,
+            not_send_or_sync: std::ptr::null(),
         }
     }
 }

--- a/tests/compile-fail/interned_custom_id_not_send.rs
+++ b/tests/compile-fail/interned_custom_id_not_send.rs
@@ -1,0 +1,38 @@
+use std::marker::PhantomData;
+use std::rc::Rc;
+
+use salsa::plumbing::{AsId, FromId};
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+struct LocalId {
+    id: salsa::Id,
+    not_send_or_sync: PhantomData<Rc<()>>,
+}
+
+impl AsId for LocalId {
+    fn as_id(&self) -> salsa::Id {
+        self.id
+    }
+}
+
+impl FromId for LocalId {
+    fn from_id(id: salsa::Id) -> Self {
+        Self {
+            id,
+            not_send_or_sync: PhantomData,
+        }
+    }
+}
+
+#[salsa::interned(no_lifetime, id = LocalId)]
+struct Interned {
+    value: u32,
+}
+
+fn assert_send<T: Send>() {}
+fn assert_sync<T: Sync>() {}
+
+fn main() {
+    assert_send::<Interned>();
+    assert_sync::<Interned>();
+}

--- a/tests/compile-fail/interned_custom_id_not_send.stderr
+++ b/tests/compile-fail/interned_custom_id_not_send.stderr
@@ -1,55 +1,45 @@
-error[E0277]: `Rc<()>` cannot be sent between threads safely
-  --> tests/compile-fail/interned_custom_id_not_send.rs:36:19
-   |
-36 |     assert_send::<Interned>();
-   |                   ^^^^^^^^ `Rc<()>` cannot be sent between threads safely
-   |
-   = help: within `Interned`, the trait `Send` is not implemented for `Rc<()>`
-note: required because it appears within the type `PhantomData<Rc<()>>`
-  --> $RUST/core/src/marker.rs
-   |
-   | pub struct PhantomData<T: PointeeSized>;
-   |            ^^^^^^^^^^^
-note: required because it appears within the type `LocalId`
-  --> tests/compile-fail/interned_custom_id_not_send.rs:7:8
-   |
- 7 | struct LocalId {
-   |        ^^^^^^^
-note: required because it appears within the type `Interned`
-  --> tests/compile-fail/interned_custom_id_not_send.rs:28:8
-   |
-28 | struct Interned {
-   |        ^^^^^^^^
-note: required by a bound in `assert_send`
-  --> tests/compile-fail/interned_custom_id_not_send.rs:32:19
-   |
-32 | fn assert_send<T: Send>() {}
-   |                   ^^^^ required by this bound in `assert_send`
-
-error[E0277]: `Rc<()>` cannot be shared between threads safely
-  --> tests/compile-fail/interned_custom_id_not_send.rs:37:19
-   |
-37 |     assert_sync::<Interned>();
-   |                   ^^^^^^^^ `Rc<()>` cannot be shared between threads safely
-   |
-   = help: within `Interned`, the trait `Sync` is not implemented for `Rc<()>`
-note: required because it appears within the type `PhantomData<Rc<()>>`
-  --> $RUST/core/src/marker.rs
-   |
-   | pub struct PhantomData<T: PointeeSized>;
-   |            ^^^^^^^^^^^
-note: required because it appears within the type `LocalId`
-  --> tests/compile-fail/interned_custom_id_not_send.rs:7:8
-   |
- 7 | struct LocalId {
-   |        ^^^^^^^
-note: required because it appears within the type `Interned`
-  --> tests/compile-fail/interned_custom_id_not_send.rs:28:8
-   |
-28 | struct Interned {
-   |        ^^^^^^^^
-note: required by a bound in `assert_sync`
+error[E0277]: `*const ()` cannot be sent between threads safely
   --> tests/compile-fail/interned_custom_id_not_send.rs:33:19
    |
-33 | fn assert_sync<T: Sync>() {}
+33 |     assert_send::<Interned>();
+   |                   ^^^^^^^^ `*const ()` cannot be sent between threads safely
+   |
+   = help: within `Interned`, the trait `Send` is not implemented for `*const ()`
+note: required because it appears within the type `LocalId`
+  --> tests/compile-fail/interned_custom_id_not_send.rs:4:8
+   |
+ 4 | struct LocalId {
+   |        ^^^^^^^
+note: required because it appears within the type `Interned`
+  --> tests/compile-fail/interned_custom_id_not_send.rs:25:8
+   |
+25 | struct Interned {
+   |        ^^^^^^^^
+note: required by a bound in `assert_send`
+  --> tests/compile-fail/interned_custom_id_not_send.rs:29:19
+   |
+29 | fn assert_send<T: Send>() {}
+   |                   ^^^^ required by this bound in `assert_send`
+
+error[E0277]: `*const ()` cannot be shared between threads safely
+  --> tests/compile-fail/interned_custom_id_not_send.rs:34:19
+   |
+34 |     assert_sync::<Interned>();
+   |                   ^^^^^^^^ `*const ()` cannot be shared between threads safely
+   |
+   = help: within `Interned`, the trait `Sync` is not implemented for `*const ()`
+note: required because it appears within the type `LocalId`
+  --> tests/compile-fail/interned_custom_id_not_send.rs:4:8
+   |
+ 4 | struct LocalId {
+   |        ^^^^^^^
+note: required because it appears within the type `Interned`
+  --> tests/compile-fail/interned_custom_id_not_send.rs:25:8
+   |
+25 | struct Interned {
+   |        ^^^^^^^^
+note: required by a bound in `assert_sync`
+  --> tests/compile-fail/interned_custom_id_not_send.rs:30:19
+   |
+30 | fn assert_sync<T: Sync>() {}
    |                   ^^^^ required by this bound in `assert_sync`

--- a/tests/compile-fail/interned_custom_id_not_send.stderr
+++ b/tests/compile-fail/interned_custom_id_not_send.stderr
@@ -1,0 +1,55 @@
+error[E0277]: `Rc<()>` cannot be sent between threads safely
+  --> tests/compile-fail/interned_custom_id_not_send.rs:36:19
+   |
+36 |     assert_send::<Interned>();
+   |                   ^^^^^^^^ `Rc<()>` cannot be sent between threads safely
+   |
+   = help: within `Interned`, the trait `Send` is not implemented for `Rc<()>`
+note: required because it appears within the type `PhantomData<Rc<()>>`
+  --> $RUST/core/src/marker.rs
+   |
+   | pub struct PhantomData<T: PointeeSized>;
+   |            ^^^^^^^^^^^
+note: required because it appears within the type `LocalId`
+  --> tests/compile-fail/interned_custom_id_not_send.rs:7:8
+   |
+ 7 | struct LocalId {
+   |        ^^^^^^^
+note: required because it appears within the type `Interned`
+  --> tests/compile-fail/interned_custom_id_not_send.rs:28:8
+   |
+28 | struct Interned {
+   |        ^^^^^^^^
+note: required by a bound in `assert_send`
+  --> tests/compile-fail/interned_custom_id_not_send.rs:32:19
+   |
+32 | fn assert_send<T: Send>() {}
+   |                   ^^^^ required by this bound in `assert_send`
+
+error[E0277]: `Rc<()>` cannot be shared between threads safely
+  --> tests/compile-fail/interned_custom_id_not_send.rs:37:19
+   |
+37 |     assert_sync::<Interned>();
+   |                   ^^^^^^^^ `Rc<()>` cannot be shared between threads safely
+   |
+   = help: within `Interned`, the trait `Sync` is not implemented for `Rc<()>`
+note: required because it appears within the type `PhantomData<Rc<()>>`
+  --> $RUST/core/src/marker.rs
+   |
+   | pub struct PhantomData<T: PointeeSized>;
+   |            ^^^^^^^^^^^
+note: required because it appears within the type `LocalId`
+  --> tests/compile-fail/interned_custom_id_not_send.rs:7:8
+   |
+ 7 | struct LocalId {
+   |        ^^^^^^^
+note: required because it appears within the type `Interned`
+  --> tests/compile-fail/interned_custom_id_not_send.rs:28:8
+   |
+28 | struct Interned {
+   |        ^^^^^^^^
+note: required by a bound in `assert_sync`
+  --> tests/compile-fail/interned_custom_id_not_send.rs:33:19
+   |
+33 | fn assert_sync<T: Sync>() {}
+   |                   ^^^^ required by this bound in `assert_sync`


### PR DESCRIPTION
Interned handles now derive Send and Sync from their custom ID type instead of overriding those auto traits unsafely.

I think this is mainly historical from when the id wrapped a `NonNull<interned::Value<...>>`