### PR TITLE
feat: report per-ingredient page occupancy

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -549,13 +549,12 @@ mod memory_usage {
 
     impl PageInfo {
         pub(crate) fn from_page_fills(page_capacity: usize, mut page_fills: Vec<usize>) -> Self {
-            page_fills.retain(|&fill| fill > 0);
-
-            if page_fills.is_empty() {
-                return Self::empty(page_capacity);
-            }
-
-            debug_assert!(page_fills.iter().all(|&fill| fill <= page_capacity));
+            debug_assert!(!page_fills.is_empty());
+            debug_assert!(
+                page_fills
+                    .iter()
+                    .all(|&fill| fill > 0 && fill <= page_capacity)
+            );
             page_fills.sort_unstable();
 
             let percentile = |percentile: usize| {
@@ -649,8 +648,8 @@ mod memory_usage {
         use super::PageInfo;
 
         #[test]
-        fn page_info_uses_nearest_rank_percentiles_and_ignores_empty_pages() {
-            let page_info = PageInfo::from_page_fills(128, (0..=100).collect());
+        fn page_info_uses_nearest_rank_percentiles() {
+            let page_info = PageInfo::from_page_fills(128, (1..=100).collect());
 
             assert_eq!(page_info.page_count(), 100);
             assert_eq!(page_info.page_capacity(), 128);
@@ -663,8 +662,8 @@ mod memory_usage {
         }
 
         #[test]
-        fn page_info_is_empty_without_non_empty_pages() {
-            let page_info = PageInfo::from_page_fills(128, vec![0, 0]);
+        fn empty_page_info_has_zero_counts() {
+            let page_info = PageInfo::empty(128);
 
             assert_eq!(page_info.page_count(), 0);
             assert_eq!(page_info.page_capacity(), 128);

--- a/src/database.rs
+++ b/src/database.rs
@@ -398,7 +398,7 @@ mod persistence {
 }
 
 #[cfg(feature = "salsa_unstable")]
-pub use memory_usage::IngredientInfo;
+pub use memory_usage::{IngredientInfo, PageInfo};
 
 #[cfg(feature = "salsa_unstable")]
 pub(crate) use memory_usage::{MemoInfo, SlotInfo};
@@ -414,6 +414,8 @@ mod memory_usage {
         pub fn memory_usage(&self) -> DatabaseInfo {
             let mut queries = HashMap::new();
             let mut structs = Vec::new();
+            let mut page_infos = self.zalsa().table().page_infos();
+            let page_capacity = self.zalsa().table().page_capacity();
 
             for input_ingredient in self.zalsa().ingredients() {
                 let Some(input_info) = input_ingredient.memory_usage(self) else {
@@ -458,6 +460,11 @@ mod memory_usage {
                     size_of_metadata,
                     heap_size_of_fields,
                     debug_name: input_ingredient.debug_name(),
+                    page_info: Some(
+                        page_infos
+                            .remove(&input_ingredient.ingredient_index())
+                            .unwrap_or_else(|| PageInfo::empty(page_capacity)),
+                    ),
                 });
             }
 
@@ -483,6 +490,7 @@ mod memory_usage {
         size_of_metadata: usize,
         size_of_fields: usize,
         heap_size_of_fields: Option<usize>,
+        page_info: Option<PageInfo>,
     }
 
     impl IngredientInfo {
@@ -512,6 +520,113 @@ mod memory_usage {
         pub fn count(&self) -> usize {
             self.count
         }
+
+        /// Returns page occupancy information for this ingredient.
+        ///
+        /// Returns `None` for query summaries. Struct ingredients without any non-empty pages
+        /// return page information with zero counts.
+        pub fn page_info(&self) -> Option<&PageInfo> {
+            self.page_info.as_ref()
+        }
+    }
+
+    /// Page occupancy information for a Salsa struct ingredient.
+    ///
+    /// Empty pages are excluded. Page fill is the number of slots that have been initialized, so
+    /// slots remain included after their values are deleted or made available for reuse.
+    /// Percentiles use the nearest-rank method across the ingredient's non-empty pages.
+    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct PageInfo {
+        page_count: usize,
+        page_capacity: usize,
+        excess_capacity: usize,
+        p25_fill: usize,
+        p50_fill: usize,
+        p75_fill: usize,
+        p90_fill: usize,
+        p99_fill: usize,
+    }
+
+    impl PageInfo {
+        pub(crate) fn from_page_fills(page_capacity: usize, mut page_fills: Vec<usize>) -> Self {
+            page_fills.retain(|&fill| fill > 0);
+
+            if page_fills.is_empty() {
+                return Self::empty(page_capacity);
+            }
+
+            debug_assert!(page_fills.iter().all(|&fill| fill <= page_capacity));
+            page_fills.sort_unstable();
+
+            let percentile = |percentile: usize| {
+                let rank = (page_fills.len() * percentile).div_ceil(100);
+                page_fills[rank - 1]
+            };
+
+            Self {
+                page_count: page_fills.len(),
+                page_capacity,
+                excess_capacity: page_fills.iter().map(|&fill| page_capacity - fill).sum(),
+                p25_fill: percentile(25),
+                p50_fill: percentile(50),
+                p75_fill: percentile(75),
+                p90_fill: percentile(90),
+                p99_fill: percentile(99),
+            }
+        }
+
+        fn empty(page_capacity: usize) -> Self {
+            Self {
+                page_count: 0,
+                page_capacity,
+                excess_capacity: 0,
+                p25_fill: 0,
+                p50_fill: 0,
+                p75_fill: 0,
+                p90_fill: 0,
+                p99_fill: 0,
+            }
+        }
+
+        /// Returns the number of non-empty pages allocated for this ingredient.
+        pub fn page_count(&self) -> usize {
+            self.page_count
+        }
+
+        /// Returns the number of slots that can be stored in each page.
+        pub fn page_capacity(&self) -> usize {
+            self.page_capacity
+        }
+
+        /// Returns the number of unused slots across all non-empty pages.
+        pub fn excess_capacity(&self) -> usize {
+            self.excess_capacity
+        }
+
+        /// Returns the 25th percentile of initialized slots per non-empty page.
+        pub fn p25_fill(&self) -> usize {
+            self.p25_fill
+        }
+
+        /// Returns the 50th percentile of initialized slots per non-empty page.
+        pub fn p50_fill(&self) -> usize {
+            self.p50_fill
+        }
+
+        /// Returns the 75th percentile of initialized slots per non-empty page.
+        pub fn p75_fill(&self) -> usize {
+            self.p75_fill
+        }
+
+        /// Returns the 90th percentile of initialized slots per non-empty page.
+        pub fn p90_fill(&self) -> usize {
+            self.p90_fill
+        }
+
+        /// Returns the 99th percentile of initialized slots per non-empty page.
+        pub fn p99_fill(&self) -> usize {
+            self.p99_fill
+        }
     }
 
     /// Memory usage information about a particular instance of struct, input or output.
@@ -527,5 +642,38 @@ mod memory_usage {
     pub struct MemoInfo {
         pub(crate) debug_name: &'static str,
         pub(crate) output: SlotInfo,
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::PageInfo;
+
+        #[test]
+        fn page_info_uses_nearest_rank_percentiles_and_ignores_empty_pages() {
+            let page_info = PageInfo::from_page_fills(128, (0..=100).collect());
+
+            assert_eq!(page_info.page_count(), 100);
+            assert_eq!(page_info.page_capacity(), 128);
+            assert_eq!(page_info.excess_capacity(), 7_750);
+            assert_eq!(page_info.p25_fill(), 25);
+            assert_eq!(page_info.p50_fill(), 50);
+            assert_eq!(page_info.p75_fill(), 75);
+            assert_eq!(page_info.p90_fill(), 90);
+            assert_eq!(page_info.p99_fill(), 99);
+        }
+
+        #[test]
+        fn page_info_is_empty_without_non_empty_pages() {
+            let page_info = PageInfo::from_page_fills(128, vec![0, 0]);
+
+            assert_eq!(page_info.page_count(), 0);
+            assert_eq!(page_info.page_capacity(), 128);
+            assert_eq!(page_info.excess_capacity(), 0);
+            assert_eq!(page_info.p25_fill(), 0);
+            assert_eq!(page_info.p50_fill(), 0);
+            assert_eq!(page_info.p75_fill(), 0);
+            assert_eq!(page_info.p90_fill(), 0);
+            assert_eq!(page_info.p99_fill(), 0);
+        }
     }
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -548,8 +548,14 @@ mod memory_usage {
     }
 
     impl PageInfo {
-        pub(crate) fn from_page_fills(page_capacity: usize, mut page_fills: Vec<usize>) -> Self {
-            debug_assert!(!page_fills.is_empty());
+        pub(crate) fn from_page_fills(
+            page_capacity: usize,
+            mut page_fills: Vec<usize>,
+        ) -> Option<Self> {
+            if page_fills.is_empty() {
+                return None;
+            }
+
             debug_assert!(
                 page_fills
                     .iter()
@@ -562,7 +568,7 @@ mod memory_usage {
                 page_fills[rank - 1]
             };
 
-            Self {
+            Some(Self {
                 page_count: page_fills.len(),
                 page_capacity,
                 excess_capacity: page_fills.iter().map(|&fill| page_capacity - fill).sum(),
@@ -571,7 +577,7 @@ mod memory_usage {
                 p75_fill: percentile(75),
                 p90_fill: percentile(90),
                 p99_fill: percentile(99),
-            }
+            })
         }
 
         fn empty(page_capacity: usize) -> Self {
@@ -649,7 +655,7 @@ mod memory_usage {
 
         #[test]
         fn page_info_uses_nearest_rank_percentiles() {
-            let page_info = PageInfo::from_page_fills(128, (1..=100).collect());
+            let page_info = PageInfo::from_page_fills(128, (1..=100).collect()).unwrap();
 
             assert_eq!(page_info.page_count(), 100);
             assert_eq!(page_info.page_capacity(), 128);
@@ -662,17 +668,8 @@ mod memory_usage {
         }
 
         #[test]
-        fn empty_page_info_has_zero_counts() {
-            let page_info = PageInfo::empty(128);
-
-            assert_eq!(page_info.page_count(), 0);
-            assert_eq!(page_info.page_capacity(), 128);
-            assert_eq!(page_info.excess_capacity(), 0);
-            assert_eq!(page_info.p25_fill(), 0);
-            assert_eq!(page_info.p50_fill(), 0);
-            assert_eq!(page_info.p75_fill(), 0);
-            assert_eq!(page_info.p90_fill(), 0);
-            assert_eq!(page_info.p99_fill(), 0);
+        fn page_info_is_none_without_page_fills() {
+            assert_eq!(PageInfo::from_page_fills(128, Vec::new()), None);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ mod nonce;
 pub use salsa_macros::{Supertype, Update, accumulator, db, input, interned, tracked};
 
 #[cfg(feature = "salsa_unstable")]
-pub use self::database::IngredientInfo;
+pub use self::database::{IngredientInfo, PageInfo};
 
 #[cfg(feature = "accumulator")]
 pub use self::accumulator::Accumulator;

--- a/src/table.rs
+++ b/src/table.rs
@@ -202,6 +202,33 @@ impl Table {
         self.pages.count()
     }
 
+    #[cfg(feature = "salsa_unstable")]
+    pub(crate) fn page_capacity(&self) -> usize {
+        PAGE_LEN
+    }
+
+    #[cfg(feature = "salsa_unstable")]
+    pub(crate) fn page_infos(&self) -> FxHashMap<IngredientIndex, crate::database::PageInfo> {
+        let mut page_fills: FxHashMap<IngredientIndex, Vec<usize>> = FxHashMap::default();
+
+        for (_, page) in self.pages.iter() {
+            let fill = page.allocated.load(Ordering::Acquire);
+            if fill > 0 {
+                page_fills.entry(page.ingredient).or_default().push(fill);
+            }
+        }
+
+        page_fills
+            .into_iter()
+            .map(|(ingredient, fills)| {
+                (
+                    ingredient,
+                    crate::database::PageInfo::from_page_fills(PAGE_LEN, fills),
+                )
+            })
+            .collect()
+    }
+
     /// Gets a reference to the page which has slots of type `T`
     ///
     /// # Panics

--- a/src/table.rs
+++ b/src/table.rs
@@ -220,11 +220,9 @@ impl Table {
 
         page_fills
             .into_iter()
-            .map(|(ingredient, fills)| {
-                (
-                    ingredient,
-                    crate::database::PageInfo::from_page_fills(PAGE_LEN, fills),
-                )
+            .filter_map(|(ingredient, fills)| {
+                crate::database::PageInfo::from_page_fills(PAGE_LEN, fills)
+                    .map(|page_info| (ingredient, page_info))
             })
             .collect()
     }

--- a/tests/memory-usage.rs
+++ b/tests/memory-usage.rs
@@ -2,7 +2,7 @@
 // Expected sizes assume a 64-bit target.
 #![cfg(target_pointer_width = "64")]
 
-use salsa::Database as _;
+use salsa::{Database as _, Setter as _};
 
 #[salsa::input(heap_size = string_tuple_size_of)]
 struct MyInput {
@@ -27,6 +27,12 @@ fn input_to_interned(db: &dyn salsa::Database, input: MyInput) -> MyInterned<'_>
 #[salsa::tracked]
 fn input_to_tracked(db: &dyn salsa::Database, input: MyInput) -> MyTracked<'_> {
     MyTracked::new(db, input.field(db))
+}
+
+#[salsa::tracked]
+fn maybe_input_to_tracked(db: &dyn salsa::Database, input: MyInput) -> Option<MyTracked<'_>> {
+    let field = input.field(db);
+    (!field.is_empty()).then(|| MyTracked::new(db, field))
 }
 
 #[salsa::tracked]
@@ -107,6 +113,27 @@ fn test() {
 
     let memory_usage = <dyn salsa::Database>::memory_usage(&db);
 
+    let input_info = memory_usage
+        .structs
+        .iter()
+        .find(|ingredient| ingredient.debug_name() == "MyInput")
+        .unwrap();
+    let input_pages = input_info.page_info().unwrap();
+    assert_eq!(input_pages.page_count(), 1);
+    assert_eq!(input_pages.page_capacity(), 1024);
+    assert_eq!(input_pages.excess_capacity(), 1021);
+    assert_eq!(input_pages.p25_fill(), 3);
+    assert_eq!(input_pages.p50_fill(), 3);
+    assert_eq!(input_pages.p75_fill(), 3);
+    assert_eq!(input_pages.p90_fill(), 3);
+    assert_eq!(input_pages.p99_fill(), 3);
+    assert!(
+        memory_usage
+            .queries
+            .values()
+            .all(|query| query.page_info().is_none())
+    );
+
     let expected = expect![[r#"
         [
             IngredientInfo {
@@ -117,6 +144,18 @@ fn test() {
                 heap_size_of_fields: Some(
                     450,
                 ),
+                page_info: Some(
+                    PageInfo {
+                        page_count: 1,
+                        page_capacity: 1024,
+                        excess_capacity: 1021,
+                        p25_fill: 3,
+                        p50_fill: 3,
+                        p75_fill: 3,
+                        p90_fill: 3,
+                        p99_fill: 3,
+                    },
+                ),
             },
             IngredientInfo {
                 debug_name: "MyInterned",
@@ -125,6 +164,18 @@ fn test() {
                 size_of_fields: 72,
                 heap_size_of_fields: Some(
                     450,
+                ),
+                page_info: Some(
+                    PageInfo {
+                        page_count: 1,
+                        page_capacity: 1024,
+                        excess_capacity: 1021,
+                        p25_fill: 3,
+                        p50_fill: 3,
+                        p75_fill: 3,
+                        p90_fill: 3,
+                        p99_fill: 3,
+                    },
                 ),
             },
             IngredientInfo {
@@ -135,6 +186,18 @@ fn test() {
                 heap_size_of_fields: Some(
                     300,
                 ),
+                page_info: Some(
+                    PageInfo {
+                        page_count: 1,
+                        page_capacity: 1024,
+                        excess_capacity: 1020,
+                        p25_fill: 4,
+                        p50_fill: 4,
+                        p75_fill: 4,
+                        p90_fill: 4,
+                        p99_fill: 4,
+                    },
+                ),
             },
             IngredientInfo {
                 debug_name: "input_to_string::interned_arguments",
@@ -142,6 +205,18 @@ fn test() {
                 size_of_metadata: 56,
                 size_of_fields: 0,
                 heap_size_of_fields: None,
+                page_info: Some(
+                    PageInfo {
+                        page_count: 1,
+                        page_capacity: 1024,
+                        excess_capacity: 1023,
+                        p25_fill: 1,
+                        p50_fill: 1,
+                        p75_fill: 1,
+                        p90_fill: 1,
+                        p99_fill: 1,
+                    },
+                ),
             },
             IngredientInfo {
                 debug_name: "input_to_string_get_size::interned_arguments",
@@ -149,6 +224,18 @@ fn test() {
                 size_of_metadata: 56,
                 size_of_fields: 0,
                 heap_size_of_fields: None,
+                page_info: Some(
+                    PageInfo {
+                        page_count: 1,
+                        page_capacity: 1024,
+                        excess_capacity: 1023,
+                        p25_fill: 1,
+                        p50_fill: 1,
+                        p75_fill: 1,
+                        p90_fill: 1,
+                        p99_fill: 1,
+                    },
+                ),
             },
         ]"#]];
 
@@ -167,6 +254,7 @@ fn test() {
                     size_of_metadata: 144,
                     size_of_fields: 24,
                     heap_size_of_fields: None,
+                    page_info: None,
                 },
             ),
             (
@@ -177,6 +265,7 @@ fn test() {
                     size_of_metadata: 32,
                     size_of_fields: 24,
                     heap_size_of_fields: None,
+                    page_info: None,
                 },
             ),
             (
@@ -189,6 +278,7 @@ fn test() {
                     heap_size_of_fields: Some(
                         1000,
                     ),
+                    page_info: None,
                 },
             ),
             (
@@ -199,6 +289,7 @@ fn test() {
                     size_of_metadata: 240,
                     size_of_fields: 16,
                     heap_size_of_fields: None,
+                    page_info: None,
                 },
             ),
             (
@@ -209,6 +300,7 @@ fn test() {
                     size_of_metadata: 144,
                     size_of_fields: 16,
                     heap_size_of_fields: None,
+                    page_info: None,
                 },
             ),
         ]"#]];
@@ -276,4 +368,32 @@ fn never_change_cycle_query_discards_edges_after_converging() {
     let after = &after.queries["cycle_input_to_length"];
     assert_eq!(after.count(), 2);
     assert!(after.size_of_metadata() > before.size_of_metadata() * 2);
+}
+
+#[test]
+fn page_info_tracks_allocated_slots_after_tracked_struct_deletion() {
+    let mut db = salsa::DatabaseImpl::new();
+    let input = MyInput::new(&db, "value".to_owned());
+
+    assert!(maybe_input_to_tracked(&db, input).is_some());
+    input.set_field(&mut db).to(String::new());
+    assert!(maybe_input_to_tracked(&db, input).is_none());
+
+    let memory_usage = <dyn salsa::Database>::memory_usage(&db);
+    let tracked = memory_usage
+        .structs
+        .iter()
+        .find(|ingredient| ingredient.debug_name() == "MyTracked")
+        .unwrap();
+
+    assert_eq!(tracked.count(), 0);
+
+    let pages = tracked.page_info().unwrap();
+    assert_eq!(pages.page_count(), 1);
+    assert_eq!(pages.excess_capacity(), pages.page_capacity() - 1);
+    assert_eq!(pages.p25_fill(), 1);
+    assert_eq!(pages.p50_fill(), 1);
+    assert_eq!(pages.p75_fill(), 1);
+    assert_eq!(pages.p90_fill(), 1);
+    assert_eq!(pages.p99_fill(), 1);
 }


### PR DESCRIPTION
I tried to get more insight into https://github.com/salsa-rs/salsa/pull/1179, specifically if there are large differences by ingredient. For this, I added per-ingredient page occupancy through Salsa's unstable memory-usage API, including non-empty page count, capacity, excess capacity, and P25/P50/P75/P90/P99 fill counts.

Empty pages are excluded, because they don't materialize (they're `MaybeInit` slices) until the first item is written to the page.

