### PR TITLE
fix: preserve query revision for non-reusable interned values

### DIFF
--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -131,8 +131,12 @@ impl ActiveQuery {
         revision: Revision,
     ) {
         self.durability = self.durability.min(durability);
-        self.changed_at = self.changed_at.max(revision);
+        self.add_changed_at(revision);
         self.input_outputs.insert(QueryEdge::input(input));
+    }
+
+    pub(super) fn add_changed_at(&mut self, revision: Revision) {
+        self.changed_at = self.changed_at.max(revision);
     }
 
     pub(super) fn add_untracked_read(&mut self, changed_at: Revision) {

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -215,6 +215,11 @@ impl ValueShared {
     ) {
         if Self::is_reusable_with_durability::<C>(durability) {
             zalsa_local.report_tracked_read_simple(index, durability, current_revision);
+        } else {
+            // The value cannot be reused, so the dependency edge is unnecessary. Its durability
+            // is derived from the active query, but its revision must still contribute to the
+            // query's stamp because the interned ID may have changed due to reuse.
+            zalsa_local.report_tracked_read_revision(current_revision);
         }
     }
 }

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -360,6 +360,19 @@ impl ZalsaLocal {
         }
     }
 
+    /// Update the active query's changed revision without recording a dependency edge.
+    #[inline(always)]
+    pub(crate) fn report_tracked_read_revision(&self, changed_at: Revision) {
+        // SAFETY: We do not access the query stack reentrantly.
+        unsafe {
+            self.with_query_stack_unchecked_mut(|stack| {
+                if let Some(top_query) = stack.last_mut() {
+                    top_query.add_changed_at(changed_at);
+                }
+            })
+        }
+    }
+
     /// Register that the current query read an untracked value
     ///
     /// # Parameters

--- a/tests/interned-revisions.rs
+++ b/tests/interned-revisions.rs
@@ -190,6 +190,42 @@ fn test_non_reusable_existing_value_does_not_record_dependency() {
     }
 }
 
+#[test]
+fn test_non_reusable_value_still_updates_query_stamp() {
+    #[salsa::tracked]
+    fn outer(db: &dyn Database, input: Input) -> bool {
+        let _ = input.field1(db);
+        let _ = Interned::new(db, BadHash(0));
+        true
+    }
+
+    #[salsa::tracked]
+    fn intern_from_input(db: &dyn Database, input: Input) -> Interned<'_> {
+        Interned::new(db, BadHash(input.field1(db)))
+    }
+
+    let mut db = common::EventLoggerDatabase::default();
+    let input = Input::new(&db, 0);
+
+    // Create an interned value with low durability in a revision after the outer query's other
+    // inputs last changed. This makes the outer query's `changed_at` depend on the interned value.
+    db.synthetic_write(Durability::LOW);
+    assert!(outer(&db, input));
+
+    // Collect the original interned value, then recreate it outside an active query. This gives the
+    // new generation high durability, making it non-reusable.
+    for key in 1..10 {
+        db.synthetic_write(Durability::LOW);
+        let _ = intern_from_input(&db, Input::new(&db, key));
+    }
+    let _ = Interned::new(&db, BadHash(0));
+
+    // Revalidating `outer` observes that the old interned value was collected and executes it
+    // again. Even though the replacement is non-reusable and needs no dependency edge, its revision
+    // must still contribute to the new query stamp.
+    assert!(outer(&db, input));
+}
+
 #[salsa::interned(revisions = usize::MAX)]
 #[derive(Debug)]
 struct Immortal<'db> {


### PR DESCRIPTION
Non-reusable interned values can omit their dependency edge, but their allocation or reuse revision must still contribute to the creating query. Otherwise, recreating a reusable key as a stable key can move changed_at backwards and trigger a backdating panic.