### PR TITLE
fix: propagate cycle heads through specify

### DIFF
--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -168,9 +168,9 @@ impl ActiveQuery {
         self.accumulated.accumulate(index, value);
     }
 
-    /// Adds a key to our list of outputs.
-    pub(super) fn add_output(&mut self, key: DatabaseKeyIndex) {
-        self.input_outputs.insert(QueryEdge::output(key));
+    /// Adds a key to our list of outputs, returning whether it was newly inserted.
+    pub(super) fn add_output(&mut self, key: DatabaseKeyIndex) -> bool {
+        self.input_outputs.insert(QueryEdge::output(key))
     }
 
     /// True if the given key was output by this query.

--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -98,6 +98,10 @@ impl ActiveQuery {
         std::mem::take(&mut self.cycle_heads)
     }
 
+    pub(crate) fn cycle_heads(&self) -> &CycleHeads {
+        &self.cycle_heads
+    }
+
     pub(crate) fn detach_input_outputs(&mut self) -> DetachedInputOutputs {
         DetachedInputOutputs(std::mem::take(&mut self.input_outputs))
     }

--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -23,10 +23,11 @@ where
     {
         let (zalsa, zalsa_local) = db.zalsas();
 
-        let (active_query_key, current_deps) = match zalsa_local.active_query() {
-            Some(v) => v,
-            None => panic!("can only use `specify` inside a tracked function"),
-        };
+        let (active_query_key, current_deps, cycle_heads) =
+            match zalsa_local.active_query_with_cycle_heads() {
+                Some(v) => v,
+                None => panic!("can only use `specify` inside a tracked function"),
+            };
 
         // `specify` only works if the key is a tracked struct created in the current query.
         //
@@ -87,22 +88,20 @@ where
 
         if let Some(old_memo) = old_memo {
             if old_memo.header.verified_at.load() == revision && old_memo.value.is_some() {
-                // The first value produced in a revision wins, so never overwrite a current memo.
                 let assigned_by_active_query = matches!(
                     old_memo.header.origin(),
                     QueryOriginRef::Assigned(owner) if owner == active_query_key
                 );
 
-                // The active query may be re-executing after its previously assigned memo was
-                // already validated. Its new execution still has to record that memo as one of its
-                // outputs.
-                if assigned_by_active_query {
-                    zalsa_local.add_output(database_key_index);
+                // A value produced by another query wins this revision. The active query can
+                // always replace its own assignment, including during fixpoint iteration.
+                if !assigned_by_active_query {
+                    return;
                 }
-                return;
             }
         }
 
+        let is_provisional = !cycle_heads.is_empty();
         let mut completed_query = CompletedQuery {
             revisions: QueryRevisions {
                 changed_at: current_deps.changed_at,
@@ -110,10 +109,16 @@ where
                 origin_and_extra: OriginAndExtra::assigned(active_query_key),
                 #[cfg(feature = "accumulator")]
                 accumulated_inputs: Default::default(),
-                verified_final: AtomicBool::new(true),
+                verified_final: AtomicBool::new(!is_provisional),
             },
             stale_tracked_structs: Vec::new(),
         };
+        if is_provisional {
+            // Assigned memos aren't cycle heads, so only their inherited head stamps matter.
+            completed_query
+                .revisions
+                .set_cycle_heads(cycle_heads, Default::default());
+        }
 
         if let Some(old_memo) = old_memo {
             completed_query

--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -93,10 +93,19 @@ where
                     QueryOriginRef::Assigned(owner) if owner == active_query_key
                 );
 
-                // A value produced by another query wins this revision. The active query can
-                // always replace its own assignment, including during fixpoint iteration.
+                // A value produced by another query wins this revision.
                 if !assigned_by_active_query {
                     return;
+                }
+
+                let first_assignment_in_execution = zalsa_local.add_output(database_key_index);
+                // Outputs from a prior provisional iteration are seeded into the active query,
+                // so they don't count as duplicate calls in this execution.
+                if cycle_heads.is_empty()
+                    && !old_memo.header.was_cycle_participant()
+                    && !first_assignment_in_execution
+                {
+                    panic!("cannot call `specify` twice for the same key in one query execution");
                 }
             }
         }

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -252,6 +252,25 @@ impl ZalsaLocal {
         }
     }
 
+    /// Returns the active query, its current dependencies, and any provisional cycle results it
+    /// depends on.
+    pub(crate) fn active_query_with_cycle_heads(
+        &self,
+    ) -> Option<(DatabaseKeyIndex, Stamp, CycleHeads)> {
+        // SAFETY: We do not access the query stack reentrantly.
+        unsafe {
+            self.with_query_stack_unchecked(|stack| {
+                stack.last().map(|active_query| {
+                    (
+                        active_query.database_key_index,
+                        active_query.stamp(),
+                        active_query.cycle_heads().clone(),
+                    )
+                })
+            })
+        }
+    }
+
     /// Add an output to the current query's list of dependencies
     ///
     /// Returns `Err` if not in a query.

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -293,14 +293,14 @@ impl ZalsaLocal {
         }
     }
 
