### PR TITLE
perf: reduce memo header monomorphization

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -38,6 +38,7 @@ mod specify;
 mod sync;
 
 pub use eviction::{EvictionPolicy, HasCapacity, Lru, NoopEviction};
+pub(crate) use memo::MemoHeader;
 
 pub type Memo<C> = memo::Memo<'static, C>;
 
@@ -390,14 +391,34 @@ where
         flattened_input_outputs: &mut FxIndexSet<QueryEdge>,
         seen: &mut FxHashSet<DatabaseKeyIndex>,
     ) {
-        let memo_index = self.memo_ingredient_index(zalsa, id);
-        let Some(memo) = self.get_memo_from_table_for(zalsa, id, memo_index) else {
-            return;
-        };
+        fn inner(
+            zalsa: &Zalsa,
+            database_key_index: DatabaseKeyIndex,
+            memo_ingredient_index: MemoIngredientIndex,
+            cycle_recovery_strategy: CycleRecoveryStrategy,
+            flattened_input_outputs: &mut FxIndexSet<QueryEdge>,
+            seen: &mut FxHashSet<DatabaseKeyIndex>,
+        ) {
+            let Some(header) = zalsa
+                .dyn_memo_table_for(database_key_index.key_index())
+                .get_memo_header(memo_ingredient_index)
+            else {
+                return;
+            };
 
-        memo.header.flatten_cycle_head_dependencies(
+            header.flatten_cycle_head_dependencies(
+                zalsa,
+                database_key_index,
+                cycle_recovery_strategy,
+                flattened_input_outputs,
+                seen,
+            );
+        }
+
+        inner(
             zalsa,
             self.database_key_index(id),
+            self.memo_ingredient_index(zalsa, id),
             C::CYCLE_STRATEGY,
             flattened_input_outputs,
             seen,

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -74,9 +74,17 @@ impl<C: Configuration> IngredientImpl<C> {
     }
 }
 
+/// A memoized query result, combining a configuration-independent [`MemoHeader`] with the
+/// configuration-specific output value.
+///
+/// The C representation and field order allow type-erased memo-table lookups to treat a pointer to
+/// any `Memo<C>` as a pointer to its header.
 #[derive(Debug)]
+#[repr(C)]
 pub struct Memo<'db, C: Configuration> {
     /// Configuration-independent state used to validate and manage this memo.
+    ///
+    /// This must remain the first field so that `Memo<C>` and `MemoHeader` have the same address.
     pub(super) header: MemoHeader,
 
     /// The result of the query, if we decide to memoize it.
@@ -84,7 +92,7 @@ pub struct Memo<'db, C: Configuration> {
 }
 
 #[derive(Debug)]
-pub(super) struct MemoHeader {
+pub(crate) struct MemoHeader {
     /// Last revision when this memo was verified; this begins
     /// as the current revision.
     pub(super) verified_at: AtomicRevision,
@@ -198,7 +206,7 @@ impl MemoHeader {
         }
     }
 
-    pub(super) fn remove_outputs(&self, zalsa: &Zalsa, executor: DatabaseKeyIndex) {
+    pub(crate) fn remove_outputs(&self, zalsa: &Zalsa, executor: DatabaseKeyIndex) {
         for stale_output in self.revisions.origin().outputs() {
             stale_output.remove_stale_output(zalsa, executor);
         }
@@ -238,10 +246,6 @@ impl<C: Configuration> crate::table::memo::Memo for Memo<'static, C>
 where
     C::Output<'static>: Send + Sync + Any,
 {
-    fn remove_outputs(&self, zalsa: &Zalsa, executor: DatabaseKeyIndex) {
-        self.header.remove_outputs(zalsa, executor);
-    }
-
     #[cfg(feature = "salsa_unstable")]
     fn memory_usage(&self) -> crate::database::MemoInfo {
         let size_of = std::mem::size_of::<Memo<C>>() + self.header.revisions.allocation_size();
@@ -488,6 +492,7 @@ mod _memory_usage {
         [(); std::mem::size_of::<[usize; 4]>()];
     const _: [(); std::mem::size_of::<super::Memo<DummyConfiguration>>()] =
         [(); std::mem::size_of::<[usize; 5]>()];
+    const _: [(); 0] = [(); std::mem::offset_of!(super::Memo<DummyConfiguration>, header)];
 
     struct DummyStruct;
 

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -749,7 +749,7 @@ where
         // SAFETY: We have `&mut MemoTable`, so no more references to these memos exist and we are good
         // to drop them.
         unsafe {
-            table_guard.0.take_memos(|memo_ingredient_index, memo| {
+            table_guard.0.take_memos(|memo_ingredient_index, header| {
                 let ingredient_index =
                     zalsa.ingredient_index_for_memo(self.ingredient_index, memo_ingredient_index);
 
@@ -757,7 +757,7 @@ where
 
                 zalsa.event(&|| Event::new(EventKind::DidDiscard { key: executor }));
 
-                memo.remove_outputs(zalsa, executor);
+                header.remove_outputs(zalsa, executor);
             })
         };
 

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -3,10 +3,9 @@ use std::fmt::Debug;
 use std::mem;
 use std::ptr::{self, NonNull};
 
-use crate::DatabaseKeyIndex;
+use crate::function::MemoHeader;
 use crate::sync::atomic::{AtomicPtr, Ordering};
 use crate::zalsa::MemoIngredientIndex;
-use crate::zalsa::Zalsa;
 
 /// The "memo table" stores the memoized results of tracked function calls.
 /// Every tracked function must take a salsa struct as its first argument
@@ -42,10 +41,6 @@ impl MemoTable {
 }
 
 pub trait Memo: Any + Send + Sync {
-    /// Removes the outputs that were created when this query ran. This includes
-    /// tracked structs and specified queries.
-    fn remove_outputs(&self, zalsa: &Zalsa, executor: DatabaseKeyIndex);
-
     /// Returns memory usage information about the memoized value.
     #[cfg(feature = "salsa_unstable")]
     fn memory_usage(&self) -> crate::database::MemoInfo;
@@ -232,8 +227,6 @@ impl MemoEntryType {
 struct DummyMemo;
 
 impl Memo for DummyMemo {
-    fn remove_outputs(&self, _zalsa: &Zalsa, _executor: DatabaseKeyIndex) {}
-
     #[cfg(feature = "salsa_unstable")]
     fn memory_usage(&self) -> crate::database::MemoInfo {
         crate::database::MemoInfo {
@@ -296,7 +289,7 @@ pub struct MemoTableWithTypes<'a> {
     memos: &'a MemoTable,
 }
 
-impl MemoTableWithTypes<'_> {
+impl<'a> MemoTableWithTypes<'a> {
     pub(crate) fn insert<M: Memo>(
         self,
         memo_ingredient_index: MemoIngredientIndex,
@@ -350,6 +343,25 @@ impl MemoTableWithTypes<'_> {
         NonNull::new(atomic_memo.load(Ordering::Acquire))
             // SAFETY: We asserted that the type is correct above.
             .map(|memo| unsafe { MemoEntryType::from_dummy(memo) })
+    }
+
+    /// Returns the configuration-independent header of the memo at the given index.
+    ///
+    /// All memo-table entries are `Memo<C>` values, which use `#[repr(C)]` and store
+    /// `MemoHeader` as their first field. This makes the type-erased pointer valid to cast to a
+    /// header pointer without knowing `C`.
+    #[inline]
+    pub(crate) fn get_memo_header(
+        self,
+        memo_ingredient_index: MemoIngredientIndex,
+    ) -> Option<&'a MemoHeader> {
+        let MemoEntry { atomic_memo } = self.memos.memos.get(memo_ingredient_index.as_usize())?;
+        let memo = NonNull::new(atomic_memo.load(Ordering::Acquire))?;
+
+        // SAFETY: Every populated memo-table entry is a `#[repr(C)] Memo<C>` with `MemoHeader` as
+        // its first field, so both pointers have the same address. The memo allocation remains
+        // live for at least `'a`.
+        Some(unsafe { memo.cast::<MemoHeader>().as_ref() })
     }
 
     #[cfg(feature = "salsa_unstable")]
@@ -437,7 +449,7 @@ impl MemoTableWithTypesMut<'_> {
     /// the database exist as there may be outstanding borrows into the pointer contents.
     pub(crate) unsafe fn take_memos(
         &mut self,
-        mut f: impl FnMut(MemoIngredientIndex, Box<dyn Memo>),
+        mut f: impl FnMut(MemoIngredientIndex, &MemoHeader),
     ) {
         self.memos
             .memos
@@ -449,7 +461,13 @@ impl MemoTableWithTypesMut<'_> {
                 let memo = unsafe { memo.take(type_)? };
                 Some((MemoIngredientIndex::from_usize(index), memo))
             })
-            .for_each(|(index, memo)| f(index, memo));
+            .for_each(|(index, memo)| {
+                // SAFETY: Every populated memo-table entry is a `#[repr(C)] Memo<C>` with
+                // `MemoHeader` as its first field. The erased trait object's data pointer and its
+                // header therefore have the same address.
+                let header = unsafe { &*(memo.as_ref() as *const dyn Memo as *const MemoHeader) };
+                f(index, header);
+            });
     }
 }
 

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -840,7 +840,7 @@ where
         // SAFETY: We have `&mut MemoTable`, so no more references to these memos exist and we are good
         // to drop them.
         unsafe {
-            table_guard.0.take_memos(|memo_ingredient_index, memo| {
+            table_guard.0.take_memos(|memo_ingredient_index, header| {
                 let ingredient_index =
                     zalsa.ingredient_index_for_memo(self.ingredient_index, memo_ingredient_index);
 
@@ -848,7 +848,7 @@ where
 
                 zalsa.event(&|| Event::new(EventKind::DidDiscard { key: executor }));
 
-                memo.remove_outputs(zalsa, executor);
+                header.remove_outputs(zalsa, executor);
             })
         };
 

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -248,6 +248,13 @@ impl Zalsa {
         unsafe { T::memo_table(self, id, self.current_revision()) }
     }
 
+    /// Returns the [`MemoTable`][] for `id` without requiring its concrete salsa struct type.
+    #[inline]
+    pub(crate) fn dyn_memo_table_for(&self, id: Id) -> MemoTableWithTypes<'_> {
+        // SAFETY: We are supplying the current revision for this database.
+        unsafe { self.table().dyn_memos(id, self.current_revision()) }
+    }
+
     /// Returns the ingredient at the given index, or panics if it is out-of-bounds.
     #[inline]
     pub fn lookup_ingredient(&self, index: IngredientIndex) -> &dyn Ingredient {


### PR DESCRIPTION
Marks `Memo` as `repr(C)` and exposes type-erased `MemoHeader` access so selected header-only operations do not monomorphize over every query configuration.

Clear candidates:
- `remove_outputs`: 2,305 fewer ty LLVM lines and 0.031% fewer cold instructions in isolation.
- `flatten_cycle_head_dependencies`: another 2,000 fewer LLVM lines; together the two changes produce 4,305 fewer LLVM lines (0.102%), 0.067% fewer cold instructions, and 1.699% fewer incremental instructions.

Deferred after benchmarking because they increased cold instructions on the current baseline: `provisional_status`, `origin`, `collect_minimum_serialized_edges`, `cycle_converged`, `set_cycle_iteration_count`, and `finalize_cycle_head`. `validate_specified_value` did not show a clear code-size win. `cycle_converged` is worth remeasuring after the separate memo-table `TypeId` check removal lands because that changes its runtime tradeoff.

Testing: `cargo fmt --all -- --check`, Clippy with persistence enabled, all 291 workspace tests, and focused Miri tests for tracked and interned memo removal passed.
