### PR TITLE
perf: skip redundant shallow memo updates

### DIFF
--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -1,5 +1,6 @@
 use crate::cycle::{CycleRecoveryStrategy, IterationStamp};
 use crate::function::eviction::EvictionPolicy;
+use crate::function::maybe_changed_after::ShallowUpdate;
 use crate::function::memo::Memo;
 use crate::function::sync::ClaimResult;
 use crate::function::{Configuration, IngredientImpl, Reentrancy};
@@ -90,8 +91,9 @@ where
             .shallow_verify_memo(zalsa, database_key_index, true);
 
         if can_shallow_update.yes() && !memo.header.may_be_provisional() {
-            memo.header
-                .update_shallow(zalsa, database_key_index, can_shallow_update);
+            if can_shallow_update == ShallowUpdate::HigherDurability {
+                memo.header.update_shallow(zalsa, database_key_index);
+            }
 
             // SAFETY: memo is present in memo_map and we have verified that it is
             // still valid for the current revision.

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -214,7 +214,9 @@ impl MemoHeader {
     ) -> Option<VerifyResult> {
         let can_shallow_update = self.shallow_verify_memo(zalsa, database_key_index, has_value);
         if can_shallow_update.yes() && !self.may_be_provisional() {
-            self.update_shallow(zalsa, database_key_index, can_shallow_update);
+            if can_shallow_update == ShallowUpdate::HigherDurability {
+                self.update_shallow(zalsa, database_key_index);
+            }
 
             Some(if self.revisions.changed_at > revision {
                 VerifyResult::changed()
@@ -242,7 +244,9 @@ impl MemoHeader {
         if can_shallow_update.yes()
             && self.validate_may_be_provisional(zalsa, zalsa_local, database_key_index, has_value)
         {
-            self.update_shallow(zalsa, database_key_index, can_shallow_update);
+            if can_shallow_update == ShallowUpdate::HigherDurability {
+                self.update_shallow(zalsa, database_key_index);
+            }
             true
         } else {
             self.deep_verify_memo(db, claim_guard, cycle_recovery_strategy, has_value)
@@ -333,16 +337,9 @@ impl MemoHeader {
     }
 
     #[inline]
-    pub(super) fn update_shallow(
-        &self,
-        zalsa: &Zalsa,
-        database_key_index: DatabaseKeyIndex,
-        update: ShallowUpdate,
-    ) {
-        if let ShallowUpdate::HigherDurability = update {
-            self.mark_as_verified(zalsa, database_key_index);
-            self.mark_outputs_as_verified(zalsa, database_key_index);
-        }
+    pub(super) fn update_shallow(&self, zalsa: &Zalsa, database_key_index: DatabaseKeyIndex) {
+        self.mark_as_verified(zalsa, database_key_index);
+        self.mark_outputs_as_verified(zalsa, database_key_index);
     }
 
     /// Validates this memo if it is a provisional memo. Returns true for:


### PR DESCRIPTION
Make shallow memo updates explicit at call sites so only higher-durability verification performs memo writes. After the hot/cold-path split, release codegen already eliminates this work on current-revision cached hits, so this no longer has a measurable hot-path benefit.

Testing: Passed release-mode targeted validation and clippy.