-    /// Add an output to the current query's list of dependencies
-    pub(crate) fn add_output(&self, entity: DatabaseKeyIndex) {
+    /// Add an output to the current query's list of dependencies, returning whether it was new.
+    pub(crate) fn add_output(&self, entity: DatabaseKeyIndex) -> bool {
         // SAFETY: We do not access the query stack reentrantly.
         unsafe {
             self.with_query_stack_unchecked_mut(|stack| {
-                if let Some(top_query) = stack.last_mut() {
-                    top_query.add_output(entity)
-                }
+                stack
+                    .last_mut()
+                    .is_some_and(|top_query| top_query.add_output(entity))
             })
         }
     }

--- a/tests/cycle_specify.rs
+++ b/tests/cycle_specify.rs
@@ -1,0 +1,53 @@
+#![cfg(feature = "inventory")]
+
+//! A value specified by a fixpoint cycle remains provisional until the cycle converges.
+
+mod common;
+
+use common::{ExecuteValidateLoggerDatabase, LogDatabase};
+use expect_test::expect;
+
+#[salsa::tracked]
+struct Item<'db> {
+    value: (),
+}
+
+#[salsa::tracked(specify)]
+fn specified(db: &dyn salsa::Database, item: Item<'_>) -> u32 {
+    item.value(db);
+    0
+}
+
+#[salsa::tracked]
+fn read_specified(db: &dyn salsa::Database, item: Item<'_>) -> u32 {
+    specified(db, item)
+}
+
+#[salsa::tracked(cycle_initial = initial)]
+fn cycle(db: &dyn salsa::Database) -> Option<Item<'_>> {
+    let item = cycle(db).unwrap_or_else(|| Item::new(db, ()));
+
+    specified::specify(db, item, 42);
+    assert_eq!(read_specified(db, item), 42);
+    Some(item)
+}
+
+fn initial(_db: &dyn salsa::Database, _id: salsa::Id) -> Option<Item<'_>> {
+    None
+}
+
+#[test]
+fn specified_value_inherits_cycle_heads() {
+    let db = ExecuteValidateLoggerDatabase::default();
+
+    assert!(cycle(&db).is_some());
+
+    db.assert_logs(expect![[r#"
+        [
+            "salsa_event(WillExecute { database_key: cycle(Id(0)) })",
+            "salsa_event(WillExecute { database_key: read_specified(Id(400)) })",
+            "salsa_event(WillIterateCycle { database_key: cycle(Id(0)), iteration: 1 })",
+            "salsa_event(WillExecute { database_key: read_specified(Id(400)) })",
+            "salsa_event(DidFinalizeCycle { database_key: cycle(Id(0)), iteration: 1 })",
+        ]"#]]);
+}

--- a/tests/tracked_fn_read_own_specify.rs
+++ b/tests/tracked_fn_read_own_specify.rs
@@ -19,9 +19,15 @@ struct MyTracked<'db> {
 fn tracked_fn(db: &dyn LogDatabase, input: MyInput) -> u32 {
     db.push_log(format!("tracked_fn({input:?})"));
     let t = MyTracked::new(db, input.field(db) * 2);
-    tracked_fn_extra::specify(db, t, 1111);
     tracked_fn_extra::specify(db, t, 2222);
     tracked_fn_extra(db, t)
+}
+
+#[salsa::tracked]
+fn tracked_fn_specify_twice(db: &dyn LogDatabase, input: MyInput) {
+    let t = MyTracked::new(db, input.field(db) * 2);
+    tracked_fn_extra::specify(db, t, 1111);
+    tracked_fn_extra::specify(db, t, 2222);
 }
 
 #[salsa::tracked(specify)]
@@ -47,4 +53,12 @@ fn execute() {
     // Re-run the query on the original input. Nothing re-executes!
     assert_eq!(tracked_fn(&db, input), 2222);
     db.assert_logs(expect!["[]"]);
+}
+
+#[test]
+#[should_panic(expected = "cannot call `specify` twice for the same key in one query execution")]
+fn specify_twice_panics() {
+    let db = common::LoggerDatabase::default();
+    let input = MyInput::new(&db, 22);
+    tracked_fn_specify_twice(&db, input);
 }

--- a/tests/tracked_fn_read_own_specify.rs
+++ b/tests/tracked_fn_read_own_specify.rs
@@ -19,6 +19,7 @@ struct MyTracked<'db> {
 fn tracked_fn(db: &dyn LogDatabase, input: MyInput) -> u32 {
     db.push_log(format!("tracked_fn({input:?})"));
     let t = MyTracked::new(db, input.field(db) * 2);
+    tracked_fn_extra::specify(db, t, 1111);
     tracked_fn_extra::specify(db, t, 2222);
     tracked_fn_extra(db, t)
 }


### PR DESCRIPTION
Specified values created during fixpoint iteration were marked final, allowing dependent queries to skip later iterations. Propagate the owner's cycle heads and let the owner refresh its assignment.

Same-query assignments can refresh during fixpoint iteration; duplicate non-cycle assignments to the same key now panic.

Fixes #1187.

Testing: Added integration coverage and ran the workspace and Shuttle test suites.
