### PR TITLE
chore: migrate benchmarks to Divan and CodSpeed macro runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,7 +166,7 @@ jobs:
           retention-days: 1
 
   benchmarks:
-    name: Benchmarks (simulation/memory)
+    name: Benchmarks
     runs-on: codspeed-macro
     needs: benchmarks-build
     steps:
@@ -190,35 +190,6 @@ jobs:
       - name: "Run benchmarks"
         uses: CodSpeedHQ/action@c145068895e045cc725ee76fcd2307624b65c3af # v4.17.5
         with:
-          mode: "simulation,memory"
+          mode: "simulation,memory,walltime"
           run: cargo codspeed run
-          token: ${{ secrets.CODSPEED_TOKEN }}
-
-  benchmarks-walltime:
-    name: Benchmarks (walltime)
-    runs-on: codspeed-macro
-    needs: benchmarks-build
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: "Setup codspeed"
-        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
-        with:
-          tool: cargo-codspeed
-
-      - name: "Download benchmark binaries"
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: benchmark-binaries
-          path: target/codspeed
-
-      - name: "Restore binary permissions"
-        run: find target/codspeed -type f -exec chmod +x {} +
-
-      - name: "Run benchmarks"
-        uses: CodSpeedHQ/action@c145068895e045cc725ee76fcd2307624b65c3af # v4.17.5
-        with:
-          mode: walltime
-          run: cargo codspeed run -m walltime
           token: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,7 +130,7 @@ jobs:
     # https://github.com/CodSpeedHQ/action/issues/126
     if: github.repository == 'salsa-rs/salsa' &&github.event_name != 'merge_group'
     name: Benchmarks (build)
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-22.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,11 +126,11 @@ jobs:
       - name: Test with Shuttle
         run: cargo nextest run --features shuttle --test parallel
 
-  benchmarks:
+  benchmarks-build:
     # https://github.com/CodSpeedHQ/action/issues/126
     if: github.repository == 'salsa-rs/salsa' &&github.event_name != 'merge_group'
-    name: Benchmarks
-    runs-on: ubuntu-latest
+    name: Benchmarks (build)
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -148,11 +148,51 @@ jobs:
           tool: cargo-codspeed
 
       - name: "Build benchmarks"
-        run: cargo codspeed build -m simulation -m memory
+        run: |
+          cargo codspeed build -m simulation -m memory \
+            --bench compare \
+            --bench incremental \
+            --bench accumulator \
+            --bench dataflow
+          cargo codspeed build -m walltime --bench lru
+
+      - name: "Upload benchmark binaries"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: benchmark-binaries
+          compression-level: 1
+          path: target/codspeed
+          if-no-files-found: "error"
+          retention-days: 1
+
+  benchmarks:
+    name: Benchmarks
+    runs-on: codspeed-macro
+    needs: benchmarks-build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: "Setup codspeed"
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+        with:
+          tool: cargo-codspeed
+
+      - name: "Download benchmark binaries"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: benchmark-binaries
+          path: target/codspeed
+
+      - name: "Restore binary permissions"
+        run: find target/codspeed -type f -exec chmod +x {} +
 
       - name: "Run benchmarks"
         uses: CodSpeedHQ/action@c145068895e045cc725ee76fcd2307624b65c3af # v4.17.5
         with:
-          mode: "simulation,memory"
-          run: cargo codspeed run
+          mode: "simulation,memory,walltime"
+          run: |
+            cargo codspeed run -m simulation
+            cargo codspeed run -m memory
+            cargo codspeed run -m walltime
           token: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Clippy / all-features
         run: cargo clippy --workspace --all-targets --features persistence -- -D warnings
       - name: Test
-        run: cargo nextest run --workspace --all-targets --features persistence --no-fail-fast
+        run: cargo nextest run --workspace --tests --examples --features persistence --no-fail-fast
       - name: Test Manual Registration / no-default-features
         run: cargo nextest run --workspace --tests --no-fail-fast --no-default-features --features macros
       - name: Test docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,7 +166,7 @@ jobs:
           retention-days: 1
 
   benchmarks:
-    name: Benchmarks
+    name: Benchmarks (simulation/memory)
     runs-on: codspeed-macro
     needs: benchmarks-build
     steps:
@@ -190,9 +190,37 @@ jobs:
       - name: "Run benchmarks"
         uses: CodSpeedHQ/action@c145068895e045cc725ee76fcd2307624b65c3af # v4.17.5
         with:
-          mode: "simulation,memory,walltime"
+          mode: "simulation,memory"
           run: |
             cargo codspeed run -m simulation
             cargo codspeed run -m memory
-            cargo codspeed run -m walltime
+          token: ${{ secrets.CODSPEED_TOKEN }}
+
+  benchmarks-walltime:
+    name: Benchmarks (walltime)
+    runs-on: codspeed-macro
+    needs: benchmarks-build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: "Setup codspeed"
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+        with:
+          tool: cargo-codspeed
+
+      - name: "Download benchmark binaries"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: benchmark-binaries
+          path: target/codspeed
+
+      - name: "Restore binary permissions"
+        run: find target/codspeed -type f -exec chmod +x {} +
+
+      - name: "Run benchmarks"
+        uses: CodSpeedHQ/action@c145068895e045cc725ee76fcd2307624b65c3af # v4.17.5
+        with:
+          mode: walltime
+          run: cargo codspeed run -m walltime
           token: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,9 +191,7 @@ jobs:
         uses: CodSpeedHQ/action@c145068895e045cc725ee76fcd2307624b65c3af # v4.17.5
         with:
           mode: "simulation,memory"
