### PR TITLE
fix: reject unregistered inventory ingredients

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -224,6 +224,7 @@ impl<Db: Database> StorageBuilder<Db> {
     /// Manually register an ingredient.
     ///
     /// Manual ingredient registration is necessary when the `inventory` feature is disabled.
+    /// When `inventory` is enabled, the ingredient must also be registered globally.
     pub fn ingredient<I: HasJar>(mut self) -> Self {
         self.jars.push(ErasedJar::erase::<I>());
         self

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -195,10 +195,21 @@ impl Zalsa {
 
         // Collect and initialize all registered ingredients.
         #[cfg(feature = "inventory")]
-        let mut jars = inventory::iter::<ErasedJar>()
-            .copied()
-            .chain(jars)
-            .collect::<Vec<_>>();
+        let mut jars = {
+            let inventory_jars = inventory::iter::<ErasedJar>().copied().collect::<Vec<_>>();
+
+            for jar in &jars {
+                assert!(
+                    inventory_jars
+                        .iter()
+                        .any(|inventory_jar| (inventory_jar.type_id)() == (jar.type_id)()),
+                    "ingredient `{}` is not registered with inventory",
+                    jar.type_name(),
+                );
+            }
+
+            inventory_jars.into_iter().chain(jars).collect::<Vec<_>>()
+        };
 
         #[cfg(not(feature = "inventory"))]
         let mut jars = jars;

--- a/tests/inventory_manual_registration.rs
+++ b/tests/inventory_manual_registration.rs
@@ -1,0 +1,93 @@
+#![cfg(feature = "inventory")]
+
+use std::any::TypeId;
+
+use salsa::plumbing::{HasJar, Ingredient, IngredientIndex, Jar, JarKind, Location, Zalsa};
+
+#[salsa::input]
+struct RegisteredInput {
+    value: u32,
+}
+
+struct UnregisteredConfiguration;
+
+impl salsa::plumbing::input::Configuration for UnregisteredConfiguration {
+    const DEBUG_NAME: &'static str = "Unregistered";
+    const FIELD_DEBUG_NAMES: &'static [&'static str] = &[];
+    const LOCATION: Location = Location {
+        file: file!(),
+        line: line!(),
+    };
+    const PERSIST: bool = false;
+
+    type Singleton = salsa::plumbing::input::NotSingleton;
+    type Struct = salsa::Id;
+    type Fields = ();
+    type Revisions = [salsa::Revision; 0];
+    type Durabilities = [salsa::Durability; 0];
+
+    fn serialize<S: salsa::plumbing::serde::Serializer>(
+        _: &Self::Fields,
+        _: S,
+    ) -> Result<S::Ok, S::Error> {
+        unreachable!()
+    }
+
+    fn deserialize<'de, D: salsa::plumbing::serde::Deserializer<'de>>(
+        _: D,
+    ) -> Result<Self::Fields, D::Error> {
+        unreachable!()
+    }
+}
+
+struct UnregisteredJar;
+
+impl Jar for UnregisteredJar {
+    fn create_ingredients(_: &mut Zalsa, first: IngredientIndex) -> Vec<Box<dyn Ingredient>> {
+        vec![Box::new(salsa::plumbing::input::IngredientImpl::<
+            UnregisteredConfiguration,
+        >::new(first))]
+    }
+
+    fn id_struct_type_id() -> TypeId {
+        TypeId::of::<salsa::Id>()
+    }
+}
+
+struct UnregisteredIngredient;
+
+impl HasJar for UnregisteredIngredient {
+    type Jar = UnregisteredJar;
+    const KIND: JarKind = JarKind::Struct;
+}
+
+#[salsa::db]
+#[derive(Clone, Default)]
+struct DatabaseImpl {
+    storage: salsa::Storage<Self>,
+}
+
+#[salsa::db]
+impl salsa::Database for DatabaseImpl {}
+
+#[test]
+#[should_panic(expected = "is not registered with inventory")]
+fn rejects_ingredients_not_registered_with_inventory() {
+    let _db = DatabaseImpl {
+        storage: salsa::Storage::builder()
+            .ingredient::<UnregisteredIngredient>()
+            .build(),
+    };
+}
+
+#[test]
+fn accepts_redundant_registration_of_inventory_ingredients() {
+    let db = DatabaseImpl {
+        storage: salsa::Storage::builder()
+            .ingredient::<RegisteredInput>()
+            .build(),
+    };
+
+    let input = RegisteredInput::new(&db, 1);
+    assert_eq!(input.value(&db), 1);
+}


### PR DESCRIPTION
Inventory-backed ingredient caches assume stable indices across databases. Reject builder-only jars during database construction while continuing to allow redundant registration of globally inventoried jars, preserving the unchecked lookup fast path.

Testing: Added inventory registration coverage and ran the full test suite and clippy.