### PR TITLE
perf: store interned revisions inline

### DIFF
--- a/src/interned.rs
+++ b/src/interned.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 use crossbeam_utils::CachePadded;
 use intrusive_collections::{LinkedList, LinkedListLink, UnsafeRef, intrusive_adapter};
 use rustc_hash::FxBuildHasher;
+use smallvec::SmallVec;
 
 use crate::durability::Durability;
 use crate::function::VerifyResult;
@@ -1103,8 +1104,8 @@ where
 /// read, as revisions may be created in bursts.
 struct RevisionQueue<C> {
     lock: Mutex<()>,
-    // Once `feature(generic_const_exprs)` is stable this can just be an array.
-    revisions: Box<[AtomicRevision]>,
+    /// Recent revisions, stored inline for the default configuration.
+    revisions: SmallVec<[AtomicRevision; 3]>,
     _configuration: PhantomData<fn() -> C>,
 }
 
@@ -1114,7 +1115,7 @@ const IMMORTAL: NonZeroUsize = NonZeroUsize::MAX;
 impl<C: Configuration> Default for RevisionQueue<C> {
     fn default() -> RevisionQueue<C> {
         let revisions = if C::REVISIONS == IMMORTAL {
-            Box::default()
+            SmallVec::new()
         } else {
             (0..C::REVISIONS.get())
                 .map(|_| AtomicRevision::start())

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -26,6 +26,13 @@ use crate::zalsa::{IngredientIndex, JarKind, Zalsa};
 use crate::zalsa_local::QueryEdge;
 use crate::{DatabaseKeyIndex, Event, EventKind, Id, Revision};
 
+#[cfg(not(test))]
+const DEFAULT_REVISIONS: usize = 3;
+
+// More aggressive garbage collection by default when testing.
+#[cfg(test)]
+const DEFAULT_REVISIONS: usize = 1;
+
 /// Trait that defines the key properties of an interned struct.
 ///
 /// Implemented by the `#[salsa::interned]` macro when applied to
@@ -38,11 +45,7 @@ pub trait Configuration: Sized + 'static {
     const PERSIST: bool;
 
     // The minimum number of revisions that must pass before a stale value is garbage collected.
-    #[cfg(not(test))]
-    const REVISIONS: NonZeroUsize = NonZeroUsize::new(3).unwrap();
-
-    #[cfg(test)] // More aggressive garbage collection by default when testing.
-    const REVISIONS: NonZeroUsize = NonZeroUsize::new(1).unwrap();
+    const REVISIONS: NonZeroUsize = NonZeroUsize::new(DEFAULT_REVISIONS).unwrap();
 
     /// The fields of the struct being interned.
     type Fields<'db>: InternedData;
@@ -1105,7 +1108,7 @@ where
 struct RevisionQueue<C> {
     lock: Mutex<()>,
     /// Recent revisions, stored inline for the default configuration.
-    revisions: SmallVec<[AtomicRevision; 3]>,
+    revisions: SmallVec<[AtomicRevision; DEFAULT_REVISIONS]>,
     _configuration: PhantomData<fn() -> C>,
 }
 

--- a/tests/interned-revisions.rs
+++ b/tests/interned-revisions.rs
@@ -196,6 +196,40 @@ struct Immortal<'db> {
     field1: BadHash,
 }
 
+#[salsa::interned(revisions = 4)]
+#[derive(Debug)]
+struct SpilledInterned<'db> {
+    field1: BadHash,
+}
+
+#[test]
+fn test_revisions_above_inline_capacity() {
+    #[salsa::tracked]
+    fn function(db: &dyn Database, input: Input) -> SpilledInterned<'_> {
+        SpilledInterned::new(db, BadHash(input.field1(db)))
+    }
+
+    let mut db = common::EventLoggerDatabase::default();
+    let input = Input::new(&db, 0);
+
+    let result = function(&db, input);
+    assert_eq!(result.field1(&db).0, 0);
+    assert_eq!(salsa::plumbing::AsId::as_id(&result).generation(), 0);
+
+    for i in 1..4 {
+        input.set_field1(&mut db).to(i);
+
+        let result = function(&db, input);
+        assert_eq!(result.field1(&db).0, i);
+        assert_eq!(salsa::plumbing::AsId::as_id(&result).generation(), 0);
+    }
+
+    input.set_field1(&mut db).to(4);
+    let result = function(&db, input);
+    assert_eq!(result.field1(&db).0, 4);
+    assert_eq!(salsa::plumbing::AsId::as_id(&result).generation(), 1);
+}
+
 #[test]
 fn test_immortal() {
     #[salsa::tracked]


### PR DESCRIPTION
Store the common three-entry interned revision queue inline, avoiding an allocation and pointer chase on every intern operation.
On ty's Tanjun benchmark, this reduced whole-workload L1 read misses by 1.85% and wall time by about 0.65%, with the wall-time result within run-to-run noise.