### PR TITLE
refactor: reduce interned constructor monomorphization

### DIFF
--- a/src/interned.rs
+++ b/src/interned.rs
@@ -342,29 +342,6 @@ where
             _marker: PhantomData,
         }
     }
-}
-
-/// Creates the sharded storage outside of the generic [`IngredientImpl::new`] context.
-///
-/// Keeping this helper non-generic avoids monomorphizing the `OnceLock` and iterator machinery for
-/// every interned struct configuration.
-fn new_shards() -> Box<[CachePadded<Mutex<IngredientShard>>]> {
-    static SHARDS: OnceLock<usize> = OnceLock::new();
-    let shards = *SHARDS.get_or_init(|| {
-        let num_cpus = std::thread::available_parallelism()
-            .map(usize::from)
-            .unwrap_or(1);
-
-        (num_cpus * 4).next_power_of_two()
-    });
-
-    (0..shards).map(|_| Default::default()).collect()
-}
-
-impl<C> IngredientImpl<C>
-where
-    C: Configuration,
-{
     /// Returns the shard for a given hash.
     ///
     /// Note that this value is guaranteed to be in-bounds for `self.shards`.
@@ -1062,6 +1039,23 @@ where
             }
         })
     }
+}
+
+/// Creates the sharded storage outside of the generic [`IngredientImpl::new`] context.
+///
+/// Keeping this helper non-generic avoids monomorphizing the `OnceLock` and iterator machinery for
+/// every interned struct configuration.
+fn new_shards() -> Box<[CachePadded<Mutex<IngredientShard>>]> {
+    static SHARDS: OnceLock<usize> = OnceLock::new();
+    let shards = *SHARDS.get_or_init(|| {
+        let num_cpus = std::thread::available_parallelism()
+            .map(usize::from)
+            .unwrap_or(1);
+
+        (num_cpus * 4).next_power_of_two()
+    });
+
+    (0..shards).map(|_| Default::default()).collect()
 }
 
 /// Inserts an ID while keeping the hasher and rehashing logic independent of `C`.

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -329,26 +329,42 @@ where
     C: Configuration,
 {
     pub fn new(ingredient_index: IngredientIndex) -> Self {
-        static SHARDS: OnceLock<usize> = OnceLock::new();
-        let shards = *SHARDS.get_or_init(|| {
-            let num_cpus = std::thread::available_parallelism()
-                .map(usize::from)
-                .unwrap_or(1);
-
-            (num_cpus * 4).next_power_of_two()
-        });
+        let shards = new_shards();
+        let shift = usize::BITS - shards.len().trailing_zeros();
 
         Self {
             ingredient_index,
             hasher: FxBuildHasher,
             memo_table_types: Arc::new(MemoTableTypes::default()),
             revision_queue: RevisionQueue::new(C::REVISIONS),
-            shift: usize::BITS - shards.trailing_zeros(),
-            shards: (0..shards).map(|_| Default::default()).collect(),
+            shift,
+            shards,
             _marker: PhantomData,
         }
     }
+}
 
+/// Creates the sharded storage outside of the generic [`IngredientImpl::new`] context.
+///
+/// Keeping this helper non-generic avoids monomorphizing the `OnceLock` and iterator machinery for
+/// every interned struct configuration.
+fn new_shards() -> Box<[CachePadded<Mutex<IngredientShard>>]> {
+    static SHARDS: OnceLock<usize> = OnceLock::new();
+    let shards = *SHARDS.get_or_init(|| {
+        let num_cpus = std::thread::available_parallelism()
+            .map(usize::from)
+            .unwrap_or(1);
+
+        (num_cpus * 4).next_power_of_two()
+    });
+
+    (0..shards).map(|_| Default::default()).collect()
+}
+
+impl<C> IngredientImpl<C>
+where
+    C: Configuration,
+{
     /// Returns the shard for a given hash.
     ///
     /// Note that this value is guaranteed to be in-bounds for `self.shards`.


### PR DESCRIPTION
Moves interned shard construction behind a non-generic helper so the compiler emits the `OnceLock` and iterator machinery once instead of per configuration.

Relative to #1204, using LLVM IR for `ty_python_semantic` drops from 3,988,276 to 3,921,670 lines: 66,606 fewer (-1.67%).

This PR is stacked on #1204, which makes the constructor independent of `C`.

Ready for review once 1204 lands

Testing: Focused tests, formatting, LLVM-line analysis, and CodSpeed simulation passed.