### PR TITLE
perf: allocate memo table slots lazily

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -69,6 +69,15 @@ pub mod shim {
             }
         }
 
+        pub fn get_mut(&mut self) -> Option<&mut T> {
+            if *self.0.get_mut() {
+                // SAFETY: The value is initialized and we have exclusive access to the lock.
+                Some(unsafe { self.1.get_mut().assume_init_mut() })
+            } else {
+                None
+            }
+        }
+
         pub fn get_or_init<F>(&self, f: F) -> &T
         where
             F: FnOnce() -> T,
@@ -92,11 +101,26 @@ pub mod shim {
 
             Ok(())
         }
+
+        pub fn take(&mut self) -> Option<T> {
+            if std::mem::take(self.0.get_mut()) {
+                // SAFETY: The value was initialized, and clearing the flag transfers ownership.
+                Some(unsafe { self.1.get_mut().assume_init_read() })
+            } else {
+                None
+            }
+        }
     }
 
     impl<T> From<T> for OnceLock<T> {
         fn from(value: T) -> OnceLock<T> {
             OnceLock(Mutex::new(true), UnsafeCell::new(MaybeUninit::new(value)))
+        }
+    }
+
+    impl<T> Drop for OnceLock<T> {
+        fn drop(&mut self) {
+            drop(self.take());
         }
     }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -69,15 +69,6 @@ pub mod shim {
             }
         }
 
-        pub fn get_mut(&mut self) -> Option<&mut T> {
-            if *self.0.get_mut() {
-                // SAFETY: The value is initialized and we have exclusive access to the lock.
-                Some(unsafe { self.1.get_mut().assume_init_mut() })
-            } else {
-                None
-            }
-        }
-
         pub fn get_or_init<F>(&self, f: F) -> &T
         where
             F: FnOnce() -> T,
@@ -101,26 +92,11 @@ pub mod shim {
 
             Ok(())
         }
-
-        pub fn take(&mut self) -> Option<T> {
-            if std::mem::take(self.0.get_mut()) {
-                // SAFETY: The value was initialized, and clearing the flag transfers ownership.
-                Some(unsafe { self.1.get_mut().assume_init_read() })
-            } else {
-                None
-            }
-        }
     }
 
     impl<T> From<T> for OnceLock<T> {
         fn from(value: T) -> OnceLock<T> {
             OnceLock(Mutex::new(true), UnsafeCell::new(MaybeUninit::new(value)))
-        }
-    }
-
-    impl<T> Drop for OnceLock<T> {
-        fn drop(&mut self) {
-            drop(self.take());
         }
     }
 

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -102,7 +102,8 @@ impl LazyMemoEntries {
             return None;
         }
 
-        Some(&self.initialize()[index])
+        let memos = self.as_slice().unwrap_or_else(|| self.initialize());
+        Some(&memos[index])
     }
 
     #[inline]
