### PR TITLE
fix: seed cycle disambiguators once

### DIFF
--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -84,10 +84,9 @@ impl ActiveQuery {
         self.durability = self.durability.min(durability);
         self.changed_at = self.changed_at.max(changed_at);
         self.untracked_read |= untracked_read;
-        self.disambiguator_map
-            .seed(active_tracked_ids.iter().map(|(id, _)| id));
 
-        // Mark all tracked structs from the previous iteration as active.
+        // Mark all tracked structs from the previous iteration as active and reserve
+        // their identities so that newly created structs receive later disambiguators.
         self.tracked_struct_ids
             .mark_all_active(active_tracked_ids.iter().copied());
         self.disambiguator_map


### PR DESCRIPTION
Cycle iteration setup seeded tracked-struct disambiguators twice, causing later identities to skip expected disambiguator values.
Seed them once while preserving previous-iteration tracked structs as active.
Testing: Existing cycle tests pass.