### PR TITLE
perf: reduce memo validation monomorphization

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -196,13 +196,12 @@ pub struct IngredientImpl<C: Configuration> {
 
     sync_table: SyncTable,
 
-    /// When `fetch` and friends executes, they return a reference to the
-    /// value stored in the memo that is extended to live as long as the `&self`
-    /// reference we start with. This means that whenever we remove something
-    /// from `memo_map` with an `&self` reference, there *could* be references to its
-    /// internals still in use. Therefore we push the memo into this queue and
-    /// only *actually* free up memory when a new revision starts (which means
-    /// we have an `&mut` reference to self).
+    /// Retains every memo allocation loaded while this ingredient is shared.
+    ///
+    /// `fetch` and related operations return references into memo allocations with the lifetime
+    /// of their `&self` borrow. Replacing a table entry while the ingredient is shared may leave
+    /// references into the old allocation, so the old memo is moved into this queue. The queue is
+    /// cleared only when a new revision provides exclusive access to the ingredient.
     ///
     /// You might think that we could do this only if the memo was verified in the
     /// current revision: you would be right, but we are being defensive, because

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,4 +1,5 @@
 pub(crate) use maybe_changed_after::VerifyResult;
+pub(crate) use memo::ErasedMemo;
 pub(crate) use sync::{ClaimGuard, ClaimResult, Reentrancy, SyncGuard, SyncOwner, SyncTable};
 
 use std::any::Any;

--- a/src/function.rs
+++ b/src/function.rs
@@ -196,12 +196,13 @@ pub struct IngredientImpl<C: Configuration> {
 
     sync_table: SyncTable,
 
-    /// Retains every memo allocation loaded while this ingredient is shared.
-    ///
-    /// `fetch` and related operations return references into memo allocations with the lifetime
-    /// of their `&self` borrow. Replacing a table entry while the ingredient is shared may leave
-    /// references into the old allocation, so the old memo is moved into this queue. The queue is
-    /// cleared only when a new revision provides exclusive access to the ingredient.
+    /// When `fetch` and friends executes, they return a reference to the
+    /// value stored in the memo that is extended to live as long as the `&self`
+    /// reference we start with. This means that whenever we remove something
+    /// from `memo_map` with an `&self` reference, there *could* be references to its
+    /// internals still in use. Therefore we push the memo into this queue and
+    /// only *actually* free up memory when a new revision starts (which means
+    /// we have an `&mut` reference to self).
     ///
     /// You might think that we could do this only if the memo was verified in the
     /// current revision: you would be right, but we are being defensive, because

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -85,9 +85,12 @@ where
 
         let database_key_index = self.database_key_index(id);
 
-        let can_shallow_update = memo
-            .header
-            .shallow_verify_memo(zalsa, database_key_index, true);
+        let can_shallow_update = memo.header.shallow_verify_memo(
+            zalsa,
+            database_key_index,
+            #[cfg(feature = "detailed-trace")]
+            true,
+        );
 
         if can_shallow_update.yes() && !memo.header.may_be_provisional() {
             memo.header
@@ -137,9 +140,13 @@ where
 
         if let Some(old_memo) = opt_old_memo {
             if old_memo.value.is_some()
-                && old_memo
-                    .header
-                    .verify_memo(db.into(), &claim_guard, C::CYCLE_STRATEGY, true)
+                && old_memo.header.verify_memo(
+                    db.into(),
+                    &claim_guard,
+                    C::CYCLE_STRATEGY,
+                    #[cfg(feature = "detailed-trace")]
+                    true,
+                )
             {
                 // SAFETY: memo is present in memo_map and we have verified that it is
                 // still valid for the current revision.

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -2,13 +2,14 @@
 use crate::accumulator::accumulated_map::InputAccumulatedValues;
 use crate::cycle::{CycleHeads, CycleRecoveryStrategy, ProvisionalStatus};
 use crate::database::RawDatabase;
-use crate::function::memo::{ErasedMemo, MemoHeader, TryClaimCycleHeadsIter, TryClaimHeadsResult};
+use crate::function::memo::{
+    ErasedMemo, FunctionMemoTable, MemoHeader, TryClaimCycleHeadsIter, TryClaimHeadsResult,
+};
 use crate::function::sync::{ClaimGuard, ClaimResult};
 use crate::function::{Configuration, IngredientImpl, Reentrancy, SyncTable};
 use std::sync::atomic::Ordering;
 
 use crate::key::DatabaseKeyIndex;
-use crate::table::memo::MemoTableWithTypes;
 use crate::zalsa::{MemoIngredientIndex, Zalsa, ZalsaDatabase};
 use crate::zalsa_local::{QueryEdgeKind, QueryEdges, QueryOriginRef, QueryRevisions, ZalsaLocal};
 use crate::{Id, Revision};
@@ -94,11 +95,10 @@ where
     ) -> VerifyResult {
         let (zalsa, zalsa_local) = db.zalsas();
         let memo_ingredient_index = self.memo_ingredient_index(zalsa, id);
+        let database_key_index = self.database_key_index(id);
         zalsa.unwind_if_revision_cancelled(zalsa_local);
 
         loop {
-            let database_key_index = self.database_key_index(id);
-
             crate::tracing::debug!(
                 "{database_key_index:?}: maybe_changed_after(revision = {revision:?})"
             );
@@ -133,11 +133,11 @@ where
         }
     }
 
-    fn maybe_changed_after_cold<'db>(
-        &'db self,
-        zalsa: &'db Zalsa,
-        zalsa_local: &'db ZalsaLocal,
-        db: &'db C::DbView,
+    fn maybe_changed_after_cold(
+        &self,
+        zalsa: &Zalsa,
+        zalsa_local: &ZalsaLocal,
+        db: &C::DbView,
         database_key_index: DatabaseKeyIndex,
         revision: Revision,
         memo_ingredient_index: MemoIngredientIndex,
@@ -157,7 +157,7 @@ where
             zalsa: &'db Zalsa,
             zalsa_local: &'db ZalsaLocal,
             db: RawDatabase<'db>,
-            memo_table: MemoTableWithTypes<'db>,
+            memo_table: FunctionMemoTable<'db>,
             database_key_index: DatabaseKeyIndex,
             revision: Revision,
             memo_ingredient_index: MemoIngredientIndex,
@@ -185,13 +185,7 @@ where
 
             // Load the current memo after claiming the query because it may have changed while
             // this query was blocked on another thread.
-            // SAFETY: `IngredientImpl::insert_memo` moves every replaced allocation into
-            // `deleted_entries`, which is cleared only while starting a new revision with
-            // exclusive access to the ingredient. The database is borrowed for `'db` here, so
-            // that reset cannot occur and the loaded allocation remains immovable and valid for
-            // shared access for `'db`, even if another thread replaces the table entry during this
-            // revision.
-            let Some(old_memo) = (unsafe { memo_table.get_erased(memo_ingredient_index) }) else {
+            let Some(old_memo) = memo_table.get_erased(memo_ingredient_index) else {
                 return ColdResult::Verified(VerifyResult::changed());
             };
 
@@ -236,7 +230,7 @@ where
             zalsa,
             zalsa_local,
             db.into(),
-            zalsa.memo_table_for::<C::SalsaStruct<'_>>(database_key_index.key_index()),
+            self.memo_table_for(zalsa, database_key_index.key_index()),
             database_key_index,
             revision,
             memo_ingredient_index,

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -95,10 +95,11 @@ where
     ) -> VerifyResult {
         let (zalsa, zalsa_local) = db.zalsas();
         let memo_ingredient_index = self.memo_ingredient_index(zalsa, id);
-        let database_key_index = self.database_key_index(id);
         zalsa.unwind_if_revision_cancelled(zalsa_local);
 
         loop {
+            let database_key_index = self.database_key_index(id);
+
             crate::tracing::debug!(
                 "{database_key_index:?}: maybe_changed_after(revision = {revision:?})"
             );
@@ -220,7 +221,6 @@ where
                     old_memo,
                 }
             } else {
-                // Otherwise, nothing for it: have to consider the value to have changed.
                 ColdResult::Verified(VerifyResult::changed())
             }
         }

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -2,11 +2,10 @@
 use crate::accumulator::accumulated_map::InputAccumulatedValues;
 use crate::cycle::{CycleHeads, CycleRecoveryStrategy, ProvisionalStatus};
 use crate::database::RawDatabase;
-use crate::function::memo::{
-    ErasedMemo, FunctionMemoTable, MemoHeader, TryClaimCycleHeadsIter, TryClaimHeadsResult,
-};
+use crate::function::memo::{ErasedMemo, MemoHeader, TryClaimCycleHeadsIter, TryClaimHeadsResult};
 use crate::function::sync::{ClaimGuard, ClaimResult};
 use crate::function::{Configuration, IngredientImpl, Reentrancy, SyncTable};
+use crate::table::memo::MemoSlot;
 use std::sync::atomic::Ordering;
 
 use crate::key::DatabaseKeyIndex;
@@ -158,10 +157,9 @@ where
             zalsa: &'db Zalsa,
             zalsa_local: &'db ZalsaLocal,
             db: RawDatabase<'db>,
-            memo_table: FunctionMemoTable<'db>,
+            memo_slot: MemoSlot<'db>,
             database_key_index: DatabaseKeyIndex,
             revision: Revision,
-            memo_ingredient_index: MemoIngredientIndex,
             cycle_recovery_strategy: CycleRecoveryStrategy,
         ) -> ColdResult<'db> {
             let claim_guard = match sync_table.try_claim(
@@ -186,7 +184,7 @@ where
 
             // Load the current memo after claiming the query because it may have changed while
             // this query was blocked on another thread.
-            let Some(old_memo) = memo_table.get_erased(memo_ingredient_index) else {
+            let Some(old_memo) = memo_slot.get_erased() else {
                 return ColdResult::Verified(VerifyResult::changed());
             };
 
@@ -225,15 +223,23 @@ where
             }
         }
 
+        // SAFETY: The table stores 'static memos (to support `Any`), the memos are in fact valid
+        // for `'db` though as we delay their dropping to the end of a revision.
+        let memo_slot = unsafe {
+            MemoSlot::new(
+                zalsa.memo_table_for::<C::SalsaStruct<'_>>(database_key_index.key_index()),
+                memo_ingredient_index,
+            )
+        };
+
         match inner(
             &self.sync_table,
             zalsa,
             zalsa_local,
             db.into(),
-            self.memo_table_for(zalsa, database_key_index.key_index()),
+            memo_slot,
             database_key_index,
             revision,
-            memo_ingredient_index,
             C::CYCLE_STRATEGY,
         ) {
             ColdResult::Retry => None,

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -1,12 +1,14 @@
 #[cfg(feature = "accumulator")]
 use crate::accumulator::accumulated_map::InputAccumulatedValues;
 use crate::cycle::{CycleHeads, CycleRecoveryStrategy, ProvisionalStatus};
-use crate::function::memo::{MemoHeader, TryClaimCycleHeadsIter, TryClaimHeadsResult};
+use crate::database::RawDatabase;
+use crate::function::memo::{ErasedMemo, MemoHeader, TryClaimCycleHeadsIter, TryClaimHeadsResult};
 use crate::function::sync::{ClaimGuard, ClaimResult};
-use crate::function::{Configuration, IngredientImpl, Reentrancy};
+use crate::function::{Configuration, IngredientImpl, Reentrancy, SyncTable};
 use std::sync::atomic::Ordering;
 
 use crate::key::DatabaseKeyIndex;
+use crate::table::memo::MemoTableWithTypes;
 use crate::zalsa::{MemoIngredientIndex, Zalsa, ZalsaDatabase};
 use crate::zalsa_local::{QueryEdgeKind, QueryEdges, QueryOriginRef, QueryRevisions, ZalsaLocal};
 use crate::{Id, Revision};
@@ -112,95 +114,163 @@ where
                 zalsa,
                 database_key_index,
                 revision,
+                #[cfg(feature = "detailed-trace")]
                 memo.value.is_some(),
             ) {
                 return result;
             }
 
-            if let Some(mcs) = self.maybe_changed_after_cold(
+            if let Some(result) = self.maybe_changed_after_cold(
                 zalsa,
                 zalsa_local,
                 db,
-                id,
+                database_key_index,
                 revision,
                 memo_ingredient_index,
             ) {
-                return mcs;
-            } else {
-                // We failed to claim, have to retry.
+                return result;
             }
         }
     }
 
-    #[inline(never)]
     fn maybe_changed_after_cold<'db>(
         &'db self,
-        zalsa: &Zalsa,
-        zalsa_local: &ZalsaLocal,
+        zalsa: &'db Zalsa,
+        zalsa_local: &'db ZalsaLocal,
         db: &'db C::DbView,
-        key_index: Id,
+        database_key_index: DatabaseKeyIndex,
         revision: Revision,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> Option<VerifyResult> {
-        let database_key_index = self.database_key_index(key_index);
+        enum ColdResult<'db> {
+            Retry,
+            Verified(VerifyResult),
+            Reexecute {
+                claim_guard: ClaimGuard<'db>,
+                old_memo: ErasedMemo<'db>,
+            },
+        }
 
-        let claim_guard =
-            match self
-                .sync_table
-                .try_claim(zalsa, zalsa_local, key_index, Reentrancy::Deny)
-            {
+        #[allow(clippy::too_many_arguments)]
+        fn inner<'db>(
+            sync_table: &'db SyncTable,
+            zalsa: &'db Zalsa,
+            zalsa_local: &'db ZalsaLocal,
+            db: RawDatabase<'db>,
+            memo_table: MemoTableWithTypes<'db>,
+            database_key_index: DatabaseKeyIndex,
+            revision: Revision,
+            memo_ingredient_index: MemoIngredientIndex,
+            cycle_recovery_strategy: CycleRecoveryStrategy,
+        ) -> ColdResult<'db> {
+            let claim_guard = match sync_table.try_claim(
+                zalsa,
+                zalsa_local,
+                database_key_index.key_index(),
+                Reentrancy::Deny,
+            ) {
                 ClaimResult::Claimed(guard) => guard,
                 ClaimResult::Running(blocked_on) => {
                     let _ = blocked_on.block_on(zalsa);
-                    return None;
+                    return ColdResult::Retry;
                 }
                 ClaimResult::Cycle { .. } => {
-                    return Some(maybe_changed_after_cold_cycle(
+                    return ColdResult::Verified(maybe_changed_after_cold_cycle(
                         zalsa_local,
                         database_key_index,
-                        C::CYCLE_STRATEGY,
+                        cycle_recovery_strategy,
                     ));
                 }
             };
-        // Load the current memo, if any.
-        let Some(old_memo) = self.get_memo_from_table_for(zalsa, key_index, memo_ingredient_index)
-        else {
-            return Some(VerifyResult::changed());
-        };
 
-        if let Some(result) = old_memo.header.maybe_changed_after_cold(
-            db.into(),
-            &claim_guard,
-            revision,
-            C::CYCLE_STRATEGY,
-            old_memo.value.is_some(),
-        ) {
-            return Some(result);
-        }
+            // Load the current memo after claiming the query because it may have changed while
+            // this query was blocked on another thread.
+            // SAFETY: `IngredientImpl::insert_memo` moves every replaced allocation into
+            // `deleted_entries`, which is cleared only while starting a new revision with
+            // exclusive access to the ingredient. The database is borrowed for `'db` here, so
+            // that reset cannot occur and the loaded allocation remains immovable and valid for
+            // shared access for `'db`, even if another thread replaces the table entry during this
+            // revision.
+            let Some(old_memo) = (unsafe { memo_table.get_erased(memo_ingredient_index) }) else {
+                return ColdResult::Verified(VerifyResult::changed());
+            };
 
-        // If inputs have changed, but we have an old value, we can re-execute.
-        // It is possible the result will be equal to the old value and hence
-        // backdated. In that case, although we will have computed a new memo,
-        // the value has not logically changed.
-        if old_memo.value.is_some() && !old_memo.header.may_be_provisional() {
-            let memo = self.execute(db, claim_guard, Some(old_memo))?;
-            let changed_at = memo.header.revisions.changed_at;
+            let old_header = old_memo.header();
 
-            // Always assume that a provisional value has changed.
-            //
-            // We don't know if a provisional value has actually changed. To determine whether a provisional
-            // value has changed, we need to iterate the outer cycle, which cannot be done here.
-            return Some(
-                if changed_at > revision || memo.header.may_be_provisional() {
+            crate::tracing::debug!(
+                "{database_key_index:?}: maybe_changed_after_cold, successful claim, \
+                    revision = {revision:?}, old_memo = {old_memo:#?}",
+                old_memo = old_header.tracing_debug(old_memo.has_value()),
+            );
+
+            if old_header.verify_memo(
+                db,
+                &claim_guard,
+                cycle_recovery_strategy,
+                #[cfg(feature = "detailed-trace")]
+                old_memo.has_value(),
+            ) {
+                return ColdResult::Verified(if old_header.revisions.changed_at > revision {
                     VerifyResult::changed()
                 } else {
-                    VerifyResult::unchanged_for_memo(&memo.header.revisions)
-                },
-            );
+                    VerifyResult::unchanged_for_memo(&old_header.revisions)
+                });
+            }
+
+            // If the memo is not provisional, the generic continuation can check whether it has
+            // an old value and re-execute. The result may equal the old value and be backdated, in
+            // which case the new memo has not logically changed.
+            if !old_header.may_be_provisional() {
+                ColdResult::Reexecute {
+                    claim_guard,
+                    old_memo,
+                }
+            } else {
+                // Otherwise, nothing for it: have to consider the value to have changed.
+                ColdResult::Verified(VerifyResult::changed())
+            }
         }
 
-        // Otherwise, nothing for it: have to consider the value to have changed.
-        Some(VerifyResult::changed())
+        match inner(
+            &self.sync_table,
+            zalsa,
+            zalsa_local,
+            db.into(),
+            zalsa.memo_table_for::<C::SalsaStruct<'_>>(database_key_index.key_index()),
+            database_key_index,
+            revision,
+            memo_ingredient_index,
+            C::CYCLE_STRATEGY,
+        ) {
+            ColdResult::Retry => None,
+            ColdResult::Verified(result) => Some(result),
+            ColdResult::Reexecute {
+                claim_guard,
+                old_memo,
+            } => {
+                let old_memo = old_memo.downcast::<C>();
+
+                if old_memo.value.is_none() {
+                    return Some(VerifyResult::changed());
+                }
+
+                let memo = self.execute(db, claim_guard, Some(old_memo))?;
+                let changed_at = memo.header.revisions.changed_at;
+
+                // Always assume that a provisional value has changed.
+                //
+                // We don't know if a provisional value has actually changed. To determine whether
+                // a provisional value has changed, we need to iterate the outer cycle, which cannot
+                // be done here.
+                Some(
+                    if changed_at > revision || memo.header.may_be_provisional() {
+                        VerifyResult::changed()
+                    } else {
+                        VerifyResult::unchanged_for_memo(&memo.header.revisions)
+                    },
+                )
+            }
+        }
     }
 }
 
@@ -210,9 +280,14 @@ impl MemoHeader {
         zalsa: &Zalsa,
         database_key_index: DatabaseKeyIndex,
         revision: Revision,
-        has_value: bool,
+        #[cfg(feature = "detailed-trace")] has_value: bool,
     ) -> Option<VerifyResult> {
-        let can_shallow_update = self.shallow_verify_memo(zalsa, database_key_index, has_value);
+        let can_shallow_update = self.shallow_verify_memo(
+            zalsa,
+            database_key_index,
+            #[cfg(feature = "detailed-trace")]
+            has_value,
+        );
         if can_shallow_update.yes() && !self.may_be_provisional() {
             self.update_shallow(zalsa, database_key_index, can_shallow_update);
 
@@ -232,50 +307,38 @@ impl MemoHeader {
         db: crate::database::RawDatabase<'_>,
         claim_guard: &ClaimGuard<'_>,
         cycle_recovery_strategy: CycleRecoveryStrategy,
-        has_value: bool,
+        #[cfg(feature = "detailed-trace")] has_value: bool,
     ) -> bool {
         let zalsa = claim_guard.zalsa();
         let zalsa_local = claim_guard.zalsa_local();
         let database_key_index = claim_guard.database_key_index();
 
-        let can_shallow_update = self.shallow_verify_memo(zalsa, database_key_index, has_value);
+        let can_shallow_update = self.shallow_verify_memo(
+            zalsa,
+            database_key_index,
+            #[cfg(feature = "detailed-trace")]
+            has_value,
+        );
         if can_shallow_update.yes()
-            && self.validate_may_be_provisional(zalsa, zalsa_local, database_key_index, has_value)
+            && self.validate_may_be_provisional(
+                zalsa,
+                zalsa_local,
+                database_key_index,
+                #[cfg(feature = "detailed-trace")]
+                has_value,
+            )
         {
             self.update_shallow(zalsa, database_key_index, can_shallow_update);
             true
         } else {
-            self.deep_verify_memo(db, claim_guard, cycle_recovery_strategy, has_value)
-                .is_unchanged()
-        }
-    }
-
-    pub(super) fn maybe_changed_after_cold(
-        &self,
-        db: crate::database::RawDatabase<'_>,
-        claim_guard: &ClaimGuard<'_>,
-        revision: Revision,
-        cycle_recovery_strategy: CycleRecoveryStrategy,
-        has_value: bool,
-    ) -> Option<VerifyResult> {
-        crate::tracing::debug!(
-            "{database_key_index:?}: maybe_changed_after_cold, successful claim, \
-                revision = {revision:?}, old_memo = {old_memo:#?}",
-            database_key_index = claim_guard.database_key_index(),
-            old_memo = self.tracing_debug(has_value)
-        );
-
-        let verified = self.verify_memo(db, claim_guard, cycle_recovery_strategy, has_value);
-
-        if verified {
-            // Check if the inputs are still valid. We can just compare `changed_at`.
-            Some(if self.revisions.changed_at > revision {
-                VerifyResult::changed()
-            } else {
-                VerifyResult::unchanged_for_memo(&self.revisions)
-            })
-        } else {
-            None
+            self.deep_verify_memo(
+                db,
+                claim_guard,
+                cycle_recovery_strategy,
+                #[cfg(feature = "detailed-trace")]
+                has_value,
+            )
+            .is_unchanged()
         }
     }
 
@@ -291,8 +354,9 @@ impl MemoHeader {
         &self,
         zalsa: &Zalsa,
         database_key_index: DatabaseKeyIndex,
-        has_value: bool,
+        #[cfg(feature = "detailed-trace")] has_value: bool,
     ) -> ShallowUpdate {
+        #[cfg(feature = "detailed-trace")]
         crate::tracing::debug!(
             "{database_key_index:?}: shallow_verify_memo(memo = {memo:#?})",
             memo = self.tracing_debug(has_value)
@@ -355,7 +419,7 @@ impl MemoHeader {
         zalsa: &Zalsa,
         zalsa_local: &ZalsaLocal,
         database_key_index: DatabaseKeyIndex,
-        has_value: bool,
+        #[cfg(feature = "detailed-trace")] has_value: bool,
     ) -> bool {
         if !self.may_be_provisional() {
             return true;
@@ -373,9 +437,10 @@ impl MemoHeader {
             return false;
         }
 
+        #[cfg(feature = "detailed-trace")]
         crate::tracing::trace!(
             "{database_key_index:?}: validate_may_be_provisional(memo = {memo:#?})",
-            memo = self.tracing_debug(has_value)
+            memo = self.tracing_debug(has_value),
         );
 
         let verified_at = self.verified_at.load();
@@ -406,13 +471,14 @@ impl MemoHeader {
         db: crate::database::RawDatabase<'_>,
         claim_guard: &ClaimGuard<'_>,
         cycle_recovery_strategy: CycleRecoveryStrategy,
-        has_value: bool,
+        #[cfg(feature = "detailed-trace")] has_value: bool,
     ) -> VerifyResult {
         let zalsa = claim_guard.zalsa();
         let database_key_index = claim_guard.database_key_index();
 
         match self.origin() {
             QueryOriginRef::Derived(edges) => {
+                #[cfg(feature = "detailed-trace")]
                 crate::tracing::debug!(
                     "{database_key_index:?}: deep_verify_memo(old_memo = {old_memo:#?})",
                     old_memo = self.tracing_debug(has_value)

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -11,10 +11,34 @@ use crate::ingredient::WaitForResult;
 use crate::key::DatabaseKeyIndex;
 use crate::revision::AtomicRevision;
 use crate::sync::atomic::Ordering;
-use crate::table::memo::{DummyMemo, MemoTableWithTypesMut, ToDynMemo};
+use crate::table::memo::{DummyMemo, MemoTableWithTypes, MemoTableWithTypesMut, ToDynMemo};
 use crate::zalsa::{MemoIngredientIndex, Zalsa};
 use crate::zalsa_local::{QueryOriginRef, QueryRevisions};
 use crate::{Event, EventKind, Id, Revision};
+
+/// A function memo table whose allocations remain valid for `'db`.
+///
+/// The private field ensures that this type can only be constructed by
+/// [`IngredientImpl::memo_table_for`], which ties `'db` to a shared borrow of the function
+/// ingredient and its memo-retention invariant.
+pub(super) struct FunctionMemoTable<'db> {
+    table: MemoTableWithTypes<'db>,
+}
+
+impl<'db> FunctionMemoTable<'db> {
+    /// Loads an erased memo that remains valid for `'db`.
+    #[inline]
+    pub(super) fn get_erased(
+        self,
+        memo_ingredient_index: MemoIngredientIndex,
+    ) -> Option<ErasedMemo<'db>> {
+        // SAFETY: `FunctionMemoTable` can only be created while holding a shared borrow of the
+        // function ingredient for `'db`. The ingredient's memo-retention invariant guarantees
+        // that every allocation loaded from this table remains valid for that borrow, even if its
+        // entry is replaced.
+        unsafe { self.table.get_erased(memo_ingredient_index) }
+    }
+}
 
 impl<C: Configuration> IngredientImpl<C> {
     /// Inserts the memo for the given key; (atomically) overwrites and returns any previously existing memo
@@ -44,6 +68,17 @@ impl<C: Configuration> IngredientImpl<C> {
             .get(memo_ingredient_index)?;
         // SAFETY: The memo table owns this allocation for at least `'db`.
         Some(unsafe { memo.as_ref() })
+    }
+
+    /// Returns this function ingredient's memo table with its allocation-lifetime guarantee.
+    pub(super) fn memo_table_for<'db>(
+        &'db self,
+        zalsa: &'db Zalsa,
+        id: Id,
+    ) -> FunctionMemoTable<'db> {
+        FunctionMemoTable {
+            table: zalsa.memo_table_for::<C::SalsaStruct<'_>>(id),
+        }
     }
 
     /// Evicts the existing memo for the given key, replacing it

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -16,30 +16,6 @@ use crate::zalsa::{MemoIngredientIndex, Zalsa};
 use crate::zalsa_local::{QueryOriginRef, QueryRevisions};
 use crate::{Event, EventKind, Id, Revision};
 
-/// A function memo table whose allocations remain valid for `'db`.
-///
-/// The private field ensures that this type can only be constructed by
-/// [`IngredientImpl::memo_table_for`], which ties `'db` to a shared borrow of the function
-/// ingredient and its memo-retention invariant.
-pub(super) struct FunctionMemoTable<'db> {
-    table: MemoTableWithTypes<'db>,
-}
-
-impl<'db> FunctionMemoTable<'db> {
-    /// Loads an erased memo that remains valid for `'db`.
-    #[inline]
-    pub(super) fn get_erased(
-        self,
-        memo_ingredient_index: MemoIngredientIndex,
-    ) -> Option<ErasedMemo<'db>> {
-        // SAFETY: `FunctionMemoTable` can only be created while holding a shared borrow of the
-        // function ingredient for `'db`. The ingredient's memo-retention invariant guarantees
-        // that every allocation loaded from this table remains valid for that borrow, even if its
-        // entry is replaced.
-        unsafe { self.table.get_erased(memo_ingredient_index) }
-    }
-}
-
 impl<C: Configuration> IngredientImpl<C> {
     /// Inserts the memo for the given key; (atomically) overwrites and returns any previously existing memo
     pub(super) fn insert_memo_into_table_for(
@@ -103,15 +79,15 @@ impl<C: Configuration> IngredientImpl<C> {
 ///
 /// # Layout
 ///
-/// [`ErasedMemo::header`] relies on `Memo` having a stable C layout with [`Memo::header`] at
-/// offset zero. Keep `Memo` as `repr(C)` and keep `header` as its first field.
+/// [`ErasedMemo`] retains a pointer to the complete `Memo` allocation so that it can recover the
+/// typed memo. Placing `header` at offset zero also lets it access [`MemoHeader`] with a direct
+/// pointer cast. The C representation makes that offset stable.
 #[repr(C)]
 #[derive(Debug)]
 pub struct Memo<C: Configuration> {
     /// Configuration-independent state used to validate and manage this memo.
     ///
-    /// This must remain the first field: [`ErasedMemo::header`] casts the `Memo` allocation pointer
-    /// to a pointer to `MemoHeader`.
+    /// Must have offset zero for [`ErasedMemo::header`].
     pub(super) header: MemoHeader,
 
     /// The result of the query, if we decide to memoize it.
@@ -120,18 +96,8 @@ pub struct Memo<C: Configuration> {
 
 /// A shared, type-erased handle to a [`Memo`].
 ///
-/// `ErasedMemo` keeps header access cheap while deferring type-dependent operations until they
-/// are needed. Its private fields maintain the following invariants:
-///
-/// * `data` retains the provenance of a complete `Memo<C>` allocation and is aligned,
-///   dereferenceable, and valid for shared access for `'db`.
-/// * `to_dyn_fn` and `type_id` describe that same `Memo<C>`.
-/// * The allocation's value is valid for `'db`. Replacing the table entry must not free the
-///   allocation while an `ErasedMemo` can still refer to it.
-///
-/// The fields are initialized together by the memo table from matching type metadata. The table
-/// may shorten the handle's lifetime when loading an erased memo, but it must uphold the
-/// allocation-lifetime invariant above.
+/// `data` retains the provenance of a complete `Memo<C>` allocation that remains valid for shared
+/// access for `'db`, even after replacement. `to_dyn_fn` and `type_id` describe the same `C`.
 #[derive(Clone, Copy)]
 pub struct ErasedMemo<'db> {
     /// A pointer to the complete [`Memo`] allocation.
@@ -143,8 +109,7 @@ pub struct ErasedMemo<'db> {
     /// The concrete memo type, used to assert that downcasts match the registered memo type.
     type_id: TypeId,
 
-    /// Ties the handle to the allocation lifetime. This shared-borrow marker is covariant, which
-    /// permits the memo table to shorten a lifetime-erased handle to the table borrow's lifetime.
+    /// Binds shared access to the allocation lifetime.
     _lifetime: PhantomData<&'db ()>,
 }
 
@@ -170,23 +135,19 @@ impl<'memo> ErasedMemo<'memo> {
         }
     }
 
-    /// Returns the configuration-independent header without a table lookup or virtual call.
+    /// Returns the configuration-independent header without a table lookup.
     #[inline(always)]
     pub(super) fn header(self) -> &'memo MemoHeader {
-        // SAFETY: The type invariant guarantees that `data` points to a complete, aligned `Memo`
-        // allocation that remains valid for shared access for `'memo`. `Memo` is `repr(C)` and
-        // `header` is its first field, so the allocation and `MemoHeader` have the same address.
-        // Casting the complete-allocation pointer preserves the provenance needed for this field.
+        // SAFETY: `data` points to a complete `Memo` valid for `'memo`, and `Memo::header` has
+        // offset zero.
         unsafe { self.data.cast::<MemoHeader>().as_ref() }
     }
 
     /// Returns whether the memo currently contains a value.
     #[inline]
     pub(super) fn has_value(self) -> bool {
-        // SAFETY: The type invariant guarantees that `to_dyn_fn` was generated for the concrete
-        // memo allocation that `data` points to and that the allocation remains valid for shared
-        // access for `'memo`. The returned trait-object pointer therefore has the correct vtable
-        // and can be dereferenced for the duration of this call.
+        // SAFETY: `to_dyn_fn` matches the concrete memo allocation, which is valid for shared
+        // access for `'memo`.
         unsafe { (self.to_dyn_fn)(self.data).as_ref() }.has_value()
     }
 
@@ -194,8 +155,7 @@ impl<'memo> ErasedMemo<'memo> {
     ///
     /// # Panics
     ///
-    /// Panics if the memo was created for a different configuration. This check makes the
-    /// downcast safe and preserves the type-checking behavior of
+    /// Panics if the memo was created for a different configuration, matching
     /// [`MemoTableWithTypes::get`](crate::table::memo::MemoTableWithTypes::get).
     #[inline]
     pub(super) fn downcast<C: Configuration>(self) -> &'memo Memo<C> {
@@ -205,9 +165,8 @@ impl<'memo> ErasedMemo<'memo> {
             "ErasedMemo downcast with the wrong configuration",
         );
 
-        // SAFETY: The type invariant guarantees that `data` retains the provenance of the complete
-        // memo allocation and remains valid for shared access for `'memo`. `TypeId` equality proves
-        // that the allocation has concrete type `Memo<C>`.
+        // SAFETY: The type check proves that `data` points to `Memo<C>`; the handle guarantees
+        // that the complete allocation is valid for shared access for `'memo`.
         unsafe { self.data.cast::<Memo<C>>().as_ref() }
     }
 }
@@ -398,6 +357,24 @@ impl<C: Configuration> crate::table::memo::Memo for Memo<C> {
                 memos: Vec::new(),
             },
         }
+    }
+}
+
+/// A function memo table whose allocations remain valid for `'db`, including after replacement.
+pub(super) struct FunctionMemoTable<'db> {
+    table: MemoTableWithTypes<'db>,
+}
+
+impl<'db> FunctionMemoTable<'db> {
+    /// Loads an erased memo that remains valid for `'db`.
+    #[inline]
+    pub(super) fn get_erased(
+        self,
+        memo_ingredient_index: MemoIngredientIndex,
+    ) -> Option<ErasedMemo<'db>> {
+        // SAFETY: `memo_table_for` ties `'db` to a shared ingredient borrow, and `deleted_entries`
+        // retains replaced allocations until the ingredient is borrowed exclusively.
+        unsafe { self.table.get_erased(memo_ingredient_index) }
     }
 }
 
@@ -616,7 +593,7 @@ mod _memory_usage {
     use std::any::TypeId;
     use std::num::NonZeroUsize;
 
-    // `ErasedMemo::header` relies on the header starting at the address of the complete memo.
+    // Required by `ErasedMemo::header`.
     const _: () = assert!(std::mem::offset_of!(super::Memo<DummyConfiguration>, header) == 0);
 
     // Memos are stored a lot, make sure their size doesn't randomly increase.

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -1,4 +1,6 @@
+use std::any::TypeId;
 use std::fmt::{Debug, Formatter};
+use std::marker::PhantomData;
 use std::ptr::NonNull;
 
 use crate::cycle::{
@@ -9,7 +11,7 @@ use crate::ingredient::WaitForResult;
 use crate::key::DatabaseKeyIndex;
 use crate::revision::AtomicRevision;
 use crate::sync::atomic::Ordering;
-use crate::table::memo::MemoTableWithTypesMut;
+use crate::table::memo::{DummyMemo, MemoTableWithTypesMut, ToDynMemo};
 use crate::zalsa::{MemoIngredientIndex, Zalsa};
 use crate::zalsa_local::{QueryOriginRef, QueryRevisions};
 use crate::{Event, EventKind, Id, Revision};
@@ -62,13 +64,117 @@ impl<C: Configuration> IngredientImpl<C> {
     }
 }
 
+/// A memoized query result.
+///
+/// # Layout
+///
+/// [`ErasedMemo::header`] relies on `Memo` having a stable C layout with [`Memo::header`] at
+/// offset zero. Keep `Memo` as `repr(C)` and keep `header` as its first field.
+#[repr(C)]
 #[derive(Debug)]
 pub struct Memo<C: Configuration> {
     /// Configuration-independent state used to validate and manage this memo.
+    ///
+    /// This must remain the first field: [`ErasedMemo::header`] casts the `Memo` allocation pointer
+    /// to a pointer to `MemoHeader`.
     pub(super) header: MemoHeader,
 
     /// The result of the query, if we decide to memoize it.
     pub(super) value: Option<C::Output<'static>>,
+}
+
+/// A shared, type-erased handle to a [`Memo`].
+///
+/// `ErasedMemo` keeps header access cheap while deferring type-dependent operations until they
+/// are needed. Its private fields maintain the following invariants:
+///
+/// * `data` retains the provenance of a complete `Memo<C>` allocation and is aligned,
+///   dereferenceable, and valid for shared access for `'db`.
+/// * `to_dyn_fn` and `type_id` describe that same `Memo<C>`.
+/// * The allocation's value is valid for `'db`. Replacing the table entry must not free the
+///   allocation while an `ErasedMemo` can still refer to it.
+///
+/// The fields are initialized together by the memo table from matching type metadata. The table
+/// may shorten the handle's lifetime when loading an erased memo, but it must uphold the
+/// allocation-lifetime invariant above.
+#[derive(Clone, Copy)]
+pub struct ErasedMemo<'db> {
+    /// A pointer to the complete [`Memo`] allocation.
+    data: NonNull<DummyMemo>,
+
+    /// Coerces `data` to a trait object using the vtable for its concrete memo type.
+    to_dyn_fn: ToDynMemo,
+
+    /// The concrete memo type, used to assert that downcasts match the registered memo type.
+    type_id: TypeId,
+
+    /// Ties the handle to the allocation lifetime. This shared-borrow marker is covariant, which
+    /// permits the memo table to shorten a lifetime-erased handle to the table borrow's lifetime.
+    _lifetime: PhantomData<&'db ()>,
+}
+
+impl<'memo> ErasedMemo<'memo> {
+    /// Constructs an erased handle from a complete memo pointer and its type metadata.
+    ///
+    /// # Safety
+    ///
+    /// `data` must retain the provenance of a complete, live, aligned `Memo<C>` allocation and
+    /// remain valid for shared access for `'memo`. `to_dyn_fn` must be the trait-object coercion
+    /// for `Memo<C>`, and `type_id` must be `TypeId::of::<Memo<C>>()` for that same `C`.
+    #[inline]
+    pub(crate) unsafe fn from_raw_parts(
+        data: NonNull<DummyMemo>,
+        to_dyn_fn: ToDynMemo,
+        type_id: TypeId,
+    ) -> Self {
+        Self {
+            data,
+            to_dyn_fn,
+            type_id,
+            _lifetime: PhantomData,
+        }
+    }
+
+    /// Returns the configuration-independent header without a table lookup or virtual call.
+    #[inline(always)]
+    pub(super) fn header(self) -> &'memo MemoHeader {
+        // SAFETY: The type invariant guarantees that `data` points to a complete, aligned `Memo`
+        // allocation that remains valid for shared access for `'memo`. `Memo` is `repr(C)` and
+        // `header` is its first field, so the allocation and `MemoHeader` have the same address.
+        // Casting the complete-allocation pointer preserves the provenance needed for this field.
+        unsafe { self.data.cast::<MemoHeader>().as_ref() }
+    }
+
+    /// Returns whether the memo currently contains a value.
+    #[inline]
+    pub(super) fn has_value(self) -> bool {
+        // SAFETY: The type invariant guarantees that `to_dyn_fn` was generated for the concrete
+        // memo allocation that `data` points to and that the allocation remains valid for shared
+        // access for `'memo`. The returned trait-object pointer therefore has the correct vtable
+        // and can be dereferenced for the duration of this call.
+        unsafe { (self.to_dyn_fn)(self.data).as_ref() }.has_value()
+    }
+
+    /// Returns the concrete memo after asserting that it uses configuration `C`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the memo was created for a different configuration. This check makes the
+    /// downcast safe and preserves the type-checking behavior of
+    /// [`MemoTableWithTypes::get`](crate::table::memo::MemoTableWithTypes::get).
+    #[inline]
+    pub(super) fn downcast<C: Configuration>(self) -> &'memo Memo<C> {
+        assert_eq!(
+            self.type_id,
+            TypeId::of::<Memo<C>>(),
+            "ErasedMemo downcast with the wrong configuration",
+        );
+
+        // SAFETY: The type invariant guarantees that `data` retains the provenance of the complete
+        // memo allocation and remains valid for shared access for `'memo`. `TypeId` equality proves
+        // that the allocation has concrete type `Memo<C>`.
+        unsafe { self.data.cast::<Memo<C>>().as_ref() }
+    }
 }
 
 #[derive(Debug)]
@@ -234,6 +340,10 @@ impl<C: Configuration> Memo<C> {
 }
 
 impl<C: Configuration> crate::table::memo::Memo for Memo<C> {
+    fn has_value(&self) -> bool {
+        self.value.is_some()
+    }
+
     fn remove_outputs(&self, zalsa: &Zalsa, executor: DatabaseKeyIndex) {
         self.header.remove_outputs(zalsa, executor);
     }
@@ -471,11 +581,16 @@ mod _memory_usage {
     use std::any::TypeId;
     use std::num::NonZeroUsize;
 
-    // Memo's are stored a lot, make sure their size doesn't randomly increase.
+    // `ErasedMemo::header` relies on the header starting at the address of the complete memo.
+    const _: () = assert!(std::mem::offset_of!(super::Memo<DummyConfiguration>, header) == 0);
+
+    // Memos are stored a lot, make sure their size doesn't randomly increase.
     const _: [(); std::mem::size_of::<super::MemoHeader>()] =
         [(); std::mem::size_of::<[usize; 4]>()];
     const _: [(); std::mem::size_of::<super::Memo<DummyConfiguration>>()] =
         [(); std::mem::size_of::<[usize; 5]>()];
+    const _: [(); std::mem::size_of::<super::ErasedMemo<'static>>()] =
+        [(); std::mem::size_of::<[usize; 4]>()];
 
     struct DummyStruct;
 

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -11,7 +11,7 @@ use crate::ingredient::WaitForResult;
 use crate::key::DatabaseKeyIndex;
 use crate::revision::AtomicRevision;
 use crate::sync::atomic::Ordering;
-use crate::table::memo::{DummyMemo, MemoTableWithTypes, MemoTableWithTypesMut, ToDynMemo};
+use crate::table::memo::{DummyMemo, MemoTableWithTypesMut, ToDynMemo};
 use crate::zalsa::{MemoIngredientIndex, Zalsa};
 use crate::zalsa_local::{QueryOriginRef, QueryRevisions};
 use crate::{Event, EventKind, Id, Revision};
@@ -46,17 +46,6 @@ impl<C: Configuration> IngredientImpl<C> {
         Some(unsafe { memo.as_ref() })
     }
 
-    /// Returns this function ingredient's memo table with its allocation-lifetime guarantee.
-    pub(super) fn memo_table_for<'db>(
-        &'db self,
-        zalsa: &'db Zalsa,
-        id: Id,
-    ) -> FunctionMemoTable<'db> {
-        FunctionMemoTable {
-            table: zalsa.memo_table_for::<C::SalsaStruct<'_>>(id),
-        }
-    }
-
     /// Evicts the existing memo for the given key, replacing it
     /// with an equivalent memo that has no value. If the memo is untracked
     /// or has values assigned as output of another query, this has no effect.
@@ -79,15 +68,16 @@ impl<C: Configuration> IngredientImpl<C> {
 ///
 /// # Layout
 ///
-/// [`ErasedMemo`] retains a pointer to the complete `Memo` allocation so that it can recover the
-/// typed memo. Placing `header` at offset zero also lets it access [`MemoHeader`] with a direct
-/// pointer cast. The C representation makes that offset stable.
+/// [`ErasedMemo`] retains a pointer to the base address of the `Memo` allocation, with spatial
+/// provenance covering the entire allocation, so that it can recover the typed memo. Placing
+/// `header` at offset zero also lets it access [`MemoHeader`] with a direct pointer cast. The C
+/// representation makes that offset stable.
 #[repr(C)]
 #[derive(Debug)]
 pub struct Memo<C: Configuration> {
     /// Configuration-independent state used to validate and manage this memo.
     ///
-    /// Must have offset zero for [`ErasedMemo::header`].
+    /// Must be at offset zero for [`ErasedMemo::header`].
     pub(super) header: MemoHeader,
 
     /// The result of the query, if we decide to memoize it.
@@ -96,11 +86,13 @@ pub struct Memo<C: Configuration> {
 
 /// A shared, type-erased handle to a [`Memo`].
 ///
-/// `data` retains the provenance of a complete `Memo<C>` allocation that remains valid for shared
-/// access for `'db`, even after replacement. `to_dyn_fn` and `type_id` describe the same `C`.
+/// `data` points to the base address of the `Memo<C>` allocation with spatial provenance
+/// covering the entire allocation, which remains valid for shared access for `'db`, even after
+/// replacement. `to_dyn_fn` and `type_id` describe the same `C`.
 #[derive(Clone, Copy)]
 pub struct ErasedMemo<'db> {
-    /// A pointer to the complete [`Memo`] allocation.
+    /// A pointer to the base address of the [`Memo`] allocation, with spatial provenance covering
+    /// the entire allocation.
     data: NonNull<DummyMemo>,
 
     /// Coerces `data` to a trait object using the vtable for its concrete memo type.
@@ -114,13 +106,14 @@ pub struct ErasedMemo<'db> {
 }
 
 impl<'memo> ErasedMemo<'memo> {
-    /// Constructs an erased handle from a complete memo pointer and its type metadata.
+    /// Constructs an erased handle from a memo allocation pointer and its type metadata.
     ///
     /// # Safety
     ///
-    /// `data` must retain the provenance of a complete, live, aligned `Memo<C>` allocation and
-    /// remain valid for shared access for `'memo`. `to_dyn_fn` must be the trait-object coercion
-    /// for `Memo<C>`, and `type_id` must be `TypeId::of::<Memo<C>>()` for that same `C`.
+    /// `data` must point to the base address of a live, aligned `Memo<C>` allocation, have
+    /// spatial provenance covering the entire allocation, and remain valid for shared access for
+    /// `'memo`. `to_dyn_fn` must be the trait-object coercion for `Memo<C>`, and `type_id` must be
+    /// `TypeId::of::<Memo<C>>()` for that same `C`.
     #[inline]
     pub(crate) unsafe fn from_raw_parts(
         data: NonNull<DummyMemo>,
@@ -138,8 +131,8 @@ impl<'memo> ErasedMemo<'memo> {
     /// Returns the configuration-independent header without a table lookup.
     #[inline(always)]
     pub(super) fn header(self) -> &'memo MemoHeader {
-        // SAFETY: `data` points to a complete `Memo` valid for `'memo`, and `Memo::header` has
-        // offset zero.
+        // SAFETY: `data` points to the base address of a `Memo` allocation valid for `'memo`, with
+        // spatial provenance covering the allocation, and `Memo::header` has offset zero.
         unsafe { self.data.cast::<MemoHeader>().as_ref() }
     }
 
@@ -166,7 +159,7 @@ impl<'memo> ErasedMemo<'memo> {
         );
 
         // SAFETY: The type check proves that `data` points to `Memo<C>`; the handle guarantees
-        // that the complete allocation is valid for shared access for `'memo`.
+        // that the allocation is valid for shared access for `'memo`.
         unsafe { self.data.cast::<Memo<C>>().as_ref() }
     }
 }
@@ -357,24 +350,6 @@ impl<C: Configuration> crate::table::memo::Memo for Memo<C> {
                 memos: Vec::new(),
             },
         }
-    }
-}
-
-/// A function memo table whose allocations remain valid for `'db`, including after replacement.
-pub(super) struct FunctionMemoTable<'db> {
-    table: MemoTableWithTypes<'db>,
-}
-
-impl<'db> FunctionMemoTable<'db> {
-    /// Loads an erased memo that remains valid for `'db`.
-    #[inline]
-    pub(super) fn get_erased(
-        self,
-        memo_ingredient_index: MemoIngredientIndex,
-    ) -> Option<ErasedMemo<'db>> {
-        // SAFETY: `memo_table_for` ties `'db` to a shared ingredient borrow, and `deleted_entries`
-        // retains replaced allocations until the ingredient is borrowed exclusively.
-        unsafe { self.table.get_erased(memo_ingredient_index) }
     }
 }
 
