### PR TITLE
fix: omit never-change input edges

### DIFF
--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -146,7 +146,10 @@ impl ActiveQuery {
     ) {
         self.durability = self.durability.min(durability);
         self.add_changed_at(revision);
-        self.input_outputs.insert(QueryEdge::input(input));
+
+        if cfg!(feature = "persistence") || durability != Durability::NEVER_CHANGE {
+            self.input_outputs.insert(QueryEdge::input(input));
+        }
     }
 
     pub(super) fn add_changed_at(&mut self, revision: Revision) {

--- a/tests/never_change.rs
+++ b/tests/never_change.rs
@@ -24,6 +24,11 @@ fn mixed_value(db: &dyn Database, immutable_input: MyInput, mutable_input: MyInp
     immutable_value(db, immutable_input) + mutable_input.value(db)
 }
 
+#[salsa::tracked]
+fn mixed_input_value(db: &dyn Database, immutable_input: MyInput, mutable_input: MyInput) -> u32 {
+    immutable_input.value(db) + mutable_input.value(db)
+}
+
 #[salsa::tracked(lru = 1)]
 #[cfg(not(feature = "persistence"))]
 fn immutable_value_with_lru(db: &dyn LogDatabase, input: MyInput) -> u32 {
@@ -85,6 +90,25 @@ fn skip_dependency_edge_to_never_change_query() {
         [
             "salsa_event(DidValidateMemoizedValue { database_key: mixed_value(Id(400)) })",
         ]"#]]);
+}
+
+#[test]
+#[cfg(all(not(feature = "persistence"), feature = "salsa_unstable"))]
+fn skip_dependency_edge_to_never_change_input() {
+    let db = salsa::DatabaseImpl::default();
+    let immutable_input = MyInput::builder(10)
+        .durability(Durability::NEVER_CHANGE)
+        .new(&db);
+    let mutable_input = MyInput::new(&db, 20);
+
+    assert_eq!(mixed_value(&db, immutable_input, mutable_input), 30);
+    assert_eq!(mixed_input_value(&db, immutable_input, mutable_input), 30);
+
+    let memory_usage = <dyn Database>::memory_usage(&db);
+    assert_eq!(
+        memory_usage.queries["mixed_input_value"].size_of_metadata(),
+        memory_usage.queries["mixed_value"].size_of_metadata()
+    );
 }
 
 #[test]


### PR DESCRIPTION
Direct reads of `NEVER_CHANGE` input fields retained dependency edges even though those fields cannot be mutated. Omit those edges outside persistence builds, reducing memo metadata while preserving persistence behavior.
