### PR TITLE
Improve ergonomics of `Update` derive helpers

### DIFF
--- a/components/salsa-macros/src/lib.rs
+++ b/components/salsa-macros/src/lib.rs
@@ -95,6 +95,7 @@ pub(crate) fn token_stream_with_error(mut tokens: TokenStream, error: syn::Error
 }
 
 mod kw {
+    syn::custom_keyword!(bounds);
     syn::custom_keyword!(with);
     syn::custom_keyword!(maybe_update);
 }

--- a/components/salsa-macros/src/lib.rs
+++ b/components/salsa-macros/src/lib.rs
@@ -96,6 +96,7 @@ pub(crate) fn token_stream_with_error(mut tokens: TokenStream, error: syn::Error
 
 mod kw {
     syn::custom_keyword!(bounds);
+    syn::custom_keyword!(fallback);
     syn::custom_keyword!(with);
     syn::custom_keyword!(maybe_update);
 }

--- a/components/salsa-macros/src/lib.rs
+++ b/components/salsa-macros/src/lib.rs
@@ -80,6 +80,59 @@ pub fn tracked(args: TokenStream, input: TokenStream) -> TokenStream {
     tracked::tracked(args, input)
 }
 
+/// Derives `salsa::Update` for a struct or enum.
+///
+/// Generic type parameters receive an implicit `salsa::Update` bound unless all their uses appear
+/// in fields that use the `fallback` or `unsafe(with(...))` update strategies.
+///
+/// The `#[update(...)]` field helper supports these forms:
+///
+/// - `#[update(fallback)]` updates the field with `salsa::update_fallback`.
+///   This form adds a `FieldTy: 'static + PartialEq` bound to the generated impl.
+/// - `#[update(unsafe(with(expr)))]` updates the field with `expr`, which must have type
+///   `unsafe fn(*mut FieldTy, FieldTy) -> bool`. The caller is responsible for
+///   ensuring the custom function upholds the `salsa::Update` safety contract.
+/// - `#[update(bounds(Predicate, ...))]` adds one or more where-predicates to the generated impl.
+///   This form can be combined with `fallback` or `unsafe(with(...))`; by itself it does not change
+///   how the field is updated.
+///
+/// # Examples
+///
+/// ```ignore
+/// #[derive(Clone, PartialEq, Eq, salsa::Update)]
+/// struct Foo<T> {
+///     value: T,
+/// }
+/// ```
+///
+/// Since `value` uses the normal update path, the generated impl requires `T: salsa::Update`.
+///
+/// ```ignore
+/// #[derive(Clone, PartialEq, Eq, salsa::Update)]
+/// struct Foo<T> {
+///     #[update(fallback)]
+///     value: T,
+/// }
+/// ```
+///
+/// The `fallback` helper uses `salsa::update_fallback` and requires `T: 'static + PartialEq`
+/// instead of `T: salsa::Update`.
+///
+/// ```ignore
+/// #[derive(Clone, PartialEq, Eq, salsa::Update)]
+/// struct Foo<T, U> {
+///     #[update(bounds(T: 'static + PartialEq, Vec<U>: Clone), unsafe(with(custom_update::<T>)))]
+///     value: T,
+///     marker: std::marker::PhantomData<U>,
+/// }
+///
+/// unsafe fn custom_update<T>(old: *mut T, new: T) -> bool
+/// where
+///     T: 'static + PartialEq,
+/// {
+///     salsa::update_fallback(old, new)
+/// }
+/// ```
 #[proc_macro_derive(Update, attributes(update))]
 pub fn update(input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as syn::DeriveInput);

--- a/components/salsa-macros/src/update.rs
+++ b/components/salsa-macros/src/update.rs
@@ -89,19 +89,18 @@ pub(crate) fn update_derive(input: syn::DeriveInput) -> syn::Result<TokenStream>
                 let attr = attr
                     .map(|attr| attr.parse_args::<UpdateFieldArgs>())
                     .transpose()?;
-                let has_update_with = attr
+                let has_escape_hatch = attr
                     .as_ref()
-                    .and_then(|attr| attr.update_with.as_ref())
-                    .is_some();
-                if !has_update_with {
+                    .is_some_and(UpdateFieldArgs::has_escape_hatch);
+                if !has_escape_hatch {
                     used_type_params.visit_type(field_ty);
                 }
 
                 let (maybe_update, unsafe_token) = match attr {
                     Some(attr) => {
                         additional_bounds.extend(attr.bounds);
-                        match attr.update_with {
-                            Some(update_with) => {
+                        match attr.update_strategy {
+                            Some(UpdateStrategy::With(update_with)) => {
                                 let UpdateWith {
                                     unsafe_token,
                                     with_token,
@@ -111,6 +110,14 @@ pub(crate) fn update_derive(input: syn::DeriveInput) -> syn::Result<TokenStream>
                                 (
                                     quote_spanned! { span =>  ({ let maybe_update: unsafe fn(*mut #field_ty, #field_ty) -> bool = #expr; maybe_update }) },
                                     unsafe_token,
+                                )
+                            }
+                            Some(UpdateStrategy::Fallback(fallback_token)) => {
+                                additional_bounds.push(syn::parse_quote!(#field_ty: 'static + ::core::cmp::PartialEq));
+                                let span = fallback_token.span();
+                                (
+                                    quote_spanned! { span => salsa::update_fallback::<#field_ty> },
+                                    Token![unsafe](Span::call_site()),
                                 )
                             }
                             None => (
@@ -197,13 +204,19 @@ fn add_trait_bounds(
 
 struct UpdateFieldArgs {
     bounds: Vec<syn::WherePredicate>,
-    update_with: Option<UpdateWith>,
+    update_strategy: Option<UpdateStrategy>,
+}
+
+impl UpdateFieldArgs {
+    fn has_escape_hatch(&self) -> bool {
+        self.update_strategy.is_some()
+    }
 }
 
 impl syn::parse::Parse for UpdateFieldArgs {
     fn parse(parser: ParseStream<'_>) -> syn::Result<Self> {
         let mut bounds = Vec::new();
-        let mut update_with = None;
+        let mut update_strategy: Option<UpdateStrategy> = None;
 
         while !parser.is_empty() {
             if parser.peek(kw::bounds) {
@@ -213,10 +226,10 @@ impl syn::parse::Parse for UpdateFieldArgs {
                 parenthesized!(content in parser);
                 bounds.extend(content.parse_terminated(syn::WherePredicate::parse, Token![,])?);
             } else if parser.peek(Token![unsafe]) {
-                if let Some(UpdateWith { unsafe_token, .. }) = update_with.as_ref() {
+                if let Some(update_strategy) = update_strategy.as_ref() {
                     return Err(syn::Error::new(
-                        unsafe_token.span,
-                        "multiple `unsafe(with(...))` options in `#[update]` attribute",
+                        update_strategy.span(),
+                        "multiple update strategies in `#[update]` attribute",
                     ));
                 }
 
@@ -230,15 +243,24 @@ impl syn::parse::Parse for UpdateFieldArgs {
                 if !content.is_empty() {
                     return Err(content.error("unexpected tokens in update function"));
                 }
-                update_with = Some(UpdateWith {
+                update_strategy = Some(UpdateStrategy::With(UpdateWith {
                     unsafe_token,
                     with_token,
                     expr,
-                });
+                }));
+            } else if parser.peek(kw::fallback) {
+                if let Some(update_strategy) = update_strategy.as_ref() {
+                    return Err(syn::Error::new(
+                        update_strategy.span(),
+                        "multiple update strategies in `#[update]` attribute",
+                    ));
+                }
+
+                update_strategy = Some(UpdateStrategy::Fallback(parser.parse()?));
             } else if parser.peek(kw::with) {
                 return Err(parser.error("expected `unsafe`"));
             } else {
-                return Err(parser.error("expected `bounds` or `unsafe`"));
+                return Err(parser.error("expected `bounds`, `fallback`, or `unsafe`"));
             }
 
             if !parser.is_empty() {
@@ -248,7 +270,7 @@ impl syn::parse::Parse for UpdateFieldArgs {
 
         Ok(Self {
             bounds,
-            update_with,
+            update_strategy,
         })
     }
 }
@@ -257,6 +279,20 @@ struct UpdateWith {
     unsafe_token: Token![unsafe],
     with_token: kw::with,
     expr: syn::Expr,
+}
+
+enum UpdateStrategy {
+    With(UpdateWith),
+    Fallback(kw::fallback),
+}
+
+impl UpdateStrategy {
+    fn span(&self) -> Span {
+        match self {
+            Self::With(UpdateWith { unsafe_token, .. }) => unsafe_token.span,
+            Self::Fallback(fallback_token) => fallback_token.span(),
+        }
+    }
 }
 
 struct UsedTypeParams {

--- a/components/salsa-macros/src/update.rs
+++ b/components/salsa-macros/src/update.rs
@@ -25,6 +25,7 @@ pub(crate) fn update_derive(input: syn::DeriveInput) -> syn::Result<TokenStream>
     let old_pointer = hygiene.ident("old_pointer");
     let new_value = hygiene.ident("new_value");
     let mut used_type_params = UsedTypeParams::new(&input.generics);
+    let mut additional_bounds = Vec::new();
 
     let fields: TokenStream = structure
         .variants()
@@ -79,40 +80,53 @@ pub(crate) fn update_derive(input: syn::DeriveInput) -> syn::Result<TokenStream>
                 if let Some(attr) = attrs.next() {
                     return Err(syn::Error::new(
                         attr.path().span(),
-                        "multiple #[update(with)] attributes on field",
+                        "multiple #[update] attributes on field",
                     ));
                 }
 
                 let field_ty = &binding.ast().ty;
                 let field_index = Literal::usize_unsuffixed(index);
-                if attr.is_none() {
+                let attr = attr
+                    .map(|attr| attr.parse_args::<UpdateFieldArgs>())
+                    .transpose()?;
+                let has_update_with = attr
+                    .as_ref()
+                    .and_then(|attr| attr.update_with.as_ref())
+                    .is_some();
+                if !has_update_with {
                     used_type_params.visit_type(field_ty);
                 }
 
                 let (maybe_update, unsafe_token) = match attr {
                     Some(attr) => {
-                        attr.parse_args_with(|parser: ParseStream| {
-                            let mut content;
-
-                            let unsafe_token = parser.parse::<Token![unsafe]>()?;
-                            parenthesized!(content in parser);
-                            let with_token = content.parse::<kw::with>()?;
-                            parenthesized!(content in content);
-                            let expr = content.parse::<syn::Expr>()?;
-                            Ok((
-                                quote_spanned! { with_token.span() =>  ({ let maybe_update: unsafe fn(*mut #field_ty, #field_ty) -> bool = #expr; maybe_update }) },
-                                unsafe_token,
-                            ))
-                        })?
-                    }
-                    None => {
-                        (
-                            quote!(
-                                salsa::plumbing::UpdateDispatch::<#field_ty>::maybe_update
+                        additional_bounds.extend(attr.bounds);
+                        match attr.update_with {
+                            Some(update_with) => {
+                                let UpdateWith {
+                                    unsafe_token,
+                                    with_token,
+                                    expr,
+                                } = update_with;
+                                let span = with_token.span();
+                                (
+                                    quote_spanned! { span =>  ({ let maybe_update: unsafe fn(*mut #field_ty, #field_ty) -> bool = #expr; maybe_update }) },
+                                    unsafe_token,
+                                )
+                            }
+                            None => (
+                                quote!(
+                                    salsa::plumbing::UpdateDispatch::<#field_ty>::maybe_update
+                                ),
+                                Token![unsafe](Span::call_site()),
                             ),
-                            Token![unsafe](Span::call_site()),
-                        )
+                        }
                     }
+                    None => (
+                        quote!(
+                            salsa::plumbing::UpdateDispatch::<#field_ty>::maybe_update
+                        ),
+                        Token![unsafe](Span::call_site()),
+                    ),
                 };
                 let update_field = quote! {
                     #maybe_update(
@@ -138,7 +152,7 @@ pub(crate) fn update_derive(input: syn::DeriveInput) -> syn::Result<TokenStream>
     let ident = &input.ident;
     let used_type_params = used_type_params.used;
     let generics = input.generics;
-    let generics = add_trait_bounds(generics, &used_type_params);
+    let generics = add_trait_bounds(generics, &used_type_params, additional_bounds);
 
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let tokens = quote! {
@@ -161,6 +175,7 @@ pub(crate) fn update_derive(input: syn::DeriveInput) -> syn::Result<TokenStream>
 fn add_trait_bounds(
     mut generics: syn::Generics,
     used_type_params: &HashSet<String>,
+    additional_bounds: Vec<syn::WherePredicate>,
 ) -> syn::Generics {
     for param in &mut generics.params {
         let syn::GenericParam::Type(type_param) = param else {
@@ -171,7 +186,77 @@ fn add_trait_bounds(
             type_param.bounds.push(syn::parse_quote!(::salsa::Update));
         }
     }
+
     generics
+        .make_where_clause()
+        .predicates
+        .extend(additional_bounds);
+
+    generics
+}
+
+struct UpdateFieldArgs {
+    bounds: Vec<syn::WherePredicate>,
+    update_with: Option<UpdateWith>,
+}
+
+impl syn::parse::Parse for UpdateFieldArgs {
+    fn parse(parser: ParseStream<'_>) -> syn::Result<Self> {
+        let mut bounds = Vec::new();
+        let mut update_with = None;
+
+        while !parser.is_empty() {
+            if parser.peek(kw::bounds) {
+                let content;
+
+                parser.parse::<kw::bounds>()?;
+                parenthesized!(content in parser);
+                bounds.extend(content.parse_terminated(syn::WherePredicate::parse, Token![,])?);
+            } else if parser.peek(Token![unsafe]) {
+                if let Some(UpdateWith { unsafe_token, .. }) = update_with.as_ref() {
+                    return Err(syn::Error::new(
+                        unsafe_token.span,
+                        "multiple `unsafe(with(...))` options in `#[update]` attribute",
+                    ));
+                }
+
+                let mut content;
+
+                let unsafe_token = parser.parse::<Token![unsafe]>()?;
+                parenthesized!(content in parser);
+                let with_token = content.parse::<kw::with>()?;
+                parenthesized!(content in content);
+                let expr = content.parse::<syn::Expr>()?;
+                if !content.is_empty() {
+                    return Err(content.error("unexpected tokens in update function"));
+                }
+                update_with = Some(UpdateWith {
+                    unsafe_token,
+                    with_token,
+                    expr,
+                });
+            } else if parser.peek(kw::with) {
+                return Err(parser.error("expected `unsafe`"));
+            } else {
+                return Err(parser.error("expected `bounds` or `unsafe`"));
+            }
+
+            if !parser.is_empty() {
+                parser.parse::<Token![,]>()?;
+            }
+        }
+
+        Ok(Self {
+            bounds,
+            update_with,
+        })
+    }
+}
+
+struct UpdateWith {
+    unsafe_token: Token![unsafe],
+    with_token: kw::with,
+    expr: syn::Expr,
 }
 
 struct UsedTypeParams {

--- a/components/salsa-macros/src/update.rs
+++ b/components/salsa-macros/src/update.rs
@@ -1,5 +1,7 @@
+use std::collections::HashSet;
+
 use proc_macro2::{Literal, Span, TokenStream};
-use syn::{Token, parenthesized, parse::ParseStream, spanned::Spanned};
+use syn::{Token, parenthesized, parse::ParseStream, spanned::Spanned, visit::Visit};
 use synstructure::BindStyle;
 
 use crate::{hygiene::Hygiene, kw};
@@ -22,6 +24,7 @@ pub(crate) fn update_derive(input: syn::DeriveInput) -> syn::Result<TokenStream>
 
     let old_pointer = hygiene.ident("old_pointer");
     let new_value = hygiene.ident("new_value");
+    let mut used_type_params = UsedTypeParams::new(&input.generics);
 
     let fields: TokenStream = structure
         .variants()
@@ -82,6 +85,9 @@ pub(crate) fn update_derive(input: syn::DeriveInput) -> syn::Result<TokenStream>
 
                 let field_ty = &binding.ast().ty;
                 let field_index = Literal::usize_unsuffixed(index);
+                if attr.is_none() {
+                    used_type_params.visit_type(field_ty);
+                }
 
                 let (maybe_update, unsafe_token) = match attr {
                     Some(attr) => {
@@ -130,8 +136,9 @@ pub(crate) fn update_derive(input: syn::DeriveInput) -> syn::Result<TokenStream>
         .collect::<syn::Result<_>>()?;
 
     let ident = &input.ident;
+    let used_type_params = used_type_params.used;
     let generics = input.generics;
-    let generics = add_trait_bounds(generics);
+    let generics = add_trait_bounds(generics, &used_type_params);
 
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let tokens = quote! {
@@ -151,14 +158,54 @@ pub(crate) fn update_derive(input: syn::DeriveInput) -> syn::Result<TokenStream>
     Ok(crate::debug::dump_tokens(&input.ident, tokens))
 }
 
-// Add a bound `T: salsa::Update` to every type parameter T
-fn add_trait_bounds(mut generics: syn::Generics) -> syn::Generics {
+fn add_trait_bounds(
+    mut generics: syn::Generics,
+    used_type_params: &HashSet<String>,
+) -> syn::Generics {
     for param in &mut generics.params {
-        if let syn::GenericParam::Type(type_param) = param {
+        let syn::GenericParam::Type(type_param) = param else {
+            continue;
+        };
+
+        if used_type_params.contains(&type_param.ident.to_string()) {
             type_param.bounds.push(syn::parse_quote!(::salsa::Update));
         }
     }
     generics
+}
+
+struct UsedTypeParams {
+    type_params: HashSet<String>,
+    used: HashSet<String>,
+}
+
+impl UsedTypeParams {
+    fn new(generics: &syn::Generics) -> Self {
+        let type_params = generics
+            .type_params()
+            .map(|type_param| type_param.ident.to_string())
+            .collect();
+
+        Self {
+            type_params,
+            used: HashSet::new(),
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for UsedTypeParams {
+    fn visit_type_path(&mut self, i: &'ast syn::TypePath) {
+        if i.qself.is_none() {
+            if let Some(segment) = i.path.segments.first() {
+                let ident = segment.ident.to_string();
+                if self.type_params.contains(&ident) {
+                    self.used.insert(ident);
+                }
+            }
+        }
+
+        syn::visit::visit_type_path(self, i);
+    }
 }
 
 pub(crate) fn assert_update(

--- a/tests/compile-pass/derive-update-escape-hatch-generics.rs
+++ b/tests/compile-pass/derive-update-escape-hatch-generics.rs
@@ -27,6 +27,12 @@ struct BoundEscaped<T, U> {
     value2: U,
 }
 
+#[derive(salsa::Update)]
+struct FallbackEscaped<T> {
+    #[update(fallback)]
+    value: T,
+}
+
 unsafe fn skip_update<T>(_: *mut T, _: T) -> bool {
     false
 }
@@ -43,4 +49,5 @@ fn assert_update<T: salsa::Update>() {}
 fn main() {
     assert_update::<Escaped<NotUpdate>>();
     assert_update::<BoundEscaped<NotUpdate, CloneOnly>>();
+    assert_update::<FallbackEscaped<NotUpdate>>();
 }

--- a/tests/compile-pass/derive-update-escape-hatch-generics.rs
+++ b/tests/compile-pass/derive-update-escape-hatch-generics.rs
@@ -1,0 +1,26 @@
+#![allow(dead_code)]
+
+struct NotUpdate;
+
+#[derive(salsa::Update)]
+struct Escaped<T> {
+    #[update(unsafe(with(skip_update::<T>)))]
+    value: T,
+}
+
+#[derive(salsa::Update)]
+struct Mixed<T> {
+    value: T,
+    #[update(unsafe(with(skip_update::<T>)))]
+    value2: T,
+}
+
+unsafe fn skip_update<T>(_: *mut T, _: T) -> bool {
+    false
+}
+
+fn assert_update<T: salsa::Update>() {}
+
+fn main() {
+    assert_update::<Escaped<NotUpdate>>();
+}

--- a/tests/compile-pass/derive-update-escape-hatch-generics.rs
+++ b/tests/compile-pass/derive-update-escape-hatch-generics.rs
@@ -1,6 +1,10 @@
 #![allow(dead_code)]
 
+#[derive(PartialEq)]
 struct NotUpdate;
+
+#[derive(Clone)]
+struct CloneOnly;
 
 #[derive(salsa::Update)]
 struct Escaped<T> {
@@ -15,7 +19,22 @@ struct Mixed<T> {
     value2: T,
 }
 
+#[derive(salsa::Update)]
+struct BoundEscaped<T, U> {
+    #[update(bounds(T: 'static + PartialEq), unsafe(with(salsa::update_fallback::<T>)))]
+    value: T,
+    #[update(bounds(U: Clone, U: 'static), unsafe(with(update_with_clone_bound::<U>)))]
+    value2: U,
+}
+
 unsafe fn skip_update<T>(_: *mut T, _: T) -> bool {
+    false
+}
+
+unsafe fn update_with_clone_bound<T>(_: *mut T, _: T) -> bool
+where
+    T: Clone + 'static,
+{
     false
 }
 
@@ -23,4 +42,5 @@ fn assert_update<T: salsa::Update>() {}
 
 fn main() {
     assert_update::<Escaped<NotUpdate>>();
+    assert_update::<BoundEscaped<NotUpdate, CloneOnly>>();
 }

--- a/tests/derive_update.rs
+++ b/tests/derive_update.rs
@@ -15,6 +15,15 @@ struct MyInput2 {
     field2: &'static str,
 }
 
+#[derive(Debug, PartialEq)]
+struct FallbackValue(&'static str);
+
+#[derive(salsa::Update)]
+struct MyInput3 {
+    #[update(fallback)]
+    field: FallbackValue,
+}
+
 unsafe fn custom_update(dest: *mut &'static str, _data: &'static str) -> bool {
     unsafe { *dest = "ill-behaved for testing purposes" };
     true
@@ -28,6 +37,32 @@ fn derived() {
     assert_eq!(m.field, "bar");
     assert!(!unsafe { salsa::Update::maybe_update(&mut m, MyInput { field: "bar" }) });
     assert_eq!(m.field, "bar");
+}
+
+#[test]
+fn derived_fallback() {
+    let mut m = MyInput3 {
+        field: FallbackValue("foo"),
+    };
+    assert_eq!(m.field, FallbackValue("foo"));
+    assert!(unsafe {
+        salsa::Update::maybe_update(
+            &mut m,
+            MyInput3 {
+                field: FallbackValue("bar"),
+            },
+        )
+    });
+    assert_eq!(m.field, FallbackValue("bar"));
+    assert!(!unsafe {
+        salsa::Update::maybe_update(
+            &mut m,
+            MyInput3 {
+                field: FallbackValue("bar"),
+            },
+        )
+    });
+    assert_eq!(m.field, FallbackValue("bar"));
 }
 
 #[test]


### PR DESCRIPTION
This reduces the need of manually implementing `Update` if some fields within are third-party, thus not implementing `Update` where they themselves then contain (via generic arguments) `'db` containing things. See the tests, without these changes those could not use the derive.