@@ -595,6 +570,10 @@ mod _memory_usage {
 
     // Required by `ErasedMemo::header`.
     const _: () = assert!(std::mem::offset_of!(super::Memo<DummyConfiguration>, header) == 0);
+    const _: () = assert!(
+        std::mem::offset_of!(super::Memo<DummyConfiguration>, value)
+            == std::mem::size_of::<super::MemoHeader>()
+    );
 
     // Memos are stored a lot, make sure their size doesn't randomly increase.
     const _: [(); std::mem::size_of::<super::MemoHeader>()] =

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -312,6 +312,38 @@ pub struct MemoTableWithTypes<'a> {
     memos: &'a MemoTable,
 }
 
+/// A memo table slot whose observed allocations remain valid for shared access for `'a`.
+pub(crate) struct MemoSlot<'a> {
+    table: MemoTableWithTypes<'a>,
+    memo_ingredient_index: MemoIngredientIndex,
+}
+
+impl<'a> MemoSlot<'a> {
+    /// Creates a memo slot with an allocation-lifetime guarantee.
+    ///
+    /// # Safety
+    ///
+    /// Any allocation observed in this slot must remain at the same address and valid for shared
+    /// access for `'a`.
+    #[inline]
+    pub(crate) unsafe fn new(
+        table: MemoTableWithTypes<'a>,
+        memo_ingredient_index: MemoIngredientIndex,
+    ) -> Self {
+        Self {
+            table,
+            memo_ingredient_index,
+        }
+    }
+
+    /// Loads the erased memo currently stored in this slot.
+    #[inline]
+    pub(crate) fn get_erased(&self) -> Option<ErasedMemo<'a>> {
+        // SAFETY: Guaranteed by the caller of `MemoSlot::new`.
+        unsafe { self.table.get_erased(self.memo_ingredient_index) }
+    }
+}
+
 impl<'a> MemoTableWithTypes<'a> {
     pub(crate) fn insert<M: Memo>(
         self,
@@ -373,10 +405,10 @@ impl<'a> MemoTableWithTypes<'a> {
     /// # Safety
     ///
     /// Any allocation observed in the table entry must remain at the same address and valid for
-    /// shared access for `'a`, even if another thread replaces the entry.
+    /// shared access for `'a`.
     #[inline]
-    pub(crate) unsafe fn get_erased(
-        self,
+    unsafe fn get_erased(
+        &self,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> Option<ErasedMemo<'a>> {
         let MemoEntry { atomic_memo } = self.memos.memos.get(memo_ingredient_index.as_usize())?;
@@ -391,9 +423,10 @@ impl<'a> MemoTableWithTypes<'a> {
 
         let memo = NonNull::new(atomic_memo.load(Ordering::Acquire))?;
 
-        // SAFETY: `insert` type-checks and release-publishes a complete-allocation pointer paired
-        // with `type_`; the acquire load observes its initialization. The caller guarantees that
-        // the allocation remains valid for `'a`.
+        // SAFETY: `insert` type-checks and release-publishes a pointer to the memo allocation's
+        // base address, with spatial provenance covering the allocation, paired with `type_`; the
+        // acquire load observes its initialization. The caller guarantees that the allocation
+        // remains valid for `'a`.
         Some(unsafe { ErasedMemo::from_raw_parts(memo, type_.to_dyn_fn, type_.type_id) })
     }
 

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -4,9 +4,19 @@ use std::mem;
 use std::ptr::{self, NonNull};
 
 use crate::DatabaseKeyIndex;
+use crate::function::ErasedMemo;
 use crate::sync::atomic::{AtomicPtr, Ordering};
 use crate::zalsa::MemoIngredientIndex;
 use crate::zalsa::Zalsa;
+
+/// Coerces an erased thin pointer to a `dyn Memo` pointer with the registered concrete type's
+/// vtable.
+///
+/// `MemoEntryType::of::<M>` creates this function together with the `TypeId` for `M`. The function
+/// does not dereference its argument. A caller that dereferences the result must first guarantee
+/// that the argument retains the provenance of a complete, live, aligned `M` allocation for the
+/// same `M` used to create the function.
+pub(crate) type ToDynMemo = fn(NonNull<DummyMemo>) -> NonNull<dyn Memo>;
 
 /// The "memo table" stores the memoized results of tracked function calls.
 /// Every tracked function must take a salsa struct as its first argument
@@ -42,6 +52,9 @@ impl MemoTable {
 }
 
 pub trait Memo: Any + Send + Sync {
+    /// Returns whether this memo contains a value.
+    fn has_value(&self) -> bool;
+
     /// Removes the outputs that were created when this query ran. This includes
     /// tracked structs and specified queries.
     fn remove_outputs(&self, zalsa: &Zalsa, executor: DatabaseKeyIndex);
@@ -187,37 +200,21 @@ impl Drop for LazyMemoEntries {
     }
 }
 
+/// Runtime type information and pointer operations for one memo-table slot.
+///
+/// All fields describe the same concrete memo type `M` and are initialized together by
+/// [`MemoEntryType::of`]. A `MemoEntryType` may only be paired with a slot containing `M`; insertion
+/// checks that invariant before publishing a pointer.
 #[derive(Clone, Copy, Debug)]
 pub struct MemoEntryType {
     /// The `type_id` of the erased memo type `M`
     type_id: TypeId,
 
-    /// A type-coercion function for the erased memo type `M`
-    to_dyn_fn: fn(NonNull<DummyMemo>) -> NonNull<dyn Memo>,
+    /// A type-coercion function for the erased memo type `M`.
+    to_dyn_fn: ToDynMemo,
 }
 
 impl MemoEntryType {
-    fn to_dummy<M: Memo>(memo: NonNull<M>) -> NonNull<DummyMemo> {
-        memo.cast()
-    }
-
-    unsafe fn from_dummy<M: Memo>(memo: NonNull<DummyMemo>) -> NonNull<M> {
-        memo.cast()
-    }
-
-    const fn to_dyn_fn<M: Memo>() -> fn(NonNull<DummyMemo>) -> NonNull<dyn Memo> {
-        let f: fn(NonNull<M>) -> NonNull<dyn Memo> = |x| x;
-
-        // SAFETY: `M: Sized` and `DummyMemo: Sized`, as such they are ABI compatible behind a
-        // `NonNull` making it safe to do type erasure.
-        unsafe {
-            mem::transmute::<
-                fn(NonNull<M>) -> NonNull<dyn Memo>,
-                fn(NonNull<DummyMemo>) -> NonNull<dyn Memo>,
-            >(f)
-        }
-    }
-
     #[inline]
     pub fn of<M: Memo>() -> Self {
         Self {
@@ -225,13 +222,42 @@ impl MemoEntryType {
             to_dyn_fn: Self::to_dyn_fn::<M>(),
         }
     }
+
+    fn to_dummy<M: Memo>(memo: NonNull<M>) -> NonNull<DummyMemo> {
+        memo.cast()
+    }
+
+    /// Restores a concrete pointer previously erased by [`MemoEntryType::to_dummy`].
+    ///
+    /// # Safety
+    ///
+    /// `memo` must point to a live, aligned `M` allocation and must have been erased without
+    /// changing its address or provenance.
+    unsafe fn from_dummy<M: Memo>(memo: NonNull<DummyMemo>) -> NonNull<M> {
+        memo.cast()
+    }
+
+    pub(crate) const fn to_dyn_fn<M: Memo>() -> ToDynMemo {
+        fn to_dyn<M: Memo>(memo: NonNull<DummyMemo>) -> NonNull<dyn Memo> {
+            let memo: NonNull<M> = memo.cast();
+            memo
+        }
+
+        to_dyn::<M>
+    }
 }
 
-/// Dummy placeholder type that we use when erasing the memo type `M` in [`MemoEntryData`][].
+/// A pointee marker for thin memo pointers whose concrete type is stored in [`MemoEntryType`].
+///
+/// The table never constructs a `DummyMemo` value or dereferences a pointer as `DummyMemo`.
 #[derive(Debug)]
-struct DummyMemo;
+pub(crate) struct DummyMemo;
 
 impl Memo for DummyMemo {
+    fn has_value(&self) -> bool {
+        unreachable!("DummyMemo is never stored in a memo table")
+    }
+
     fn remove_outputs(&self, _zalsa: &Zalsa, _executor: DatabaseKeyIndex) {}
 
     #[cfg(feature = "salsa_unstable")]
@@ -296,7 +322,7 @@ pub struct MemoTableWithTypes<'a> {
     memos: &'a MemoTable,
 }
 
-impl MemoTableWithTypes<'_> {
+impl<'a> MemoTableWithTypes<'a> {
     pub(crate) fn insert<M: Memo>(
         self,
         memo_ingredient_index: MemoIngredientIndex,
@@ -350,6 +376,45 @@ impl MemoTableWithTypes<'_> {
         NonNull::new(atomic_memo.load(Ordering::Acquire))
             // SAFETY: We asserted that the type is correct above.
             .map(|memo| unsafe { MemoEntryType::from_dummy(memo) })
+    }
+
+    /// Returns a type-erased view of the memo at the given index, if one has been inserted.
+    ///
+    /// # Safety
+    ///
+    /// Every allocation that the acquire load can observe in the table entry must remain
+    /// allocated, immovable, and valid for shared access for all of `'a`, even if another thread
+    /// replaces the entry. `MemoTable` does not itself guarantee the lifetime of an allocation
+    /// after replacement.
+    ///
+    /// If this function returns `Some`, the returned handle retains the complete allocation
+    /// pointer's provenance and uses the type metadata registered for this slot.
+    #[inline]
+    pub(crate) unsafe fn get_erased(
+        self,
+        memo_ingredient_index: MemoIngredientIndex,
+    ) -> Option<ErasedMemo<'a>> {
+        let MemoEntry { atomic_memo } = self.memos.memos.get(memo_ingredient_index.as_usize())?;
+
+        // SAFETY: Any indices that are in-bounds for the `MemoTable` are also in-bounds for its
+        // corresponding `MemoTableTypes`, by construction.
+        let type_ = unsafe {
+            self.types
+                .types
+                .get_unchecked(memo_ingredient_index.as_usize())
+        };
+
+        // The acquire load observes the fully initialized allocation published by `insert`'s
+        // release operation before the pointer is converted into a shared handle.
+        let memo = NonNull::new(atomic_memo.load(Ordering::Acquire))?;
+
+        // SAFETY: The `MemoTableWithTypes` construction invariant pairs this slot with `type_`, and
+        // `insert` checks the concrete type before publishing a pointer produced by
+        // `MemoEntryType::to_dummy`, which preserves the complete allocation's provenance. The
+        // caller guarantees that the loaded allocation remains live, aligned, immovable, and valid
+        // for shared access for `'a`. The metadata fields were initialized together for that same
+        // concrete slot type.
+        Some(unsafe { ErasedMemo::from_raw_parts(memo, type_.to_dyn_fn, type_.type_id) })
     }
 
     #[cfg(feature = "salsa_unstable")]

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -9,13 +9,9 @@ use crate::sync::atomic::{AtomicPtr, Ordering};
 use crate::zalsa::MemoIngredientIndex;
 use crate::zalsa::Zalsa;
 
-/// Coerces an erased thin pointer to a `dyn Memo` pointer with the registered concrete type's
-/// vtable.
+/// Adds the registered concrete memo type's vtable without dereferencing the pointer.
 ///
-/// `MemoEntryType::of::<M>` creates this function together with the `TypeId` for `M`. The function
-/// does not dereference its argument. A caller that dereferences the result must first guarantee
-/// that the argument retains the provenance of a complete, live, aligned `M` allocation for the
-/// same `M` used to create the function.
+/// Dereferencing the result requires a live, aligned allocation of the same concrete type.
 pub(crate) type ToDynMemo = fn(NonNull<DummyMemo>) -> NonNull<dyn Memo>;
 
 /// The "memo table" stores the memoized results of tracked function calls.
@@ -52,7 +48,6 @@ impl MemoTable {
 }
 
 pub trait Memo: Any + Send + Sync {
-    /// Returns whether this memo contains a value.
     fn has_value(&self) -> bool;
 
     /// Removes the outputs that were created when this query ran. This includes
@@ -200,11 +195,9 @@ impl Drop for LazyMemoEntries {
     }
 }
 
-/// Runtime type information and pointer operations for one memo-table slot.
+/// Type metadata for one memo-table slot.
 ///
-/// All fields describe the same concrete memo type `M` and are initialized together by
-/// [`MemoEntryType::of`]. A `MemoEntryType` may only be paired with a slot containing `M`; insertion
-/// checks that invariant before publishing a pointer.
+/// Both fields describe the slot's concrete memo type, and the slot stores only that type.
 #[derive(Clone, Copy, Debug)]
 pub struct MemoEntryType {
     /// The `type_id` of the erased memo type `M`
@@ -231,8 +224,7 @@ impl MemoEntryType {
     ///
     /// # Safety
     ///
-    /// `memo` must point to a live, aligned `M` allocation and must have been erased without
-    /// changing its address or provenance.
+    /// `memo` must have been produced by [`MemoEntryType::to_dummy`] from a live, aligned `M`.
     unsafe fn from_dummy<M: Memo>(memo: NonNull<DummyMemo>) -> NonNull<M> {
         memo.cast()
     }
@@ -247,9 +239,7 @@ impl MemoEntryType {
     }
 }
 
-/// A pointee marker for thin memo pointers whose concrete type is stored in [`MemoEntryType`].
-///
-/// The table never constructs a `DummyMemo` value or dereferences a pointer as `DummyMemo`.
+/// Pointee marker for erased memo pointers; never instantiated or dereferenced.
 #[derive(Debug)]
 pub(crate) struct DummyMemo;
 
@@ -378,17 +368,12 @@ impl<'a> MemoTableWithTypes<'a> {
             .map(|memo| unsafe { MemoEntryType::from_dummy(memo) })
     }
 
-    /// Returns a type-erased view of the memo at the given index, if one has been inserted.
+    /// Returns a type-erased view with the slot's registered type metadata.
     ///
     /// # Safety
     ///
-    /// Every allocation that the acquire load can observe in the table entry must remain
-    /// allocated, immovable, and valid for shared access for all of `'a`, even if another thread
-    /// replaces the entry. `MemoTable` does not itself guarantee the lifetime of an allocation
-    /// after replacement.
-    ///
-    /// If this function returns `Some`, the returned handle retains the complete allocation
-    /// pointer's provenance and uses the type metadata registered for this slot.
+    /// Any allocation observed in the table entry must remain at the same address and valid for
+    /// shared access for `'a`, even if another thread replaces the entry.
     #[inline]
     pub(crate) unsafe fn get_erased(
         self,
@@ -404,16 +389,11 @@ impl<'a> MemoTableWithTypes<'a> {
                 .get_unchecked(memo_ingredient_index.as_usize())
         };
 
-        // The acquire load observes the fully initialized allocation published by `insert`'s
-        // release operation before the pointer is converted into a shared handle.
         let memo = NonNull::new(atomic_memo.load(Ordering::Acquire))?;
 
-        // SAFETY: The `MemoTableWithTypes` construction invariant pairs this slot with `type_`, and
-        // `insert` checks the concrete type before publishing a pointer produced by
-        // `MemoEntryType::to_dummy`, which preserves the complete allocation's provenance. The
-        // caller guarantees that the loaded allocation remains live, aligned, immovable, and valid
-        // for shared access for `'a`. The metadata fields were initialized together for that same
-        // concrete slot type.
+        // SAFETY: `insert` type-checks and release-publishes a complete-allocation pointer paired
+        // with `type_`; the acquire load observes its initialization. The caller guarantees that
+        // the allocation remains valid for `'a`.
         Some(unsafe { ErasedMemo::from_raw_parts(memo, type_.to_dyn_fn, type_.type_id) })
     }
 


### PR DESCRIPTION
Move configuration-independent memo validation into a type-erased cold path, reducing ty's generated LLVM IR by 22,813 lines. I plan on using the erased memo for more changes, which should justify the introduced complexity. But I thought this change is worth splitting out, to ease reviewing.

