### PR TITLE
perf: avoid type checks in memo and field lookups

### DIFF
--- a/components/salsa-macro-rules/src/setup_input_struct.rs
+++ b/components/salsa-macro-rules/src/setup_input_struct.rs
@@ -152,6 +152,16 @@ macro_rules! setup_input_struct {
                     Self::ingredient_(db.zalsa())
                 }
 
+                #[inline]
+                fn ingredient_in_db<'db, $Db>(db: &'db $Db) -> $zalsa::IngredientInDb<'db, $Db, $zalsa_struct::IngredientImpl<Self>>
+                where
+                    $Db: ?Sized + $zalsa::Database,
+                {
+                    // SAFETY: `ingredient_` looks up the input ingredient in the `Zalsa`
+                    // supplied by `IngredientInDb`.
+                    unsafe { $zalsa::IngredientInDb::new_unchecked(db, Self::ingredient_) }
+                }
+
                 fn ingredient_(zalsa: &$zalsa::Zalsa) -> &$zalsa_struct::IngredientImpl<Self> {
                     static CACHE: $zalsa::IngredientCache<$zalsa_struct::IngredientImpl<$Configuration>> =
                         $zalsa::IngredientCache::new();
@@ -271,13 +281,7 @@ macro_rules! setup_input_struct {
                         // FIXME(rust-lang/rust#65991): The `db` argument *should* have the type `dyn Database`
                         $Db: ?Sized + $zalsa::Database,
                     {
-                        let (zalsa, zalsa_local) = db.zalsas();
-                        let fields = $Configuration::ingredient_(zalsa).field(
-                            zalsa,
-                            zalsa_local,
-                            self,
-                            $field_index,
-                        );
+                        let fields = $Configuration::ingredient_in_db(db).field(self, $field_index);
                         $zalsa::return_mode_expression!(
                             $field_option,
                             $field_ty,

--- a/components/salsa-macro-rules/src/setup_input_struct.rs
+++ b/components/salsa-macro-rules/src/setup_input_struct.rs
@@ -153,13 +153,13 @@ macro_rules! setup_input_struct {
                 }
 
                 #[inline]
-                fn ingredient_in_db<'db, $Db>(db: &'db $Db) -> $zalsa::IngredientInDb<'db, $Db, $zalsa_struct::IngredientImpl<Self>>
+                fn ingredient_in_db<'db, $Db>(db: &'db $Db) -> ($zalsa::IngredientInDb<'db, $Db, $zalsa_struct::IngredientImpl<Self>>, &'db $zalsa::ZalsaLocal)
                 where
                     $Db: ?Sized + $zalsa::Database,
                 {
                     // SAFETY: `ingredient_` looks up the input ingredient in the `Zalsa`
                     // supplied by `IngredientInDb`.
-                    unsafe { $zalsa::IngredientInDb::new_unchecked(db, Self::ingredient_) }
+                    unsafe { $zalsa::IngredientInDb::new_unchecked_with_zalsa_local(db, Self::ingredient_) }
                 }
 
                 fn ingredient_(zalsa: &$zalsa::Zalsa) -> &$zalsa_struct::IngredientImpl<Self> {
@@ -281,7 +281,8 @@ macro_rules! setup_input_struct {
                         // FIXME(rust-lang/rust#65991): The `db` argument *should* have the type `dyn Database`
                         $Db: ?Sized + $zalsa::Database,
                     {
-                        let fields = $Configuration::ingredient_in_db(db).field(self, $field_index);
+                        let (ingredient, zalsa_local) = $Configuration::ingredient_in_db(db);
+                        let fields = ingredient.field(zalsa_local, self, $field_index);
                         $zalsa::return_mode_expression!(
                             $field_option,
                             $field_ty,

--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -217,6 +217,16 @@ macro_rules! setup_interned_struct {
                         CACHE.get_or_create::<$zalsa_struct::JarImpl<$Configuration>, 0>(zalsa)
                     }
                 }
+
+                #[inline]
+                fn ingredient_in_db<'db, $Db>(db: &'db $Db) -> $zalsa::IngredientInDb<'db, $Db, $zalsa_struct::IngredientImpl<Self>>
+                where
+                    $Db: ?Sized + $zalsa::Database,
+                {
+                    // SAFETY: `ingredient` looks up the interned ingredient in the `Zalsa`
+                    // supplied by `IngredientInDb`.
+                    unsafe { $zalsa::IngredientInDb::new_unchecked(db, Self::ingredient) }
+                }
             }
 
             impl< $($db_lt_arg)? > $zalsa::AsId for $Struct< $($db_lt_arg)? > {
@@ -323,8 +333,7 @@ macro_rules! setup_interned_struct {
                         // FIXME(rust-lang/rust#65991): The `db` argument *should* have the type `dyn Database`
                         $Db: ?Sized + $zalsa::Database,
                     {
-                        let zalsa = db.zalsa();
-                        let fields = $Configuration::ingredient(zalsa).fields(zalsa, self);
+                        let fields = $Configuration::ingredient_in_db(db).fields(self);
                         $zalsa::return_mode_expression!(
                             $field_option,
                             $field_ty,

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -269,17 +269,16 @@ macro_rules! setup_tracked_fn {
             impl $Configuration {
                 #[inline(always)]
                 fn fn_ingredient<'db>(db: &'db dyn $Db) -> $zalsa::function::IngredientInDb<'db, $Configuration> {
-                    let (zalsa, zalsa_local) = db.zalsas();
                     // SAFETY: `lookup_jar_by_type` returns a valid ingredient index, and the first
-                    // ingredient created by our jar is the function ingredient.
-                    let ingredient = unsafe {
-                        $FN_CACHE.get_or_create::<$fn_name, 0>(zalsa)
+                    // ingredient created by our jar is the function ingredient in the provided
+                    // `zalsa`.
+                    unsafe {
+                        $zalsa::function::IngredientInDb::new_unchecked(db, |zalsa| {
+                            $FN_CACHE
+                                .get_or_create::<$fn_name, 0>(zalsa)
+                                .get_or_init(|| *<dyn $Db as $Db>::zalsa_register_downcaster(db))
+                        })
                     }
-                    .get_or_init(|| *<dyn $Db as $Db>::zalsa_register_downcaster(db));
-
-                    // SAFETY: `zalsa` and `zalsa_local` were obtained from `db`, and `ingredient`
-                    // was looked up in `zalsa` above.
-                    unsafe { $zalsa::function::IngredientInDb::new_unchecked(ingredient, db, zalsa, zalsa_local) }
                 }
 
                 pub fn fn_ingredient_mut(db: &mut dyn $Db) -> &mut $zalsa::function::IngredientImpl<Self> {

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -99,15 +99,19 @@ macro_rules! setup_tracked_fn {
 
             $zalsa::attach($db, || {
                 let (zalsa, zalsa_local) = $db.zalsas();
-                let result = $zalsa::macro_if! {
-                    if $needs_interner {
-                        {
-                            let key = $fn_name::intern_ingredient_(zalsa).intern_id(zalsa, zalsa_local, ($($input_id),*), |_, data| data);
-                            $fn_name::fn_ingredient_($db, zalsa).fetch($db, zalsa, zalsa_local, key)
-                        }
-                    } else {
-                        {
-                            $fn_name::fn_ingredient_($db, zalsa).fetch($db, zalsa, zalsa_local, $zalsa::AsId::as_id(&($($input_id),*)))
+                // SAFETY: `zalsa` and `zalsa_local` were obtained from `$db`, and
+                // `fn_ingredient_` looks up the function ingredient in `zalsa`.
+                let result = unsafe {
+                    $zalsa::macro_if! {
+                        if $needs_interner {
+                            {
+                                let key = $fn_name::intern_ingredient_(zalsa).intern_id(zalsa, zalsa_local, ($($input_id),*), |_, data| data);
+                                $fn_name::fn_ingredient_($db, zalsa).fetch($db, zalsa, zalsa_local, key)
+                            }
+                        } else {
+                            {
+                                $fn_name::fn_ingredient_($db, zalsa).fetch($db, zalsa, zalsa_local, $zalsa::AsId::as_id(&($($input_id),*)))
+                            }
                         }
                     }
                 };
@@ -479,7 +483,9 @@ macro_rules! setup_tracked_fn {
                             }
                         };
 
-                        $Configuration::fn_ingredient($db).accumulated_by::<A>($db, key)
+                        // SAFETY: `fn_ingredient` looks up the function ingredient in the `Zalsa`
+                        // owned by `$db`.
+                        unsafe { $Configuration::fn_ingredient($db).accumulated_by::<A>($db, key) }
                     }
                 }
 

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -98,18 +98,17 @@ macro_rules! setup_tracked_fn {
             use ::salsa::plumbing as $zalsa;
 
             $zalsa::attach($db, || {
-                let (zalsa, zalsa_local) = $db.zalsas();
-                // SAFETY: `zalsa` and `zalsa_local` were obtained from `$db`, and
-                // `fn_ingredient_` looks up the function ingredient in `zalsa`.
+                let fn_ingredient = $fn_name::fn_ingredient_($db);
+                let (zalsa, zalsa_local) = fn_ingredient.zalsas();
                 let result = $zalsa::macro_if! {
                     if $needs_interner {
                         {
                             let key = $fn_name::intern_ingredient_(zalsa).intern_id(zalsa, zalsa_local, ($($input_id),*), |_, data| data);
-                            unsafe { $fn_name::fn_ingredient_($db, zalsa).fetch($db, zalsa, zalsa_local, key) }
+                            fn_ingredient.fetch(key)
                         }
                     } else {
                         {
-                            unsafe { $fn_name::fn_ingredient_($db, zalsa).fetch($db, zalsa, zalsa_local, $zalsa::AsId::as_id(&($($input_id),*))) }
+                            fn_ingredient.fetch($zalsa::AsId::as_id(&($($input_id),*)))
                         }
                     }
                 };
@@ -268,19 +267,19 @@ macro_rules! setup_tracked_fn {
             }
 
             impl $Configuration {
-                fn fn_ingredient(db: &dyn $Db) -> &$zalsa::function::IngredientImpl<$Configuration> {
-                    let zalsa = db.zalsa();
-                    Self::fn_ingredient_(db, zalsa)
-                }
-
-                #[inline]
-                fn fn_ingredient_<'z>(db: &dyn $Db, zalsa: &'z $zalsa::Zalsa) -> &'z $zalsa::function::IngredientImpl<$Configuration> {
+                #[inline(always)]
+                fn fn_ingredient<'db>(db: &'db dyn $Db) -> $zalsa::function::IngredientInDb<'db, $Configuration> {
+                    let (zalsa, zalsa_local) = db.zalsas();
                     // SAFETY: `lookup_jar_by_type` returns a valid ingredient index, and the first
                     // ingredient created by our jar is the function ingredient.
-                    unsafe {
+                    let ingredient = unsafe {
                         $FN_CACHE.get_or_create::<$fn_name, 0>(zalsa)
                     }
-                    .get_or_init(|| *<dyn $Db as $Db>::zalsa_register_downcaster(db))
+                    .get_or_init(|| *<dyn $Db as $Db>::zalsa_register_downcaster(db));
+
+                    // SAFETY: `zalsa` and `zalsa_local` were obtained from `db`, and `ingredient`
+                    // was looked up in `zalsa` above.
+                    unsafe { $zalsa::function::IngredientInDb::new_unchecked(ingredient, db, zalsa, zalsa_local) }
                 }
 
                 pub fn fn_ingredient_mut(db: &mut dyn $Db) -> &mut $zalsa::function::IngredientImpl<Self> {
@@ -472,18 +471,17 @@ macro_rules! setup_tracked_fn {
                         $($input_id: $interned_input_ty,)*
                     ) -> Vec<&$db_lt A> {
                         use ::salsa::plumbing as $zalsa;
+                        let fn_ingredient = $Configuration::fn_ingredient($db);
                         let key = $zalsa::macro_if! {
                             if $needs_interner {{
-                                let (zalsa, zalsa_local) = $db.zalsas();
+                                let (zalsa, zalsa_local) = fn_ingredient.zalsas();
                                 $Configuration::intern_ingredient(zalsa).intern_id(zalsa, zalsa_local, ($($input_id),*), |_, data| data)
                             }} else {
                                 $zalsa::AsId::as_id(&($($input_id),*))
                             }
                         };
 
-                        // SAFETY: `fn_ingredient` looks up the function ingredient in the `Zalsa`
-                        // owned by `$db`.
-                        unsafe { $Configuration::fn_ingredient($db).accumulated_by::<A>($db, key) }
+                        fn_ingredient.accumulated_by::<A>(key)
                     }
                 }
 
@@ -495,7 +493,6 @@ macro_rules! setup_tracked_fn {
                     ) {
                         let key = $zalsa::AsId::as_id(&($($input_id),*));
                         $Configuration::fn_ingredient($db).specify_and_record(
-                            $db,
                             key,
                             value,
                         )
@@ -522,8 +519,8 @@ macro_rules! setup_tracked_fn {
                 }
 
                 #[inline]
-                fn fn_ingredient_<'z>(db: &dyn $Db, zalsa: &'z $zalsa::Zalsa) -> &'z $zalsa::function::IngredientImpl<$Configuration> {
-                    $Configuration::fn_ingredient_(db, zalsa)
+                fn fn_ingredient_<'db>(db: &'db dyn $Db) -> $zalsa::function::IngredientInDb<'db, $Configuration> {
+                    $Configuration::fn_ingredient(db)
                 }
             }
         };

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -101,17 +101,15 @@ macro_rules! setup_tracked_fn {
                 let (zalsa, zalsa_local) = $db.zalsas();
                 // SAFETY: `zalsa` and `zalsa_local` were obtained from `$db`, and
                 // `fn_ingredient_` looks up the function ingredient in `zalsa`.
-                let result = unsafe {
-                    $zalsa::macro_if! {
-                        if $needs_interner {
-                            {
-                                let key = $fn_name::intern_ingredient_(zalsa).intern_id(zalsa, zalsa_local, ($($input_id),*), |_, data| data);
-                                $fn_name::fn_ingredient_($db, zalsa).fetch($db, zalsa, zalsa_local, key)
-                            }
-                        } else {
-                            {
-                                $fn_name::fn_ingredient_($db, zalsa).fetch($db, zalsa, zalsa_local, $zalsa::AsId::as_id(&($($input_id),*)))
-                            }
+                let result = $zalsa::macro_if! {
+                    if $needs_interner {
+                        {
+                            let key = $fn_name::intern_ingredient_(zalsa).intern_id(zalsa, zalsa_local, ($($input_id),*), |_, data| data);
+                            unsafe { $fn_name::fn_ingredient_($db, zalsa).fetch($db, zalsa, zalsa_local, key) }
+                        }
+                    } else {
+                        {
+                            unsafe { $fn_name::fn_ingredient_($db, zalsa).fetch($db, zalsa, zalsa_local, $zalsa::AsId::as_id(&($($input_id),*))) }
                         }
                     }
                 };

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -267,7 +267,7 @@ macro_rules! setup_tracked_fn {
             }
 
             impl $Configuration {
-                #[inline(always)]
+                #[inline]
                 fn fn_ingredient<'db>(db: &'db dyn $Db) -> $zalsa::function::IngredientInDb<'db, $Configuration> {
                     // SAFETY: `lookup_jar_by_type` returns a valid ingredient index, and the first
                     // ingredient created by our jar is the function ingredient in the provided

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -98,17 +98,17 @@ macro_rules! setup_tracked_fn {
             use ::salsa::plumbing as $zalsa;
 
             $zalsa::attach($db, || {
-                let fn_ingredient = $fn_name::fn_ingredient_($db);
-                let (zalsa, zalsa_local) = fn_ingredient.zalsas();
+                let (fn_ingredient, zalsa_local) = $fn_name::fn_ingredient_($db);
                 let result = $zalsa::macro_if! {
                     if $needs_interner {
                         {
+                            let zalsa = fn_ingredient.zalsa();
                             let key = $fn_name::intern_ingredient_(zalsa).intern_id(zalsa, zalsa_local, ($($input_id),*), |_, data| data);
-                            fn_ingredient.fetch(key)
+                            fn_ingredient.fetch(zalsa_local, key)
                         }
                     } else {
                         {
-                            fn_ingredient.fetch($zalsa::AsId::as_id(&($($input_id),*)))
+                            fn_ingredient.fetch(zalsa_local, $zalsa::AsId::as_id(&($($input_id),*)))
                         }
                     }
                 };
@@ -268,12 +268,12 @@ macro_rules! setup_tracked_fn {
 
             impl $Configuration {
                 #[inline]
-                fn fn_ingredient<'db>(db: &'db dyn $Db) -> $zalsa::IngredientInDb<'db, dyn $Db, $zalsa::function::IngredientImpl<$Configuration>> {
+                fn fn_ingredient<'db>(db: &'db dyn $Db) -> ($zalsa::IngredientInDb<'db, dyn $Db, $zalsa::function::IngredientImpl<$Configuration>>, &'db $zalsa::ZalsaLocal) {
                     // SAFETY: `lookup_jar_by_type` returns a valid ingredient index, and the first
                     // ingredient created by our jar is the function ingredient in the provided
                     // `zalsa`.
                     unsafe {
-                        $zalsa::IngredientInDb::new_unchecked(db, |zalsa| {
+                        $zalsa::IngredientInDb::new_unchecked_with_zalsa_local(db, |zalsa| {
                             $FN_CACHE
                                 .get_or_create::<$fn_name, 0>(zalsa)
                                 .get_or_init(|| *<dyn $Db as $Db>::zalsa_register_downcaster(db))
@@ -470,17 +470,17 @@ macro_rules! setup_tracked_fn {
                         $($input_id: $interned_input_ty,)*
                     ) -> Vec<&$db_lt A> {
                         use ::salsa::plumbing as $zalsa;
-                        let fn_ingredient = $Configuration::fn_ingredient($db);
+                        let (fn_ingredient, zalsa_local) = $Configuration::fn_ingredient($db);
                         let key = $zalsa::macro_if! {
                             if $needs_interner {{
-                                let (zalsa, zalsa_local) = fn_ingredient.zalsas();
+                                let zalsa = fn_ingredient.zalsa();
                                 $Configuration::intern_ingredient(zalsa).intern_id(zalsa, zalsa_local, ($($input_id),*), |_, data| data)
                             }} else {
                                 $zalsa::AsId::as_id(&($($input_id),*))
                             }
                         };
 
-                        fn_ingredient.accumulated_by::<A>(key)
+                        fn_ingredient.accumulated_by::<A>(zalsa_local, key)
                     }
                 }
 
@@ -491,7 +491,9 @@ macro_rules! setup_tracked_fn {
                         value: $output_ty,
                     ) {
                         let key = $zalsa::AsId::as_id(&($($input_id),*));
-                        $Configuration::fn_ingredient($db).specify_and_record(
+                        let (fn_ingredient, zalsa_local) = $Configuration::fn_ingredient($db);
+                        fn_ingredient.specify_and_record(
+                            zalsa_local,
                             key,
                             value,
                         )
@@ -518,7 +520,7 @@ macro_rules! setup_tracked_fn {
                 }
 
                 #[inline]
-                fn fn_ingredient_<'db>(db: &'db dyn $Db) -> $zalsa::IngredientInDb<'db, dyn $Db, $zalsa::function::IngredientImpl<$Configuration>> {
+                fn fn_ingredient_<'db>(db: &'db dyn $Db) -> ($zalsa::IngredientInDb<'db, dyn $Db, $zalsa::function::IngredientImpl<$Configuration>>, &'db $zalsa::ZalsaLocal) {
                     $Configuration::fn_ingredient(db)
                 }
             }

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -268,12 +268,12 @@ macro_rules! setup_tracked_fn {
 
             impl $Configuration {
                 #[inline]
-                fn fn_ingredient<'db>(db: &'db dyn $Db) -> $zalsa::function::IngredientInDb<'db, $Configuration> {
+                fn fn_ingredient<'db>(db: &'db dyn $Db) -> $zalsa::IngredientInDb<'db, dyn $Db, $zalsa::function::IngredientImpl<$Configuration>> {
                     // SAFETY: `lookup_jar_by_type` returns a valid ingredient index, and the first
                     // ingredient created by our jar is the function ingredient in the provided
                     // `zalsa`.
                     unsafe {
-                        $zalsa::function::IngredientInDb::new_unchecked(db, |zalsa| {
+                        $zalsa::IngredientInDb::new_unchecked(db, |zalsa| {
                             $FN_CACHE
                                 .get_or_create::<$fn_name, 0>(zalsa)
                                 .get_or_init(|| *<dyn $Db as $Db>::zalsa_register_downcaster(db))
@@ -518,7 +518,7 @@ macro_rules! setup_tracked_fn {
                 }
 
                 #[inline]
-                fn fn_ingredient_<'db>(db: &'db dyn $Db) -> $zalsa::function::IngredientInDb<'db, $Configuration> {
+                fn fn_ingredient_<'db>(db: &'db dyn $Db) -> $zalsa::IngredientInDb<'db, dyn $Db, $zalsa::function::IngredientImpl<$Configuration>> {
                     $Configuration::fn_ingredient(db)
                 }
             }

--- a/components/salsa-macro-rules/src/setup_tracked_struct.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_struct.rs
@@ -247,6 +247,16 @@ macro_rules! setup_tracked_struct {
                     unsafe { $zalsa::IngredientInDb::new_unchecked(db, Self::ingredient_) }
                 }
 
+                #[inline]
+                fn ingredient_in_db_with_zalsa_local<'db, $Db>(db: &'db $Db) -> ($zalsa::IngredientInDb<'db, $Db, $zalsa_struct::IngredientImpl<Self>>, &'db $zalsa::ZalsaLocal)
+                where
+                    $Db: ?Sized + $zalsa::Database,
+                {
+                    // SAFETY: `ingredient_` looks up the tracked-struct ingredient in the `Zalsa`
+                    // supplied by `IngredientInDb`.
+                    unsafe { $zalsa::IngredientInDb::new_unchecked_with_zalsa_local(db, Self::ingredient_) }
+                }
+
                 fn ingredient_(zalsa: &$zalsa::Zalsa) -> &$zalsa_struct::IngredientImpl<Self> {
                     static CACHE: $zalsa::IngredientCache<$zalsa_struct::IngredientImpl<$Configuration>> =
                         $zalsa::IngredientCache::new();
@@ -370,7 +380,8 @@ macro_rules! setup_tracked_struct {
                         // FIXME(rust-lang/rust#65991): The `db` argument *should* have the type `dyn Database`
                         $Db: ?Sized + $zalsa::Database,
                     {
-                        let fields = $Configuration::ingredient_in_db(db).tracked_field(self, $relative_tracked_index);
+                        let (ingredient, zalsa_local) = $Configuration::ingredient_in_db_with_zalsa_local(db);
+                        let fields = ingredient.tracked_field(zalsa_local, self, $relative_tracked_index);
                         $crate::return_mode_expression!(
                             $tracked_option,
                             $tracked_ty,

--- a/components/salsa-macro-rules/src/setup_tracked_struct.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_struct.rs
@@ -237,6 +237,16 @@ macro_rules! setup_tracked_struct {
                     Self::ingredient_(db.zalsa())
                 }
 
+                #[inline]
+                fn ingredient_in_db<'db, $Db>(db: &'db $Db) -> $zalsa::IngredientInDb<'db, $Db, $zalsa_struct::IngredientImpl<Self>>
+                where
+                    $Db: ?Sized + $zalsa::Database,
+                {
+                    // SAFETY: `ingredient_` looks up the tracked-struct ingredient in the `Zalsa`
+                    // supplied by `IngredientInDb`.
+                    unsafe { $zalsa::IngredientInDb::new_unchecked(db, Self::ingredient_) }
+                }
+
                 fn ingredient_(zalsa: &$zalsa::Zalsa) -> &$zalsa_struct::IngredientImpl<Self> {
                     static CACHE: $zalsa::IngredientCache<$zalsa_struct::IngredientImpl<$Configuration>> =
                         $zalsa::IngredientCache::new();
@@ -360,8 +370,7 @@ macro_rules! setup_tracked_struct {
                         // FIXME(rust-lang/rust#65991): The `db` argument *should* have the type `dyn Database`
                         $Db: ?Sized + $zalsa::Database,
                     {
-                        let (zalsa, zalsa_local) = db.zalsas();
-                        let fields = $Configuration::ingredient_(zalsa).tracked_field(zalsa, zalsa_local, self, $relative_tracked_index);
+                        let fields = $Configuration::ingredient_in_db(db).tracked_field(self, $relative_tracked_index);
                         $crate::return_mode_expression!(
                             $tracked_option,
                             $tracked_ty,
@@ -377,8 +386,7 @@ macro_rules! setup_tracked_struct {
                         // FIXME(rust-lang/rust#65991): The `db` argument *should* have the type `dyn Database`
                         $Db: ?Sized + $zalsa::Database,
                     {
-                        let zalsa = db.zalsa();
-                        let fields = $Configuration::ingredient_(zalsa).untracked_field(zalsa, self);
+                        let fields = $Configuration::ingredient_in_db(db).untracked_field(self);
                         $crate::return_mode_expression!(
                             $untracked_option,
                             $untracked_ty,

--- a/src/function.rs
+++ b/src/function.rs
@@ -512,7 +512,8 @@ where
     ) {
         // SAFETY: The `db` belongs to the ingredient as per caller invariant
         let db = unsafe { self.view_caster().downcast_unchecked(db) };
-        self.accumulated_map(db, key_index)
+        // SAFETY: The caller guarantees that `db` belongs to this ingredient.
+        unsafe { self.accumulated_map(db, key_index) }
     }
 
     fn is_persistable(&self) -> bool {

--- a/src/function.rs
+++ b/src/function.rs
@@ -513,8 +513,10 @@ where
         // SAFETY: The `db` belongs to the ingredient as per caller invariant
         let db = unsafe { self.view_caster().downcast_unchecked(db) };
         // SAFETY: The caller guarantees that `self` is registered in the `Zalsa` owned by `db`.
-        let ingredient = unsafe { crate::ingredient::IngredientInDb::new_unchecked(db, |_| self) };
-        ingredient.accumulated_map(key_index)
+        let (ingredient, zalsa_local) = unsafe {
+            crate::ingredient::IngredientInDb::new_unchecked_with_zalsa_local(db, |_| self)
+        };
+        ingredient.accumulated_map(zalsa_local, key_index)
     }
 
     fn is_persistable(&self) -> bool {

--- a/src/function.rs
+++ b/src/function.rs
@@ -173,17 +173,15 @@ impl<'db, C: Configuration> IngredientInDb<'db, C> {
     ///
     /// # Safety
     ///
-    /// `ingredient` must be registered in `zalsa`, `db` must use `zalsa` as its storage, and
-    /// `zalsa_local` must be the local state paired with `db`.
+    /// `get_ingredient` must return an ingredient registered in the `Zalsa` it receives.
     #[inline(always)]
     pub unsafe fn new_unchecked(
-        ingredient: &'db IngredientImpl<C>,
         db: &'db C::DbView,
-        zalsa: &'db Zalsa,
-        zalsa_local: &'db ZalsaLocal,
+        get_ingredient: impl FnOnce(&'db Zalsa) -> &'db IngredientImpl<C>,
     ) -> Self {
-        debug_assert!(std::ptr::eq(db.zalsa(), zalsa));
-        debug_assert!(std::ptr::eq(db.zalsa_local(), zalsa_local));
+        let (zalsa, zalsa_local) = db.zalsas();
+        let ingredient = get_ingredient(zalsa);
+
         debug_assert!(std::ptr::eq(
             ingredient,
             zalsa
@@ -202,6 +200,14 @@ impl<'db, C: Configuration> IngredientInDb<'db, C> {
     #[inline(always)]
     pub fn zalsas(&self) -> (&'db Zalsa, &'db ZalsaLocal) {
         (self.zalsa, self.zalsa_local)
+    }
+}
+
+impl<C: Configuration> std::ops::Deref for IngredientInDb<'_, C> {
+    type Target = IngredientImpl<C>;
+
+    fn deref(&self) -> &Self::Target {
+        self.ingredient
     }
 }
 
@@ -558,8 +564,9 @@ where
     ) {
         // SAFETY: The `db` belongs to the ingredient as per caller invariant
         let db = unsafe { self.view_caster().downcast_unchecked(db) };
-        // SAFETY: The caller guarantees that `db` belongs to this ingredient.
-        unsafe { self.accumulated_map(db, key_index) }
+        // SAFETY: The caller guarantees that `self` is registered in the `Zalsa` owned by `db`.
+        let ingredient = unsafe { IngredientInDb::new_unchecked(db, |_| self) };
+        ingredient.accumulated_map(key_index)
     }
 
     fn is_persistable(&self) -> bool {

--- a/src/function.rs
+++ b/src/function.rs
@@ -20,8 +20,8 @@ use crate::sync::Arc;
 use crate::table::Table;
 use crate::table::memo::MemoTableTypes;
 use crate::views::DatabaseDownCaster;
-use crate::zalsa::{IngredientIndex, JarKind, MemoIngredientIndex, Zalsa, ZalsaDatabase};
-use crate::zalsa_local::{QueryEdge, QueryOriginRef, ZalsaLocal};
+use crate::zalsa::{IngredientIndex, JarKind, MemoIngredientIndex, Zalsa};
+use crate::zalsa_local::{QueryEdge, QueryOriginRef};
 use crate::{Cycle, Id, Revision};
 
 #[cfg(feature = "accumulator")]
@@ -157,58 +157,6 @@ pub unsafe trait Configuration: Any {
     fn deserialize<'de, D>(deserializer: D) -> Result<Self::Output<'static>, D::Error>
     where
         D: plumbing::serde::Deserializer<'de>;
-}
-
-/// A function ingredient bound to the database that registered it.
-#[doc(hidden)]
-pub struct IngredientInDb<'db, C: Configuration> {
-    ingredient: &'db IngredientImpl<C>,
-    db: &'db C::DbView,
-    zalsa: &'db Zalsa,
-    zalsa_local: &'db ZalsaLocal,
-}
-
-impl<'db, C: Configuration> IngredientInDb<'db, C> {
-    /// Creates a function ingredient bound to a database.
-    ///
-    /// # Safety
-    ///
-    /// `get_ingredient` must return an ingredient registered in the `Zalsa` it receives.
-    #[inline]
-    pub unsafe fn new_unchecked(
-        db: &'db C::DbView,
-        get_ingredient: impl FnOnce(&'db Zalsa) -> &'db IngredientImpl<C>,
-    ) -> Self {
-        let (zalsa, zalsa_local) = db.zalsas();
-        let ingredient = get_ingredient(zalsa);
-
-        debug_assert!(std::ptr::eq(
-            ingredient,
-            zalsa
-                .lookup_ingredient(ingredient.index)
-                .assert_type::<IngredientImpl<C>>()
-        ));
-
-        Self {
-            ingredient,
-            db,
-            zalsa,
-            zalsa_local,
-        }
-    }
-
-    #[inline]
-    pub fn zalsas(&self) -> (&'db Zalsa, &'db ZalsaLocal) {
-        (self.zalsa, self.zalsa_local)
-    }
-}
-
-impl<C: Configuration> std::ops::Deref for IngredientInDb<'_, C> {
-    type Target = IngredientImpl<C>;
-
-    fn deref(&self) -> &Self::Target {
-        self.ingredient
-    }
 }
 
 /// Function ingredients are the "workhorse" of salsa.
@@ -565,7 +513,7 @@ where
         // SAFETY: The `db` belongs to the ingredient as per caller invariant
         let db = unsafe { self.view_caster().downcast_unchecked(db) };
         // SAFETY: The caller guarantees that `self` is registered in the `Zalsa` owned by `db`.
-        let ingredient = unsafe { IngredientInDb::new_unchecked(db, |_| self) };
+        let ingredient = unsafe { crate::ingredient::IngredientInDb::new_unchecked(db, |_| self) };
         ingredient.accumulated_map(key_index)
     }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -20,8 +20,8 @@ use crate::sync::Arc;
 use crate::table::Table;
 use crate::table::memo::MemoTableTypes;
 use crate::views::DatabaseDownCaster;
-use crate::zalsa::{IngredientIndex, JarKind, MemoIngredientIndex, Zalsa};
-use crate::zalsa_local::{QueryEdge, QueryOriginRef};
+use crate::zalsa::{IngredientIndex, JarKind, MemoIngredientIndex, Zalsa, ZalsaDatabase};
+use crate::zalsa_local::{QueryEdge, QueryOriginRef, ZalsaLocal};
 use crate::{Cycle, Id, Revision};
 
 #[cfg(feature = "accumulator")]
@@ -157,6 +157,52 @@ pub unsafe trait Configuration: Any {
     fn deserialize<'de, D>(deserializer: D) -> Result<Self::Output<'static>, D::Error>
     where
         D: plumbing::serde::Deserializer<'de>;
+}
+
+/// A function ingredient bound to the database that registered it.
+#[doc(hidden)]
+pub struct IngredientInDb<'db, C: Configuration> {
+    ingredient: &'db IngredientImpl<C>,
+    db: &'db C::DbView,
+    zalsa: &'db Zalsa,
+    zalsa_local: &'db ZalsaLocal,
+}
+
+impl<'db, C: Configuration> IngredientInDb<'db, C> {
+    /// Creates a function ingredient bound to a database.
+    ///
+    /// # Safety
+    ///
+    /// `ingredient` must be registered in `zalsa`, `db` must use `zalsa` as its storage, and
+    /// `zalsa_local` must be the local state paired with `db`.
+    #[inline(always)]
+    pub unsafe fn new_unchecked(
+        ingredient: &'db IngredientImpl<C>,
+        db: &'db C::DbView,
+        zalsa: &'db Zalsa,
+        zalsa_local: &'db ZalsaLocal,
+    ) -> Self {
+        debug_assert!(std::ptr::eq(db.zalsa(), zalsa));
+        debug_assert!(std::ptr::eq(db.zalsa_local(), zalsa_local));
+        debug_assert!(std::ptr::eq(
+            ingredient,
+            zalsa
+                .lookup_ingredient(ingredient.index)
+                .assert_type::<IngredientImpl<C>>()
+        ));
+
+        Self {
+            ingredient,
+            db,
+            zalsa,
+            zalsa_local,
+        }
+    }
+
+    #[inline(always)]
+    pub fn zalsas(&self) -> (&'db Zalsa, &'db ZalsaLocal) {
+        (self.zalsa, self.zalsa_local)
+    }
 }
 
 /// Function ingredients are the "workhorse" of salsa.

--- a/src/function.rs
+++ b/src/function.rs
@@ -174,7 +174,7 @@ impl<'db, C: Configuration> IngredientInDb<'db, C> {
     /// # Safety
     ///
     /// `get_ingredient` must return an ingredient registered in the `Zalsa` it receives.
-    #[inline(always)]
+    #[inline]
     pub unsafe fn new_unchecked(
         db: &'db C::DbView,
         get_ingredient: impl FnOnce(&'db Zalsa) -> &'db IngredientImpl<C>,
@@ -197,7 +197,7 @@ impl<'db, C: Configuration> IngredientInDb<'db, C> {
         }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn zalsas(&self) -> (&'db Zalsa, &'db ZalsaLocal) {
         (self.zalsa, self.zalsa_local)
     }

--- a/src/function/accumulated.rs
+++ b/src/function/accumulated.rs
@@ -1,10 +1,24 @@
 use crate::accumulator::accumulated_map::{AccumulatedMap, InputAccumulatedValues};
 use crate::accumulator::{self};
-use crate::function::{Configuration, IngredientImpl};
+use crate::function::{Configuration, IngredientImpl, IngredientInDb};
 use crate::hash::FxHashSet;
 use crate::zalsa::ZalsaDatabase;
 use crate::zalsa_local::QueryOriginRef;
 use crate::{DatabaseKeyIndex, Id};
+
+impl<'db, C> IngredientInDb<'db, C>
+where
+    C: Configuration,
+{
+    #[inline]
+    pub fn accumulated_by<A>(&self, key: Id) -> Vec<&'db A>
+    where
+        A: accumulator::Accumulator,
+    {
+        // SAFETY: `IngredientInDb` binds the ingredient to the database.
+        unsafe { self.ingredient.accumulated_by::<A>(self.db, key) }
+    }
+}
 
 impl<C> IngredientImpl<C>
 where

--- a/src/function/accumulated.rs
+++ b/src/function/accumulated.rs
@@ -12,7 +12,11 @@ where
 {
     /// Helper used by `accumulate` functions. Computes the results accumulated by `database_key_index`
     /// and its inputs.
-    pub fn accumulated_by<'db, A>(&self, db: &'db C::DbView, key: Id) -> Vec<&'db A>
+    ///
+    /// # Safety
+    ///
+    /// `self` must be registered in the `Zalsa` owned by `db`.
+    pub unsafe fn accumulated_by<'db, A>(&self, db: &'db C::DbView, key: Id) -> Vec<&'db A>
     where
         A: accumulator::Accumulator,
     {
@@ -37,7 +41,9 @@ where
         let mut output = vec![];
 
         // First ensure the result is up to date
-        self.fetch(db, zalsa, zalsa_local, key);
+        // SAFETY: The caller guarantees that `self` is registered in the `Zalsa` owned by `db`,
+        // and `zalsa` and `zalsa_local` were obtained from `db` above.
+        unsafe { self.fetch(db, zalsa, zalsa_local, key) };
 
         let db_key = self.database_key_index(key);
         let mut visited: FxHashSet<DatabaseKeyIndex> = FxHashSet::default();

--- a/src/function/accumulated.rs
+++ b/src/function/accumulated.rs
@@ -1,8 +1,7 @@
 use crate::accumulator::accumulated_map::{AccumulatedMap, InputAccumulatedValues};
 use crate::accumulator::{self};
-use crate::function::{Configuration, IngredientImpl, IngredientInDb};
+use crate::function::{Configuration, IngredientInDb};
 use crate::hash::FxHashSet;
-use crate::zalsa::ZalsaDatabase;
 use crate::zalsa_local::QueryOriginRef;
 use crate::{DatabaseKeyIndex, Id};
 
@@ -10,31 +9,14 @@ impl<'db, C> IngredientInDb<'db, C>
 where
     C: Configuration,
 {
-    #[inline]
+    /// Helper used by `accumulate` functions. Computes the results accumulated by
+    /// `database_key_index` and its inputs.
     pub fn accumulated_by<A>(&self, key: Id) -> Vec<&'db A>
     where
         A: accumulator::Accumulator,
     {
-        // SAFETY: `IngredientInDb` binds the ingredient to the database.
-        unsafe { self.ingredient.accumulated_by::<A>(self.db, key) }
-    }
-}
-
-impl<C> IngredientImpl<C>
-where
-    C: Configuration,
-{
-    /// Helper used by `accumulate` functions. Computes the results accumulated by `database_key_index`
-    /// and its inputs.
-    ///
-    /// # Safety
-    ///
-    /// `self` must be registered in the `Zalsa` owned by `db`.
-    pub unsafe fn accumulated_by<'db, A>(&self, db: &'db C::DbView, key: Id) -> Vec<&'db A>
-    where
-        A: accumulator::Accumulator,
-    {
-        let (zalsa, zalsa_local) = db.zalsas();
+        let (zalsa, zalsa_local) = self.zalsas();
+        let db = self.db;
 
         // NOTE: We don't have a precise way to track accumulated values at present,
         // so we report any read of them as an untracked read.
@@ -55,9 +37,7 @@ where
         let mut output = vec![];
 
         // First ensure the result is up to date
-        // SAFETY: The caller guarantees that `self` is registered in the `Zalsa` owned by `db`,
-        // and `zalsa` and `zalsa_local` were obtained from `db` above.
-        unsafe { self.fetch(db, zalsa, zalsa_local, key) };
+        self.fetch(key);
 
         let db_key = self.database_key_index(key);
         let mut visited: FxHashSet<DatabaseKeyIndex> = FxHashSet::default();
@@ -73,7 +53,7 @@ where
 
             let ingredient = zalsa.lookup_ingredient(k.ingredient_index());
             // Extend `output` with any values accumulated by `k`.
-            // SAFETY: `db` owns the `ingredient`
+            // SAFETY: `ingredient` and `k` belong to the `Zalsa` obtained from `db`.
             let (accumulated_map, input) =
                 unsafe { ingredient.accumulated(db.into(), k.key_index()) };
             if let Some(accumulated_map) = accumulated_map {
@@ -107,21 +87,12 @@ where
         output
     }
 
-    /// Returns the values accumulated by `key`.
-    ///
-    /// # Safety
-    ///
-    /// `self` must be registered in the `Zalsa` owned by `db`.
-    pub(super) unsafe fn accumulated_map<'db>(
-        &'db self,
-        db: &'db C::DbView,
+    pub(super) fn accumulated_map(
+        &self,
         key: Id,
     ) -> (Option<&'db AccumulatedMap>, InputAccumulatedValues) {
-        let (zalsa, zalsa_local) = db.zalsas();
         // NEXT STEP: stash and refactor `fetch` to return an `&Memo` so we can make this work
-        // SAFETY: The caller guarantees that `self` is registered in the `Zalsa` owned by `db`,
-        // and `zalsa` and `zalsa_local` were obtained from `db` above.
-        let memo = unsafe { self.refresh_memo(db, zalsa, zalsa_local, key) };
+        let memo = self.refresh_memo(key);
         (
             memo.header.revisions.accumulated(),
             memo.header.revisions.accumulated_inputs.load(),

--- a/src/function/accumulated.rs
+++ b/src/function/accumulated.rs
@@ -3,7 +3,7 @@ use crate::accumulator::{self};
 use crate::function::{Configuration, IngredientImpl};
 use crate::hash::FxHashSet;
 use crate::ingredient::IngredientInDb;
-use crate::zalsa_local::QueryOriginRef;
+use crate::zalsa_local::{QueryOriginRef, ZalsaLocal};
 use crate::{DatabaseKeyIndex, Id};
 
 impl<'db, C> IngredientInDb<'db, C::DbView, IngredientImpl<C>>
@@ -12,11 +12,11 @@ where
 {
     /// Helper used by `accumulate` functions. Computes the results accumulated by
     /// `database_key_index` and its inputs.
-    pub fn accumulated_by<A>(&self, key: Id) -> Vec<&'db A>
+    pub fn accumulated_by<A>(&self, zalsa_local: &'db ZalsaLocal, key: Id) -> Vec<&'db A>
     where
         A: accumulator::Accumulator,
     {
-        let (zalsa, zalsa_local) = self.zalsas();
+        let zalsa = self.zalsa();
         let db = self.db();
 
         // NOTE: We don't have a precise way to track accumulated values at present,
@@ -38,7 +38,7 @@ where
         let mut output = vec![];
 
         // First ensure the result is up to date
-        self.fetch(key);
+        self.fetch(zalsa_local, key);
 
         let db_key = self.ingredient().database_key_index(key);
         let mut visited: FxHashSet<DatabaseKeyIndex> = FxHashSet::default();
@@ -90,10 +90,11 @@ where
 
     pub(super) fn accumulated_map(
         &self,
+        zalsa_local: &'db ZalsaLocal,
         key: Id,
     ) -> (Option<&'db AccumulatedMap>, InputAccumulatedValues) {
         // NEXT STEP: stash and refactor `fetch` to return an `&Memo` so we can make this work
-        let memo = self.refresh_memo(key);
+        let memo = self.refresh_memo(zalsa_local, key);
         (
             memo.header.revisions.accumulated(),
             memo.header.revisions.accumulated_inputs.load(),

--- a/src/function/accumulated.rs
+++ b/src/function/accumulated.rs
@@ -1,11 +1,12 @@
 use crate::accumulator::accumulated_map::{AccumulatedMap, InputAccumulatedValues};
 use crate::accumulator::{self};
-use crate::function::{Configuration, IngredientInDb};
+use crate::function::{Configuration, IngredientImpl};
 use crate::hash::FxHashSet;
+use crate::ingredient::IngredientInDb;
 use crate::zalsa_local::QueryOriginRef;
 use crate::{DatabaseKeyIndex, Id};
 
-impl<'db, C> IngredientInDb<'db, C>
+impl<'db, C> IngredientInDb<'db, C::DbView, IngredientImpl<C>>
 where
     C: Configuration,
 {
@@ -16,7 +17,7 @@ where
         A: accumulator::Accumulator,
     {
         let (zalsa, zalsa_local) = self.zalsas();
-        let db = self.db;
+        let db = self.db();
 
         // NOTE: We don't have a precise way to track accumulated values at present,
         // so we report any read of them as an untracked read.
@@ -39,7 +40,7 @@ where
         // First ensure the result is up to date
         self.fetch(key);
 
-        let db_key = self.database_key_index(key);
+        let db_key = self.ingredient().database_key_index(key);
         let mut visited: FxHashSet<DatabaseKeyIndex> = FxHashSet::default();
         let mut stack: Vec<DatabaseKeyIndex> = vec![db_key];
 

--- a/src/function/accumulated.rs
+++ b/src/function/accumulated.rs
@@ -93,14 +93,21 @@ where
         output
     }
 
-    pub(super) fn accumulated_map<'db>(
+    /// Returns the values accumulated by `key`.
+    ///
+    /// # Safety
+    ///
+    /// `self` must be registered in the `Zalsa` owned by `db`.
+    pub(super) unsafe fn accumulated_map<'db>(
         &'db self,
         db: &'db C::DbView,
         key: Id,
     ) -> (Option<&'db AccumulatedMap>, InputAccumulatedValues) {
         let (zalsa, zalsa_local) = db.zalsas();
         // NEXT STEP: stash and refactor `fetch` to return an `&Memo` so we can make this work
-        let memo = self.refresh_memo(db, zalsa, zalsa_local, key);
+        // SAFETY: The caller guarantees that `self` is registered in the `Zalsa` owned by `db`,
+        // and `zalsa` and `zalsa_local` were obtained from `db` above.
+        let memo = unsafe { self.refresh_memo(db, zalsa, zalsa_local, key) };
         (
             memo.header.revisions.accumulated(),
             memo.header.revisions.accumulated_inputs.load(),

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -41,7 +41,8 @@ where
         #[cfg(feature = "detailed-trace")]
         let _span = crate::tracing::debug_span!("fetch", query = ?database_key_index).entered();
 
-        let memo = self.refresh_memo(db, zalsa, zalsa_local, id);
+        // SAFETY: Guaranteed by the caller and asserted above in debug builds.
+        let memo = unsafe { self.refresh_memo(db, zalsa, zalsa_local, id) };
 
         // SAFETY: We just refreshed the memo so it is guaranteed to contain a value now.
         let memo_value = unsafe { memo.value().unwrap_unchecked() };
@@ -64,7 +65,13 @@ where
     }
 
     #[inline(always)]
-    pub(super) fn refresh_memo<'db>(
+    /// Refreshes the memo for `id`.
+    ///
+    /// # Safety
+    ///
+    /// `self` must be registered in `zalsa`, `db` must use `zalsa` as its storage, and
+    /// `zalsa_local` must be the local state paired with `db`.
+    pub(super) unsafe fn refresh_memo<'db>(
         &'db self,
         db: &'db C::DbView,
         zalsa: &'db Zalsa,
@@ -77,7 +84,8 @@ where
             // Keep the hot and cold probes in distinct control-flow blocks. Using `or_else`
             // here can outline both into one function, making hot hits pay for the cold path's
             // stack frame.
-            if let Some(memo) = self.fetch_hot(zalsa, id, memo_ingredient_index) {
+            // SAFETY: Guaranteed by the caller of `refresh_memo`.
+            if let Some(memo) = unsafe { self.fetch_hot(zalsa, id, memo_ingredient_index) } {
                 return memo;
             }
 
@@ -88,13 +96,21 @@ where
     }
 
     #[inline(always)]
-    fn fetch_hot<'db>(
+    /// Attempts to fetch a memo that is already valid in the current revision.
+    ///
+    /// # Safety
+    ///
+    /// `self` must be registered in `zalsa`.
+    unsafe fn fetch_hot<'db>(
         &'db self,
         zalsa: &'db Zalsa,
         id: Id,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> Option<&'db Memo<C>> {
-        let memo = self.get_memo_from_table_for(zalsa, id, memo_ingredient_index)?;
+        // SAFETY: The caller guarantees that `self` is registered in `zalsa`, and
+        // `memo_ingredient_index` was read from this ingredient's memo map.
+        let memo =
+            unsafe { self.get_memo_from_table_for_unchecked(zalsa, id, memo_ingredient_index)? };
 
         memo.value.as_ref()?;
 

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -3,7 +3,7 @@ use crate::function::eviction::EvictionPolicy;
 use crate::function::memo::Memo;
 use crate::function::sync::ClaimResult;
 use crate::function::{Configuration, IngredientImpl, Reentrancy};
-use crate::zalsa::{MemoIngredientIndex, Zalsa};
+use crate::zalsa::{MemoIngredientIndex, Zalsa, ZalsaDatabase};
 use crate::zalsa_local::{QueryRevisions, ZalsaLocal};
 use crate::{DatabaseKeyIndex, Id};
 
@@ -11,14 +11,29 @@ impl<C> IngredientImpl<C>
 where
     C: Configuration,
 {
+    /// Fetches the memoized value for `id`, executing the tracked function if necessary.
+    ///
+    /// # Safety
+    ///
+    /// `self` must be registered in `zalsa`, `db` must use `zalsa` as its storage, and
+    /// `zalsa_local` must be the local state paired with `db`.
     #[inline]
-    pub fn fetch<'db>(
+    pub unsafe fn fetch<'db>(
         &'db self,
         db: &'db C::DbView,
         zalsa: &'db Zalsa,
         zalsa_local: &'db ZalsaLocal,
         id: Id,
     ) -> &'db C::Output<'db> {
+        debug_assert!(std::ptr::eq(db.zalsa(), zalsa));
+        debug_assert!(std::ptr::eq(db.zalsa_local(), zalsa_local));
+        debug_assert!(std::ptr::eq(
+            self,
+            zalsa
+                .lookup_ingredient(self.index)
+                .assert_type::<IngredientImpl<C>>()
+        ));
+
         zalsa.unwind_if_revision_cancelled(zalsa_local);
 
         let database_key_index = self.database_key_index(id);

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -2,10 +2,24 @@ use crate::cycle::{CycleRecoveryStrategy, IterationStamp};
 use crate::function::eviction::EvictionPolicy;
 use crate::function::memo::Memo;
 use crate::function::sync::ClaimResult;
-use crate::function::{Configuration, IngredientImpl, Reentrancy};
-use crate::zalsa::{MemoIngredientIndex, Zalsa, ZalsaDatabase};
+use crate::function::{Configuration, IngredientImpl, IngredientInDb, Reentrancy};
+use crate::zalsa::{MemoIngredientIndex, Zalsa};
 use crate::zalsa_local::{QueryRevisions, ZalsaLocal};
 use crate::{DatabaseKeyIndex, Id};
+
+impl<'db, C> IngredientInDb<'db, C>
+where
+    C: Configuration,
+{
+    #[inline(always)]
+    pub fn fetch(&self, id: Id) -> &'db C::Output<'db> {
+        // SAFETY: `IngredientInDb` binds the ingredient, database, storage, and local state.
+        unsafe {
+            self.ingredient
+                .fetch(self.db, self.zalsa, self.zalsa_local, id)
+        }
+    }
+}
 
 impl<C> IngredientImpl<C>
 where
@@ -25,15 +39,6 @@ where
         zalsa_local: &'db ZalsaLocal,
         id: Id,
     ) -> &'db C::Output<'db> {
-        debug_assert!(std::ptr::eq(db.zalsa(), zalsa));
-        debug_assert!(std::ptr::eq(db.zalsa_local(), zalsa_local));
-        debug_assert!(std::ptr::eq(
-            self,
-            zalsa
-                .lookup_ingredient(self.index)
-                .assert_type::<IngredientImpl<C>>()
-        ));
-
         zalsa.unwind_if_revision_cancelled(zalsa_local);
 
         let database_key_index = self.database_key_index(id);

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -2,23 +2,24 @@ use crate::cycle::{CycleRecoveryStrategy, IterationStamp};
 use crate::function::eviction::EvictionPolicy;
 use crate::function::memo::Memo;
 use crate::function::sync::ClaimResult;
-use crate::function::{Configuration, IngredientImpl, IngredientInDb, Reentrancy};
+use crate::function::{Configuration, IngredientImpl, Reentrancy};
+use crate::ingredient::IngredientInDb;
 use crate::zalsa::{MemoIngredientIndex, Zalsa};
 use crate::zalsa_local::{QueryRevisions, ZalsaLocal};
 use crate::{DatabaseKeyIndex, Id};
 
-impl<'db, C> IngredientInDb<'db, C>
+impl<'db, C> IngredientInDb<'db, C::DbView, IngredientImpl<C>>
 where
     C: Configuration,
 {
     #[inline]
     pub fn fetch(&self, id: Id) -> &'db C::Output<'db> {
-        let zalsa = self.zalsa;
-        let zalsa_local = self.zalsa_local;
+        let zalsa = self.zalsa();
+        let zalsa_local = self.zalsa_local();
 
         zalsa.unwind_if_revision_cancelled(zalsa_local);
 
-        let database_key_index = self.database_key_index(id);
+        let database_key_index = self.ingredient().database_key_index(id);
 
         #[cfg(feature = "detailed-trace")]
         let _span = crate::tracing::debug_span!("fetch", query = ?database_key_index).entered();
@@ -28,7 +29,7 @@ where
         // SAFETY: We just refreshed the memo so it is guaranteed to contain a value now.
         let memo_value = unsafe { memo.value().unwrap_unchecked() };
 
-        self.eviction.record_use(id);
+        self.ingredient().eviction.record_use(id);
 
         let revisions = &memo.header.revisions;
         zalsa_local.report_tracked_read(
@@ -47,10 +48,10 @@ where
 
     #[inline(always)]
     pub(super) fn refresh_memo(&self, id: Id) -> &'db Memo<C> {
-        let ingredient = self.ingredient;
-        let db = self.db;
-        let zalsa = self.zalsa;
-        let zalsa_local = self.zalsa_local;
+        let ingredient = self.ingredient();
+        let db = self.db();
+        let zalsa = self.zalsa();
+        let zalsa_local = self.zalsa_local();
         let memo_ingredient_index = ingredient.memo_ingredient_index(zalsa, id);
 
         loop {
@@ -75,8 +76,8 @@ where
         id: Id,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> Option<&'db Memo<C>> {
-        let ingredient = self.ingredient;
-        let zalsa = self.zalsa;
+        let ingredient = self.ingredient();
+        let zalsa = self.zalsa();
 
         // SAFETY: `IngredientInDb` guarantees that the ingredient is registered in `zalsa`, and
         // `memo_ingredient_index` was read from that ingredient's memo map.
@@ -86,7 +87,7 @@ where
 
         memo.value()?;
 
-        let database_key_index = self.database_key_index(id);
+        let database_key_index = ingredient.database_key_index(id);
 
         let can_shallow_update = memo.header.shallow_verify_memo(
             zalsa,

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -11,7 +11,7 @@ impl<'db, C> IngredientInDb<'db, C>
 where
     C: Configuration,
 {
-    #[inline(always)]
+    #[inline]
     pub fn fetch(&self, id: Id) -> &'db C::Output<'db> {
         let zalsa = self.zalsa;
         let zalsa_local = self.zalsa_local;
@@ -48,9 +48,7 @@ where
     #[inline(always)]
     pub(super) fn refresh_memo(&self, id: Id) -> &'db Memo<C> {
         let ingredient = self.ingredient;
-        let db = self.db;
         let zalsa = self.zalsa;
-        let zalsa_local = self.zalsa_local;
         let memo_ingredient_index = ingredient.memo_ingredient_index(zalsa, id);
 
         loop {
@@ -61,9 +59,7 @@ where
                 return memo;
             }
 
-            if let Some(memo) =
-                ingredient.fetch_cold(zalsa, zalsa_local, db, id, memo_ingredient_index)
-            {
+            if let Some(memo) = self.fetch_cold(id, memo_ingredient_index) {
                 return memo;
             }
         }
@@ -105,6 +101,21 @@ where
         } else {
             None
         }
+    }
+
+    #[inline(always)]
+    fn fetch_cold(
+        &self,
+        id: Id,
+        memo_ingredient_index: MemoIngredientIndex,
+    ) -> Option<&'db Memo<'db, C>> {
+        self.ingredient.fetch_cold(
+            self.zalsa,
+            self.zalsa_local,
+            self.db,
+            id,
+            memo_ingredient_index,
+        )
     }
 }
 

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -13,9 +13,8 @@ where
     C: Configuration,
 {
     #[inline]
-    pub fn fetch(&self, id: Id) -> &'db C::Output<'db> {
+    pub fn fetch(&self, zalsa_local: &'db ZalsaLocal, id: Id) -> &'db C::Output<'db> {
         let zalsa = self.zalsa();
-        let zalsa_local = self.zalsa_local();
 
         zalsa.unwind_if_revision_cancelled(zalsa_local);
 
@@ -24,7 +23,7 @@ where
         #[cfg(feature = "detailed-trace")]
         let _span = crate::tracing::debug_span!("fetch", query = ?database_key_index).entered();
 
-        let memo = self.refresh_memo(id);
+        let memo = self.refresh_memo(zalsa_local, id);
 
         // SAFETY: We just refreshed the memo so it is guaranteed to contain a value now.
         let memo_value = unsafe { memo.value().unwrap_unchecked() };
@@ -47,11 +46,10 @@ where
     }
 
     #[inline(always)]
-    pub(super) fn refresh_memo(&self, id: Id) -> &'db Memo<C> {
+    pub(super) fn refresh_memo(&self, zalsa_local: &'db ZalsaLocal, id: Id) -> &'db Memo<C> {
         let ingredient = self.ingredient();
         let db = self.db();
         let zalsa = self.zalsa();
-        let zalsa_local = self.zalsa_local();
         let memo_ingredient_index = ingredient.memo_ingredient_index(zalsa, id);
 
         loop {

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -48,7 +48,9 @@ where
     #[inline(always)]
     pub(super) fn refresh_memo(&self, id: Id) -> &'db Memo<C> {
         let ingredient = self.ingredient;
+        let db = self.db;
         let zalsa = self.zalsa;
+        let zalsa_local = self.zalsa_local;
         let memo_ingredient_index = ingredient.memo_ingredient_index(zalsa, id);
 
         loop {
@@ -59,7 +61,9 @@ where
                 return memo;
             }
 
-            if let Some(memo) = self.fetch_cold(id, memo_ingredient_index) {
+            if let Some(memo) =
+                ingredient.fetch_cold(zalsa, zalsa_local, db, id, memo_ingredient_index)
+            {
                 return memo;
             }
         }
@@ -101,21 +105,6 @@ where
         } else {
             None
         }
-    }
-
-    #[inline(always)]
-    fn fetch_cold(
-        &self,
-        id: Id,
-        memo_ingredient_index: MemoIngredientIndex,
-    ) -> Option<&'db Memo<'db, C>> {
-        self.ingredient.fetch_cold(
-            self.zalsa,
-            self.zalsa_local,
-            self.db,
-            id,
-            memo_ingredient_index,
-        )
     }
 }
 

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -13,32 +13,9 @@ where
 {
     #[inline(always)]
     pub fn fetch(&self, id: Id) -> &'db C::Output<'db> {
-        // SAFETY: `IngredientInDb` binds the ingredient, database, storage, and local state.
-        unsafe {
-            self.ingredient
-                .fetch(self.db, self.zalsa, self.zalsa_local, id)
-        }
-    }
-}
+        let zalsa = self.zalsa;
+        let zalsa_local = self.zalsa_local;
 
-impl<C> IngredientImpl<C>
-where
-    C: Configuration,
-{
-    /// Fetches the memoized value for `id`, executing the tracked function if necessary.
-    ///
-    /// # Safety
-    ///
-    /// `self` must be registered in `zalsa`, `db` must use `zalsa` as its storage, and
-    /// `zalsa_local` must be the local state paired with `db`.
-    #[inline]
-    pub unsafe fn fetch<'db>(
-        &'db self,
-        db: &'db C::DbView,
-        zalsa: &'db Zalsa,
-        zalsa_local: &'db ZalsaLocal,
-        id: Id,
-    ) -> &'db C::Output<'db> {
         zalsa.unwind_if_revision_cancelled(zalsa_local);
 
         let database_key_index = self.database_key_index(id);
@@ -46,8 +23,7 @@ where
         #[cfg(feature = "detailed-trace")]
         let _span = crate::tracing::debug_span!("fetch", query = ?database_key_index).entered();
 
-        // SAFETY: Guaranteed by the caller and asserted above in debug builds.
-        let memo = unsafe { self.refresh_memo(db, zalsa, zalsa_local, id) };
+        let memo = self.refresh_memo(id);
 
         // SAFETY: We just refreshed the memo so it is guaranteed to contain a value now.
         let memo_value = unsafe { memo.value().unwrap_unchecked() };
@@ -70,54 +46,45 @@ where
     }
 
     #[inline(always)]
-    /// Refreshes the memo for `id`.
-    ///
-    /// # Safety
-    ///
-    /// `self` must be registered in `zalsa`, `db` must use `zalsa` as its storage, and
-    /// `zalsa_local` must be the local state paired with `db`.
-    pub(super) unsafe fn refresh_memo<'db>(
-        &'db self,
-        db: &'db C::DbView,
-        zalsa: &'db Zalsa,
-        zalsa_local: &'db ZalsaLocal,
-        id: Id,
-    ) -> &'db Memo<C> {
-        let memo_ingredient_index = self.memo_ingredient_index(zalsa, id);
+    pub(super) fn refresh_memo(&self, id: Id) -> &'db Memo<C> {
+        let ingredient = self.ingredient;
+        let db = self.db;
+        let zalsa = self.zalsa;
+        let zalsa_local = self.zalsa_local;
+        let memo_ingredient_index = ingredient.memo_ingredient_index(zalsa, id);
 
         loop {
             // Keep the hot and cold probes in distinct control-flow blocks. Using `or_else`
             // here can outline both into one function, making hot hits pay for the cold path's
             // stack frame.
-            // SAFETY: Guaranteed by the caller of `refresh_memo`.
-            if let Some(memo) = unsafe { self.fetch_hot(zalsa, id, memo_ingredient_index) } {
+            if let Some(memo) = self.fetch_hot(id, memo_ingredient_index) {
                 return memo;
             }
 
-            if let Some(memo) = self.fetch_cold(zalsa, zalsa_local, db, id, memo_ingredient_index) {
+            if let Some(memo) =
+                ingredient.fetch_cold(zalsa, zalsa_local, db, id, memo_ingredient_index)
+            {
                 return memo;
             }
         }
     }
 
     #[inline(always)]
-    /// Attempts to fetch a memo that is already valid in the current revision.
-    ///
-    /// # Safety
-    ///
-    /// `self` must be registered in `zalsa`.
-    unsafe fn fetch_hot<'db>(
-        &'db self,
-        zalsa: &'db Zalsa,
+    fn fetch_hot(
+        &self,
         id: Id,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> Option<&'db Memo<C>> {
-        // SAFETY: The caller guarantees that `self` is registered in `zalsa`, and
-        // `memo_ingredient_index` was read from this ingredient's memo map.
-        let memo =
-            unsafe { self.get_memo_from_table_for_unchecked(zalsa, id, memo_ingredient_index)? };
+        let ingredient = self.ingredient;
+        let zalsa = self.zalsa;
 
-        memo.value.as_ref()?;
+        // SAFETY: `IngredientInDb` guarantees that the ingredient is registered in `zalsa`, and
+        // `memo_ingredient_index` was read from that ingredient's memo map.
+        let memo = unsafe {
+            ingredient.get_memo_from_table_for_unchecked(zalsa, id, memo_ingredient_index)?
+        };
+
+        memo.value()?;
 
         let database_key_index = self.database_key_index(id);
 
@@ -134,12 +101,17 @@ where
 
             // SAFETY: memo is present in memo_map and we have verified that it is
             // still valid for the current revision.
-            unsafe { Some(self.extend_memo_lifetime(memo)) }
+            unsafe { Some(ingredient.extend_memo_lifetime(memo)) }
         } else {
             None
         }
     }
+}
 
+impl<C> IngredientImpl<C>
+where
+    C: Configuration,
+{
     fn fetch_cold<'db>(
         &'db self,
         zalsa: &'db Zalsa,

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -39,9 +39,13 @@ impl<C: Configuration> IngredientImpl<C> {
         id: Id,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> Option<&'db Memo<C>> {
-        let memo = zalsa
-            .memo_table_for::<C::SalsaStruct<'_>>(id)
-            .get(memo_ingredient_index)?;
+        // SAFETY: `memo_ingredient_index` comes from this ingredient's memo ingredient map, which
+        // registered `Memo<C>` as the type for the index.
+        let memo = unsafe {
+            zalsa
+                .memo_table_for::<C::SalsaStruct<'_>>(id)
+                .get(memo_ingredient_index)?
+        };
         // SAFETY: The memo table owns this allocation for at least `'db`.
         Some(unsafe { memo.as_ref() })
     }

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -39,12 +39,31 @@ impl<C: Configuration> IngredientImpl<C> {
         id: Id,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> Option<&'db Memo<C>> {
-        // SAFETY: `memo_ingredient_index` comes from this ingredient's memo ingredient map, which
-        // registered `Memo<C>` as the type for the index.
+        let memo = zalsa
+            .memo_table_for::<C::SalsaStruct<'_>>(id)
+            .get(memo_ingredient_index)?;
+        // SAFETY: The memo table owns this allocation for at least `'db`.
+        Some(unsafe { memo.as_ref() })
+    }
+
+    /// Loads the current memo without checking its registered type.
+    ///
+    /// # Safety
+    ///
+    /// `self` must be registered in `zalsa`, and `memo_ingredient_index` must come from this
+    /// ingredient's memo ingredient map.
+    pub(super) unsafe fn get_memo_from_table_for_unchecked<'db>(
+        &self,
+        zalsa: &'db Zalsa,
+        id: Id,
+        memo_ingredient_index: MemoIngredientIndex,
+    ) -> Option<&'db Memo<C>> {
+        // SAFETY: The caller guarantees that this ingredient's memo map registered `Memo<C>` at
+        // `memo_ingredient_index` in `zalsa`.
         let memo = unsafe {
             zalsa
                 .memo_table_for::<C::SalsaStruct<'_>>(id)
-                .get(memo_ingredient_index)?
+                .get_unchecked(memo_ingredient_index)?
         };
         // SAFETY: The memo table owns this allocation for at least `'db`.
         Some(unsafe { memo.as_ref() })

--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -3,7 +3,8 @@ use crate::accumulator::accumulated_map::InputAccumulatedValues;
 use crate::active_query::CompletedQuery;
 use crate::function::memo::Memo;
 use crate::function::sync::{ClaimResult, Reentrancy};
-use crate::function::{Configuration, IngredientImpl, IngredientInDb};
+use crate::function::{Configuration, IngredientImpl};
+use crate::ingredient::IngredientInDb;
 use crate::revision::AtomicRevision;
 use crate::sync::atomic::AtomicBool;
 use crate::tracked_struct::TrackedStructInDb;
@@ -11,7 +12,7 @@ use crate::zalsa::{Zalsa, ZalsaDatabase};
 use crate::zalsa_local::{OriginAndExtra, QueryOriginRef, QueryRevisions};
 use crate::{DatabaseKeyIndex, Id};
 
-impl<'db, C> IngredientInDb<'db, C>
+impl<'db, C> IngredientInDb<'db, C::DbView, IngredientImpl<C>>
 where
     C: Configuration,
 {
@@ -20,7 +21,7 @@ where
     where
         C::Input<'db>: TrackedStructInDb,
     {
-        self.ingredient.specify_and_record(self.db, key, value)
+        self.ingredient().specify_and_record(self.db(), key, value)
     }
 }
 

--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -5,7 +5,6 @@ use crate::function::memo::Memo;
 use crate::function::sync::{ClaimResult, Reentrancy};
 use crate::function::{Configuration, IngredientImpl};
 use crate::ingredient::IngredientInDb;
-use crate::revision::AtomicRevision;
 use crate::sync::atomic::AtomicBool;
 use crate::tracked_struct::TrackedStructInDb;
 use crate::zalsa::Zalsa;

--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -3,12 +3,26 @@ use crate::accumulator::accumulated_map::InputAccumulatedValues;
 use crate::active_query::CompletedQuery;
 use crate::function::memo::Memo;
 use crate::function::sync::{ClaimResult, Reentrancy};
-use crate::function::{Configuration, IngredientImpl};
+use crate::function::{Configuration, IngredientImpl, IngredientInDb};
+use crate::revision::AtomicRevision;
 use crate::sync::atomic::AtomicBool;
 use crate::tracked_struct::TrackedStructInDb;
 use crate::zalsa::{Zalsa, ZalsaDatabase};
 use crate::zalsa_local::{OriginAndExtra, QueryOriginRef, QueryRevisions};
 use crate::{DatabaseKeyIndex, Id};
+
+impl<'db, C> IngredientInDb<'db, C>
+where
+    C: Configuration,
+{
+    #[inline]
+    pub fn specify_and_record(&self, key: Id, value: C::Output<'db>)
+    where
+        C::Input<'db>: TrackedStructInDb,
+    {
+        self.ingredient.specify_and_record(self.db, key, value)
+    }
+}
 
 impl<C> IngredientImpl<C>
 where

--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -8,34 +8,22 @@ use crate::ingredient::IngredientInDb;
 use crate::revision::AtomicRevision;
 use crate::sync::atomic::AtomicBool;
 use crate::tracked_struct::TrackedStructInDb;
-use crate::zalsa::{Zalsa, ZalsaDatabase};
-use crate::zalsa_local::{OriginAndExtra, QueryOriginRef, QueryRevisions};
+use crate::zalsa::Zalsa;
+use crate::zalsa_local::{OriginAndExtra, QueryOriginRef, QueryRevisions, ZalsaLocal};
 use crate::{DatabaseKeyIndex, Id};
 
 impl<'db, C> IngredientInDb<'db, C::DbView, IngredientImpl<C>>
 where
     C: Configuration,
 {
-    #[inline]
-    pub fn specify_and_record(&self, key: Id, value: C::Output<'db>)
-    where
-        C::Input<'db>: TrackedStructInDb,
-    {
-        self.ingredient().specify_and_record(self.db(), key, value)
-    }
-}
-
-impl<C> IngredientImpl<C>
-where
-    C: Configuration,
-{
     /// Specify the value for `key` *and* record that we did so.
     /// Used for explicit calls to `specify`, but not needed for pre-declared tracked struct fields.
-    pub fn specify_and_record<'db>(&'db self, db: &'db C::DbView, key: Id, value: C::Output<'db>)
+    pub fn specify_and_record(&self, zalsa_local: &'db ZalsaLocal, key: Id, value: C::Output<'db>)
     where
         C::Input<'db>: TrackedStructInDb,
     {
-        let (zalsa, zalsa_local) = db.zalsas();
+        let ingredient = self.ingredient();
+        let zalsa = self.zalsa();
 
         let (active_query_key, current_deps, cycle_heads) =
             match zalsa_local.active_query_with_cycle_heads() {
@@ -80,12 +68,12 @@ where
         // - a result that is NOT verified and has untracked inputs, which will re-execute (and likely panic)
 
         let revision = zalsa.current_revision();
-        let database_key_index = self.database_key_index(key);
-        let memo_ingredient_index = self.memo_ingredient_index(zalsa, key);
+        let database_key_index = ingredient.database_key_index(key);
+        let memo_ingredient_index = ingredient.memo_ingredient_index(zalsa, key);
 
         zalsa.unwind_if_revision_cancelled(zalsa_local);
         let _claim_guard =
-            match self
+            match ingredient
                 .sync_table
                 .try_claim(zalsa, zalsa_local, key, Reentrancy::Deny)
             {
@@ -98,7 +86,7 @@ where
 
         // Re-read the memo after claiming the query so that no concurrent execution or
         // specification can replace it while we decide whether to keep or overwrite it.
-        let old_memo = self.get_memo_from_table_for(zalsa, key, memo_ingredient_index);
+        let old_memo = ingredient.get_memo_from_table_for(zalsa, key, memo_ingredient_index);
 
         if let Some(old_memo) = old_memo {
             if old_memo.header.verified_at.load() == revision && old_memo.value.is_some() {
@@ -143,7 +131,7 @@ where
             completed_query
                 .stale_tracked_structs
                 .extend_from_slice(old_memo.header.revisions.tracked_struct_ids());
-            self.backdate_if_appropriate(
+            ingredient.backdate_if_appropriate(
                 old_memo,
                 database_key_index,
                 &mut completed_query.revisions,
@@ -161,12 +149,17 @@ where
             memo.tracing_debug(),
             key
         );
-        self.insert_memo(zalsa, key, memo, memo_ingredient_index);
+        ingredient.insert_memo(zalsa, key, memo, memo_ingredient_index);
 
         // Record that the current query *specified* a value for this cell.
         zalsa_local.add_output(database_key_index);
     }
+}
 
+impl<C> IngredientImpl<C>
+where
+    C: Configuration,
+{
     /// Invoked when the query `executor` has been validated as having green inputs
     /// and `key` is a value that was specified by `executor`.
     /// Marks `key` as valid in the current revision since if `executor` had re-executed,

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -43,7 +43,6 @@ pub struct IngredientInDb<'db, Db: ?Sized, I> {
     ingredient: &'db I,
     db: &'db Db,
     zalsa: &'db Zalsa,
-    zalsa_local: &'db ZalsaLocal,
 }
 
 impl<'db, Db, I> IngredientInDb<'db, Db, I>
@@ -61,7 +60,31 @@ where
         db: &'db Db,
         get_ingredient: impl FnOnce(&'db Zalsa) -> &'db I,
     ) -> Self {
+        Self::new_unchecked_with_zalsa(db, db.zalsa(), get_ingredient)
+    }
+
+    /// Creates an ingredient bound to a database and returns its thread-local state.
+    ///
+    /// # Safety
+    ///
+    /// `get_ingredient` must return an ingredient registered in the `Zalsa` it receives.
+    #[inline]
+    pub unsafe fn new_unchecked_with_zalsa_local(
+        db: &'db Db,
+        get_ingredient: impl FnOnce(&'db Zalsa) -> &'db I,
+    ) -> (Self, &'db ZalsaLocal) {
         let (zalsa, zalsa_local) = db.zalsas();
+        (
+            Self::new_unchecked_with_zalsa(db, zalsa, get_ingredient),
+            zalsa_local,
+        )
+    }
+
+    fn new_unchecked_with_zalsa(
+        db: &'db Db,
+        zalsa: &'db Zalsa,
+        get_ingredient: impl FnOnce(&'db Zalsa) -> &'db I,
+    ) -> Self {
         let ingredient = get_ingredient(zalsa);
 
         debug_assert!(std::ptr::eq(
@@ -75,17 +98,11 @@ where
             ingredient,
             db,
             zalsa,
-            zalsa_local,
         }
     }
 }
 
 impl<'db, Db: ?Sized, I> IngredientInDb<'db, Db, I> {
-    #[inline]
-    pub fn zalsas(&self) -> (&'db Zalsa, &'db ZalsaLocal) {
-        (self.zalsa, self.zalsa_local)
-    }
-
     #[inline(always)]
     pub(crate) fn ingredient(&self) -> &'db I {
         self.ingredient
@@ -97,13 +114,8 @@ impl<'db, Db: ?Sized, I> IngredientInDb<'db, Db, I> {
     }
 
     #[inline(always)]
-    pub(crate) fn zalsa(&self) -> &'db Zalsa {
+    pub fn zalsa(&self) -> &'db Zalsa {
         self.zalsa
-    }
-
-    #[inline(always)]
-    pub(crate) fn zalsa_local(&self) -> &'db ZalsaLocal {
-        self.zalsa_local
     }
 }
 

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -7,10 +7,12 @@ use crate::function::VerifyResult;
 use crate::hash::{FxHashSet, FxIndexSet};
 use crate::runtime::Running;
 use crate::sync::Arc;
-use crate::table::Table;
 use crate::table::memo::MemoTableTypes;
-use crate::zalsa::{IngredientIndex, JarKind, Zalsa, transmute_data_mut_ptr, transmute_data_ptr};
-use crate::zalsa_local::{QueryEdge, QueryOriginRef};
+use crate::table::{Slot, Table};
+use crate::zalsa::{
+    IngredientIndex, JarKind, Zalsa, ZalsaDatabase, transmute_data_mut_ptr, transmute_data_ptr,
+};
+use crate::zalsa_local::{QueryEdge, QueryOriginRef, ZalsaLocal};
 use crate::{DatabaseKeyIndex, Id, Revision};
 
 /// A "jar" is a group of ingredients that are added atomically.
@@ -33,6 +35,100 @@ pub trait Jar: Any {
 pub struct Location {
     pub file: &'static str,
     pub line: u32,
+}
+
+/// An ingredient bound to the database that registered it.
+#[doc(hidden)]
+pub struct IngredientInDb<'db, Db: ?Sized, I> {
+    ingredient: &'db I,
+    db: &'db Db,
+    zalsa: &'db Zalsa,
+    zalsa_local: &'db ZalsaLocal,
+}
+
+impl<'db, Db, I> IngredientInDb<'db, Db, I>
+where
+    Db: ?Sized + ZalsaDatabase,
+    I: Ingredient,
+{
+    /// Creates an ingredient bound to a database.
+    ///
+    /// # Safety
+    ///
+    /// `get_ingredient` must return an ingredient registered in the `Zalsa` it receives.
+    #[inline]
+    pub unsafe fn new_unchecked(
+        db: &'db Db,
+        get_ingredient: impl FnOnce(&'db Zalsa) -> &'db I,
+    ) -> Self {
+        let (zalsa, zalsa_local) = db.zalsas();
+        let ingredient = get_ingredient(zalsa);
+
+        debug_assert!(std::ptr::eq(
+            ingredient,
+            zalsa
+                .lookup_ingredient(ingredient.ingredient_index())
+                .assert_type::<I>()
+        ));
+
+        Self {
+            ingredient,
+            db,
+            zalsa,
+            zalsa_local,
+        }
+    }
+}
+
+impl<'db, Db: ?Sized, I> IngredientInDb<'db, Db, I> {
+    #[inline]
+    pub fn zalsas(&self) -> (&'db Zalsa, &'db ZalsaLocal) {
+        (self.zalsa, self.zalsa_local)
+    }
+
+    #[inline(always)]
+    pub(crate) fn ingredient(&self) -> &'db I {
+        self.ingredient
+    }
+
+    #[inline(always)]
+    pub(crate) fn db(&self) -> &'db Db {
+        self.db
+    }
+
+    #[inline(always)]
+    pub(crate) fn zalsa(&self) -> &'db Zalsa {
+        self.zalsa
+    }
+
+    #[inline(always)]
+    pub(crate) fn zalsa_local(&self) -> &'db ZalsaLocal {
+        self.zalsa_local
+    }
+}
+
+impl<'db, Db: ?Sized, I: TableIngredient> IngredientInDb<'db, Db, I> {
+    #[inline(always)]
+    pub(crate) fn slot(&self, id: Id) -> &'db I::Slot {
+        // SAFETY: `IngredientInDb` guarantees that `ingredient` is registered in `zalsa`.
+        // `TableIngredient` guarantees that pages owned by the ingredient store `I::Slot`.
+        unsafe {
+            self.zalsa
+                .table()
+                .get_for_ingredient(id, self.ingredient.ingredient_index())
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn slot_raw(&self, id: Id) -> *mut I::Slot {
+        // SAFETY: `IngredientInDb` guarantees that `ingredient` is registered in `zalsa`.
+        // `TableIngredient` guarantees that pages owned by the ingredient store `I::Slot`.
+        unsafe {
+            self.zalsa
+                .table()
+                .get_raw_for_ingredient(id, self.ingredient.ingredient_index())
+        }
+    }
 }
 
 pub trait Ingredient: Any + fmt::Debug + Send + Sync {
@@ -282,6 +378,16 @@ pub trait Ingredient: Any + fmt::Debug + Send + Sync {
             "called `deserialize` on ingredient where `should_serialize` returns `false`"
         )
     }
+}
+
+/// Associates a table-owning ingredient with the type stored in its pages.
+///
+/// # Safety
+///
+/// Every table page owned by an implementation's ingredient index must store `Self::Slot`.
+#[doc(hidden)]
+pub unsafe trait TableIngredient: Ingredient {
+    type Slot: Slot;
 }
 
 impl dyn Ingredient {

--- a/src/ingredient_cache.rs
+++ b/src/ingredient_cache.rs
@@ -56,7 +56,8 @@ mod imp {
             &self,
             zalsa: &'db Zalsa,
         ) -> &'db I {
-            let mut ingredient_index = self.ingredient_index.load(Ordering::Acquire);
+            // The cached number does not publish any other state.
+            let mut ingredient_index = self.ingredient_index.load(Ordering::Relaxed);
             if ingredient_index == Self::UNINITIALIZED {
                 ingredient_index = get_or_create_index_slow(
                     &self.ingredient_index,
@@ -101,7 +102,7 @@ mod imp {
 
         // It doesn't matter if we overwrite any stores, as the jar lookup should
         // always return the same index when the `inventory` feature is enabled.
-        cached_index.store(ingredient_index.as_u32(), Ordering::Release);
+        cached_index.store(ingredient_index.as_u32(), Ordering::Relaxed);
 
         ingredient_index
     }
@@ -194,7 +195,8 @@ mod imp {
                 mem::size_of::<(Nonce<StorageNonce>, IngredientIndex)>() == mem::size_of::<u64>()
             );
 
-            let cached_data = self.cached_data.load(Ordering::Acquire);
+            // The cached number does not publish any other state.
+            let cached_data = self.cached_data.load(Ordering::Relaxed);
             if cached_data == UNINITIALIZED {
                 return get_or_create_index_slow(
                     &self.cached_data,
@@ -243,7 +245,7 @@ mod imp {
         debug_assert_ne!(packed, UNINITIALIZED);
 
         // Discard the result, whether we won over the cache or not doesn't matter.
-        _ = cache.compare_exchange(UNINITIALIZED, packed, Ordering::Release, Ordering::Relaxed);
+        _ = cache.compare_exchange(UNINITIALIZED, packed, Ordering::Relaxed, Ordering::Relaxed);
 
         // Use our locally computed index regardless of which one was cached.
         index

--- a/src/input.rs
+++ b/src/input.rs
@@ -121,6 +121,27 @@ pub struct IngredientImpl<C: Configuration> {
     _phantom: std::marker::PhantomData<C::Struct>,
 }
 
+impl<'db, Db: ?Sized, C: Configuration>
+    crate::ingredient::IngredientInDb<'db, Db, IngredientImpl<C>>
+{
+    /// Access a field of an input.
+    #[inline]
+    pub fn field(&self, id: C::Struct, field_index: usize) -> &'db C::Fields {
+        let ingredient = self.ingredient();
+        let field_ingredient_index = ingredient.ingredient_index.successor(field_index);
+        let id = id.as_id();
+        let value = self.slot(id);
+        let durability = value.durabilities[field_index];
+        let revision = value.revisions[field_index];
+        self.zalsa_local().report_tracked_read_simple(
+            DatabaseKeyIndex::new(field_ingredient_index, id),
+            durability,
+            revision,
+        );
+        &value.fields
+    }
+}
+
 impl<C: Configuration> IngredientImpl<C> {
     pub fn new(index: IngredientIndex) -> Self {
         Self {
@@ -222,29 +243,6 @@ impl<C: Configuration> IngredientImpl<C> {
         self.singleton
             .index()
             .map(|id| FromIdWithDb::from_id(id, zalsa))
-    }
-
-    /// Access field of an input.
-    /// Note that this function returns the entire tuple of value fields.
-    /// The caller is responsible for selecting the appropriate element.
-    pub fn field<'db>(
-        &'db self,
-        zalsa: &'db Zalsa,
-        zalsa_local: &'db ZalsaLocal,
-        id: C::Struct,
-        field_index: usize,
-    ) -> &'db C::Fields {
-        let field_ingredient_index = self.ingredient_index.successor(field_index);
-        let id = id.as_id();
-        let value = Self::data(zalsa, id);
-        let durability = value.durabilities[field_index];
-        let revision = value.revisions[field_index];
-        zalsa_local.report_tracked_read_simple(
-            DatabaseKeyIndex::new(field_ingredient_index, id),
-            durability,
-            revision,
-        );
-        &value.fields
     }
 
     /// Returns all data corresponding to the input struct.
@@ -466,6 +464,11 @@ where
 
 pub trait HasBuilder {
     type Builder;
+}
+
+// SAFETY: `IngredientImpl<C>` only allocates pages containing `Value<C>`.
+unsafe impl<C: Configuration> crate::ingredient::TableIngredient for IngredientImpl<C> {
+    type Slot = Value<C>;
 }
 
 // SAFETY: `Value<C>` is our private type branded over the unique configuration `C`.

--- a/src/input.rs
+++ b/src/input.rs
@@ -126,14 +126,19 @@ impl<'db, Db: ?Sized, C: Configuration>
 {
     /// Access a field of an input.
     #[inline]
-    pub fn field(&self, id: C::Struct, field_index: usize) -> &'db C::Fields {
+    pub fn field(
+        &self,
+        zalsa_local: &ZalsaLocal,
+        id: C::Struct,
+        field_index: usize,
+    ) -> &'db C::Fields {
         let ingredient = self.ingredient();
         let field_ingredient_index = ingredient.ingredient_index.successor(field_index);
         let id = id.as_id();
         let value = self.slot(id);
         let durability = value.durabilities[field_index];
         let revision = value.revisions[field_index];
-        self.zalsa_local().report_tracked_read_simple(
+        zalsa_local.report_tracked_read_simple(
             DatabaseKeyIndex::new(field_ingredient_index, id),
             durability,
             revision,

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -111,6 +111,22 @@ pub struct IngredientImpl<C: Configuration> {
     _marker: PhantomData<fn() -> C>,
 }
 
+impl<'db, Db: ?Sized, C: Configuration>
+    crate::ingredient::IngredientInDb<'db, Db, IngredientImpl<C>>
+{
+    /// Lookup the fields from an interned struct.
+    #[inline]
+    pub fn fields(&self, s: C::Struct<'db>) -> &'db C::Fields<'db> {
+        self.data(AsId::as_id(&s))
+    }
+
+    fn data(&self, id: Id) -> &'db C::Fields<'db> {
+        let ingredient = self.ingredient();
+        let value = self.slot(id);
+        ingredient.data_from_value(self.zalsa(), id, value)
+    }
+}
+
 struct IngredientShard {
     /// Maps from data to the existing interned ID for that data.
     ///
@@ -972,6 +988,15 @@ where
     pub fn data<'db>(&'db self, zalsa: &'db Zalsa, id: Id) -> &'db C::Fields<'db> {
         let value = zalsa.table().get::<Value<C>>(id);
 
+        self.data_from_value(zalsa, id, value)
+    }
+
+    fn data_from_value<'db>(
+        &'db self,
+        zalsa: &'db Zalsa,
+        id: Id,
+        value: &'db Value<C>,
+    ) -> &'db C::Fields<'db> {
         debug_assert!(
             {
                 let _shard = self.shards[value.header.shard as usize].lock();
@@ -1277,6 +1302,11 @@ where
             .field("index", &self.ingredient_index)
             .finish()
     }
+}
+
+// SAFETY: `IngredientImpl<C>` only allocates pages containing `Value<C>`.
+unsafe impl<C: Configuration> crate::ingredient::TableIngredient for IngredientImpl<C> {
+    type Slot = Value<C>;
 }
 
 // SAFETY: `Value<C>` is our private type branded over the unique configuration `C`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,7 +412,7 @@ pub mod plumbing {
     }
 
     pub mod function {
-        pub use crate::function::{Configuration, IngredientImpl, Memo};
+        pub use crate::function::{Configuration, IngredientImpl, IngredientInDb, Memo};
         pub use crate::function::{EvictionPolicy, HasCapacity, Lru, NoopEviction};
         pub use crate::table::memo::MemoEntryType;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,7 +352,7 @@ pub mod plumbing {
     pub use crate::database::{Database, current_revision};
     pub use crate::durability::Durability;
     pub use crate::id::{AsId, FromId, FromIdWithDb, Id};
-    pub use crate::ingredient::{Ingredient, Jar, Location};
+    pub use crate::ingredient::{Ingredient, IngredientInDb, Jar, Location};
     pub use crate::ingredient_cache::IngredientCache;
     pub use crate::interned::{HashEqLike, Lookup};
     pub use crate::key::DatabaseKeyIndex;
@@ -412,7 +412,7 @@ pub mod plumbing {
     }
 
     pub mod function {
-        pub use crate::function::{Configuration, IngredientImpl, IngredientInDb, Memo};
+        pub use crate::function::{Configuration, IngredientImpl, Memo};
         pub use crate::function::{EvictionPolicy, HasCapacity, Lru, NoopEviction};
         pub use crate::table::memo::MemoEntryType;
     }

--- a/src/table.rs
+++ b/src/table.rs
@@ -197,6 +197,60 @@ impl Table {
         page_ref.page_data()[slot.0].get().cast::<T>()
     }
 
+    /// Get a reference to the data for `id`, checking its page owner instead of its type.
+    ///
+    /// # Safety
+    ///
+    /// Pages owned by `ingredient` must store values of type `T`.
+    #[inline(always)]
+    pub(crate) unsafe fn get_for_ingredient<T: Slot>(
+        &self,
+        id: Id,
+        ingredient: IngredientIndex,
+    ) -> &T {
+        let (page, slot) = split_id(id);
+        // SAFETY: Guaranteed by the caller.
+        let page_ref = unsafe { self.page_for_ingredient::<T>(page, ingredient) };
+        &page_ref.data()[slot.0]
+    }
+
+    /// Get a raw pointer to the data for `id`, checking its page owner instead of its type.
+    ///
+    /// # Safety
+    ///
+    /// Pages owned by `ingredient` must store values of type `T`. See [`Page::get_raw`][].
+    #[inline(always)]
+    pub(crate) unsafe fn get_raw_for_ingredient<T: Slot>(
+        &self,
+        id: Id,
+        ingredient: IngredientIndex,
+    ) -> *mut T {
+        let (page, slot) = split_id(id);
+        // SAFETY: Guaranteed by the caller.
+        let page_ref = unsafe { self.page_for_ingredient::<T>(page, ingredient) };
+        page_ref.page_data()[slot.0].get().cast::<T>()
+    }
+
+    /// Gets a typed view of a page owned by `ingredient`.
+    ///
+    /// # Safety
+    ///
+    /// Pages owned by `ingredient` must store values of type `T`.
+    #[inline(always)]
+    unsafe fn page_for_ingredient<T: Slot>(
+        &self,
+        page: PageIndex,
+        ingredient: IngredientIndex,
+    ) -> PageView<'_, T> {
+        let page = &self.pages[page.0];
+        if page.ingredient != ingredient {
+            ingredient_assert_failed(page, ingredient);
+        }
+
+        debug_assert_eq!(page.slot_type_id, TypeId::of::<T>());
+        PageView(page, PhantomData)
+    }
+
     /// Returns the number of pages that have been allocated.
     pub fn page_count(&self) -> usize {
         self.pages.count()
@@ -570,6 +624,16 @@ fn type_assert_failed<T: 'static>(page: &Page) -> ! {
         "page has slot type `{:?}` but `{:?}` was expected",
         (page.slot_vtable.type_name)(),
         std::any::type_name::<T>(),
+    )
+}
+
+/// This function is explicitly outlined to keep debug machinery out of the hot path.
+#[cold]
+#[inline(never)]
+fn ingredient_assert_failed(page: &Page, expected: IngredientIndex) -> ! {
+    panic!(
+        "page belongs to ingredient `{:?}` but ingredient `{expected:?}` was expected",
+        page.ingredient,
     )
 }
 

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -390,7 +390,7 @@ impl<'a> MemoTableWithTypes<'a> {
                 .get_unchecked(memo_ingredient_index.as_usize())
         };
 
-        // Verify that we are casting to the correct type.
+        // Verify that the we are casting to the correct type.
         if type_.type_id != TypeId::of::<M>() {
             type_assert_failed(memo_ingredient_index);
         }

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -375,12 +375,39 @@ impl<'a> MemoTableWithTypes<'a> {
     }
 
     /// Returns a pointer to the memo at the given index, if one has been inserted.
+    #[inline]
+    pub(crate) fn get<M: Memo>(
+        self,
+        memo_ingredient_index: MemoIngredientIndex,
+    ) -> Option<NonNull<M>> {
+        let MemoEntry { atomic_memo } = self.memos.memos.get(memo_ingredient_index.as_usize())?;
+
+        // SAFETY: Any indices that are in-bounds for the `MemoTable` are also in-bounds for its
+        // corresponding `MemoTableTypes`, by construction.
+        let type_ = unsafe {
+            self.types
+                .types
+                .get_unchecked(memo_ingredient_index.as_usize())
+        };
+
+        // Verify that we are casting to the correct type.
+        if type_.type_id != TypeId::of::<M>() {
+            type_assert_failed(memo_ingredient_index);
+        }
+
+        NonNull::new(atomic_memo.load(Ordering::Acquire))
+            // SAFETY: We asserted that the type is correct above.
+            .map(|memo| unsafe { MemoEntryType::from_dummy(memo) })
+    }
+
+    /// Returns a pointer to the memo at the given index, if one has been inserted, without
+    /// checking its registered type.
     ///
     /// # Safety
     ///
     /// `M` must be the type registered for `memo_ingredient_index`.
     #[inline]
-    pub(crate) unsafe fn get<M: Memo>(
+    pub(crate) unsafe fn get_unchecked<M: Memo>(
         self,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> Option<NonNull<M>> {

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -375,28 +375,26 @@ impl<'a> MemoTableWithTypes<'a> {
     }
 
     /// Returns a pointer to the memo at the given index, if one has been inserted.
+    ///
+    /// # Safety
+    ///
+    /// `M` must be the type registered for `memo_ingredient_index`.
     #[inline]
-    pub(crate) fn get<M: Memo>(
+    pub(crate) unsafe fn get<M: Memo>(
         self,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> Option<NonNull<M>> {
         let MemoEntry { atomic_memo } = self.memos.memos.get(memo_ingredient_index.as_usize())?;
 
-        // SAFETY: Any indices that are in-bounds for the `MemoTable` are also in-bounds for its
-        // corresponding `MemoTableTypes`, by construction.
-        let type_ = unsafe {
-            self.types
-                .types
-                .get_unchecked(memo_ingredient_index.as_usize())
-        };
-
-        // Verify that the we are casting to the correct type.
-        if type_.type_id != TypeId::of::<M>() {
-            type_assert_failed(memo_ingredient_index);
-        }
+        debug_assert_eq!(
+            self.types.types[memo_ingredient_index.as_usize()].type_id,
+            TypeId::of::<M>(),
+            "inconsistent type-id for `{memo_ingredient_index:?}`"
+        );
 
         NonNull::new(atomic_memo.load(Ordering::Acquire))
-            // SAFETY: We asserted that the type is correct above.
+            // SAFETY: The caller guarantees that the registered type is `M`, and `insert` checks
+            // the registered type before storing the pointer.
             .map(|memo| unsafe { MemoEntryType::from_dummy(memo) })
     }
 

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -205,6 +205,52 @@ where
     memo_table_types: Arc<MemoTableTypes>,
 }
 
+impl<'db, Db: ?Sized, C: Configuration>
+    crate::ingredient::IngredientInDb<'db, Db, IngredientImpl<C>>
+{
+    /// Access a tracked field.
+    #[inline]
+    pub fn tracked_field(
+        &self,
+        s: C::Struct<'db>,
+        relative_tracked_index: usize,
+    ) -> &'db C::Fields<'db> {
+        let ingredient = self.ingredient();
+        let id = AsId::as_id(&s);
+        let field_ingredient_index = ingredient
+            .ingredient_index
+            .successor(relative_tracked_index);
+        let data = self.slot_raw(id);
+
+        // SAFETY: `data` belongs to the bound ingredient and database.
+        let fields = unsafe { ingredient.lock_fields(data, self.zalsa().current_revision()) };
+
+        // SAFETY: We acquired the read lock above, so `revisions` and `durability` are not aliased.
+        let field_changed_at = unsafe { (&(*data).revisions)[relative_tracked_index].load() };
+        let durability = unsafe { (*data).durability };
+        self.zalsa_local().report_tracked_read_simple(
+            DatabaseKeyIndex::new(field_ingredient_index, id),
+            durability,
+            field_changed_at,
+        );
+
+        fields
+    }
+
+    /// Access an untracked field.
+    #[inline]
+    pub fn untracked_field(&self, s: C::Struct<'db>) -> &'db C::Fields<'db> {
+        let data = self.slot_raw(AsId::as_id(&s));
+
+        // IDs that are reused increment their generation, invalidating dependent queries directly.
+        // SAFETY: `data` belongs to the bound ingredient and database.
+        unsafe {
+            self.ingredient()
+                .lock_fields(data, self.zalsa().current_revision())
+        }
+    }
+}
+
 /// Defines the identity of a tracked struct.
 /// This is the key to a hashmap that is (initially)
 /// stored in the [`ActiveQuery`](`crate::active_query::ActiveQuery`)
@@ -875,56 +921,6 @@ where
         unsafe { self.lock_fields(data, zalsa.current_revision()) }
     }
 
-    /// Access to this tracked field.
-    ///
-    /// Note that this function returns the entire tuple of value fields.
-    /// The caller is responsible for selecting the appropriate element.
-    pub fn tracked_field<'db>(
-        &'db self,
-        zalsa: &'db Zalsa,
-        zalsa_local: &'db ZalsaLocal,
-        s: C::Struct<'db>,
-        relative_tracked_index: usize,
-    ) -> &'db C::Fields<'db> {
-        let id = AsId::as_id(&s);
-        let field_ingredient_index = self.ingredient_index.successor(relative_tracked_index);
-        let data = Self::data_raw(zalsa.table(), id);
-
-        // SAFETY: `data` is a valid pointer acquired from the table.
-        let fields = unsafe { self.lock_fields(data, zalsa.current_revision()) };
-
-        // SAFETY: We just acquired the read lock (in `Self::fields`), so accessing `revisions` will not be able to alias
-        let field_changed_at = unsafe { (&(*data).revisions)[relative_tracked_index].load() };
-
-        // SAFETY: We just acquired the read lock (in `Self::fields`), so accessing `durability` will not be able to alias
-        zalsa_local.report_tracked_read_simple(
-            DatabaseKeyIndex::new(field_ingredient_index, id),
-            unsafe { (*data).durability },
-            field_changed_at,
-        );
-
-        fields
-    }
-
-    /// Access to this untracked field.
-    ///
-    /// Note that this function returns the entire tuple of value fields.
-    /// The caller is responsible for selecting the appropriate element.
-    pub fn untracked_field<'db>(
-        &'db self,
-        zalsa: &'db Zalsa,
-        s: C::Struct<'db>,
-    ) -> &'db C::Fields<'db> {
-        let id = AsId::as_id(&s);
-        let data = Self::data_raw(zalsa.table(), id);
-
-        // Note that we do not need to add a dependency on the tracked struct
-        // as IDs that are reused increment their generation, invalidating any
-        // dependent queries directly.
-        // SAFETY: `data` is a valid pointer acquired from the table.
-        unsafe { self.lock_fields(data, zalsa.current_revision()) }
-    }
-
     /// Returns all data corresponding to the tracked struct.
     pub fn entries<'db>(&'db self, zalsa: &'db Zalsa) -> impl Iterator<Item = StructEntry<'db, C>> {
         zalsa
@@ -1175,6 +1171,11 @@ where
             memos: memos.memory_usage(),
         }
     }
+}
+
+// SAFETY: `IngredientImpl<C>` only allocates pages containing `Value<C>`.
+unsafe impl<C: Configuration> crate::ingredient::TableIngredient for IngredientImpl<C> {
+    type Slot = Value<C>;
 }
 
 // SAFETY: `Value<C>` is our private type branded over the unique configuration `C`.

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -212,6 +212,7 @@ impl<'db, Db: ?Sized, C: Configuration>
     #[inline]
     pub fn tracked_field(
         &self,
+        zalsa_local: &ZalsaLocal,
         s: C::Struct<'db>,
         relative_tracked_index: usize,
     ) -> &'db C::Fields<'db> {
@@ -228,7 +229,7 @@ impl<'db, Db: ?Sized, C: Configuration>
         // SAFETY: We acquired the read lock above, so `revisions` and `durability` are not aliased.
         let field_changed_at = unsafe { (&(*data).revisions)[relative_tracked_index].load() };
         let durability = unsafe { (*data).durability };
-        self.zalsa_local().report_tracked_read_simple(
+        zalsa_local.report_tracked_read_simple(
             DatabaseKeyIndex::new(field_ingredient_index, id),
             durability,
             field_changed_at,

--- a/tests/compile-fail/specify-does-not-work-if-the-key-is-a-salsa-input.stderr
+++ b/tests/compile-fail/specify-does-not-work-if-the-key-is-a-salsa-input.stderr
@@ -14,12 +14,12 @@ help: the trait `salsa::plumbing::TrackedStructInDb` is implemented for `MyTrack
    |
 10 | #[salsa::tracked]
    | ^^^^^^^^^^^^^^^^^
-note: required by a bound in `salsa::function::specify::<impl salsa::function::IngredientImpl<C>>::specify_and_record`
+note: required by a bound in `salsa::function::specify::<impl salsa::function::IngredientInDb<'db, C>>::specify_and_record`
   --> src/function/specify.rs
    |
-   |     pub fn specify_and_record<'db>(&'db self, db: &'db C::DbView, key: Id, value: C::Output<'db>)
+   |     pub fn specify_and_record(&self, key: Id, value: C::Output<'db>)
    |            ------------------ required by a bound in this associated function
    |     where
    |         C::Input<'db>: TrackedStructInDb,
-   |                        ^^^^^^^^^^^^^^^^^ required by this bound in `salsa::function::specify::<impl IngredientImpl<C>>::specify_and_record`
+   |                        ^^^^^^^^^^^^^^^^^ required by this bound in `salsa::function::specify::<impl IngredientInDb<'db, C>>::specify_and_record`
    = note: this error originates in the macro `salsa::plumbing::setup_tracked_fn` which comes from the expansion of the attribute macro `salsa::tracked` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-fail/specify-does-not-work-if-the-key-is-a-salsa-interned.stderr
+++ b/tests/compile-fail/specify-does-not-work-if-the-key-is-a-salsa-interned.stderr
@@ -14,12 +14,12 @@ help: the trait `salsa::plumbing::TrackedStructInDb` is implemented for `MyTrack
    |
 10 | #[salsa::tracked]
    | ^^^^^^^^^^^^^^^^^
-note: required by a bound in `salsa::function::specify::<impl salsa::function::IngredientImpl<C>>::specify_and_record`
+note: required by a bound in `salsa::function::specify::<impl salsa::function::IngredientInDb<'db, C>>::specify_and_record`
   --> src/function/specify.rs
    |
-   |     pub fn specify_and_record<'db>(&'db self, db: &'db C::DbView, key: Id, value: C::Output<'db>)
+   |     pub fn specify_and_record(&self, key: Id, value: C::Output<'db>)
    |            ------------------ required by a bound in this associated function
    |     where
    |         C::Input<'db>: TrackedStructInDb,
-   |                        ^^^^^^^^^^^^^^^^^ required by this bound in `salsa::function::specify::<impl IngredientImpl<C>>::specify_and_record`
+   |                        ^^^^^^^^^^^^^^^^^ required by this bound in `salsa::function::specify::<impl IngredientInDb<'db, C>>::specify_and_record`
    = note: this error originates in the macro `salsa::plumbing::setup_tracked_fn` which comes from the expansion of the attribute macro `salsa::tracked` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/field_access_in_db.rs
+++ b/tests/field_access_in_db.rs
@@ -1,0 +1,24 @@
+#[salsa::input]
+struct FirstInput {
+    #[returns(copy)]
+    value: u32,
+}
+
+#[salsa::input]
+struct SecondInput {
+    #[returns(copy)]
+    value: u32,
+}
+
+#[test]
+#[should_panic(expected = "page belongs to ingredient")]
+fn field_access_rejects_id_owned_by_another_ingredient() {
+    let db = salsa::DatabaseImpl::default();
+    let _first = FirstInput::new(&db, 1);
+    let second = SecondInput::new(&db, 2);
+
+    let forged =
+        <FirstInput as salsa::plumbing::FromId>::from_id(salsa::plumbing::AsId::as_id(&second));
+
+    forged.value(&db);
+}


### PR DESCRIPTION
Memo and field lookups repeated TypeId checks even though the database-bound ingredient fixes the accessed type. Bind each ingredient to its database context and acquire thread-local state only for operations that need it.

Fixed hot memo hits drop from 233 to 228 instructions (-2.15%), untracked tracked-struct field bodies drop from 59 to 58, CodSpeed reports a 6.76% aggregate improvement, and ty's 29-case suite improves by 0.145% weighted overall.

Testing: Full target, manual-registration, lint, and performance suites passed.