### PR TITLE
perf: defer query key construction on cache hits

### DIFF
--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -1,5 +1,6 @@
 use crate::cycle::{CycleRecoveryStrategy, IterationStamp};
 use crate::function::eviction::EvictionPolicy;
+use crate::function::maybe_changed_after::ShallowUpdate;
 use crate::function::memo::Memo;
 use crate::function::sync::ClaimResult;
 use crate::function::{Configuration, IngredientImpl, Reentrancy};
@@ -83,15 +84,18 @@ where
 
         memo.value.as_ref()?;
 
-        let database_key_index = self.database_key_index(id);
-
-        let can_shallow_update = memo
-            .header
-            .shallow_verify_memo(zalsa, database_key_index, true);
+        let can_shallow_update = memo.header.shallow_verify_memo(
+            zalsa,
+            #[cfg(feature = "detailed-trace")]
+            self.database_key_index(id),
+            true,
+        );
 
         if can_shallow_update.yes() && !memo.header.may_be_provisional() {
-            memo.header
-                .update_shallow(zalsa, database_key_index, can_shallow_update);
+            if can_shallow_update == ShallowUpdate::HigherDurability {
+                memo.header
+                    .update_shallow(zalsa, self.database_key_index(id), can_shallow_update);
+            }
 
             // SAFETY: memo is present in memo_map and we have verified that it is
             // still valid for the current revision.

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -212,7 +212,12 @@ impl MemoHeader {
         revision: Revision,
         has_value: bool,
     ) -> Option<VerifyResult> {
-        let can_shallow_update = self.shallow_verify_memo(zalsa, database_key_index, has_value);
+        let can_shallow_update = self.shallow_verify_memo(
+            zalsa,
+            #[cfg(feature = "detailed-trace")]
+            database_key_index,
+            has_value,
+        );
         if can_shallow_update.yes() && !self.may_be_provisional() {
             self.update_shallow(zalsa, database_key_index, can_shallow_update);
 
@@ -238,7 +243,12 @@ impl MemoHeader {
         let zalsa_local = claim_guard.zalsa_local();
         let database_key_index = claim_guard.database_key_index();
 
-        let can_shallow_update = self.shallow_verify_memo(zalsa, database_key_index, has_value);
+        let can_shallow_update = self.shallow_verify_memo(
+            zalsa,
+            #[cfg(feature = "detailed-trace")]
+            database_key_index,
+            has_value,
+        );
         if can_shallow_update.yes()
             && self.validate_may_be_provisional(zalsa, zalsa_local, database_key_index, has_value)
         {
@@ -286,16 +296,20 @@ impl MemoHeader {
     /// eagerly finalize all provisional memos in cycle iteration, we have to lazily check here
     /// (via `validate_provisional`) whether a may-be-provisional memo should actually be verified
     /// final, because its cycle heads are all now final.
+    ///
+    /// The key is only needed to populate detailed trace events. Gating it avoids constructing
+    /// trace-only data on every memo hit when detailed tracing is disabled.
     #[inline]
     pub(super) fn shallow_verify_memo(
         &self,
         zalsa: &Zalsa,
-        database_key_index: DatabaseKeyIndex,
-        has_value: bool,
+        #[cfg(feature = "detailed-trace")] database_key_index: DatabaseKeyIndex,
+        _has_value: bool,
     ) -> ShallowUpdate {
+        #[cfg(feature = "detailed-trace")]
         crate::tracing::debug!(
             "{database_key_index:?}: shallow_verify_memo(memo = {memo:#?})",
-            memo = self.tracing_debug(has_value)
+            memo = self.tracing_debug(_has_value)
         );
         let verified_at = self.verified_at.load();
         let revision_now = zalsa.current_revision();
@@ -305,7 +319,12 @@ impl MemoHeader {
             return ShallowUpdate::Verified;
         }
 
-        self.shallow_verify_memo_cold(zalsa, database_key_index, verified_at)
+        self.shallow_verify_memo_cold(
+            zalsa,
+            #[cfg(feature = "detailed-trace")]
+            database_key_index,
+            verified_at,
+        )
     }
 
     #[cold]
@@ -313,10 +332,11 @@ impl MemoHeader {
     fn shallow_verify_memo_cold(
         &self,
         zalsa: &Zalsa,
-        database_key_index: DatabaseKeyIndex,
+        #[cfg(feature = "detailed-trace")] database_key_index: DatabaseKeyIndex,
         verified_at: Revision,
     ) -> ShallowUpdate {
         let last_changed = zalsa.last_changed_revision(self.revisions.durability);
+        #[cfg(feature = "detailed-trace")]
         crate::tracing::trace!(
             "{database_key_index:?}: check_durability({database_key_index:#?}, last_changed={:?} <= verified_at={:?}) = {:?}",
             last_changed,


### PR DESCRIPTION
Cached query hits constructed a DatabaseKeyIndex for shallow verification even though the key is only used by detailed tracing or a higher-durability refresh.

Gate the tracing-only argument and construct the key lazily for refreshes, reducing the focused cached-hit instruction count from 236 to 229.

Testing: Passed the workspace test suite, strict MSRV clippy, detailed-trace checks, and CodSpeed simulation.