### PR TITLE
perf: inline current-revision memo validation

### DIFF
--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -287,7 +287,7 @@ impl MemoHeader {
     /// eagerly finalize all provisional memos in cycle iteration, we have to lazily check here
     /// (via `validate_provisional`) whether a may-be-provisional memo should actually be verified
     /// final, because its cycle heads are all now final.
-    #[inline]
+    #[inline(always)]
     pub(super) fn shallow_verify_memo(
         &self,
         zalsa: &Zalsa,


### PR DESCRIPTION
Force the common current-revision comparison inline now that durability validation lives in a cold helper. This reduces the verified cached-hit path by 26 instructions (10.9%) on current master.

Testing: Passed release-mode targeted validation and clippy.