@@ -122,6 +123,9 @@ impl LazyMemoEntries {
     fn as_slice(&self) -> Option<&[MemoEntry]> {
         let ptr = NonNull::new(self.ptr.load(Ordering::Acquire))?;
 
+        // The acquire load synchronizes with the release operation that published the pointer,
+        // ensuring that the memo entries are initialized before we create references to them.
+        //
         // SAFETY: A non-null pointer comes from a boxed slice of length `self.len`. The allocation
         // cannot be freed while `self` is shared.
         Some(unsafe { std::slice::from_raw_parts(ptr.as_ptr(), self.len) })
@@ -138,14 +142,12 @@ impl LazyMemoEntries {
 
     #[cold]
     fn initialize(&self) -> &[MemoEntry] {
-        if let Some(memos) = self.as_slice() {
-            return memos;
-        }
-
         let new_memos: Box<[MemoEntry]> = (0..self.len).map(|_| MemoEntry::default()).collect();
         let new_memos = Box::into_raw(new_memos);
         let new_memos_ptr = new_memos.cast::<MemoEntry>();
 
+        // Release publishes the initialized memo entries. If another thread won the race, acquire
+        // synchronizes with its release operation before we create references to its allocation.
         let ptr = match self.ptr.compare_exchange(
             ptr::null_mut(),
             new_memos_ptr,

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -142,8 +142,9 @@ impl LazyMemoEntries {
             return memos;
         }
 
-        let mut new_memos: Box<[MemoEntry]> = (0..self.len).map(|_| MemoEntry::default()).collect();
-        let new_memos_ptr = new_memos.as_mut_ptr();
+        let new_memos: Box<[MemoEntry]> = (0..self.len).map(|_| MemoEntry::default()).collect();
+        let new_memos = Box::into_raw(new_memos);
+        let new_memos_ptr = new_memos.cast::<MemoEntry>();
 
         let ptr = match self.ptr.compare_exchange(
             ptr::null_mut(),
@@ -151,11 +152,13 @@ impl LazyMemoEntries {
             Ordering::Release,
             Ordering::Acquire,
         ) {
-            Ok(_) => {
-                mem::forget(new_memos);
-                new_memos_ptr
+            Ok(_) => new_memos_ptr,
+            Err(ptr) => {
+                // SAFETY: The compare-exchange failed, so `new_memos` was not published and this
+                // thread retains ownership of the allocation.
+                unsafe { drop(Box::from_raw(new_memos)) };
+                ptr
             }
-            Err(ptr) => ptr,
         };
 
         // SAFETY: `ptr` is either the boxed slice allocated above or the boxed slice published by

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -3,10 +3,7 @@ use std::fmt::Debug;
 use std::mem;
 use std::ptr::{self, NonNull};
 
-use thin_vec::ThinVec;
-
 use crate::DatabaseKeyIndex;
-use crate::sync::OnceLock;
 use crate::sync::atomic::{AtomicPtr, Ordering};
 use crate::zalsa::MemoIngredientIndex;
 use crate::zalsa::Zalsa;
@@ -15,7 +12,7 @@ use crate::zalsa::Zalsa;
 /// Every tracked function must take a salsa struct as its first argument
 /// and memo tables are attached to those salsa structs as auxiliary data.
 pub struct MemoTable {
-    memos: OnceLock<ThinVec<MemoEntry>>,
+    memos: LazyMemoEntries,
 }
 
 #[cfg(not(feature = "shuttle"))]
@@ -27,9 +24,12 @@ impl MemoTable {
     /// # Safety
     ///
     /// The created memo table must only be accessed with the same `MemoTableTypes`.
-    pub unsafe fn new(_types: &MemoTableTypes) -> Self {
+    pub unsafe fn new(types: &MemoTableTypes) -> Self {
+        // Note that the safety invariant guarantees that any indices in-bounds for
+        // this table are also in-bounds for its `MemoTableTypes`, as `MemoTableTypes`
+        // is append-only.
         Self {
-            memos: OnceLock::new(),
+            memos: LazyMemoEntries::new(types.len()),
         }
     }
 
@@ -37,15 +37,7 @@ impl MemoTable {
     ///
     /// Note that the memo entries should be freed manually before calling this function.
     pub fn reset(&mut self) {
-        self.memos.take();
-    }
-
-    fn get_or_init(&self, len: usize) -> &ThinVec<MemoEntry> {
-        self.memos.get_or_init(|| {
-            let mut memos = ThinVec::with_capacity(len);
-            memos.extend((0..len).map(|_| MemoEntry::default()));
-            memos
-        })
+        self.memos.clear();
     }
 }
 
@@ -80,6 +72,114 @@ pub trait Memo: Any + Send + Sync {
 struct MemoEntry {
     /// An [`AtomicPtr`][] to a `Box<M>` for the erased memo type `M`
     atomic_memo: AtomicPtr<DummyMemo>,
+}
+
+/// Lazily allocated, fixed-length memo entries.
+///
+/// The pointer and length have the same inline layout as an eager `Box<[MemoEntry]>`, but a null
+/// pointer represents an allocation that has not been created yet.
+struct LazyMemoEntries {
+    ptr: AtomicPtr<MemoEntry>,
+    len: usize,
+}
+
+impl LazyMemoEntries {
+    fn new(len: usize) -> Self {
+        Self {
+            ptr: AtomicPtr::new(ptr::null_mut()),
+            len,
+        }
+    }
+
+    #[inline]
+    fn get(&self, index: usize) -> Option<&MemoEntry> {
+        self.as_slice()?.get(index)
+    }
+
+    #[inline]
+    fn get_or_init(&self, index: usize) -> Option<&MemoEntry> {
+        if index >= self.len {
+            return None;
+        }
+
+        Some(&self.initialize()[index])
+    }
+
+    #[inline]
+    fn get_mut(&mut self, index: usize) -> Option<&mut MemoEntry> {
+        self.as_mut_slice()?.get_mut(index)
+    }
+
+    fn iter(&self) -> std::slice::Iter<'_, MemoEntry> {
+        self.as_slice().unwrap_or_default().iter()
+    }
+
+    fn iter_mut(&mut self) -> std::slice::IterMut<'_, MemoEntry> {
+        self.as_mut_slice().unwrap_or_default().iter_mut()
+    }
+
+    #[inline]
+    fn as_slice(&self) -> Option<&[MemoEntry]> {
+        let ptr = NonNull::new(self.ptr.load(Ordering::Acquire))?;
+
+        // SAFETY: A non-null pointer comes from a boxed slice of length `self.len`. The allocation
+        // cannot be freed while `self` is shared.
+        Some(unsafe { std::slice::from_raw_parts(ptr.as_ptr(), self.len) })
+    }
+
+    #[inline]
+    fn as_mut_slice(&mut self) -> Option<&mut [MemoEntry]> {
+        let ptr = NonNull::new(*self.ptr.get_mut())?;
+
+        // SAFETY: A non-null pointer comes from a boxed slice of length `self.len`, and exclusive
+        // access guarantees that no other references exist.
+        Some(unsafe { std::slice::from_raw_parts_mut(ptr.as_ptr(), self.len) })
+    }
+
+    #[cold]
+    fn initialize(&self) -> &[MemoEntry] {
+        if let Some(memos) = self.as_slice() {
+            return memos;
+        }
+
+        let mut new_memos: Box<[MemoEntry]> = (0..self.len).map(|_| MemoEntry::default()).collect();
+        let new_memos_ptr = new_memos.as_mut_ptr();
+
+        let ptr = match self.ptr.compare_exchange(
+            ptr::null_mut(),
+            new_memos_ptr,
+            Ordering::Release,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => {
+                mem::forget(new_memos);
+                new_memos_ptr
+            }
+            Err(ptr) => ptr,
+        };
+
+        // SAFETY: `ptr` is either the boxed slice allocated above or the boxed slice published by
+        // another thread. Both allocations have length `self.len` and cannot be freed while `self`
+        // is shared.
+        unsafe { std::slice::from_raw_parts(ptr, self.len) }
+    }
+
+    fn clear(&mut self) {
+        let ptr = mem::replace(self.ptr.get_mut(), ptr::null_mut());
+        if ptr.is_null() {
+            return;
+        }
+
+        // SAFETY: `ptr` came from a boxed slice of length `self.len`, and exclusive access
+        // guarantees that no references to the allocation remain.
+        unsafe { drop(Box::from_raw(ptr::slice_from_raw_parts_mut(ptr, self.len))) };
+    }
+}
+
+impl Drop for LazyMemoEntries {
+    fn drop(&mut self) {
+        self.clear();
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -197,16 +297,22 @@ impl MemoTableWithTypes<'_> {
         memo_ingredient_index: MemoIngredientIndex,
         memo: NonNull<M>,
     ) -> Option<NonNull<M>> {
-        let memo_ingredient_index = memo_ingredient_index.as_usize();
-        let type_ = self.types.types.get(memo_ingredient_index)?;
         let MemoEntry { atomic_memo } = self
             .memos
-            .get_or_init(self.types.len())
-            .get(memo_ingredient_index)?;
+            .memos
+            .get_or_init(memo_ingredient_index.as_usize())?;
+
+        // SAFETY: Any indices that are in-bounds for the `MemoTable` are also in-bounds for its
+        // corresponding `MemoTableTypes`, by construction.
+        let type_ = unsafe {
+            self.types
+                .types
+                .get_unchecked(memo_ingredient_index.as_usize())
+        };
 
         // Verify that the we are casting to the correct type.
         if type_.type_id != TypeId::of::<M>() {
-            type_assert_failed(MemoIngredientIndex::from_usize(memo_ingredient_index));
+            type_assert_failed(memo_ingredient_index);
         }
 
         let old_memo = atomic_memo.swap(MemoEntryType::to_dummy(memo).as_ptr(), Ordering::AcqRel);
@@ -221,11 +327,7 @@ impl MemoTableWithTypes<'_> {
         self,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> Option<NonNull<M>> {
-        let MemoEntry { atomic_memo } = self
-            .memos
-            .memos
-            .get()?
-            .get(memo_ingredient_index.as_usize())?;
+        let MemoEntry { atomic_memo } = self.memos.memos.get(memo_ingredient_index.as_usize())?;
 
         // SAFETY: Any indices that are in-bounds for the `MemoTable` are also in-bounds for its
         // corresponding `MemoTableTypes`, by construction.
@@ -248,10 +350,7 @@ impl MemoTableWithTypes<'_> {
     #[cfg(feature = "salsa_unstable")]
     pub(crate) fn memory_usage(&self) -> Vec<crate::database::MemoInfo> {
         let mut memory_usage = Vec::new();
-        let Some(memos) = self.memos.memos.get() else {
-            return memory_usage;
-        };
-        for (index, memo) in memos.iter().enumerate() {
+        for (index, memo) in self.memos.memos.iter().enumerate() {
             let Some(memo) = NonNull::new(memo.atomic_memo.load(Ordering::Acquire)) else {
                 continue;
             };
@@ -283,10 +382,8 @@ impl MemoTableWithTypesMut<'_> {
         memo_ingredient_index: MemoIngredientIndex,
         f: impl FnOnce(&mut M),
     ) {
-        let Some(memos) = self.memos.memos.get_mut() else {
-            return;
-        };
-        let Some(MemoEntry { atomic_memo }) = memos.get_mut(memo_ingredient_index.as_usize())
+        let Some(MemoEntry { atomic_memo }) =
+            self.memos.memos.get_mut(memo_ingredient_index.as_usize())
         else {
             return;
         };
@@ -322,11 +419,8 @@ impl MemoTableWithTypesMut<'_> {
     /// the database exist as there may be outstanding borrows into the pointer contents.
     #[inline]
     pub unsafe fn drop(&mut self) {
-        let Some(memos) = self.memos.memos.get_mut() else {
-            return;
-        };
         let types = self.types.types.iter();
-        for (type_, memo) in std::iter::zip(types, memos) {
+        for (type_, memo) in std::iter::zip(types, self.memos.memos.iter_mut()) {
             // SAFETY: The types match as per our constructor invariant.
             unsafe { memo.take(type_) };
         }
@@ -340,10 +434,8 @@ impl MemoTableWithTypesMut<'_> {
         &mut self,
         mut f: impl FnMut(MemoIngredientIndex, Box<dyn Memo>),
     ) {
-        let Some(memos) = self.memos.memos.get_mut() else {
-            return;
-        };
-        memos
+        self.memos
+            .memos
             .iter_mut()
             .zip(self.types.types.iter())
             .enumerate()

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -3,7 +3,10 @@ use std::fmt::Debug;
 use std::mem;
 use std::ptr::{self, NonNull};
 
+use thin_vec::ThinVec;
+
 use crate::DatabaseKeyIndex;
+use crate::sync::OnceLock;
 use crate::sync::atomic::{AtomicPtr, Ordering};
 use crate::zalsa::MemoIngredientIndex;
 use crate::zalsa::Zalsa;
@@ -12,21 +15,21 @@ use crate::zalsa::Zalsa;
 /// Every tracked function must take a salsa struct as its first argument
 /// and memo tables are attached to those salsa structs as auxiliary data.
 pub struct MemoTable {
-    memos: Box<[MemoEntry]>,
+    memos: OnceLock<ThinVec<MemoEntry>>,
 }
 
+#[cfg(not(feature = "shuttle"))]
+const _: [(); mem::size_of::<MemoTable>()] = [(); 2 * mem::size_of::<usize>()];
+
 impl MemoTable {
-    /// Create a `MemoTable` with slots for memos from the provided `MemoTableTypes`.
+    /// Create a `MemoTable` that allocates slots on the first memo insertion.
     ///
     /// # Safety
     ///
     /// The created memo table must only be accessed with the same `MemoTableTypes`.
-    pub unsafe fn new(types: &MemoTableTypes) -> Self {
-        // Note that the safety invariant guarantees that any indices in-bounds for
-        // this table are also in-bounds for its `MemoTableTypes`, as `MemoTableTypes`
-        // is append-only.
+    pub unsafe fn new(_types: &MemoTableTypes) -> Self {
         Self {
-            memos: (0..types.len()).map(|_| MemoEntry::default()).collect(),
+            memos: OnceLock::new(),
         }
     }
 
@@ -34,9 +37,15 @@ impl MemoTable {
     ///
     /// Note that the memo entries should be freed manually before calling this function.
     pub fn reset(&mut self) {
-        for memo in &mut self.memos {
-            *memo = MemoEntry::default();
-        }
+        self.memos.take();
+    }
+
+    fn get_or_init(&self, len: usize) -> &ThinVec<MemoEntry> {
+        self.memos.get_or_init(|| {
+            let mut memos = ThinVec::with_capacity(len);
+            memos.extend((0..len).map(|_| MemoEntry::default()));
+            memos
+        })
     }
 }
 
@@ -188,19 +197,16 @@ impl MemoTableWithTypes<'_> {
         memo_ingredient_index: MemoIngredientIndex,
         memo: NonNull<M>,
     ) -> Option<NonNull<M>> {
-        let MemoEntry { atomic_memo } = self.memos.memos.get(memo_ingredient_index.as_usize())?;
-
-        // SAFETY: Any indices that are in-bounds for the `MemoTable` are also in-bounds for its
-        // corresponding `MemoTableTypes`, by construction.
-        let type_ = unsafe {
-            self.types
-                .types
-                .get_unchecked(memo_ingredient_index.as_usize())
-        };
+        let memo_ingredient_index = memo_ingredient_index.as_usize();
+        let type_ = self.types.types.get(memo_ingredient_index)?;
+        let MemoEntry { atomic_memo } = self
+            .memos
+            .get_or_init(self.types.len())
+            .get(memo_ingredient_index)?;
 
         // Verify that the we are casting to the correct type.
         if type_.type_id != TypeId::of::<M>() {
-            type_assert_failed(memo_ingredient_index);
+            type_assert_failed(MemoIngredientIndex::from_usize(memo_ingredient_index));
         }
 
         let old_memo = atomic_memo.swap(MemoEntryType::to_dummy(memo).as_ptr(), Ordering::AcqRel);
@@ -215,7 +221,11 @@ impl MemoTableWithTypes<'_> {
         self,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> Option<NonNull<M>> {
-        let MemoEntry { atomic_memo } = self.memos.memos.get(memo_ingredient_index.as_usize())?;
+        let MemoEntry { atomic_memo } = self
+            .memos
+            .memos
+            .get()?
+            .get(memo_ingredient_index.as_usize())?;
 
         // SAFETY: Any indices that are in-bounds for the `MemoTable` are also in-bounds for its
         // corresponding `MemoTableTypes`, by construction.
@@ -238,7 +248,10 @@ impl MemoTableWithTypes<'_> {
     #[cfg(feature = "salsa_unstable")]
     pub(crate) fn memory_usage(&self) -> Vec<crate::database::MemoInfo> {
         let mut memory_usage = Vec::new();
-        for (index, memo) in self.memos.memos.iter().enumerate() {
+        let Some(memos) = self.memos.memos.get() else {
+            return memory_usage;
+        };
+        for (index, memo) in memos.iter().enumerate() {
             let Some(memo) = NonNull::new(memo.atomic_memo.load(Ordering::Acquire)) else {
                 continue;
             };
@@ -270,8 +283,10 @@ impl MemoTableWithTypesMut<'_> {
         memo_ingredient_index: MemoIngredientIndex,
         f: impl FnOnce(&mut M),
     ) {
-        let Some(MemoEntry { atomic_memo }) =
-            self.memos.memos.get_mut(memo_ingredient_index.as_usize())
+        let Some(memos) = self.memos.memos.get_mut() else {
+            return;
+        };
+        let Some(MemoEntry { atomic_memo }) = memos.get_mut(memo_ingredient_index.as_usize())
         else {
             return;
         };
@@ -307,8 +322,11 @@ impl MemoTableWithTypesMut<'_> {
     /// the database exist as there may be outstanding borrows into the pointer contents.
     #[inline]
     pub unsafe fn drop(&mut self) {
+        let Some(memos) = self.memos.memos.get_mut() else {
+            return;
+        };
         let types = self.types.types.iter();
-        for (type_, memo) in std::iter::zip(types, &mut self.memos.memos) {
+        for (type_, memo) in std::iter::zip(types, memos) {
             // SAFETY: The types match as per our constructor invariant.
             unsafe { memo.take(type_) };
         }
@@ -322,8 +340,10 @@ impl MemoTableWithTypesMut<'_> {
         &mut self,
         mut f: impl FnMut(MemoIngredientIndex, Box<dyn Memo>),
     ) {
-        self.memos
-            .memos
+        let Some(memos) = self.memos.memos.get_mut() else {
+            return;
+        };
+        memos
             .iter_mut()
             .zip(self.types.types.iter())
             .enumerate()

--- a/tests/parallel/main.rs
+++ b/tests/parallel/main.rs
@@ -19,6 +19,7 @@ mod cycle_nested_three_threads_changed;
 mod cycle_panic;
 mod cycle_provisional_depending_on_itself;
 mod lru_eviction_cancels_cycle;
+mod memo_table_first_insert;
 
 #[cfg(not(feature = "shuttle"))]
 pub(crate) mod sync {

--- a/tests/parallel/memo_table_first_insert.rs
+++ b/tests/parallel/memo_table_first_insert.rs
@@ -1,0 +1,36 @@
+use crate::sync::thread;
+use crate::{Knobs, KnobsDatabase};
+
+#[salsa::input]
+struct Input {
+    value: u32,
+}
+
+#[salsa::tracked]
+fn query_a(db: &dyn KnobsDatabase, input: Input) -> u32 {
+    db.signal(1);
+    db.wait_for(2);
+    input.value(db)
+}
+
+#[salsa::tracked]
+fn query_b(db: &dyn KnobsDatabase, input: Input) -> u32 {
+    db.wait_for(1);
+    db.signal(2);
+    input.value(db)
+}
+
+#[test_log::test]
+fn concurrent_first_insert() {
+    crate::sync::check(|| {
+        let db_a = Knobs::default();
+        let input = Input::new(&db_a, 42);
+        let db_b = db_a.clone();
+
+        let a = thread::spawn(move || query_a(&db_a, input));
+        let b = thread::spawn(move || query_b(&db_b, input));
+
+        assert_eq!(a.join().unwrap(), 42);
+        assert_eq!(b.join().unwrap(), 42);
+    });
+}


### PR DESCRIPTION
Allocate memo-table slots on first insertion so Salsa values that are never queried avoid an empty slot allocation.

Salsa stores the memo results on the tracked struct in an associated memo table. Today, these memo tables are allocated eagerly. Meaning, creating any salsa struct immediately allocates a Memo table with N entries (where N are the queries parametrized by the struct). This is wasteful if the struct is never used to store any memo result. This, to some extend, defeats Salsa's lazyness, because answering an LSP request might only need to run queries on a few of all the created salsa structs (e.g. a semantic index that creates a struct for every definition in a scope, but the LSP then only runs the queries for a handful of definitions).

This shows a 4-5% peak memory reduction in ty's simulated benchmark, and performance is neutral (+- a few percent across projects), see https://github.com/astral-sh/ruff/pull/26202

A `ty check` CLI measurement showed roughly a 2-3% RSS reduction
