### PR TITLE
fix: require exclusive tracked struct inspection

### DIFF
--- a/components/salsa-macro-rules/src/setup_tracked_struct.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_struct.rs
@@ -220,8 +220,11 @@ macro_rules! setup_tracked_struct {
             }
 
             impl $Configuration {
-                pub fn ingredient(db: &dyn $zalsa::Database) -> &$zalsa_struct::IngredientImpl<Self> {
-                    Self::ingredient_(db.zalsa())
+                pub fn ingredient<$Db>(db: &$Db) -> $zalsa_struct::IngredientHandle<Self>
+                where
+                    $Db: ?Sized + $zalsa::Database,
+                {
+                    $zalsa_struct::IngredientHandle::new(db)
                 }
 
                 fn ingredient_(zalsa: &$zalsa::Zalsa) -> &$zalsa_struct::IngredientImpl<Self> {
@@ -263,8 +266,7 @@ macro_rules! setup_tracked_struct {
                 fn entries(
                     zalsa: &$zalsa::Zalsa
                 ) -> impl Iterator<Item = $zalsa::DatabaseKeyIndex> + '_ {
-                    let ingredient_index = zalsa.lookup_jar_by_type::<$zalsa_struct::JarImpl<$Configuration>>();
-                    <$Configuration>::ingredient_(zalsa).entries(zalsa).map(|entry| entry.key())
+                    <$Configuration>::ingredient_(zalsa).entry_keys(zalsa)
                 }
 
                 #[inline]

--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -13,7 +13,7 @@ use crate::ingredient::{Ingredient, Jar};
 use crate::plumbing::ZalsaLocal;
 use crate::sync::Arc;
 use crate::table::memo::MemoTableTypes;
-use crate::zalsa::{IngredientIndex, JarKind, Zalsa};
+use crate::zalsa::{IngredientIndex, JarKind, Zalsa, ZalsaMut};
 use crate::zalsa_local::QueryEdge;
 use crate::{Database, DatabaseKeyIndex, Id, Revision};
 
@@ -113,7 +113,7 @@ impl<A: Accumulator> Ingredient for IngredientImpl<A> {
 
     fn collect_minimum_serialized_edges(
         &self,
-        _zalsa: &Zalsa,
+        _zalsa: &ZalsaMut<'_>,
         _edge: QueryEdge,
         _serialized_edges: &mut FxIndexSet<QueryEdge>,
         _visited_edges: &mut FxHashSet<QueryEdge>,

--- a/src/database.rs
+++ b/src/database.rs
@@ -162,7 +162,7 @@ pub fn current_revision<Db: ?Sized + Database>(db: &Db) -> Revision {
 #[cfg(feature = "persistence")]
 mod persistence {
     use crate::plumbing::Ingredient;
-    use crate::zalsa::Zalsa;
+    use crate::zalsa::{Zalsa, ZalsaMut};
     use crate::{Database, IngredientIndex, Runtime};
 
     use std::fmt;
@@ -173,10 +173,14 @@ mod persistence {
     impl dyn Database {
         /// Returns a type implementing [`serde::Serialize`], that can be used to serialize the
         /// current state of the database.
+        ///
+        /// **WARNING:** This triggers cancellation and waits for all other database handles to be
+        /// dropped. Calling it while another handle is retained by the current thread can deadlock.
         pub fn as_serialize(&mut self) -> impl serde::Serialize + '_ {
+            let zalsa_mut = ZalsaMut::new(self.zalsa_mut());
             SerializeDatabase {
-                runtime: self.zalsa().runtime(),
-                ingredients: SerializeIngredients(self.zalsa()),
+                runtime: zalsa_mut.zalsa().runtime(),
+                ingredients: SerializeIngredients(zalsa_mut),
             }
         }
 
@@ -198,14 +202,14 @@ mod persistence {
         pub ingredients: SerializeIngredients<'db>,
     }
 
-    pub struct SerializeIngredients<'db>(pub &'db Zalsa);
+    pub struct SerializeIngredients<'db>(pub ZalsaMut<'db>);
 
     impl serde::Serialize for SerializeIngredients<'_> {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: serde::Serializer,
         {
-            let SerializeIngredients(zalsa) = self;
+            let zalsa = &self.0;
 
             let mut ingredients = zalsa
                 .ingredients()
@@ -228,7 +232,7 @@ mod persistence {
         }
     }
 
-    struct SerializeIngredient<'db>(&'db dyn Ingredient, &'db Zalsa);
+    struct SerializeIngredient<'a>(&'a dyn Ingredient, &'a ZalsaMut<'a>);
 
     impl serde::Serialize for SerializeIngredient<'_> {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -238,16 +242,13 @@ mod persistence {
             let mut result = None;
             let mut serializer = Some(serializer);
 
-            // SAFETY: `<dyn Database>::as_serialize` take `&mut self`.
-            unsafe {
-                self.0.serialize(self.1, &mut |serialize| {
-                    let serializer = serializer.take().expect(
-                        "`Ingredient::serialize` must invoke the serialization callback only once",
-                    );
+            self.0.serialize(self.1, &mut |serialize| {
+                let serializer = serializer.take().expect(
+                    "`Ingredient::serialize` must invoke the serialization callback only once",
+                );
 
-                    result = Some(erased_serde::serialize(&serialize, serializer))
-                })
-            };
+                result = Some(erased_serde::serialize(&serialize, serializer))
+            });
 
             result.expect("`Ingredient::serialize` must invoke the serialization callback")
         }
@@ -404,15 +405,20 @@ mod memory_usage {
     use hashbrown::HashMap;
 
     use crate::Database;
+    use crate::zalsa::ZalsaMut;
 
     impl dyn Database {
         /// Returns memory usage information about ingredients in the database.
-        pub fn memory_usage(&self) -> DatabaseInfo {
+        ///
+        /// **WARNING:** This triggers cancellation and waits for all other database handles to be
+        /// dropped. Calling it while another handle is retained by the current thread can deadlock.
+        pub fn memory_usage(&mut self) -> DatabaseInfo {
             let mut queries = HashMap::new();
             let mut structs = Vec::new();
+            let zalsa_mut = ZalsaMut::new(self.zalsa_mut());
 
-            for input_ingredient in self.zalsa().ingredients() {
-                let Some(input_info) = input_ingredient.memory_usage(self) else {
+            for input_ingredient in zalsa_mut.ingredients() {
+                let Some(input_info) = input_ingredient.memory_usage(&zalsa_mut) else {
                     continue;
                 };
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -19,7 +19,7 @@ use crate::sync::Arc;
 use crate::table::Table;
 use crate::table::memo::MemoTableTypes;
 use crate::views::DatabaseDownCaster;
-use crate::zalsa::{IngredientIndex, JarKind, MemoIngredientIndex, Zalsa};
+use crate::zalsa::{IngredientIndex, JarKind, MemoIngredientIndex, Zalsa, ZalsaMut};
 use crate::zalsa_local::{QueryEdge, QueryOriginRef};
 use crate::{Cycle, Id, Revision};
 
@@ -330,16 +330,18 @@ where
 
     fn collect_minimum_serialized_edges(
         &self,
-        zalsa: &Zalsa,
+        zalsa: &ZalsaMut<'_>,
         edge: QueryEdge,
         serialized_edges: &mut FxIndexSet<QueryEdge>,
         visited_edges: &mut FxHashSet<QueryEdge>,
     ) {
         let input = edge.key().key_index();
 
-        let Some(memo) =
-            self.get_memo_from_table_for(zalsa, input, self.memo_ingredient_index(zalsa, input))
-        else {
+        let Some(memo) = self.get_memo_from_table_for_exclusive(
+            zalsa,
+            input,
+            self.memo_ingredient_index(zalsa, input),
+        ) else {
             return;
         };
 
@@ -574,7 +576,7 @@ where
         C::PERSIST
     }
 
-    fn should_serialize(&self, zalsa: &Zalsa) -> bool {
+    fn should_serialize(&self, zalsa: &ZalsaMut<'_>) -> bool {
         if !C::PERSIST {
             return false;
         }
@@ -583,8 +585,11 @@ where
         for entry in <C::SalsaStruct<'_> as SalsaStructInDb>::entries(zalsa) {
             let memo_ingredient_index = self.memo_ingredient_indices.get(entry.ingredient_index());
 
-            let memo =
-                self.get_memo_from_table_for(zalsa, entry.key_index(), memo_ingredient_index);
+            let memo = self.get_memo_from_table_for_exclusive(
+                zalsa,
+                entry.key_index(),
+                memo_ingredient_index,
+            );
 
             if memo.is_some_and(|memo| memo.should_serialize()) {
                 return true;
@@ -595,11 +600,7 @@ where
     }
 
     #[cfg(feature = "persistence")]
-    unsafe fn serialize<'db>(
-        &'db self,
-        zalsa: &'db Zalsa,
-        f: &mut dyn FnMut(&dyn erased_serde::Serialize),
-    ) {
+    fn serialize(&self, zalsa: &ZalsaMut<'_>, f: &mut dyn FnMut(&dyn erased_serde::Serialize)) {
         f(&persistence::SerializeIngredient {
             zalsa,
             ingredient: self,
@@ -637,7 +638,7 @@ mod persistence {
     use super::{Configuration, IngredientImpl, Memo};
     use crate::hash::{FxHashSet, FxIndexSet};
     use crate::plumbing::{MemoIngredientMap, SalsaStructInDb};
-    use crate::zalsa::Zalsa;
+    use crate::zalsa::{Zalsa, ZalsaMut};
     use crate::zalsa_local::persistence::PersistentQueryOrigin;
     use crate::zalsa_local::{QueryEdge, QueryOriginRef};
     use crate::{Id, IngredientIndex};
@@ -647,12 +648,12 @@ mod persistence {
 
     use std::ptr::NonNull;
 
-    pub struct SerializeIngredient<'db, C>
+    pub struct SerializeIngredient<'a, C>
     where
         C: Configuration,
     {
-        pub zalsa: &'db Zalsa,
-        pub ingredient: &'db IngredientImpl<C>,
+        pub zalsa: &'a ZalsaMut<'a>,
+        pub ingredient: &'a IngredientImpl<C>,
     }
 
     impl<C> serde::Serialize for SerializeIngredient<'_, C>
@@ -671,7 +672,7 @@ mod persistence {
                         .memo_ingredient_indices
                         .get(entry.ingredient_index());
 
-                    let memo = ingredient.get_memo_from_table_for(
+                    let memo = ingredient.get_memo_from_table_for_exclusive(
                         zalsa,
                         entry.key_index(),
                         memo_ingredient_index,
@@ -691,7 +692,7 @@ mod persistence {
                     .memo_ingredient_indices
                     .get(entry.ingredient_index());
 
-                let memo = ingredient.get_memo_from_table_for(
+                let memo = ingredient.get_memo_from_table_for_exclusive(
                     zalsa,
                     entry.key_index(),
                     memo_ingredient_index,
@@ -753,7 +754,7 @@ mod persistence {
 
     // Flatten the dependency edges before serialization.
     fn collect_minimum_serialized_edges(
-        zalsa: &Zalsa,
+        zalsa: &ZalsaMut<'_>,
         edges: crate::zalsa_local::QueryEdges<'_>,
         visited_edges: &mut FxHashSet<QueryEdge>,
         flattened_edges: &mut FxIndexSet<QueryEdge>,

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -12,7 +12,7 @@ use crate::key::DatabaseKeyIndex;
 use crate::revision::AtomicRevision;
 use crate::sync::atomic::Ordering;
 use crate::table::memo::MemoTableWithTypesMut;
-use crate::zalsa::{MemoIngredientIndex, Zalsa};
+use crate::zalsa::{MemoIngredientIndex, Zalsa, ZalsaMut};
 use crate::zalsa_local::{QueryOriginRef, QueryRevisions};
 use crate::{Event, EventKind, Id, Revision};
 
@@ -51,6 +51,19 @@ impl<C: Configuration> IngredientImpl<C> {
         let static_memo = zalsa
             .memo_table_for::<C::SalsaStruct<'_>>(id)
             .get(memo_ingredient_index)?;
+        // SAFETY: The table stores 'static memos (to support `Any`), the memos are in fact valid
+        // for `'db` though as we delay their dropping to the end of a revision.
+        Some(unsafe { transmute::<&Memo<'static, C>, &'db Memo<'db, C>>(static_memo.as_ref()) })
+    }
+
+    /// Loads the current memo for `key_index` without acquiring a tracked-struct read lock.
+    pub(super) fn get_memo_from_table_for_exclusive<'db>(
+        &self,
+        zalsa: &ZalsaMut<'db>,
+        id: Id,
+        memo_ingredient_index: MemoIngredientIndex,
+    ) -> Option<&'db Memo<'db, C>> {
+        let static_memo = zalsa.memo_table(id).get(memo_ingredient_index)?;
         // SAFETY: The table stores 'static memos (to support `Any`), the memos are in fact valid
         // for `'db` though as we delay their dropping to the end of a revision.
         Some(unsafe { transmute::<&Memo<'static, C>, &'db Memo<'db, C>>(static_memo.as_ref()) })

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -9,7 +9,9 @@ use crate::runtime::Running;
 use crate::sync::Arc;
 use crate::table::Table;
 use crate::table::memo::MemoTableTypes;
-use crate::zalsa::{IngredientIndex, JarKind, Zalsa, transmute_data_mut_ptr, transmute_data_ptr};
+use crate::zalsa::{
+    IngredientIndex, JarKind, Zalsa, ZalsaMut, transmute_data_mut_ptr, transmute_data_ptr,
+};
 use crate::zalsa_local::{QueryEdge, QueryOriginRef};
 use crate::{DatabaseKeyIndex, Id, Revision};
 
@@ -62,7 +64,7 @@ pub trait Ingredient: Any + fmt::Debug + Send + Sync {
     /// Note that any ingredients returned by this function must be persistable.
     fn collect_minimum_serialized_edges(
         &self,
-        zalsa: &Zalsa,
+        zalsa: &ZalsaMut<'_>,
         edge: QueryEdge,
         serialized_edges: &mut FxIndexSet<QueryEdge>,
         visited_edges: &mut FxHashSet<QueryEdge>,
@@ -235,7 +237,7 @@ pub trait Ingredient: Any + fmt::Debug + Send + Sync {
     /// Returns memory usage information about any instances of the ingredient,
     /// if applicable.
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(&self, _db: &dyn crate::Database) -> Option<Vec<crate::database::SlotInfo>> {
+    fn memory_usage(&self, _zalsa: &ZalsaMut<'_>) -> Option<Vec<crate::database::SlotInfo>> {
         None
     }
 
@@ -248,26 +250,17 @@ pub trait Ingredient: Any + fmt::Debug + Send + Sync {
     ///
     /// If this returns `false`, the ingredient will not be serialized, even if `is_persistable`
     /// returns `true`.
-    fn should_serialize(&self, _zalsa: &Zalsa) -> bool {
+    fn should_serialize(&self, _zalsa: &ZalsaMut<'_>) -> bool {
         false
     }
 
     /// Serialize the ingredient.
     ///
     /// This function should invoke the provided callback with a reference to an object implementing [`erased_serde::Serialize`].
-    ///
-    /// # Safety
-    ///
-    /// While this method takes an immutable reference to the database, it can only be called when a
-    /// the serializer has exclusive access to the database.
     // See <https://github.com/dtolnay/erased-serde/issues/113> for why this callback signature is necessary, instead
     // of providing an `erased_serde::Serializer` directly.
     #[cfg(feature = "persistence")]
-    unsafe fn serialize<'db>(
-        &'db self,
-        _zalsa: &'db Zalsa,
-        _f: &mut dyn FnMut(&dyn erased_serde::Serialize),
-    ) {
+    fn serialize(&self, _zalsa: &ZalsaMut<'_>, _f: &mut dyn FnMut(&dyn erased_serde::Serialize)) {
         unimplemented!("called `serialize` on ingredient where `should_serialize` returns `false`")
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -18,7 +18,7 @@ use crate::plumbing::{self, Jar, ZalsaLocal};
 use crate::sync::Arc;
 use crate::table::memo::{MemoTable, MemoTableTypes};
 use crate::table::{Slot, Table};
-use crate::zalsa::{IngredientIndex, JarKind, Zalsa};
+use crate::zalsa::{IngredientIndex, JarKind, Zalsa, ZalsaMut};
 use crate::zalsa_local::QueryEdge;
 use crate::{Durability, Id, Revision, Runtime};
 
@@ -309,7 +309,7 @@ impl<C: Configuration> Ingredient for IngredientImpl<C> {
 
     fn collect_minimum_serialized_edges(
         &self,
-        _zalsa: &Zalsa,
+        _zalsa: &ZalsaMut<'_>,
         _edge: QueryEdge,
         _serialized_edges: &mut FxIndexSet<QueryEdge>,
         _visited_edges: &mut FxHashSet<QueryEdge>,
@@ -345,9 +345,9 @@ impl<C: Configuration> Ingredient for IngredientImpl<C> {
 
     /// Returns memory usage information about any inputs.
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(&self, db: &dyn crate::Database) -> Option<Vec<crate::database::SlotInfo>> {
+    fn memory_usage(&self, zalsa: &ZalsaMut<'_>) -> Option<Vec<crate::database::SlotInfo>> {
         let memory_usage = self
-            .entries(db.zalsa())
+            .entries(zalsa)
             // SAFETY: The memo table belongs to a value that we allocated, so it
             // has the correct type.
             .map(|entry| unsafe { entry.value.memory_usage(&self.memo_table_types) })
@@ -360,16 +360,12 @@ impl<C: Configuration> Ingredient for IngredientImpl<C> {
         C::PERSIST
     }
 
-    fn should_serialize(&self, zalsa: &Zalsa) -> bool {
+    fn should_serialize(&self, zalsa: &ZalsaMut<'_>) -> bool {
         C::PERSIST && self.entries(zalsa).next().is_some()
     }
 
     #[cfg(feature = "persistence")]
-    unsafe fn serialize<'db>(
-        &'db self,
-        zalsa: &'db Zalsa,
-        f: &mut dyn FnMut(&dyn erased_serde::Serialize),
-    ) {
+    fn serialize(&self, zalsa: &ZalsaMut<'_>, f: &mut dyn FnMut(&dyn erased_serde::Serialize)) {
         f(&persistence::SerializeIngredient {
             zalsa,
             _ingredient: self,
@@ -490,14 +486,14 @@ mod persistence {
     use crate::input::singleton::SingletonChoice;
     use crate::plumbing::Ingredient;
     use crate::table::memo::MemoTable;
-    use crate::zalsa::Zalsa;
+    use crate::zalsa::{Zalsa, ZalsaMut};
 
-    pub struct SerializeIngredient<'db, C>
+    pub struct SerializeIngredient<'a, C>
     where
         C: Configuration,
     {
-        pub zalsa: &'db Zalsa,
-        pub _ingredient: &'db IngredientImpl<C>,
+        pub zalsa: &'a ZalsaMut<'a>,
+        pub _ingredient: &'a IngredientImpl<C>,
     }
 
     impl<C> serde::Serialize for SerializeIngredient<'_, C>

--- a/src/input/input_field.rs
+++ b/src/input/input_field.rs
@@ -7,7 +7,7 @@ use crate::ingredient::Ingredient;
 use crate::input::{Configuration, IngredientImpl, Value};
 use crate::sync::Arc;
 use crate::table::memo::MemoTableTypes;
-use crate::zalsa::{IngredientIndex, JarKind, Zalsa};
+use crate::zalsa::{IngredientIndex, JarKind, Zalsa, ZalsaMut};
 use crate::zalsa_local::QueryEdge;
 use crate::{DatabaseKeyIndex, Id, Revision};
 
@@ -68,7 +68,7 @@ where
 
     fn collect_minimum_serialized_edges(
         &self,
-        _zalsa: &Zalsa,
+        _zalsa: &ZalsaMut<'_>,
         edge: QueryEdge,
         serialized_edges: &mut FxIndexSet<QueryEdge>,
         _visited_edges: &mut FxHashSet<QueryEdge>,
@@ -124,7 +124,7 @@ where
         C::PERSIST
     }
 
-    fn should_serialize(&self, _zalsa: &Zalsa) -> bool {
+    fn should_serialize(&self, _zalsa: &ZalsaMut<'_>) -> bool {
         // However, they are never serialized directly.
         false
     }

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -21,7 +21,7 @@ use crate::revision::AtomicRevision;
 use crate::sync::{Arc, Mutex, OnceLock};
 use crate::table::Slot;
 use crate::table::memo::{MemoTable, MemoTableTypes, MemoTableWithTypesMut};
-use crate::zalsa::{IngredientIndex, JarKind, Zalsa};
+use crate::zalsa::{IngredientIndex, JarKind, Zalsa, ZalsaMut};
 use crate::zalsa_local::QueryEdge;
 use crate::{DatabaseKeyIndex, Event, EventKind, Id, Revision};
 
@@ -958,7 +958,7 @@ where
 
     fn collect_minimum_serialized_edges(
         &self,
-        _zalsa: &Zalsa,
+        _zalsa: &ZalsaMut<'_>,
         edge: QueryEdge,
         serialized_edges: &mut FxIndexSet<QueryEdge>,
         _visited_edges: &mut FxHashSet<QueryEdge>,
@@ -1003,7 +1003,7 @@ where
 
     /// Returns memory usage information about any interned values.
     #[cfg(all(not(feature = "shuttle"), feature = "salsa_unstable"))]
-    fn memory_usage(&self, db: &dyn crate::Database) -> Option<Vec<crate::database::SlotInfo>> {
+    fn memory_usage(&self, zalsa: &ZalsaMut<'_>) -> Option<Vec<crate::database::SlotInfo>> {
         use parking_lot::lock_api::RawMutex;
 
         for shard in self.shards.iter() {
@@ -1012,7 +1012,7 @@ where
         }
 
         // SAFETY: We hold the locks for all shards.
-        let entries = unsafe { self.entries_inner(false, db.zalsa()) };
+        let entries = unsafe { self.entries_inner(false, zalsa) };
 
         let memory_usage = entries
             // SAFETY: The memo table belongs to a value that we allocated, so it
@@ -1032,16 +1032,12 @@ where
         C::PERSIST
     }
 
-    fn should_serialize(&self, zalsa: &Zalsa) -> bool {
+    fn should_serialize(&self, zalsa: &ZalsaMut<'_>) -> bool {
         C::PERSIST && self.entries(zalsa).next().is_some()
     }
 
     #[cfg(feature = "persistence")]
-    unsafe fn serialize<'db>(
-        &'db self,
-        zalsa: &'db Zalsa,
-        f: &mut dyn FnMut(&dyn erased_serde::Serialize),
-    ) {
+    fn serialize(&self, zalsa: &ZalsaMut<'_>, f: &mut dyn FnMut(&dyn erased_serde::Serialize)) {
         f(&persistence::SerializeIngredient {
             zalsa,
             ingredient: self,
@@ -1535,15 +1531,15 @@ mod persistence {
     use super::{Configuration, IngredientImpl, Value, ValueShared};
     use crate::plumbing::Ingredient;
     use crate::table::memo::MemoTable;
-    use crate::zalsa::Zalsa;
+    use crate::zalsa::{Zalsa, ZalsaMut};
     use crate::{Durability, Id, Revision};
 
-    pub struct SerializeIngredient<'db, C>
+    pub struct SerializeIngredient<'a, C>
     where
         C: Configuration,
     {
-        pub zalsa: &'db Zalsa,
-        pub ingredient: &'db IngredientImpl<C>,
+        pub zalsa: &'a ZalsaMut<'a>,
+        pub ingredient: &'a IngredientImpl<C>,
     }
 
     impl<C> serde::Serialize for SerializeIngredient<'_, C>
@@ -1565,8 +1561,7 @@ mod persistence {
             let mut map = serializer.serialize_map(Some(count))?;
 
             for (_, value) in zalsa.table().slots_of::<Value<C>>() {
-                // SAFETY: The safety invariant of `Ingredient::serialize` ensures we have exclusive access
-                // to the database.
+                // SAFETY: `SerializeIngredient` carries exclusive database access.
                 let id = unsafe { (*value.shared.get()).id };
 
                 map.serialize_entry(&id.as_bits(), value)?;
@@ -1594,12 +1589,10 @@ mod persistence {
                 memos: _,
             } = self;
 
-            // SAFETY: The safety invariant of `Ingredient::serialize` ensures we have exclusive access
-            // to the database.
+            // SAFETY: `SerializeIngredient` carries exclusive database access.
             let fields = unsafe { &*fields.get() };
 
-            // SAFETY: The safety invariant of `Ingredient::serialize` ensures we have exclusive access
-            // to the database.
+            // SAFETY: `SerializeIngredient` carries exclusive database access.
             let ValueShared {
                 durability,
                 last_interned_at,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ pub mod plumbing {
     pub use crate::update::{Update, always_update};
     pub use crate::views::DatabaseDownCaster;
     pub use crate::zalsa::{
-        ErasedJar, HasJar, IngredientIndex, JarKind, Zalsa, ZalsaDatabase, register_jar,
+        ErasedJar, HasJar, IngredientIndex, JarKind, Zalsa, ZalsaDatabase, ZalsaMut, register_jar,
         transmute_data_ptr, views,
     };
     pub use crate::zalsa_local::ZalsaLocal;
@@ -168,6 +168,8 @@ pub mod plumbing {
 
     pub mod tracked_struct {
         pub use crate::tracked_struct::tracked_field::FieldIngredientImpl;
-        pub use crate::tracked_struct::{Configuration, IngredientImpl, JarImpl, Value};
+        pub use crate::tracked_struct::{
+            Configuration, IngredientHandle, IngredientImpl, JarImpl, Value,
+        };
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -42,6 +42,17 @@ pub unsafe trait Slot: Any + Send + Sync {
     /// The current revision MUST be the current revision of the database containing this slot.
     unsafe fn memos(slot: *const Self, current_revision: Revision) -> *const MemoTable;
 
+    /// Access the [`MemoTable`] for this slot without acquiring a tracked-struct read lock.
+    ///
+    /// # Safety condition
+    ///
+    /// The caller must have exclusive access to the database containing this slot, and
+    /// `current_revision` must be the database's current revision.
+    unsafe fn memos_exclusive(slot: *const Self, current_revision: Revision) -> *const MemoTable {
+        // SAFETY: The caller provides the guarantees required by `memos`.
+        unsafe { Self::memos(slot, current_revision) }
+    }
+
     /// Mutably access the [`MemoTable`] for this slot.
     fn memos_mut(&mut self) -> &mut MemoTable;
 }
@@ -59,6 +70,7 @@ struct SlotVTable {
     layout: Layout,
     /// [`Slot`] methods
     memos: SlotMemosFnErased,
+    memos_exclusive: SlotMemosFnErased,
     memos_mut: SlotMemosMutFnErased,
     /// The type name of what is stored as entries in data.
     type_name: fn() -> &'static str,
@@ -88,6 +100,10 @@ impl SlotVTable {
                 type_name: std::any::type_name::<T>,
                 // SAFETY: The signatures are ABI-compatible.
                 memos: unsafe { mem::transmute::<SlotMemosFn<T>, SlotMemosFnErased>(T::memos) },
+                // SAFETY: The signatures are ABI-compatible.
+                memos_exclusive: unsafe {
+                    mem::transmute::<SlotMemosFn<T>, SlotMemosFnErased>(T::memos_exclusive)
+                },
                 // SAFETY: The signatures are ABI-compatible.
                 memos_mut: unsafe {
                     mem::transmute::<SlotMemosMutFn<T>, SlotMemosMutFnErased>(T::memos_mut)
@@ -326,6 +342,26 @@ impl Table {
         unsafe { page.memo_types.attach_memos(memos) }
     }
 
+    /// Get the memo table associated with `id` without acquiring a tracked-struct read lock.
+    ///
+    /// # Safety
+    ///
+    /// The caller must have exclusive access to the database containing this table for the
+    /// lifetime of the returned memo table, and `current_revision` must be its current revision.
+    pub(crate) unsafe fn dyn_memos_exclusive(
+        &self,
+        id: Id,
+        current_revision: Revision,
+    ) -> MemoTableWithTypes<'_> {
+        let (page, slot) = split_id(id);
+        let page = &self.pages[page.0];
+        // SAFETY: We supply a valid slot pointer, and the caller provides the other guarantees.
+        let memos =
+            unsafe { &*(page.slot_vtable.memos_exclusive)(page.get(slot), current_revision) };
+        // SAFETY: The `Page` keeps the correct memo types.
+        unsafe { page.memo_types.attach_memos(memos) }
+    }
+
     /// Get the memo table associated with `id`
     pub(crate) fn memos_mut(&mut self, id: Id) -> MemoTableWithTypesMut<'_> {
         let (page, slot) = split_id(id);
@@ -352,6 +388,18 @@ impl Table {
                         let id = make_id(PageIndex::new(page_index), SlotIndex::new(slot_index));
                         (id, value)
                     })
+            })
+    }
+
+    /// Returns the IDs of slots with type `T` without creating references to their values.
+    pub(crate) fn slot_ids_of<T: Slot>(&self) -> impl Iterator<Item = Id> + '_ {
+        self.pages
+            .iter()
+            .filter_map(|(page_index, page)| Some((page_index, page.cast_type::<T>()?)))
+            .flat_map(|(page_index, view)| {
+                (0..view.page_data().len()).map(move |slot_index| {
+                    make_id(PageIndex::new(page_index), SlotIndex::new(slot_index))
+                })
             })
     }
 

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -23,7 +23,7 @@ use crate::salsa_struct::SalsaStructInDb;
 use crate::sync::Arc;
 use crate::table::memo::{MemoTable, MemoTableTypes, MemoTableWithTypesMut};
 use crate::table::{Slot, Table};
-use crate::zalsa::{IngredientIndex, JarKind, Zalsa};
+use crate::zalsa::{IngredientIndex, JarKind, Zalsa, ZalsaMut};
 use crate::zalsa_local::QueryEdge;
 use crate::{Durability, Event, EventKind, Id, Revision};
 
@@ -917,20 +917,85 @@ where
         unsafe { self.lock_fields(data, zalsa.current_revision()) }
     }
 
-    /// Returns all data corresponding to the tracked struct.
-    pub fn entries<'db>(&'db self, zalsa: &'db Zalsa) -> impl Iterator<Item = StructEntry<'db, C>> {
+    /// Returns the keys of all live tracked structs without borrowing their values.
+    #[doc(hidden)]
+    pub fn entry_keys<'db>(
+        &self,
+        zalsa: &'db Zalsa,
+    ) -> impl Iterator<Item = DatabaseKeyIndex> + 'db {
+        let ingredient_index = self.ingredient_index;
         zalsa
             .table()
-            .slots_of::<Value<C>>()
-            .filter(|(_, value)| {
+            .slot_ids_of::<Value<C>>()
+            .filter(move |id| {
+                let value = Self::data_raw(zalsa.table(), *id);
                 // Deleted values remain allocated for reuse with `updated_at == None`.
-                value.updated_at.load().is_some()
+                // SAFETY: `updated_at` is never exclusively borrowed. Reading it through a raw
+                // slot pointer does not create a reference to fields another thread may update.
+                unsafe { (*value).updated_at.load().is_some() }
             })
-            .map(|(id, value)| StructEntry {
-                value,
-                key: self.database_key_index(id),
-            })
+            .map(move |id| DatabaseKeyIndex::new(ingredient_index, id))
     }
+}
+
+/// A handle to a tracked-struct ingredient.
+#[derive(Copy, Clone)]
+pub struct IngredientHandle<C: Configuration>(PhantomData<fn() -> C>);
+
+impl<C: Configuration> IngredientHandle<C> {
+    #[doc(hidden)]
+    pub fn new<Db>(db: &Db) -> Self
+    where
+        Db: ?Sized + crate::Database,
+    {
+        let zalsa = db.zalsa();
+        let ingredient_index = zalsa.lookup_jar_by_type::<JarImpl<C>>();
+
+        // Assert that the registered jar contains the tracked-struct ingredient expected here.
+        zalsa
+            .lookup_ingredient(ingredient_index)
+            .assert_type::<IngredientImpl<C>>();
+
+        Self(PhantomData)
+    }
+
+    /// Returns all live values for this tracked-struct ingredient.
+    ///
+    /// **WARNING:** This triggers cancellation and waits for all other database handles to be
+    /// dropped. Calling it while another handle is retained by the current thread can deadlock.
+    pub fn entries<'db, Db>(
+        &self,
+        db: &'db mut Db,
+    ) -> impl Iterator<Item = StructEntry<'db, C>> + 'db
+    where
+        Db: ?Sized + crate::Database,
+    {
+        // Taking mutable access cancels and waits for all other database handles. The returned
+        // entries keep that mutable borrow alive for as long as their values can be inspected.
+        let zalsa_mut = ZalsaMut::new(db.zalsa_mut());
+        let ingredient_index = zalsa_mut.lookup_jar_by_type::<JarImpl<C>>();
+
+        entries(&zalsa_mut, ingredient_index)
+    }
+}
+
+/// Returns references to live tracked-struct values.
+fn entries<'db, C>(
+    zalsa: &ZalsaMut<'db>,
+    ingredient_index: IngredientIndex,
+) -> impl Iterator<Item = StructEntry<'db, C>> + 'db + use<'db, C>
+where
+    C: Configuration,
+{
+    let zalsa = zalsa.zalsa();
+    zalsa
+        .table()
+        .slots_of::<Value<C>>()
+        .filter(|(_, value)| value.updated_at.load().is_some())
+        .map(move |(id, value)| StructEntry {
+            value,
+            key: DatabaseKeyIndex::new(ingredient_index, id),
+        })
 }
 
 /// A tracked struct entry.
@@ -988,7 +1053,7 @@ where
 
     fn collect_minimum_serialized_edges(
         &self,
-        _zalsa: &Zalsa,
+        _zalsa: &ZalsaMut<'_>,
         _edge: QueryEdge,
         _serialized_edges: &mut FxIndexSet<QueryEdge>,
         _visited_edges: &mut FxHashSet<QueryEdge>,
@@ -1044,9 +1109,8 @@ where
 
     /// Returns memory usage information about any tracked structs.
     #[cfg(feature = "salsa_unstable")]
-    fn memory_usage(&self, db: &dyn crate::Database) -> Option<Vec<crate::database::SlotInfo>> {
-        let memory_usage = self
-            .entries(db.zalsa())
+    fn memory_usage(&self, zalsa: &ZalsaMut<'_>) -> Option<Vec<crate::database::SlotInfo>> {
+        let memory_usage = entries::<C>(zalsa, self.ingredient_index)
             // SAFETY: The memo table belongs to a value that we allocated, so it
             // has the correct type.
             .map(|entry| unsafe { entry.value.memory_usage(&self.memo_table_types) })
@@ -1059,22 +1123,12 @@ where
         C::PERSIST
     }
 
-    fn should_serialize(&self, zalsa: &Zalsa) -> bool {
-        C::PERSIST
-            && zalsa
-                .table()
-                .slots_of::<Value<C>>()
-                // Serialization has exclusive database access, so any value that is not
-                // write-locked is live, even if it has not been verified in this revision.
-                .any(|(_, value)| value.updated_at.load().is_some())
+    fn should_serialize(&self, zalsa: &ZalsaMut<'_>) -> bool {
+        C::PERSIST && self.entry_keys(zalsa).next().is_some()
     }
 
     #[cfg(feature = "persistence")]
-    unsafe fn serialize<'db>(
-        &'db self,
-        zalsa: &'db Zalsa,
-        f: &mut dyn FnMut(&dyn erased_serde::Serialize),
-    ) {
+    fn serialize(&self, zalsa: &ZalsaMut<'_>, f: &mut dyn FnMut(&dyn erased_serde::Serialize)) {
         f(&persistence::SerializeIngredient {
             zalsa,
             _ingredient: self,
@@ -1183,6 +1237,16 @@ where
         unsafe { acquire_read_lock(&(*this).updated_at, current_revision) };
         // SAFETY: `this` is a valid pointer given the caller obligation and we have acquired a read
         // lock, so `values` is not aliased
+        unsafe { &raw const (*this).memos }
+    }
+
+    #[inline(always)]
+    unsafe fn memos_exclusive(
+        this: *const Self,
+        _current_revision: Revision,
+    ) -> *const crate::table::memo::MemoTable {
+        // SAFETY: Caller obligation demands this pointer to be valid, and exclusive database
+        // access guarantees that the tracked struct is not being updated or deleted.
         unsafe { &raw const (*this).memos }
     }
 
@@ -1304,15 +1368,15 @@ mod persistence {
     use crate::plumbing::Ingredient;
     use crate::revision::OptionalAtomicRevision;
     use crate::table::memo::MemoTable;
-    use crate::zalsa::Zalsa;
+    use crate::zalsa::{Zalsa, ZalsaMut};
     use crate::{Durability, Id};
 
-    pub struct SerializeIngredient<'db, C>
+    pub struct SerializeIngredient<'a, C>
     where
         C: Configuration,
     {
-        pub zalsa: &'db Zalsa,
-        pub _ingredient: &'db IngredientImpl<C>,
+        pub zalsa: &'a ZalsaMut<'a>,
+        pub _ingredient: &'a IngredientImpl<C>,
     }
 
     impl<C> serde::Serialize for SerializeIngredient<'_, C>

--- a/src/tracked_struct/tracked_field.rs
+++ b/src/tracked_struct/tracked_field.rs
@@ -6,7 +6,7 @@ use crate::ingredient::Ingredient;
 use crate::sync::Arc;
 use crate::table::memo::MemoTableTypes;
 use crate::tracked_struct::{Configuration, Value};
-use crate::zalsa::{IngredientIndex, JarKind, Zalsa};
+use crate::zalsa::{IngredientIndex, JarKind, Zalsa, ZalsaMut};
 use crate::zalsa_local::QueryEdge;
 use crate::{DatabaseKeyIndex, Id};
 
@@ -74,7 +74,7 @@ where
 
     fn collect_minimum_serialized_edges(
         &self,
-        _zalsa: &Zalsa,
+        _zalsa: &ZalsaMut<'_>,
         _edge: QueryEdge,
         _serialized_edges: &mut FxIndexSet<QueryEdge>,
         _visited_edges: &mut FxHashSet<QueryEdge>,
@@ -124,7 +124,7 @@ where
         C::PERSIST
     }
 
-    fn should_serialize(&self, _zalsa: &Zalsa) -> bool {
+    fn should_serialize(&self, _zalsa: &ZalsaMut<'_>) -> bool {
         // However, they are never serialized directly.
         false
     }

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -168,6 +168,42 @@ pub struct Zalsa {
     event_callback: Option<Box<dyn Fn(crate::Event) + Send + Sync>>,
 }
 
+/// Shared access to [`Zalsa`] while the database is exclusively borrowed.
+///
+/// This capability is created from `&mut Zalsa`. Database entry points obtain that mutable
+/// reference only after all other database handles have been cancelled and dropped. The
+/// capability lets read-only operations carry the exclusivity guarantee without requiring
+/// `unsafe` methods throughout the ingredient API.
+#[doc(hidden)]
+pub struct ZalsaMut<'db>(&'db Zalsa);
+
+impl<'db> ZalsaMut<'db> {
+    pub(crate) fn new(zalsa: &'db mut Zalsa) -> Self {
+        Self(zalsa)
+    }
+
+    pub(crate) fn zalsa(&self) -> &'db Zalsa {
+        self.0
+    }
+
+    pub(crate) fn memo_table(&self, id: Id) -> MemoTableWithTypes<'db> {
+        // SAFETY: `ZalsaMut` can only be constructed from an exclusive `Zalsa` borrow.
+        unsafe {
+            self.0
+                .table()
+                .dyn_memos_exclusive(id, self.0.current_revision())
+        }
+    }
+}
+
+impl std::ops::Deref for ZalsaMut<'_> {
+    type Target = Zalsa;
+
+    fn deref(&self) -> &Self::Target {
+        self.0
+    }
+}
+
 /// All fields on Zalsa are locked behind [`Mutex`]es and [`RwLock`]s and cannot enter
 /// inconsistent states. The contents of said fields are largely ID mappings, with the exception
 /// of [`Runtime::dependency_graph`]. However, [`Runtime::dependency_graph`] does not

--- a/tests/compile-fail/tracked-entry-cannot-read-through-db.rs
+++ b/tests/compile-fail/tracked-entry-cannot-read-through-db.rs
@@ -1,0 +1,14 @@
+#[salsa::tracked]
+struct Entity<'db> {
+    value: u32,
+}
+
+fn main() {
+    let mut db = salsa::DatabaseImpl::default();
+    let entry = Entity::ingredient(&db)
+        .entries(&mut db)
+        .next()
+        .unwrap();
+
+    entry.as_struct().value(&db);
+}

--- a/tests/compile-fail/tracked-entry-cannot-read-through-db.stderr
+++ b/tests/compile-fail/tracked-entry-cannot-read-through-db.stderr
@@ -1,0 +1,10 @@
+error[E0502]: cannot borrow `db` as immutable because it is also borrowed as mutable
+  --> tests/compile-fail/tracked-entry-cannot-read-through-db.rs:13:29
+   |
+ 9 |         .entries(&mut db)
+   |                  ------- mutable borrow occurs here
+...
+13 |     entry.as_struct().value(&db);
+   |                       ----- ^^^ immutable borrow occurs here
+   |                       |
+   |                       mutable borrow later used by call

--- a/tests/debug_db_contents.rs
+++ b/tests/debug_db_contents.rs
@@ -23,7 +23,7 @@ fn tracked_fn(db: &dyn salsa::Database, input: InputStruct) -> TrackedStruct<'_>
 #[test]
 fn execute() {
     use salsa::plumbing::ZalsaDatabase;
-    let db = salsa::DatabaseImpl::new();
+    let mut db = salsa::DatabaseImpl::new();
 
     let interned1 = InternedStruct::new(&db, "Salsa".to_string());
     let interned2 = InternedStruct::new(&db, "Salsa2".to_string());
@@ -55,10 +55,9 @@ fn execute() {
     assert_eq!(tracked1.field(&db), 44);
 
     let tracked = TrackedStruct::ingredient(&db)
-        .entries(db.zalsa())
+        .entries(&mut db)
         .collect::<Vec<_>>();
 
     assert_eq!(tracked.len(), 1);
-    assert_eq!(tracked[0].as_struct(), tracked1);
-    assert_eq!(tracked[0].value().fields().0, tracked1.field(&db));
+    assert_eq!(tracked[0].value().fields().0, 44);
 }

--- a/tests/memory-usage.rs
+++ b/tests/memory-usage.rs
@@ -68,7 +68,7 @@ fn input_to_tracked_tuple(
 fn test() {
     use expect_test::expect;
 
-    let db = salsa::DatabaseImpl::new();
+    let mut db = salsa::DatabaseImpl::new();
 
     let input1 = MyInput::new(&db, "a".repeat(50));
     let input2 = MyInput::new(&db, "a".repeat(150));
@@ -86,7 +86,7 @@ fn test() {
     let _string1 = input_to_string(&db);
     let _string2 = input_to_string_get_size(&db);
 
-    let memory_usage = <dyn salsa::Database>::memory_usage(&db);
+    let memory_usage = <dyn salsa::Database>::memory_usage(&mut db);
 
     let expected = expect![[r#"
         [
@@ -204,14 +204,14 @@ fn cancellation_does_not_allocate_extra_for_ordinary_memos() {
     let input2 = MyInput::new(&db, "a".repeat(150));
 
     assert_eq!(input_to_length(&db, input1), 50);
-    let before = <dyn salsa::Database>::memory_usage(&db);
+    let before = <dyn salsa::Database>::memory_usage(&mut db);
     let before = &before.queries["input_to_length"];
     assert_eq!(before.count(), 1);
 
     db.trigger_lru_eviction();
 
     assert_eq!(input_to_length(&db, input2), 150);
-    let after = <dyn salsa::Database>::memory_usage(&db);
+    let after = <dyn salsa::Database>::memory_usage(&mut db);
     let after = &after.queries["input_to_length"];
     assert_eq!(after.count(), 2);
     assert_eq!(after.size_of_metadata(), before.size_of_metadata() * 2);

--- a/tests/tracked-struct-entries-persistence.rs
+++ b/tests/tracked-struct-entries-persistence.rs
@@ -38,3 +38,49 @@ fn deleted_tracked_structs_are_not_persisted() {
     let serialized = serde_json::to_string(&<dyn salsa::Database>::as_serialize(&mut db)).unwrap();
     assert!(!serialized.contains(DELETED_VALUE));
 }
+
+mod stale {
+    use super::*;
+
+    #[salsa::input(persist)]
+    struct Input {
+        value: u32,
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+    struct CollidingValue(u32);
+
+    impl std::hash::Hash for CollidingValue {
+        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+            std::hash::Hash::hash(&0_u8, state);
+        }
+    }
+
+    #[salsa::tracked(persist)]
+    struct Entity<'db> {
+        value: CollidingValue,
+    }
+
+    #[salsa::tracked(persist)]
+    fn make_entity(db: &dyn salsa::Database, input: Input) -> Entity<'_> {
+        Entity::new(db, CollidingValue(input.value(db)))
+    }
+
+    #[salsa::tracked(persist)]
+    fn consume(db: &dyn salsa::Database, entity: Entity<'_>) -> u32 {
+        entity.value(db).0
+    }
+
+    #[test]
+    fn serializing_a_stale_value_does_not_mark_it_current() {
+        let mut db = salsa::DatabaseImpl::default();
+        let input = Input::new(&db, 1);
+        let entity = make_entity(&db, input);
+        assert_eq!(consume(&db, entity), 1);
+
+        input.set_value(&mut db).to(2);
+        serde_json::to_string(&<dyn salsa::Database>::as_serialize(&mut db)).unwrap();
+
+        assert_eq!(make_entity(&db, input).value(&db).0, 2);
+    }
+}

--- a/tests/tracked-struct-entries.rs
+++ b/tests/tracked-struct-entries.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "inventory")]
 
 use salsa::Setter;
-use salsa::plumbing::ZalsaDatabase;
 
 mod deleted {
     use super::*;
@@ -30,7 +29,7 @@ mod deleted {
         input.set_enabled(&mut db).to(false);
         assert!(maybe_entity(&db, input).is_none());
 
-        assert_eq!(Entity::ingredient(&db).entries(db.zalsa()).count(), 0);
+        assert_eq!(Entity::ingredient(&db).entries(&mut db).count(), 0);
     }
 }
 
@@ -42,25 +41,41 @@ mod stale {
         value: u32,
     }
 
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct CollidingValue(u32);
+
+    impl std::hash::Hash for CollidingValue {
+        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+            std::hash::Hash::hash(&0_u8, state);
+        }
+    }
+
     #[salsa::tracked]
     struct Entity<'db> {
-        value: u32,
+        value: CollidingValue,
     }
 
     #[salsa::tracked]
     fn make_entity(db: &dyn salsa::Database, input: Input) -> Entity<'_> {
-        Entity::new(db, input.value(db))
+        Entity::new(db, CollidingValue(input.value(db)))
     }
 
     #[test]
-    fn stale_tracked_structs_remain_enumerated() {
+    fn inspecting_a_stale_value_does_not_mark_it_current() {
         let mut db = salsa::DatabaseImpl::default();
         let input = Input::new(&db, 1);
-        assert_eq!(make_entity(&db, input).value(&db), 1);
+        assert_eq!(make_entity(&db, input).value(&db).0, 1);
 
         input.set_value(&mut db).to(2);
 
-        assert_eq!(Entity::ingredient(&db).entries(db.zalsa()).count(), 1);
-        assert_eq!(make_entity(&db, input).value(&db), 2);
+        _ = <dyn salsa::Database>::memory_usage(&mut db);
+
+        {
+            let entries = Entity::ingredient(&db).entries(&mut db).collect::<Vec<_>>();
+            assert_eq!(entries.len(), 1);
+            assert_eq!(entries[0].value().fields().0.0, 1);
+        }
+
+        assert_eq!(make_entity(&db, input).value(&db).0, 2);
     }
 }


### PR DESCRIPTION
Require exclusive database access when inspecting tracked-struct entries, memory usage, and persisted memo tables, preventing concurrent mutation and stale-value verification from changing query results.

Carry that guarantee through an internal ZalsaMut capability. The affected APIs are unstable, so this remains a normal fix rather than a breaking change.

Closes #1169.

Testing: Passed the workspace test matrix, Clippy, and formatting checks.
