### PR TITLE
perf: Introduce detailed-trace feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,9 @@ ordermap = { version = "1", optional = true }
 [features]
 default = ["salsa_unstable", "rayon", "macros", "inventory", "accumulator"]
 inventory = ["dep:inventory"]
+
+# Enables Salsa's `DEBUG` and `TRACE` tracing events and spans. Disabled by default.
+detailed-trace = []
 persistence = [
     "dep:serde",
     "dep:erased-serde",

--- a/src/database_impl.rs
+++ b/src/database_impl.rs
@@ -13,14 +13,16 @@ pub struct DatabaseImpl {
 impl Default for DatabaseImpl {
     fn default() -> Self {
         Self {
-            // Default behavior: tracing debug log the event.
-            storage: Storage::new(if tracing::enabled!(Level::DEBUG) {
-                Some(Box::new(|event| {
-                    crate::tracing::debug!("salsa_event({:?})", event)
-                }))
-            } else {
-                None
-            }),
+            // Default behavior: trace events at DEBUG when detailed tracing is enabled.
+            storage: Storage::new(
+                if cfg!(feature = "detailed-trace") && tracing::enabled!(Level::DEBUG) {
+                    Some(Box::new(|event| {
+                        crate::tracing::debug!("salsa_event({:?})", event)
+                    }))
+                } else {
+                    None
+                },
+            ),
         }
     }
 }

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -23,7 +23,7 @@ where
 
         let database_key_index = self.database_key_index(id);
 
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "detailed-trace")]
         let _span = crate::tracing::debug_span!("fetch", query = ?database_key_index).entered();
 
         let memo = self.refresh_memo(db, zalsa, zalsa_local, id);

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -258,11 +258,10 @@ impl MemoHeader {
         cycle_recovery_strategy: CycleRecoveryStrategy,
         has_value: bool,
     ) -> Option<VerifyResult> {
-        let database_key_index = claim_guard.database_key_index();
-
         crate::tracing::debug!(
             "{database_key_index:?}: maybe_changed_after_cold, successful claim, \
                 revision = {revision:?}, old_memo = {old_memo:#?}",
+            database_key_index = claim_guard.database_key_index(),
             old_memo = self.tracing_debug(has_value)
         );
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -150,7 +150,7 @@ impl Running<'_> {
             })
         });
 
-        crate::tracing::info!(
+        crate::tracing::debug!(
             "block_on: thread {thread_id:?} is blocking on {database_key:?} in thread {other_id:?}",
         );
 

--- a/src/runtime/dependency_graph.rs
+++ b/src/runtime/dependency_graph.rs
@@ -347,7 +347,7 @@ impl DependencyGraph {
             if current_thread != new_owner_thread
                 && !dg.depends_on(new_owner_thread, current_thread)
             {
-                crate::tracing::info!(
+                crate::tracing::debug!(
                     "block_on: thread {current_thread:?} is blocking on {new_owner:?} in thread {new_owner_thread:?}",
                 );
                 Self::block_on(me, current_thread, new_owner, new_owner_thread, guard);

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -1,10 +1,15 @@
-//! Wrappers around `tracing` macros that avoid inlining debug machinery into the hot path,
-//! as tracing events are typically only enabled for debugging purposes.
+//! Wrappers around `tracing` macros.
+//!
+//! `DEBUG` and `TRACE` events are enabled only with the `detailed-trace` feature. This gating
+//! applies only to events; spans must be gated at their call sites. The wrappers also avoid
+//! inlining most tracing machinery into hot paths.
 
 macro_rules! trace {
-    ($($x:tt)*) => {
-        crate::tracing::event!(TRACE, $($x)*)
-    };
+    ($($x:tt)*) => {{
+        if cfg!(feature = "detailed-trace") {
+            crate::tracing::event!(TRACE, $($x)*)
+        }
+    }};
 }
 
 macro_rules! warn_event {
@@ -20,11 +25,14 @@ macro_rules! info {
 }
 
 macro_rules! debug {
-    ($($x:tt)*) => {
-        crate::tracing::event!(DEBUG, $($x)*)
-    };
+    ($($x:tt)*) => {{
+        if cfg!(feature = "detailed-trace") {
+            crate::tracing::event!(DEBUG, $($x)*)
+        }
+    }};
 }
 
+#[allow(unused_macros)]
 macro_rules! debug_span {
     ($($x:tt)*) => {
         crate::tracing::span!(DEBUG, $($x)*)
@@ -50,6 +58,7 @@ macro_rules! event {
     }};
 }
 
+#[allow(unused_macros)]
 macro_rules! span {
     ($level:ident, $($x:tt)*) => {{
         let span = {

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -519,8 +519,10 @@ where
 
         if let Some(id) = zalsa_local.tracked_struct_id(&identity) {
             // The struct already exists in the intern map.
-            let index = self.database_key_index(id);
-            crate::tracing::trace!("Reuse tracked struct {id:?}", id = index);
+            crate::tracing::trace!(
+                "Reuse tracked struct {id:?}",
+                id = self.database_key_index(id)
+            );
 
             // SAFETY: The `id` was present in the interned map, so the value must be initialized.
             let update_result = unsafe { self.update(zalsa, id, &current_deps, fields) };
@@ -543,8 +545,10 @@ where
         // We failed to perform the update, or this is a new tracked struct, so allocate a new entry
         // in the struct map.
         let id = self.allocate(zalsa, zalsa_local, &current_deps, fields);
-        let key = self.database_key_index(id);
-        crate::tracing::trace!("Allocated new tracked struct {key:?}");
+        crate::tracing::trace!(
+            "Allocated new tracked struct {key:?}",
+            key = self.database_key_index(id)
+        );
         zalsa_local.store_tracked_struct_id(identity, id);
         FromId::from_id(id)
     }

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -436,6 +436,7 @@ impl Zalsa {
     #[doc(hidden)]
     pub fn new_revision(&mut self) -> Revision {
         let new_revision = self.runtime.new_revision();
+        #[cfg(feature = "detailed-trace")]
         let _span = crate::tracing::debug_span!("new_revision", ?new_revision).entered();
 
         for ingredient in &self.ingredients_requiring_reset {
@@ -449,6 +450,7 @@ impl Zalsa {
     /// **NOT SEMVER STABLE**
     #[doc(hidden)]
     pub fn evict_lru(&mut self) {
+        #[cfg(feature = "detailed-trace")]
         let _span = crate::tracing::debug_span!("evict_lru").entered();
         for ingredient in &self.ingredients_requiring_reset {
             self.ingredients_vec[ingredient.as_u32() as usize]


### PR DESCRIPTION
## Summary

The `debug` and `trace` level calls add a fair amount of instructions to Salsa's hot path. Given that these traces are mainly useful to us maintainers when debugging a Salsa bug, it seems unjustified to have every application pay that cost. 

This PR introduces a new detailed-trace feature (off by default) that removes those tracing calls entirely. 

The remaining tracing usages are info and warning level messages:

* Log the execution of a query
* When starting a fixpoint iteration
* When starting the next fixpoint iteration
* When a query panicked

A next step could be to add a `tracing` or `trace` feature, so that upstream tools that don't want any salsa logging can opt-out fully. 