-          run: |
-            cargo codspeed run -m simulation
-            cargo codspeed run -m memory
+          run: cargo codspeed run
           token: ${{ secrets.CODSPEED_TOKEN }}
 
   benchmarks-walltime:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ ordered-float = "=5.3.0"
 
 # tests/benches
 annotate-snippets = "=0.12.16"
-codspeed-criterion-compat = { version = "=4.7.0", default-features = false }
+divan = { package = "codspeed-divan-compat", version = "=4.7.0" }
 expect-test = "=1.5.1"
 rustversion = "=1.0.22"
 test-log = { version = "=0.2.21", features = ["trace"] }

--- a/benches/accumulator.rs
+++ b/benches/accumulator.rs
@@ -1,7 +1,10 @@
 use std::hint::black_box;
 
-use codspeed_criterion_compat::{BatchSize, Criterion, criterion_group, criterion_main};
 use salsa::Accumulator;
+
+fn main() {
+    divan::main();
+}
 
 #[salsa::input]
 struct Input {
@@ -42,31 +45,25 @@ fn infer_expression<'db>(db: &'db dyn salsa::Database, expression: Expression<'d
     number
 }
 
-fn accumulator(criterion: &mut Criterion) {
-    criterion.bench_function("accumulator", |b| {
-        b.iter_batched_ref(
-            || {
-                let db = salsa::DatabaseImpl::new();
+#[divan::bench]
+fn accumulator(bencher: divan::Bencher) {
+    bencher
+        .with_inputs(|| {
+            let db = salsa::DatabaseImpl::new();
 
-                let input = Input::new(black_box(&db), black_box(10_000));
+            let input = Input::new(black_box(&db), black_box(10_000));
 
-                // Pre-warm
-                let result = root(black_box(&db), black_box(input));
-                assert!(!black_box(result).is_empty());
+            // Pre-warm
+            let result = root(black_box(&db), black_box(input));
+            assert!(!black_box(result).is_empty());
 
-                (db, input)
-            },
-            |(db, input)| {
-                // Measure the cost of collecting accumulators ignoring the cost of running the
-                // query itself.
-                let diagnostics = root::accumulated::<Diagnostic>(black_box(db), *black_box(input));
+            (db, input)
+        })
+        .bench_local_refs(|(db, input)| {
+            // Measure the cost of collecting accumulators ignoring the cost of running the
+            // query itself.
+            let diagnostics = root::accumulated::<Diagnostic>(black_box(db), *black_box(input));
 
-                assert_eq!(black_box(diagnostics).len(), 1000);
-            },
-            BatchSize::SmallInput,
-        );
-    });
+            assert_eq!(black_box(diagnostics).len(), 1000);
+        });
 }
-
-criterion_group!(benches, accumulator);
-criterion_main!(benches);

--- a/benches/accumulator.rs
+++ b/benches/accumulator.rs
@@ -45,7 +45,7 @@ fn infer_expression<'db>(db: &'db dyn salsa::Database, expression: Expression<'d
     number
 }
 
