### PR TITLE
perf: inline tracked struct revision loads

### DIFF
--- a/benches/compare.rs
+++ b/benches/compare.rs
@@ -46,8 +46,27 @@ pub fn either_length<'db>(db: &'db dyn salsa::Database, input: SupertypeInput<'d
     }
 }
 
+#[salsa::tracked]
+pub struct Tracked<'db> {
+    pub value: usize,
+}
+
+#[salsa::tracked]
+pub fn make_tracked(db: &dyn salsa::Database, input: Input) -> Tracked<'_> {
+    Tracked::new(db, input.text(db).len())
+}
+
 mod benches {
     use super::*;
+
+    #[divan::bench(name = "tracked_struct::read_field")]
+    fn read_tracked_field(bencher: divan::Bencher) {
+        let db = salsa::DatabaseImpl::default();
+        let input = Input::new(&db, "hello, world!".to_owned());
+        let tracked = make_tracked(&db, input);
+
+        bencher.bench_local(|| tracked.value(black_box(&db)));
+    }
 
     #[divan::bench(
         name = "mutating_inputs::Mutating Inputs::mutating",

--- a/src/revision.rs
+++ b/src/revision.rs
@@ -197,6 +197,7 @@ impl OptionalAtomicRevision {
         }
     }
 
+    #[inline]
     pub(crate) fn load(&self) -> Option<Revision> {
         Revision::from_opt(self.data.load(Ordering::Acquire))
     }


### PR DESCRIPTION
Inline the atomic revision load used by tracked struct read locking and add a focused field-read benchmark. This removes an out-of-line call from every tracked field getter.

The focused benchmark improves by about 11%; ty's 37 simulation cases all improve, including 0.189% fewer instructions for cold checking and 0.492% fewer for incremental checking.

Testing: Passed the Salsa workspace suite, strict Clippy, formatting, focused benchmarks, and ty simulation benchmarks.