### PR TITLE
refactor: reduce specified value validation monomorphization

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -455,7 +455,10 @@ where
         executor: DatabaseKeyIndex,
         output_key: crate::Id,
     ) {
-        self.validate_specified_value(zalsa, executor, output_key);
+        let memo_ingredient_index = self.memo_ingredient_index(zalsa, output_key);
+        let database_key_index = self.database_key_index(output_key);
+        let memo_slot = self.memo_slot(zalsa, output_key, memo_ingredient_index);
+        specify::validate_specified_value(zalsa, executor, database_key_index, memo_slot);
     }
 
     fn remove_stale_output(

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -223,14 +223,8 @@ where
             }
         }
 
-        // SAFETY: The table stores 'static memos (to support `Any`), the memos are in fact valid
-        // for `'db` though as we delay their dropping to the end of a revision.
-        let memo_slot = unsafe {
-            MemoSlot::new(
-                zalsa.memo_table_for::<C::SalsaStruct<'_>>(database_key_index.key_index()),
-                memo_ingredient_index,
-            )
-        };
+        let memo_slot =
+            self.memo_slot(zalsa, database_key_index.key_index(), memo_ingredient_index);
 
         match inner(
             &self.sync_table,

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -11,7 +11,7 @@ use crate::ingredient::WaitForResult;
 use crate::key::DatabaseKeyIndex;
 use crate::revision::AtomicRevision;
 use crate::sync::atomic::Ordering;
-use crate::table::memo::{DummyMemo, MemoTableWithTypesMut, ToDynMemo};
+use crate::table::memo::{DummyMemo, MemoSlot, MemoTableWithTypesMut, ToDynMemo};
 use crate::zalsa::{MemoIngredientIndex, Zalsa};
 use crate::zalsa_local::{QueryOriginRef, QueryRevisions};
 use crate::{Event, EventKind, Id, Revision};
@@ -44,6 +44,22 @@ impl<C: Configuration> IngredientImpl<C> {
             .get(memo_ingredient_index)?;
         // SAFETY: The memo table owns this allocation for at least `'db`.
         Some(unsafe { memo.as_ref() })
+    }
+
+    pub(super) fn memo_slot<'db>(
+        &self,
+        zalsa: &'db Zalsa,
+        id: Id,
+        memo_ingredient_index: MemoIngredientIndex,
+    ) -> MemoSlot<'db> {
+        // SAFETY: The table stores 'static memos (to support `Any`), but the memos remain valid
+        // for `'db` because dropping them is delayed until the end of the revision.
+        unsafe {
+            MemoSlot::new(
+                zalsa.memo_table_for::<C::SalsaStruct<'_>>(id),
+                memo_ingredient_index,
+            )
+        }
     }
 
     /// Evicts the existing memo for the given key, replacing it

--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -5,6 +5,7 @@ use crate::function::memo::Memo;
 use crate::function::sync::{ClaimResult, Reentrancy};
 use crate::function::{Configuration, IngredientImpl};
 use crate::sync::atomic::AtomicBool;
+use crate::table::memo::MemoSlot;
 use crate::tracked_struct::TrackedStructInDb;
 use crate::zalsa::{Zalsa, ZalsaDatabase};
 use crate::zalsa_local::{OriginAndExtra, QueryOriginRef, QueryRevisions};
@@ -151,41 +152,36 @@ where
         // Record that the current query *specified* a value for this cell.
         zalsa_local.add_output(database_key_index);
     }
+}
 
-    /// Invoked when the query `executor` has been validated as having green inputs
-    /// and `key` is a value that was specified by `executor`.
-    /// Marks `key` as valid in the current revision since if `executor` had re-executed,
-    /// it would have specified `key` again.
-    pub(super) fn validate_specified_value(
-        &self,
-        zalsa: &Zalsa,
-        executor: DatabaseKeyIndex,
-        key: Id,
-    ) {
-        let memo_ingredient_index = self.memo_ingredient_index(zalsa, key);
+/// Marks the value at `database_key_index` as valid after its assigning `executor` is found green.
+/// Re-executing a green executor would specify the same value again.
+pub(super) fn validate_specified_value(
+    zalsa: &Zalsa,
+    executor: DatabaseKeyIndex,
+    database_key_index: DatabaseKeyIndex,
+    memo_slot: MemoSlot<'_>,
+) {
+    let Some(memo) = memo_slot.get_erased() else {
+        return;
+    };
+    let header = memo.header();
 
-        let memo = match self.get_memo_from_table_for(zalsa, key, memo_ingredient_index) {
-            Some(m) => m,
-            None => return,
-        };
-
-        // If we are marking this as validated, it must be a value that was
-        // assigned by `executor`.
-        match memo.header.origin() {
-            QueryOriginRef::Assigned(by_query) => assert_eq!(by_query, executor),
-            _ => panic!(
-                "expected a query assigned by `{:?}`, not `{:?}`",
-                executor,
-                memo.header.origin(),
-            ),
-        }
-
-        let database_key_index = self.database_key_index(key);
-        memo.header.mark_as_verified(zalsa, database_key_index);
-        #[cfg(feature = "accumulator")]
-        memo.header
-            .revisions
-            .accumulated_inputs
-            .store(InputAccumulatedValues::Empty);
+    // If we are marking this as validated, it must be a value that was
+    // assigned by `executor`.
+    match header.origin() {
+        QueryOriginRef::Assigned(by_query) => assert_eq!(by_query, executor),
+        _ => panic!(
+            "expected a query assigned by `{:?}`, not `{:?}`",
+            executor,
+            header.origin(),
+        ),
     }
+
+    header.mark_as_verified(zalsa, database_key_index);
+    #[cfg(feature = "accumulator")]
+    header
+        .revisions
+        .accumulated_inputs
+        .store(InputAccumulatedValues::Empty);
 }


### PR DESCRIPTION
Moves specified-value validation onto the erased memo path introduced by #1206, avoiding one validator instantiation per tracked query. This removes 14,950 LLVM lines (0.36%) from ty's main query crate.

Depends on #1206.


(Ready for review, once 1206 is merged)