-#[divan::bench]
+#[divan::bench(name = "benches::accumulator::accumulator")]
 fn accumulator(bencher: divan::Bencher) {
     bencher
         .with_inputs(|| {

--- a/benches/compare.rs
+++ b/benches/compare.rs
@@ -46,10 +46,13 @@ pub fn either_length<'db>(db: &'db dyn salsa::Database, input: SupertypeInput<'d
     }
 }
 
-mod mutating_inputs {
+mod benches {
     use super::*;
 
-    #[divan::bench(args = [10, 20, 30])]
+    #[divan::bench(
+        name = "mutating_inputs::Mutating Inputs::mutating",
+        args = [10, 20, 30]
+    )]
     fn mutating(bencher: divan::Bencher, n: usize) {
         bencher
             .with_inputs(move || {
@@ -73,7 +76,7 @@ mod mutating_inputs {
             });
     }
 
-    #[divan::bench(name = "new[InternedInput]")]
+    #[divan::bench(name = "inputs::Mutating Inputs::new[InternedInput]")]
     fn new_interned_input(bencher: divan::Bencher) {
         bencher
             .with_inputs(|| {
@@ -93,7 +96,7 @@ mod mutating_inputs {
             });
     }
 
-    #[divan::bench(name = "amortized[InternedInput]")]
+    #[divan::bench(name = "inputs::Mutating Inputs::amortized[InternedInput]")]
     fn amortized_interned_input(bencher: divan::Bencher) {
         bencher
             .with_inputs(|| {
@@ -111,7 +114,7 @@ mod mutating_inputs {
             });
     }
 
-    #[divan::bench(name = "new[Input]")]
+    #[divan::bench(name = "inputs::Mutating Inputs::new[Input]")]
     fn new_input(bencher: divan::Bencher) {
         bencher
             .with_inputs(|| {
@@ -131,7 +134,7 @@ mod mutating_inputs {
             });
     }
 
-    #[divan::bench(name = "amortized[Input]")]
+    #[divan::bench(name = "inputs::Mutating Inputs::amortized[Input]")]
     fn amortized_input(bencher: divan::Bencher) {
         bencher
             .with_inputs(|| {
@@ -149,7 +152,7 @@ mod mutating_inputs {
             });
     }
 
-    #[divan::bench(name = "cached[Input]")]
+    #[divan::bench(name = "inputs::Mutating Inputs::cached[Input]")]
     fn cached_input(bencher: divan::Bencher) {
         let db = salsa::DatabaseImpl::default();
         let input = Input::new(&db, "hello, world!".to_owned());
@@ -161,7 +164,7 @@ mod mutating_inputs {
         bencher.bench_local(|| length(black_box(&db), black_box(input)));
     }
 
-    #[divan::bench(name = "new[SupertypeInput]")]
+    #[divan::bench(name = "inputs::Mutating Inputs::new[SupertypeInput]")]
     fn new_supertype_input(bencher: divan::Bencher) {
         bencher
             .with_inputs(|| {
@@ -199,7 +202,7 @@ mod mutating_inputs {
             });
     }
 
-    #[divan::bench(name = "amortized[SupertypeInput]")]
+    #[divan::bench(name = "inputs::Mutating Inputs::amortized[SupertypeInput]")]
     fn amortized_supertype_input(bencher: divan::Bencher) {
         bencher
             .with_inputs(|| {

--- a/benches/compare.rs
+++ b/benches/compare.rs
@@ -1,10 +1,11 @@
 use std::hint::black_box;
 use std::mem::transmute;
 
-use codspeed_criterion_compat::{
-    BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main,
-};
 use salsa::Setter;
+
+fn main() {
+    divan::main();
+}
 
 #[salsa::input]
 pub struct Input {
@@ -45,49 +46,37 @@ pub fn either_length<'db>(db: &'db dyn salsa::Database, input: SupertypeInput<'d
     }
 }
 
-fn mutating_inputs(c: &mut Criterion) {
-    let mut group: codspeed_criterion_compat::BenchmarkGroup<
-        codspeed_criterion_compat::measurement::WallTime,
-    > = c.benchmark_group("Mutating Inputs");
+mod mutating_inputs {
+    use super::*;
 
-    for n in &[10, 20, 30] {
-        group.bench_function(BenchmarkId::new("mutating", n), |b| {
-            b.iter_batched_ref(
-                || {
-                    let db = salsa::DatabaseImpl::default();
-                    let base_string = "hello, world!".to_owned();
-                    let base_len = base_string.len();
+    #[divan::bench(args = [10, 20, 30])]
+    fn mutating(bencher: divan::Bencher, n: usize) {
+        bencher
+            .with_inputs(move || {
+                let db = salsa::DatabaseImpl::default();
+                let base_string = "hello, world!".to_owned();
+                let base_len = base_string.len();
 
-                    let string = base_string.clone().repeat(*n);
-                    let new_len = string.len();
+                let string = base_string.clone().repeat(n);
+                let new_len = string.len();
 
-                    let input = Input::new(black_box(&db), black_box(base_string.clone()));
-                    let actual_len = length(&db, input);
-                    assert_eq!(black_box(actual_len), base_len);
+                let input = Input::new(black_box(&db), black_box(base_string.clone()));
+                let actual_len = length(&db, input);
+                assert_eq!(black_box(actual_len), base_len);
 
-                    (db, input, string, new_len)
-                },
-                |&mut (ref mut db, input, ref string, new_len)| {
-                    input.set_text(black_box(db)).to(black_box(string).clone());
-                    let actual_len = length(db, input);
-                    assert_eq!(black_box(actual_len), new_len);
-                },
-                BatchSize::SmallInput,
-            )
-        });
+                (db, input, string, new_len)
+            })
+            .bench_local_refs(|&mut (ref mut db, input, ref string, new_len)| {
+                input.set_text(black_box(db)).to(black_box(string).clone());
+                let actual_len = length(db, input);
+                assert_eq!(black_box(actual_len), new_len);
+            });
     }
 
-    group.finish();
-}
-
-fn inputs(c: &mut Criterion) {
-    let mut group: codspeed_criterion_compat::BenchmarkGroup<
-        codspeed_criterion_compat::measurement::WallTime,
-    > = c.benchmark_group("Mutating Inputs");
-
-    group.bench_function(BenchmarkId::new("new", "InternedInput"), |b| {
-        b.iter_batched_ref(
-            || {
+    #[divan::bench(name = "new[InternedInput]")]
+    fn new_interned_input(bencher: divan::Bencher) {
+        bencher
+            .with_inputs(|| {
                 let db = salsa::DatabaseImpl::default();
                 // Prepopulate ingredients.
                 let input =
@@ -95,20 +84,19 @@ fn inputs(c: &mut Criterion) {
                 let interned_len = interned_length(black_box(&db), black_box(input));
                 assert_eq!(black_box(interned_len), 13);
                 db
-            },
-            |db| {
+            })
+            .bench_local_refs(|db| {
                 let input =
                     InternedInput::new(black_box(db), black_box("hello, world!".to_owned()));
                 let interned_len = interned_length(black_box(db), black_box(input));
                 assert_eq!(black_box(interned_len), 13);
-            },
-            BatchSize::SmallInput,
-        )
-    });
+            });
+    }
 
-    group.bench_function(BenchmarkId::new("amortized", "InternedInput"), |b| {
-        b.iter_batched_ref(
-            || {
+    #[divan::bench(name = "amortized[InternedInput]")]
+    fn amortized_interned_input(bencher: divan::Bencher) {
+        bencher
+            .with_inputs(|| {
                 let db = salsa::DatabaseImpl::default();
                 // we can't pass this along otherwise, and the lifetime is generally informational
                 let input: InternedInput<'static> =
@@ -116,18 +104,17 @@ fn inputs(c: &mut Criterion) {
                 let interned_len = interned_length(black_box(&db), black_box(input));
                 assert_eq!(black_box(interned_len), 13);
                 (db, input)
-            },
-            |&mut (ref db, input)| {
-                let interned_len = interned_length(black_box(db), black_box(input));
+            })
+            .bench_local_refs(|(db, input)| {
+                let interned_len = interned_length(black_box(db), black_box(*input));
                 assert_eq!(black_box(interned_len), 13);
-            },
-            BatchSize::SmallInput,
-        )
-    });
+            });
+    }
 
-    group.bench_function(BenchmarkId::new("new", "Input"), |b| {
-        b.iter_batched_ref(
-            || {
+    #[divan::bench(name = "new[Input]")]
+    fn new_input(bencher: divan::Bencher) {
+        bencher
+            .with_inputs(|| {
                 let db = salsa::DatabaseImpl::default();
 
                 // Prepopulate ingredients.
@@ -136,19 +123,18 @@ fn inputs(c: &mut Criterion) {
                 assert_eq!(black_box(len), 13);
 
                 db
-            },
-            |db| {
+            })
+            .bench_local_refs(|db| {
                 let input = Input::new(black_box(db), black_box("hello, world!".to_owned()));
                 let len = length(black_box(db), black_box(input));
                 assert_eq!(black_box(len), 13);
-            },
-            BatchSize::SmallInput,
-        )
-    });
+            });
+    }
 
-    group.bench_function(BenchmarkId::new("amortized", "Input"), |b| {
-        b.iter_batched_ref(
-            || {
+    #[divan::bench(name = "amortized[Input]")]
+    fn amortized_input(bencher: divan::Bencher) {
+        bencher
+            .with_inputs(|| {
                 let db = salsa::DatabaseImpl::default();
 
                 let input = Input::new(black_box(&db), black_box("hello, world!".to_owned()));
@@ -156,16 +142,15 @@ fn inputs(c: &mut Criterion) {
                 assert_eq!(black_box(len), 13);
 
                 (db, input)
-            },
-            |&mut (ref db, input)| {
-                let len = length(black_box(db), black_box(input));
+            })
+            .bench_local_refs(|(db, input)| {
+                let len = length(black_box(db), black_box(*input));
                 assert_eq!(black_box(len), 13);
-            },
-            BatchSize::SmallInput,
-        )
-    });
+            });
+    }
 
-    group.bench_function(BenchmarkId::new("cached", "Input"), |b| {
+    #[divan::bench(name = "cached[Input]")]
+    fn cached_input(bencher: divan::Bencher) {
         let db = salsa::DatabaseImpl::default();
         let input = Input::new(&db, "hello, world!".to_owned());
 
@@ -173,12 +158,13 @@ fn inputs(c: &mut Criterion) {
         // the current revision.
         assert_eq!(length(&db, input), 13);
 
-        b.iter(|| length(black_box(&db), black_box(input)))
-    });
+        bencher.bench_local(|| length(black_box(&db), black_box(input)));
+    }
 
-    group.bench_function(BenchmarkId::new("new", "SupertypeInput"), |b| {
-        b.iter_batched_ref(
-            || {
+    #[divan::bench(name = "new[SupertypeInput]")]
+    fn new_supertype_input(bencher: divan::Bencher) {
+        bencher
+            .with_inputs(|| {
                 let db = salsa::DatabaseImpl::default();
 
                 // Prepopulate ingredients.
@@ -196,8 +182,8 @@ fn inputs(c: &mut Criterion) {
                 assert_eq!(black_box(len), 13);
 
                 db
-            },
-            |db| {
+            })
+            .bench_local_refs(|db| {
                 let input = SupertypeInput::Input(Input::new(
                     black_box(db),
                     black_box("hello, world!".to_owned()),
@@ -210,14 +196,13 @@ fn inputs(c: &mut Criterion) {
                 assert_eq!(black_box(len), 13);
                 let len = either_length(black_box(db), black_box(interned_input));
                 assert_eq!(black_box(len), 13);
-            },
-            BatchSize::SmallInput,
-        )
-    });
+            });
+    }
 
-    group.bench_function(BenchmarkId::new("amortized", "SupertypeInput"), |b| {
-        b.iter_batched_ref(
-            || {
+    #[divan::bench(name = "amortized[SupertypeInput]")]
+    fn amortized_supertype_input(bencher: divan::Bencher) {
+        bencher
+            .with_inputs(|| {
                 let db = salsa::DatabaseImpl::default();
 
                 let input = SupertypeInput::Input(Input::new(
@@ -236,19 +221,12 @@ fn inputs(c: &mut Criterion) {
                 assert_eq!(black_box(len), 13);
 
                 (db, input, interned_input)
-            },
-            |&mut (ref db, input, interned_input)| {
-                let len = either_length(black_box(db), black_box(input));
+            })
+            .bench_local_refs(|(db, input, interned_input)| {
+                let len = either_length(black_box(db), black_box(*input));
                 assert_eq!(black_box(len), 13);
-                let len = either_length(black_box(db), black_box(interned_input));
+                let len = either_length(black_box(db), black_box(*interned_input));
                 assert_eq!(black_box(len), 13);
-            },
-            BatchSize::SmallInput,
-        )
-    });
-
-    group.finish();
+            });
+    }
 }
-
-criterion_group!(benches, mutating_inputs, inputs);
-criterion_main!(benches);

--- a/benches/dataflow.rs
+++ b/benches/dataflow.rs
@@ -5,8 +5,11 @@
 use std::collections::BTreeSet;
 use std::iter::IntoIterator;
 
-use codspeed_criterion_compat::{BatchSize, Criterion, criterion_group, criterion_main};
 use salsa::{Database as Db, Setter};
+
+fn main() {
+    divan::main();
+}
 
 /// A Use of a symbol.
 #[salsa::input]
@@ -128,45 +131,42 @@ fn add(a: &Type, b: &Type) -> Type {
     }
 }
 
-fn dataflow(criterion: &mut Criterion) {
-    criterion.bench_function("converge_diverge", |b| {
-        b.iter_batched_ref(
-            || {
-                let mut db = salsa::DatabaseImpl::new();
+#[divan::bench]
+fn converge_diverge(bencher: divan::Bencher) {
+    bencher
+        .with_inputs(|| {
+            let mut db = salsa::DatabaseImpl::new();
 
-                let defx0 = Definition::new(&db, None, 0);
-                let defy0 = Definition::new(&db, None, 0);
-                let defx1 = Definition::new(&db, None, 0);
-                let defy1 = Definition::new(&db, None, 0);
-                let use_x = Use::new(&db, vec![defx0, defx1]);
-                let use_y = Use::new(&db, vec![defy0, defy1]);
-                defx1.set_base(&mut db).to(Some(use_y));
-                defy1.set_base(&mut db).to(Some(use_x));
+            let defx0 = Definition::new(&db, None, 0);
+            let defy0 = Definition::new(&db, None, 0);
+            let defx1 = Definition::new(&db, None, 0);
+            let defy1 = Definition::new(&db, None, 0);
+            let use_x = Use::new(&db, vec![defx0, defx1]);
+            let use_y = Use::new(&db, vec![defy0, defy1]);
+            defx1.set_base(&mut db).to(Some(use_y));
+            defy1.set_base(&mut db).to(Some(use_x));
 
-                // prewarm cache
-                let _ = infer_use(&db, use_x);
-                let _ = infer_use(&db, use_y);
+            // prewarm cache
+            let _ = infer_use(&db, use_x);
+            let _ = infer_use(&db, use_y);
 
-                (db, defx1, use_x, use_y)
-            },
-            |(db, defx1, use_x, use_y)| {
-                // Set the increment on x to 0.
-                defx1.set_increment(db).to(0);
+            (db, defx1, use_x, use_y)
+        })
+        .bench_local_refs(|(db, defx1, use_x, use_y)| {
+            // Set the increment on x to 0.
+            defx1.set_increment(db).to(0);
 
-                // Both symbols converge on 0.
-                assert_eq!(infer_use(db, *use_x), Type::Values(Box::from([0])));
-                assert_eq!(infer_use(db, *use_y), Type::Values(Box::from([0])));
+            // Both symbols converge on 0.
+            assert_eq!(infer_use(db, *use_x), Type::Values(Box::from([0])));
+            assert_eq!(infer_use(db, *use_y), Type::Values(Box::from([0])));
 
-                // Set the increment on x to 1.
-                defx1.set_increment(db).to(1);
+            // Set the increment on x to 1.
+            defx1.set_increment(db).to(1);
 
-                // Now the loop diverges and we fall back to Top.
-                assert_eq!(infer_use(db, *use_x), Type::Top);
-                assert_eq!(infer_use(db, *use_y), Type::Top);
-            },
-            BatchSize::LargeInput,
-        );
-    });
+            // Now the loop diverges and we fall back to Top.
+            assert_eq!(infer_use(db, *use_x), Type::Top);
+            assert_eq!(infer_use(db, *use_y), Type::Top);
+        });
 }
 
 /// Emulates a data flow problem of the form:
@@ -177,38 +177,32 @@ fn dataflow(criterion: &mut Criterion) {
 /// self.x3 = self.x0 + self.x1 + self.x2 + self.x4
 /// self.x4 = 0
 /// ```
-fn nested(criterion: &mut Criterion) {
-    criterion.bench_function("converge_diverge_nested", |b| {
-        b.iter_batched_ref(
-            || {
-                let mut db = salsa::DatabaseImpl::new();
+#[divan::bench]
+fn converge_diverge_nested(bencher: divan::Bencher) {
+    bencher
+        .with_inputs(|| {
+            let mut db = salsa::DatabaseImpl::new();
 
-                let def_x0 = Definition::new(&db, None, 0);
-                let def_x1 = Definition::new(&db, None, 0);
-                let def_x2 = Definition::new(&db, None, 0);
-                let def_x3 = Definition::new(&db, None, 0);
-                let def_x4 = Definition::new(&db, None, 0);
+            let def_x0 = Definition::new(&db, None, 0);
+            let def_x1 = Definition::new(&db, None, 0);
+            let def_x2 = Definition::new(&db, None, 0);
+            let def_x3 = Definition::new(&db, None, 0);
+            let def_x4 = Definition::new(&db, None, 0);
 
-                let use_x0 = Use::new(&db, vec![def_x1, def_x2, def_x3, def_x4]);
-                let use_x1 = Use::new(&db, vec![def_x0, def_x2, def_x3, def_x4]);
-                let use_x2 = Use::new(&db, vec![def_x0, def_x1, def_x3, def_x4]);
-                let use_x3 = Use::new(&db, vec![def_x0, def_x1, def_x3, def_x4]);
+            let use_x0 = Use::new(&db, vec![def_x1, def_x2, def_x3, def_x4]);
+            let use_x1 = Use::new(&db, vec![def_x0, def_x2, def_x3, def_x4]);
+            let use_x2 = Use::new(&db, vec![def_x0, def_x1, def_x3, def_x4]);
+            let use_x3 = Use::new(&db, vec![def_x0, def_x1, def_x3, def_x4]);
 
-                def_x0.set_base(&mut db).to(Some(use_x0));
-                def_x1.set_base(&mut db).to(Some(use_x1));
-                def_x2.set_base(&mut db).to(Some(use_x2));
-                def_x3.set_base(&mut db).to(Some(use_x3));
+            def_x0.set_base(&mut db).to(Some(use_x0));
+            def_x1.set_base(&mut db).to(Some(use_x1));
+            def_x2.set_base(&mut db).to(Some(use_x2));
+            def_x3.set_base(&mut db).to(Some(use_x3));
 
-                (db, def_x0)
-            },
-            |(db, def_x0)| {
-                // All symbols converge on 0.
-                assert_eq!(infer_definition(db, *def_x0), Type::Values(Box::from([0])));
-            },
-            BatchSize::LargeInput,
-        );
-    });
+            (db, def_x0)
+        })
+        .bench_local_refs(|(db, def_x0)| {
+            // All symbols converge on 0.
+            assert_eq!(infer_definition(db, *def_x0), Type::Values(Box::from([0])));
+        });
 }
-
-criterion_group!(benches, dataflow, nested);
-criterion_main!(benches);

--- a/benches/dataflow.rs
+++ b/benches/dataflow.rs
@@ -131,7 +131,7 @@ fn add(a: &Type, b: &Type) -> Type {
     }
 }
 
-#[divan::bench]
+#[divan::bench(name = "benches::dataflow::converge_diverge")]
 fn converge_diverge(bencher: divan::Bencher) {
     bencher
         .with_inputs(|| {
@@ -177,7 +177,7 @@ fn converge_diverge(bencher: divan::Bencher) {
 /// self.x3 = self.x0 + self.x1 + self.x2 + self.x4
 /// self.x4 = 0
 /// ```
-#[divan::bench]
+#[divan::bench(name = "benches::nested::converge_diverge_nested")]
 fn converge_diverge_nested(bencher: divan::Bencher) {
     bencher
         .with_inputs(|| {

--- a/benches/incremental.rs
+++ b/benches/incremental.rs
@@ -1,7 +1,10 @@
 use std::hint::black_box;
 
-use codspeed_criterion_compat::{BatchSize, Criterion, criterion_group, criterion_main};
 use salsa::Setter;
+
+fn main() {
+    divan::main();
+}
 
 #[salsa::input]
 struct Input {
@@ -26,35 +29,29 @@ fn root(db: &dyn salsa::Database, input: Input) -> usize {
     index.len()
 }
 
-fn many_tracked_structs(criterion: &mut Criterion) {
-    criterion.bench_function("many_tracked_structs", |b| {
-        b.iter_batched_ref(
-            || {
-                let db = salsa::DatabaseImpl::new();
+#[divan::bench]
+fn many_tracked_structs(bencher: divan::Bencher) {
+    bencher
+        .with_inputs(|| {
+            let db = salsa::DatabaseImpl::new();
 
-                let input = Input::new(black_box(&db), black_box(1_000));
-                let input2 = Input::new(black_box(&db), black_box(1));
+            let input = Input::new(black_box(&db), black_box(1_000));
+            let input2 = Input::new(black_box(&db), black_box(1));
 
-                // prewarm cache
-                let root1 = root(black_box(&db), black_box(input));
-                assert_eq!(black_box(root1), 1_000);
-                let root2 = root(black_box(&db), black_box(input2));
-                assert_eq!(black_box(root2), 1);
+            // prewarm cache
+            let root1 = root(black_box(&db), black_box(input));
+            assert_eq!(black_box(root1), 1_000);
+            let root2 = root(black_box(&db), black_box(input2));
+            assert_eq!(black_box(root2), 1);
 
-                (db, input, input2)
-            },
-            |(db, input, input2)| {
-                // Make a change, but fetch the result for the other input
-                input2.set_field(black_box(db)).to(black_box(2));
+            (db, input, input2)
+        })
+        .bench_local_refs(|(db, input, input2)| {
+            // Make a change, but fetch the result for the other input
+            input2.set_field(black_box(db)).to(black_box(2));
 
-                let result = root(black_box(db), *black_box(input));
+            let result = root(black_box(db), *black_box(input));
 
-                assert_eq!(black_box(result), 1_000);
-            },
-            BatchSize::LargeInput,
-        );
-    });
+            assert_eq!(black_box(result), 1_000);
+        });
 }
-
-criterion_group!(benches, many_tracked_structs);
-criterion_main!(benches);

--- a/benches/incremental.rs
+++ b/benches/incremental.rs
@@ -29,7 +29,7 @@ fn root(db: &dyn salsa::Database, input: Input) -> usize {
     index.len()
 }
 
-#[divan::bench]
+#[divan::bench(name = "benches::many_tracked_structs::many_tracked_structs")]
 fn many_tracked_structs(bencher: divan::Bencher) {
     bencher
         .with_inputs(|| {

--- a/benches/lru.rs
+++ b/benches/lru.rs
@@ -1,10 +1,11 @@
 use std::hint::black_box;
 
-use codspeed_criterion_compat::{
-    BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main,
-};
 use rayon::prelude::*;
 use salsa::Database as _;
+
+fn main() {
+    divan::main();
+}
 
 const HOT_ITEMS: usize = 1_024;
 const CONCURRENT_WORKERS: usize = 4;
@@ -112,140 +113,123 @@ fn evenly_spaced_items(items: &[Item], count: usize) -> Vec<Item> {
     (0..count).map(|index| items[index * step]).collect()
 }
 
-fn lru(criterion: &mut Criterion) {
-    let mut group: codspeed_criterion_compat::BenchmarkGroup<
-        codspeed_criterion_compat::measurement::WallTime,
-    > = criterion.benchmark_group("LRU");
+#[divan::bench(name = "hot_cache_hits[1024]")]
+fn hot_cache_hits(bencher: divan::Bencher) {
+    let (db, items, expected) = hot_cache();
 
-    group.bench_function(BenchmarkId::new("hot_cache_hits", HOT_ITEMS), |b| {
-        let (db, items, expected) = hot_cache();
-
-        b.iter(|| {
-            let actual = access_all(black_box(&db), black_box(&items));
-            assert_eq!(black_box(actual), expected);
-        });
+    bencher.bench_local(|| {
+        let actual = access_all(black_box(&db), black_box(&items));
+        assert_eq!(black_box(actual), expected);
     });
-
-    group.bench_function(
-        BenchmarkId::new(
-            "concurrent_hot_cache_hits",
-            format!("{CONCURRENT_WORKERS}x{HOT_ITEMS}"),
-        ),
-        |b| {
-            let (db, items, expected) = hot_cache();
-            let pool = rayon::ThreadPoolBuilder::new()
-                .num_threads(CONCURRENT_WORKERS)
-                .build()
-                .unwrap();
-
-            b.iter(|| {
-                for actual in access_all_concurrently(&pool, black_box(&db), black_box(&items)) {
-                    assert_eq!(black_box(actual), expected);
-                }
-            });
-        },
-    );
-
-    group.bench_function(
-        BenchmarkId::new("hot_cache_hits_and_sweep", HOT_ITEMS),
-        |b| {
-            b.iter_batched_ref(
-                hot_cache_for_sweep,
-                |(db, items, expected)| {
-                    let actual = access_all_and_collect(black_box(db), black_box(items));
-                    assert_eq!(black_box(actual), *expected);
-                },
-                BatchSize::LargeInput,
-            );
-        },
-    );
-
-    group.bench_function(
-        BenchmarkId::new(
-            "concurrent_hot_cache_hits_and_sweep",
-            format!("{CONCURRENT_WORKERS}x{HOT_ITEMS}"),
-        ),
-        |b| {
-            let pool = rayon::ThreadPoolBuilder::new()
-                .num_threads(CONCURRENT_WORKERS)
-                .build()
-                .unwrap();
-
-            b.iter_batched_ref(
-                hot_cache_for_sweep,
-                |(db, items, expected)| {
-                    for actual in access_all_concurrently(&pool, black_box(db), black_box(items)) {
-                        assert_eq!(black_box(actual), *expected);
-                    }
-                    db.trigger_lru_eviction();
-                },
-                BatchSize::LargeInput,
-            );
-        },
-    );
-
-    group.bench_function(BenchmarkId::new("disabled_capacity_hits", HOT_ITEMS), |b| {
-        let mut db = salsa::DatabaseImpl::new();
-        lru_value::set_lru_capacity(&mut db, 0);
-        let items = new_items(&db, HOT_ITEMS);
-        let expected = prewarm(&db, &items);
-
-        b.iter(|| {
-            let actual = access_all(black_box(&db), black_box(&items));
-            assert_eq!(black_box(actual), expected);
-        });
-    });
-
-    group.bench_function(
-        BenchmarkId::new("working_set_over_capacity", EVICTION_ITEMS),
-        |b| {
-            b.iter_batched_ref(
-                || {
-                    let mut db = salsa::DatabaseImpl::new();
-                    lru_value::set_lru_capacity(&mut db, EVICTION_CAPACITY);
-                    let items = new_items(&db, EVICTION_ITEMS);
-                    let expected = prewarm(&db, &items);
-                    let hot_items = &items[EVICTION_ITEMS - EVICTION_CAPACITY..];
-                    let actual = access_all(&db, hot_items);
-                    assert_eq!(black_box(actual), expected_sum(hot_items, &db));
-                    db.trigger_lru_eviction();
-                    (db, items, expected)
-                },
-                |(db, items, expected)| {
-                    let actual = access_all_and_collect(black_box(db), black_box(items));
-                    assert_eq!(black_box(actual), *expected);
-                },
-                BatchSize::LargeInput,
-            );
-        },
-    );
-
-    group.bench_function(
-        BenchmarkId::new("scattered_hot_set_over_capacity", EVICTION_ITEMS),
-        |b| {
-            b.iter_batched_ref(
-                || {
-                    let mut db = salsa::DatabaseImpl::new();
-                    lru_value::set_lru_capacity(&mut db, EVICTION_CAPACITY);
-                    let items = new_items(&db, EVICTION_ITEMS);
-                    let expected = prewarm(&db, &items);
-                    let hot_items = evenly_spaced_items(&items, SCATTERED_HOT_ITEMS);
-                    let actual = access_all(&db, &hot_items);
-                    assert_eq!(black_box(actual), expected_sum(&hot_items, &db));
-                    db.trigger_lru_eviction();
-                    (db, items, expected)
-                },
-                |(db, items, expected)| {
-                    let actual = access_all_and_collect(black_box(db), black_box(items));
-                    assert_eq!(black_box(actual), *expected);
-                },
-                BatchSize::LargeInput,
-            );
-        },
-    );
-
-    group.finish();
 }
 
-criterion_group!(benches, lru);
-criterion_main!(benches);
+#[divan::bench(name = "concurrent_hot_cache_hits[4x1024]")]
+fn concurrent_hot_cache_hits(bencher: divan::Bencher) {
+    let (db, items, expected) = hot_cache();
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(CONCURRENT_WORKERS)
+        .build()
+        .unwrap();
+
+    bencher.bench_local(|| {
+        for actual in access_all_concurrently(&pool, black_box(&db), black_box(&items)) {
+            assert_eq!(black_box(actual), expected);
+        }
+    });
+}
+
+#[divan::bench(
+    name = "hot_cache_hits_and_sweep[1024]",
+    sample_count = 20,
+    sample_size = 1
+)]
+fn hot_cache_hits_and_sweep(bencher: divan::Bencher) {
+    bencher
+        .with_inputs(hot_cache_for_sweep)
+        .bench_local_refs(|(db, items, expected)| {
+            let actual = access_all_and_collect(black_box(db), black_box(items));
+            assert_eq!(black_box(actual), *expected);
+        });
+}
+
+#[divan::bench(
+    name = "concurrent_hot_cache_hits_and_sweep[4x1024]",
+    sample_count = 20,
+    sample_size = 1
+)]
+fn concurrent_hot_cache_hits_and_sweep(bencher: divan::Bencher) {
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(CONCURRENT_WORKERS)
+        .build()
+        .unwrap();
+
+    bencher
+        .with_inputs(hot_cache_for_sweep)
+        .bench_local_refs(|(db, items, expected)| {
+            for actual in access_all_concurrently(&pool, black_box(db), black_box(items)) {
+                assert_eq!(black_box(actual), *expected);
+            }
+            db.trigger_lru_eviction();
+        });
+}
+
+#[divan::bench(name = "disabled_capacity_hits[1024]")]
+fn disabled_capacity_hits(bencher: divan::Bencher) {
+    let mut db = salsa::DatabaseImpl::new();
+    lru_value::set_lru_capacity(&mut db, 0);
+    let items = new_items(&db, HOT_ITEMS);
+    let expected = prewarm(&db, &items);
+
+    bencher.bench_local(|| {
+        let actual = access_all(black_box(&db), black_box(&items));
+        assert_eq!(black_box(actual), expected);
+    });
+}
+
+#[divan::bench(
+    name = "working_set_over_capacity[4096]",
+    sample_count = 20,
+    sample_size = 1
+)]
+fn working_set_over_capacity(bencher: divan::Bencher) {
+    bencher
+        .with_inputs(|| {
+            let mut db = salsa::DatabaseImpl::new();
+            lru_value::set_lru_capacity(&mut db, EVICTION_CAPACITY);
+            let items = new_items(&db, EVICTION_ITEMS);
+            let expected = prewarm(&db, &items);
+            let hot_items = &items[EVICTION_ITEMS - EVICTION_CAPACITY..];
+            let actual = access_all(&db, hot_items);
+            assert_eq!(black_box(actual), expected_sum(hot_items, &db));
+            db.trigger_lru_eviction();
+            (db, items, expected)
+        })
+        .bench_local_refs(|(db, items, expected)| {
+            let actual = access_all_and_collect(black_box(db), black_box(items));
+            assert_eq!(black_box(actual), *expected);
+        });
+}
+
+#[divan::bench(
+    name = "scattered_hot_set_over_capacity[4096]",
+    sample_count = 20,
+    sample_size = 1
+)]
+fn scattered_hot_set_over_capacity(bencher: divan::Bencher) {
+    bencher
+        .with_inputs(|| {
+            let mut db = salsa::DatabaseImpl::new();
+            lru_value::set_lru_capacity(&mut db, EVICTION_CAPACITY);
+            let items = new_items(&db, EVICTION_ITEMS);
+            let expected = prewarm(&db, &items);
+            let hot_items = evenly_spaced_items(&items, SCATTERED_HOT_ITEMS);
+            let actual = access_all(&db, &hot_items);
+            assert_eq!(black_box(actual), expected_sum(&hot_items, &db));
+            db.trigger_lru_eviction();
+            (db, items, expected)
+        })
+        .bench_local_refs(|(db, items, expected)| {
+            let actual = access_all_and_collect(black_box(db), black_box(items));
+            assert_eq!(black_box(actual), *expected);
+        });
+}


### PR DESCRIPTION
Run simulation and memory benchmarks on CodSpeed macro runners again, while keeping compilation and Cargo cache work on an ARM64 GitHub runner. It turns out, it does help with flakiness. CodSpeed was also so kind to grant us some extra free minutes and we're in the process of switching to Pro. 

I also use this PR as an opportunity to move the allocation-heavy LRU to walltime mode. Codspeed simulation benchmarks aren't made for allocation (sys call heavy) workloads. 
