### PR TITLE
perf: skip empty cycle-head propagation

### DIFF
--- a/src/cycle.rs
+++ b/src/cycle.rs
@@ -309,6 +309,10 @@ impl CycleHeads {
 
     #[inline]
     pub(crate) fn extend(&mut self, other: &Self) {
+        if other.is_empty() {
+            return;
+        }
+
         self.0.reserve(other.0.len());
 
         for head in other {


### PR DESCRIPTION
Most cycle-head propagation in the Tanjun workload extends with an empty set, but reserving zero capacity still enters allocation machinery. Return early for empty sources, reducing the single-threaded Callgrind instruction count by 0.86% (38.1 million instructions).

Testing: The full test suite passes.