### PR TITLE
docs: document proc macros and Salsa concepts

### DIFF
--- a/components/salsa-macros/src/lib.rs
+++ b/components/salsa-macros/src/lib.rs
@@ -1,4 +1,9 @@
-//! This crate provides salsa's macros and attributes.
+//! Procedural macros for defining Salsa databases, ingredients, and queries.
+//!
+//! This crate is an implementation detail of [`salsa`](../salsa/index.html). Its macros are
+//! re-exported from that crate and should normally be invoked through the `salsa::` path.
+//!
+//! See the [`salsa` crate documentation](../salsa/index.html) for the concepts behind each macro.
 
 #![recursion_limit = "256"]
 
@@ -50,48 +55,464 @@ mod tracked_struct;
 mod update;
 mod xform;
 
+/// Defines a type whose values can be accumulated by tracked functions.
+///
+/// Accumulated values are auxiliary outputs, such as diagnostics, collected while a tracked query
+/// runs. They are stored alongside the query's memoized result but do not contribute to that result
+/// or its equality.
+///
+/// The macro implements [`salsa::Accumulator`] for the annotated struct.
+///
+/// See [accumulators in the `salsa` crate documentation] for their semantics and lifecycle.
+///
+/// This macro accepts no options. The annotated type must be a struct and implement
+/// [`Send`] + [`Sync`] + [`UnwindSafe`] + `'static`.
+///
+/// # Example
+///
+/// ```ignore
+/// #[salsa::accumulator]
+/// struct Diagnostic(String);
+///
+/// #[salsa::tracked]
+/// fn check(db: &dyn salsa::Database) {
+///     salsa::Accumulator::accumulate(Diagnostic("something went wrong".into()), db);
+/// }
+/// ```
+///
+/// [`salsa::Accumulator`]: ../salsa/trait.Accumulator.html
+/// [`UnwindSafe`]: std::panic::UnwindSafe
+/// [accumulators in the `salsa` crate documentation]: ../salsa/index.html#accumulators
 #[proc_macro_attribute]
 pub fn accumulator(args: TokenStream, input: TokenStream) -> TokenStream {
     accumulator::accumulator(args, input)
 }
 
+/// Defines a Salsa database struct or database trait.
+///
+/// A database is the state container passed to Salsa operations. Its storage holds inputs, tracked
+/// and interned values, and memoized query results.
+///
+/// This macro accepts no options. Its effect depends on the annotated item:
+///
+/// - On a struct, it implements Salsa's storage plumbing. The struct must have named fields and
+///   one of them must be named `storage`, conventionally with type [`salsa::Storage<Self>`].
+/// - On a trait, it adds the hidden methods Salsa uses to view a database as that trait. Database
+///   traits conventionally extend [`salsa::Database`].
+/// - On a trait implementation, it implements those hidden view methods. Every implementation of
+///   a trait annotated with `#[salsa::db]` must also carry `#[salsa::db]`.
+///
+/// # Example
+///
+/// ```ignore
+/// #[salsa::db]
+/// #[derive(Clone, Default)]
+/// struct MyDatabase {
+///     storage: salsa::Storage<Self>,
+/// }
+///
+/// #[salsa::db]
+/// trait MyDatabaseView: salsa::Database {}
+///
+/// #[salsa::db]
+/// impl MyDatabaseView for MyDatabase {}
+///
+/// #[salsa::db]
+/// impl salsa::Database for MyDatabase {}
+/// ```
+///
+/// [`salsa::Database`]: ../salsa/trait.Database.html
+/// [`salsa::Storage<Self>`]: ../salsa/struct.Storage.html
 #[proc_macro_attribute]
 pub fn db(args: TokenStream, input: TokenStream) -> TokenStream {
     db::db(args, input)
 }
 
+/// Defines an interned struct.
+///
+/// All fields jointly determine the struct's identity. Within a revision, every occurrence of equal
+/// field values maps to the same compact handle. Interned fields are immutable.
+///
+/// The annotated item must be a struct with named fields. It may declare one lifetime parameter,
+/// which Salsa treats as the database lifetime, but no type or const parameters. The generated
+/// struct is [`Copy`] and provides a constructor and field getters. Every field type must implement
+/// [`Clone`] + [`Eq`] + [`Hash`] + [`Send`] + [`Sync`] + [`salsa::Update`].
+///
+/// See [interned structs in the `salsa` crate documentation] for their identity and lifecycle.
+///
+/// # Options
+///
+/// Options are comma-separated inside the attribute:
+///
+/// - `constructor = IDENT` renames the generated constructor from `new` to `IDENT`.
+/// - `debug` implements [`Debug`] using the field values when a database is attached to the current
+///   thread. The generated `default_debug_fmt` method can also be called from a manual [`Debug`]
+///   implementation.
+/// - `revisions = EXPR` sets the minimum number of active revisions an unused value is retained
+///   before its slot may be reused. The default is `3`. The value must be nonzero; `usize::MAX`
+///   disables reuse.
+/// - `heap_size = PATH` records heap use for Salsa's unstable memory-usage reporting. `PATH` must
+///   accept a reference to the tuple of all fields and return its heap allocation size in bytes.
+/// - `persist` enables persistent caching when Salsa's `persistence` feature is enabled. Fields
+///   are serialized as a tuple with [`serde`] by default.
+/// - `persist(serialize = PATH, deserialize = PATH)` enables persistence with custom tuple
+///   serialization functions. Either path may be omitted to use the corresponding [`serde`]
+///   implementation.
+///
+/// ## Legacy adapters
+///
+/// These options exist to adapt older code or external representations to Salsa. New code should
+/// use the default lifetime-bearing struct and [`salsa::Id`], and its field types should implement
+/// [`salsa::Update`].
+///
+/// - `id = PATH` uses `PATH` as a legacy ID adapter instead of [`salsa::Id`]. The custom type must
+///   implement `salsa::plumbing::AsId` and `salsa::plumbing::FromId`.
+/// - **Unsafe: `no_lifetime` is strongly discouraged.** It adapts code that cannot carry the
+///   database lifetime by generating a struct without one. This bypasses the compile-time
+///   guarantee that an interned handle cannot outlive its database revision. The caller becomes
+///   responsible for ensuring every handle remains valid as revisions advance and interned slots
+///   may be reclaimed or reused.
+/// - **Unsafe: `unsafe(non_update_types)` is strongly discouraged.** It adapts field types that do
+///   not implement [`salsa::Update`] by suppressing the generated checks. The caller becomes
+///   responsible for ensuring reused values cannot contain dangling references. Prefer deriving
+///   or implementing [`salsa::Update`] for every field type.
+///
+/// # Field attributes
+///
+/// Every field generates a getter with the same name and visibility as the field. These helper
+/// attributes configure that getter:
+///
+/// - `#[returns(MODE)]` selects how the getter returns the field. `clone` (the default) returns an
+///   owned `FieldTy` using [`Clone`]; `copy` returns an owned `FieldTy` using [`Copy`]; `ref`
+///   returns `&FieldTy`; and `deref` uses [`Deref`] to return
+///   `&<FieldTy as Deref>::Target`. `as_ref` and `as_deref` use [`salsa::SalsaAsRef`] and
+///   [`salsa::SalsaAsDeref`] to return borrowed forms such as `Option<&T>` and
+///   `Option<&T::Target>`. Every borrowed result is tied to the database borrow.
+/// - `#[get(IDENT)]` renames the generated getter.
+///
+/// Other attributes, including documentation and lint attributes, are copied to the generated
+/// getter.
+///
+/// # Example
+///
+/// ```ignore
+/// #[salsa::interned(debug)]
+/// struct Name<'db> {
+///     #[returns(ref)]
+///     text: String,
+///     #[get(disambiguator)]
+///     index: u32,
+/// }
+/// ```
+///
+/// [`Debug`]: std::fmt::Debug
+/// [`Deref`]: std::ops::Deref
+/// [`Hash`]: std::hash::Hash
+/// [`salsa::Id`]: ../salsa/struct.Id.html
+/// [`salsa::SalsaAsDeref`]: ../salsa/trait.SalsaAsDeref.html
+/// [`salsa::SalsaAsRef`]: ../salsa/trait.SalsaAsRef.html
+/// [`salsa::Update`]: ../salsa/trait.Update.html
+/// [`serde`]: https://docs.rs/serde/latest/serde/
+/// [interned structs in the `salsa` crate documentation]: ../salsa/index.html#interned-structs
+/// [return mode]: ../salsa/index.html#return-modes
 #[proc_macro_attribute]
 pub fn interned(args: TokenStream, input: TokenStream) -> TokenStream {
     interned::interned(args, input)
 }
 
+/// Derives a heterogeneous query key from an enum of Salsa structs.
+///
+/// Use a supertype when one tracked function should accept several input, tracked, or interned
+/// struct types. Salsa uses the wrapped struct's ID directly as the query key, while its concrete
+/// Salsa struct type determines the enum variant. Every wrapped value is therefore memoized
+/// independently.
+///
+/// Variants may also wrap another supertype, allowing supertypes to be nested. A concrete Salsa
+/// struct type must be reachable through exactly one variant, including through nested supertypes,
+/// so that Salsa can determine its enum variant unambiguously.
+///
+/// See [supertypes in the `salsa` crate documentation] for more details.
+///
+/// # Example
+///
+/// ```ignore
+/// #[salsa::input]
+/// struct File {
+///     #[returns(ref)]
+///     path: String,
+/// }
+///
+/// #[salsa::interned]
+/// struct Symbol<'db> {
+///     #[returns(ref)]
+///     name: String,
+/// }
+///
+/// #[derive(Clone, Copy, PartialEq, Eq, Hash, salsa::Supertype)]
+/// enum Source<'db> {
+///     File(File),
+///     Symbol(Symbol<'db>),
+/// }
+///
+/// #[salsa::tracked(returns(ref))]
+/// fn display_name<'db>(db: &'db dyn salsa::Database, source: Source<'db>) -> String {
+///     let name = match source {
+///         Source::File(file) => file.path(db),
+///         Source::Symbol(symbol) => symbol.name(db),
+///     };
+///     name.clone()
+/// }
+/// ```
+///
+/// [supertypes in the `salsa` crate documentation]: ../salsa/index.html#supertypes
 #[proc_macro_derive(Supertype)]
 pub fn supertype(input: TokenStream) -> TokenStream {
     supertype::supertype(input)
 }
 
+/// Defines a mutable input to a Salsa database.
+///
+/// Each constructed input has a distinct identity that remains stable when its fields are changed.
+/// Reading a field records a dependency on that field; setting it invalidates queries that read it.
+///
+/// The macro replaces a named-field struct with a compact, [`Copy`] Salsa ID and generates a
+/// constructor, a builder, and getter and setter methods for every field.
+///
+/// See [input structs in the `salsa` crate documentation] for their identity, field-level
+/// dependencies, and lifecycle.
+///
+/// The annotated item must be a struct with named fields and no generic parameters.
+///
+/// # Options
+///
+/// Options are comma-separated inside the attribute:
+///
+/// - `constructor = IDENT` renames the generated constructor from `new` to `IDENT`.
+/// - `debug` implements [`Debug`] using the field values when a database is attached to the current
+///   thread. The generated `default_debug_fmt` method can also be called from a manual [`Debug`]
+///   implementation.
+/// - `singleton` permits only one instance of this input type in a database and generates
+///   `try_get(db)` and `get(db)` methods for retrieving it.
+/// - `heap_size = PATH` records heap use for Salsa's unstable memory-usage reporting. `PATH` must
+///   accept a reference to the tuple of all fields and return its heap allocation size in bytes.
+/// - `persist` enables persistent caching when Salsa's `persistence` feature is enabled. Fields
+///   are serialized as a tuple with [`serde`] by default.
+/// - `persist(serialize = PATH, deserialize = PATH)` enables persistence with custom tuple
+///   serialization functions. Either path may be omitted to use the corresponding [`serde`]
+///   implementation.
+///
+/// # Field attributes
+///
+/// Every field generates getter and setter methods with the same name and visibility as the field.
+/// These helper attributes configure those methods:
+///
+/// - `#[returns(MODE)]` selects how the getter returns the field. `clone` (the default) returns an
+///   owned `FieldTy` using [`Clone`]; `copy` returns an owned `FieldTy` using [`Copy`]; `ref`
+///   returns `&FieldTy`; and `deref` uses [`Deref`] to return
+///   `&<FieldTy as Deref>::Target`. `as_ref` and `as_deref` use [`salsa::SalsaAsRef`] and
+///   [`salsa::SalsaAsDeref`] to return borrowed forms such as `Option<&T>` and
+///   `Option<&T::Target>`. Every borrowed result is tied to the database borrow.
+/// - `#[get(IDENT)]` renames the generated getter.
+/// - `#[set(IDENT)]` renames the generated setter.
+/// - `#[default]` initializes the field with [`Default::default`], omits it from the constructor's
+///   arguments, and adds a builder method for overriding the default.
+///
+/// Other attributes, including documentation and lint attributes, are copied to the generated
+/// getter.
+///
+/// [`Debug`]: std::fmt::Debug
+/// [`Deref`]: std::ops::Deref
+/// [`salsa::SalsaAsDeref`]: ../salsa/trait.SalsaAsDeref.html
+/// [`salsa::SalsaAsRef`]: ../salsa/trait.SalsaAsRef.html
+/// [`serde`]: https://docs.rs/serde/latest/serde/
+/// [input structs in the `salsa` crate documentation]: ../salsa/index.html#input-structs
+/// [return mode]: ../salsa/index.html#return-modes
 #[proc_macro_attribute]
 pub fn input(args: TokenStream, input: TokenStream) -> TokenStream {
     input::input(args, input)
 }
 
+/// Defines a tracked struct or function, or enables tracked methods in an `impl` block.
+///
+/// The accepted syntax and generated API depend on the annotated item. See the sections below for
+/// the options and field attributes accepted by each form.
+///
+/// # Tracked structs
+///
+/// A tracked struct represents a derived entity created during tracked-function execution. Its
+/// identity belongs to the producing query, which can recreate and update the entity in a later
+/// revision.
+///
+/// The annotated item must have named fields and exactly one lifetime parameter, conventionally
+/// `'db`; type and const parameters are not supported.
+///
+/// See [tracked structs in the `salsa` crate documentation] for their identity, change tracking,
+/// and lifecycle.
+///
+/// ## Struct options
+///
+/// - `constructor = IDENT` renames the generated constructor from `new` to `IDENT`.
+/// - `debug` implements [`Debug`] using the field values when a database is attached to the current
+///   thread. The generated `default_debug_fmt` method can also be called from a manual [`Debug`]
+///   implementation.
+/// - `heap_size = PATH` records heap use for Salsa's unstable memory-usage reporting. `PATH` must
+///   accept a reference to the tuple of all fields and return its heap allocation size in bytes.
+/// - `persist` enables persistent caching when Salsa's `persistence` feature is enabled. Fields
+///   are serialized as a tuple with [`serde`] by default.
+/// - `persist(serialize = PATH, deserialize = PATH)` enables persistence with custom tuple
+///   serialization functions. Either path may be omitted to use the corresponding [`serde`]
+///   implementation.
+///
+/// ## Struct field attributes
+///
+/// - `#[tracked]` excludes the field from the struct's identity. When the producing query recreates
+///   the same entity with a new value for this field, Salsa updates the existing entity instead of
+///   creating a new one. Reads of the field are tracked separately, so changing it invalidates only
+///   queries that read that field. Use this for properties that may change while the conceptual
+///   entity remains the same.
+/// - `#[returns(MODE)]` selects how the getter returns the field. `clone` (the default) returns an
+///   owned `FieldTy` using [`Clone`]; `copy` returns an owned `FieldTy` using [`Copy`]; `ref`
+///   returns `&FieldTy`; and `deref` uses [`Deref`] to return
+///   `&<FieldTy as Deref>::Target`. `as_ref` and `as_deref` use [`salsa::SalsaAsRef`] and
+///   [`salsa::SalsaAsDeref`] to return borrowed forms such as `Option<&T>` and
+///   `Option<&T::Target>`. Every borrowed result is tied to the database borrow.
+/// - `#[get(IDENT)]` renames the generated getter.
+/// - `#[no_eq]` replaces the stored value and treats the field as changed whenever the struct is
+///   recreated, avoiding equality and [`salsa::Update`] requirements.
+/// - `#[maybe_update(EXPR)]` uses `EXPR` to update the stored field. The expression must have type
+///   `unsafe fn(*mut FieldTy, FieldTy) -> bool` and return whether the value changed. The caller is
+///   responsible for upholding the [`salsa::Update`] safety contract.
+///
+/// Other attributes, including documentation and lint attributes, are copied to the generated
+/// getter.
+///
+/// # Tracked functions
+///
+/// A tracked function memoizes its result and records the Salsa values read by its body. Salsa
+/// reuses the memoized result while those dependencies remain unchanged.
+///
+/// The first parameter must be an immutable `&dyn DatabaseTrait`; the remaining parameters form
+/// the query key. The function may declare one database lifetime but no type or const parameters.
+/// With no key parameters, the function has one memoized query per database. A single key parameter
+/// must be a Salsa struct and uses its ID directly. With multiple key parameters, Salsa first
+/// interns their tuple to obtain an ID, adding an interning step to every call; their [`Eq`] and
+/// [`Hash`] implementations determine whether calls use the same memo.
+///
+/// See [tracked functions in the `salsa` crate documentation] for query identity, dependency
+/// tracking, result equality, and memo lifecycle.
+///
+/// ## Function options
+///
+/// - `returns(MODE)` selects how callers receive the memoized result. `clone` (the default) returns
+///   an owned `Output` using [`Clone`]; `copy` returns an owned `Output` using [`Copy`]; `ref`
+///   returns `&Output`; and `deref` uses [`Deref`] to return `&<Output as Deref>::Target`.
+///   `as_ref` and `as_deref` use [`salsa::SalsaAsRef`] and [`salsa::SalsaAsDeref`] to return
+///   borrowed forms such as `Option<&T>` and `Option<&T::Target>`. Every borrowed result is tied to
+///   the database borrow and remains stored in the query's memo.
+/// - `no_eq` treats every newly computed result as changed and removes the output's equality
+///   requirement. It cannot be combined with `cycle_fn`.
+/// - `specify` generates `FUNCTION::specify(db, key, value)`. It supports queries that have both a
+///   per-key incremental implementation and a batch implementation that computes many results at
+///   once. The function must take exactly one key argument, and it must be a tracked struct, not an
+///   input or interned struct. `specify` must be called during the same tracked query invocation
+///   that created the key. It cannot be combined with `lru`. See [specifying query results in the
+///   Salsa book] for an example.
+/// - `lru = INTEGER` bounds the number of memoized values retained by the function and sets the
+///   initial capacity used by `FUNCTION::set_lru_capacity`.
+/// - `cycle_initial = EXPR` enables fixed-point cycle recovery and computes the initial value. The
+///   expression is called as `(db, cycle_head_id, query_arguments...)`.
+/// - `cycle_fn = EXPR` combines successive fixed-point values. It must be accompanied by
+///   `cycle_initial` and is called as
+///   `(db, cycle, previous_value, new_value, query_arguments...)`. See [fixed-point cycle recovery
+///   in the Salsa book] for the convergence requirements and a complete example.
+/// - `cycle_result = EXPR` supplies an immediate fallback for cycles instead of fixed-point
+///   iteration. It is called with the same arguments as `cycle_initial` and cannot be combined
+///   with `cycle_initial` or `cycle_fn`.
+/// - `heap_size = PATH` records heap use for Salsa's unstable memory-usage reporting. `PATH` must
+///   accept a reference to the output and return its heap allocation size in bytes.
+/// - `persist` enables persistent caching when Salsa's `persistence` feature is enabled. The query
+///   inputs and output must implement [`serde::Serialize`] and [`serde::Deserialize`].
+/// - `self_ty = TYPE` prefixes the query's debug name with `TYPE`. The impl-block form supplies
+///   this automatically for methods and associated functions.
+///
+/// ## Legacy function adapter
+///
+/// - **Unsafe: `unsafe(non_update_types)` is strongly discouraged.** It adapts output or internally
+///   interned input types that do not implement [`salsa::Update`] by suppressing the generated
+///   checks. The caller becomes responsible for ensuring reused values cannot contain dangling
+///   references. Prefer deriving or implementing [`salsa::Update`] for those types.
+///
+/// # Tracked impl blocks
+///
+/// Applying `#[salsa::tracked]` to an inherent or trait `impl` allows individual methods and
+/// associated functions in it to also use `#[salsa::tracked(...)]`. The outer attribute accepts no
+/// options; inner attributes accept all tracked-function options.
+///
+/// A tracked method takes `self` by value followed by the database parameter. A tracked associated
+/// function takes the database parameter first. Other methods and associated items are left
+/// unchanged.
+///
+/// # Examples
+///
+/// ```ignore
+/// #[salsa::input]
+/// struct File {
+///     #[returns(ref)]
+///     text: String,
+/// }
+///
+/// #[salsa::tracked]
+/// fn word_count(db: &dyn salsa::Database, file: File) -> usize {
+///     file.text(db).split_whitespace().count()
+/// }
+///
+/// #[salsa::tracked]
+/// impl File {
+///     #[salsa::tracked]
+///     fn line_count(self, db: &dyn salsa::Database) -> usize {
+///         self.text(db).lines().count()
+///     }
+/// }
+/// ```
+///
+/// [`Debug`]: std::fmt::Debug
+/// [`Deref`]: std::ops::Deref
+/// [`Eq`]: std::cmp::Eq
+/// [`Hash`]: std::hash::Hash
+/// [`salsa::SalsaAsDeref`]: ../salsa/trait.SalsaAsDeref.html
+/// [`salsa::SalsaAsRef`]: ../salsa/trait.SalsaAsRef.html
+/// [`salsa::Update`]: ../salsa/trait.Update.html
+/// [`serde`]: https://docs.rs/serde/latest/serde/
+/// [`serde::Deserialize`]: https://docs.rs/serde/latest/serde/trait.Deserialize.html
+/// [`serde::Serialize`]: https://docs.rs/serde/latest/serde/trait.Serialize.html
+/// [fixed-point cycle recovery in the Salsa book]: https://salsa-rs.github.io/salsa/cycles.html#fixed-point-iteration
+/// [return mode]: ../salsa/index.html#return-modes
+/// [specifying query results in the Salsa book]: https://salsa-rs.github.io/salsa/overview.html#specify-the-result-of-tracked-functions-for-particular-structs
+/// [tracked functions in the `salsa` crate documentation]: ../salsa/index.html#tracked-functions-and-memoized-values
+/// [tracked structs in the `salsa` crate documentation]: ../salsa/index.html#tracked-structs
 #[proc_macro_attribute]
 pub fn tracked(args: TokenStream, input: TokenStream) -> TokenStream {
     tracked::tracked(args, input)
 }
 
-/// Derives `salsa::Update` for a struct or enum.
+/// Derives [`salsa::Update`] for a struct or enum.
 ///
-/// Generic type parameters receive an implicit `salsa::Update` bound unless all their uses appear
+/// The generated implementation updates fields in place and returns whether any field changed.
+/// Named fields, tuple fields, unit structs, and enum variants are supported; unions are not.
+///
+/// Generic type parameters receive an implicit [`salsa::Update`] bound unless all their uses appear
 /// in fields that use the `fallback` or `unsafe(with(...))` update strategies.
 ///
-/// The `#[update(...)]` field helper supports these forms:
+/// # Field attributes
 ///
-/// - `#[update(fallback)]` updates the field with `salsa::update_fallback`.
-///   This form adds a `FieldTy: 'static + PartialEq` bound to the generated impl.
+/// A field accepts at most one `#[update(...)]` attribute. The helper supports these forms:
+///
+/// - `#[update(fallback)]` updates the field with [`salsa::update_fallback`].
+///   This form adds a `FieldTy: 'static + PartialEq` bound to the generated impl, where
+///   [`PartialEq`] is the standard equality trait.
 /// - `#[update(unsafe(with(expr)))]` updates the field with `expr`, which must have type
 ///   `unsafe fn(*mut FieldTy, FieldTy) -> bool`. The caller is responsible for
-///   ensuring the custom function upholds the `salsa::Update` safety contract.
+///   ensuring the custom function upholds the [`salsa::Update`] safety contract.
 /// - `#[update(bounds(Predicate, ...))]` adds one or more where-predicates to the generated impl.
 ///   This form can be combined with `fallback` or `unsafe(with(...))`; by itself it does not change
 ///   how the field is updated.
@@ -105,7 +526,8 @@ pub fn tracked(args: TokenStream, input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// Since `value` uses the normal update path, the generated impl requires `T: salsa::Update`.
+/// Since `value` uses the normal update path, the generated impl requires [`salsa::Update`] for
+/// `T`.
 ///
 /// ```ignore
 /// #[derive(Clone, PartialEq, Eq, salsa::Update)]
@@ -115,8 +537,8 @@ pub fn tracked(args: TokenStream, input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// The `fallback` helper uses `salsa::update_fallback` and requires `T: 'static + PartialEq`
-/// instead of `T: salsa::Update`.
+/// The `fallback` helper uses [`salsa::update_fallback`] and requires
+/// `T: 'static + PartialEq` instead of [`salsa::Update`] for `T`.
 ///
 /// ```ignore
 /// #[derive(Clone, PartialEq, Eq, salsa::Update)]
@@ -133,6 +555,10 @@ pub fn tracked(args: TokenStream, input: TokenStream) -> TokenStream {
 ///     salsa::update_fallback(old, new)
 /// }
 /// ```
+///
+/// [`PartialEq`]: std::cmp::PartialEq
+/// [`salsa::Update`]: ../salsa/trait.Update.html
+/// [`salsa::update_fallback`]: ../salsa/fn.update_fallback.html
 #[proc_macro_derive(Update, attributes(update))]
 pub fn update(input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as syn::DeriveInput);

--- a/components/salsa-macros/src/lib.rs
+++ b/components/salsa-macros/src/lib.rs
@@ -382,8 +382,8 @@ pub fn input(args: TokenStream, input: TokenStream) -> TokenStream {
 /// - `#[get(IDENT)]` renames the generated getter.
 /// - `#[no_eq]` replaces the stored value and treats the field as changed whenever the struct is
 ///   recreated, avoiding equality and [`salsa::Update`] requirements. It is most useful together
-///   with `#[tracked]` for a non-identity field that should always invalidate its readers when the
-///   entity is recreated.
+///   with `#[tracked]`: because the field does not contribute to identity, the struct can retain
+///   its identity when recreated, while readers of the field are always invalidated.
 /// - `#[maybe_update(EXPR)]` uses `EXPR` to update the stored field. The expression must have type
 ///   `unsafe fn(*mut FieldTy, FieldTy) -> bool` and return whether the value changed. The caller is
 ///   responsible for upholding the [`salsa::Update`] safety contract.

--- a/components/salsa-macros/src/lib.rs
+++ b/components/salsa-macros/src/lib.rs
@@ -398,10 +398,12 @@ pub fn input(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// The first parameter must be an immutable `&dyn DatabaseTrait`; the remaining parameters form
 /// the query key. The function may declare one database lifetime but no type or const parameters.
-/// With no key parameters, the function has one memoized query per database. A single key parameter
-/// must be a Salsa struct and uses its ID directly. With multiple key parameters, Salsa first
-/// interns their tuple to obtain an ID, adding an interning step to every call; their [`Eq`] and
-/// [`Hash`] implementations determine whether calls use the same memo.
+/// Every key parameter and the output must implement [`Send`] + [`Sync`]. With no key parameters,
+/// the function has one memoized query per database. A single key parameter must be a Salsa struct
+/// and uses its ID directly. With multiple key parameters, Salsa first interns their tuple to
+/// obtain an ID, adding an interning step to every call. Each key parameter must additionally
+/// implement [`Clone`] + [`Eq`] + [`Hash`]. Equality and hashing determine whether calls use the
+/// same memo, and Salsa always clones the stored tuple when materializing the function arguments.
 ///
 /// See [tracked functions in the `salsa` crate documentation] for query identity, dependency
 /// tracking, result equality, and memo lifecycle.
@@ -553,11 +555,12 @@ pub fn tracked(args: TokenStream, input: TokenStream) -> TokenStream {
 ///     marker: std::marker::PhantomData<U>,
 /// }
 ///
-/// unsafe fn custom_update<T>(old: *mut T, new: T) -> bool
+/// unsafe fn custom_update<T>(_old: *mut T, _new: T) -> bool
 /// where
 ///     T: 'static + PartialEq,
 /// {
-///     salsa::update_fallback(old, new)
+///     // Custom update logic that upholds `Update::maybe_update`'s safety contract...
+///     todo!()
 /// }
 /// ```
 ///

--- a/components/salsa-macros/src/lib.rs
+++ b/components/salsa-macros/src/lib.rs
@@ -378,7 +378,9 @@ pub fn input(args: TokenStream, input: TokenStream) -> TokenStream {
 ///   `Option<&T::Target>`. Every borrowed result is tied to the database borrow.
 /// - `#[get(IDENT)]` renames the generated getter.
 /// - `#[no_eq]` replaces the stored value and treats the field as changed whenever the struct is
-///   recreated, avoiding equality and [`salsa::Update`] requirements.
+///   recreated, avoiding equality and [`salsa::Update`] requirements. It is most useful together
+///   with `#[tracked]` for a non-identity field that should always invalidate its readers when the
+///   entity is recreated.
 /// - `#[maybe_update(EXPR)]` uses `EXPR` to update the stored field. The expression must have type
 ///   `unsafe fn(*mut FieldTy, FieldTy) -> bool` and return whether the value changed. The caller is
 ///   responsible for upholding the [`salsa::Update`] safety contract.

--- a/components/salsa-macros/src/lib.rs
+++ b/components/salsa-macros/src/lib.rs
@@ -1,9 +1,11 @@
 //! Procedural macros for defining Salsa databases, ingredients, and queries.
 //!
-//! This crate is an implementation detail of [`salsa`](../salsa/index.html). Its macros are
-//! re-exported from that crate and should normally be invoked through the `salsa::` path.
+//! This crate is an implementation detail of [`salsa`](https://docs.rs/salsa/latest/salsa/). Its
+//! macros are re-exported from that crate and should normally be invoked through the `salsa::`
+//! path.
 //!
-//! See the [`salsa` crate documentation](../salsa/index.html) for the concepts behind each macro.
+//! See the [`salsa` crate documentation](https://docs.rs/salsa/latest/salsa/) for the concepts
+//! behind each macro.
 
 #![recursion_limit = "256"]
 
@@ -80,9 +82,9 @@ mod xform;
 /// }
 /// ```
 ///
-/// [`salsa::Accumulator`]: ../salsa/trait.Accumulator.html
+/// [`salsa::Accumulator`]: https://docs.rs/salsa/latest/salsa/trait.Accumulator.html
 /// [`UnwindSafe`]: std::panic::UnwindSafe
-/// [accumulators in the `salsa` crate documentation]: ../salsa/index.html#accumulators
+/// [accumulators in the `salsa` crate documentation]: https://docs.rs/salsa/latest/salsa/#accumulators
 #[proc_macro_attribute]
 pub fn accumulator(args: TokenStream, input: TokenStream) -> TokenStream {
     accumulator::accumulator(args, input)
@@ -121,8 +123,8 @@ pub fn accumulator(args: TokenStream, input: TokenStream) -> TokenStream {
 /// impl salsa::Database for MyDatabase {}
 /// ```
 ///
-/// [`salsa::Database`]: ../salsa/trait.Database.html
-/// [`salsa::Storage<Self>`]: ../salsa/struct.Storage.html
+/// [`salsa::Database`]: https://docs.rs/salsa/latest/salsa/trait.Database.html
+/// [`salsa::Storage<Self>`]: https://docs.rs/salsa/latest/salsa/struct.Storage.html
 #[proc_macro_attribute]
 pub fn db(args: TokenStream, input: TokenStream) -> TokenStream {
     db::db(args, input)
@@ -166,7 +168,8 @@ pub fn db(args: TokenStream, input: TokenStream) -> TokenStream {
 /// [`salsa::Update`].
 ///
 /// - `id = PATH` uses `PATH` as a legacy ID adapter instead of [`salsa::Id`]. The custom type must
-///   implement `salsa::plumbing::AsId` and `salsa::plumbing::FromId`.
+///   implement [`Copy`] + [`Clone`] + [`PartialEq`] + [`Eq`] + [`Hash`] as well as
+///   `salsa::plumbing::AsId` and `salsa::plumbing::FromId`.
 /// - **Unsafe: `no_lifetime` is strongly discouraged.** It adapts code that cannot carry the
 ///   database lifetime by generating a struct without one. This bypasses the compile-time
 ///   guarantee that an interned handle cannot outlive its database revision. The caller becomes
@@ -208,13 +211,13 @@ pub fn db(args: TokenStream, input: TokenStream) -> TokenStream {
 /// [`Debug`]: std::fmt::Debug
 /// [`Deref`]: std::ops::Deref
 /// [`Hash`]: std::hash::Hash
-/// [`salsa::Id`]: ../salsa/struct.Id.html
-/// [`salsa::SalsaAsDeref`]: ../salsa/trait.SalsaAsDeref.html
-/// [`salsa::SalsaAsRef`]: ../salsa/trait.SalsaAsRef.html
-/// [`salsa::Update`]: ../salsa/trait.Update.html
+/// [`salsa::Id`]: https://docs.rs/salsa/latest/salsa/struct.Id.html
+/// [`salsa::SalsaAsDeref`]: https://docs.rs/salsa/latest/salsa/trait.SalsaAsDeref.html
+/// [`salsa::SalsaAsRef`]: https://docs.rs/salsa/latest/salsa/trait.SalsaAsRef.html
+/// [`salsa::Update`]: https://docs.rs/salsa/latest/salsa/trait.Update.html
 /// [`serde`]: https://docs.rs/serde/latest/serde/
-/// [interned structs in the `salsa` crate documentation]: ../salsa/index.html#interned-structs
-/// [return mode]: ../salsa/index.html#return-modes
+/// [interned structs in the `salsa` crate documentation]: https://docs.rs/salsa/latest/salsa/#interned-structs
+/// [return mode]: https://docs.rs/salsa/latest/salsa/#return-modes
 #[proc_macro_attribute]
 pub fn interned(args: TokenStream, input: TokenStream) -> TokenStream {
     interned::interned(args, input)
@@ -264,7 +267,7 @@ pub fn interned(args: TokenStream, input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// [supertypes in the `salsa` crate documentation]: ../salsa/index.html#supertypes
+/// [supertypes in the `salsa` crate documentation]: https://docs.rs/salsa/latest/salsa/#supertypes
 #[proc_macro_derive(Supertype)]
 pub fn supertype(input: TokenStream) -> TokenStream {
     supertype::supertype(input)
@@ -322,11 +325,11 @@ pub fn supertype(input: TokenStream) -> TokenStream {
 ///
 /// [`Debug`]: std::fmt::Debug
 /// [`Deref`]: std::ops::Deref
-/// [`salsa::SalsaAsDeref`]: ../salsa/trait.SalsaAsDeref.html
-/// [`salsa::SalsaAsRef`]: ../salsa/trait.SalsaAsRef.html
+/// [`salsa::SalsaAsDeref`]: https://docs.rs/salsa/latest/salsa/trait.SalsaAsDeref.html
+/// [`salsa::SalsaAsRef`]: https://docs.rs/salsa/latest/salsa/trait.SalsaAsRef.html
 /// [`serde`]: https://docs.rs/serde/latest/serde/
-/// [input structs in the `salsa` crate documentation]: ../salsa/index.html#input-structs
-/// [return mode]: ../salsa/index.html#return-modes
+/// [input structs in the `salsa` crate documentation]: https://docs.rs/salsa/latest/salsa/#input-structs
+/// [return mode]: https://docs.rs/salsa/latest/salsa/#return-modes
 #[proc_macro_attribute]
 pub fn input(args: TokenStream, input: TokenStream) -> TokenStream {
     input::input(args, input)
@@ -481,17 +484,17 @@ pub fn input(args: TokenStream, input: TokenStream) -> TokenStream {
 /// [`Deref`]: std::ops::Deref
 /// [`Eq`]: std::cmp::Eq
 /// [`Hash`]: std::hash::Hash
-/// [`salsa::SalsaAsDeref`]: ../salsa/trait.SalsaAsDeref.html
-/// [`salsa::SalsaAsRef`]: ../salsa/trait.SalsaAsRef.html
-/// [`salsa::Update`]: ../salsa/trait.Update.html
+/// [`salsa::SalsaAsDeref`]: https://docs.rs/salsa/latest/salsa/trait.SalsaAsDeref.html
+/// [`salsa::SalsaAsRef`]: https://docs.rs/salsa/latest/salsa/trait.SalsaAsRef.html
+/// [`salsa::Update`]: https://docs.rs/salsa/latest/salsa/trait.Update.html
 /// [`serde`]: https://docs.rs/serde/latest/serde/
 /// [`serde::Deserialize`]: https://docs.rs/serde/latest/serde/trait.Deserialize.html
 /// [`serde::Serialize`]: https://docs.rs/serde/latest/serde/trait.Serialize.html
 /// [fixed-point cycle recovery in the Salsa book]: https://salsa-rs.github.io/salsa/cycles.html#fixed-point-iteration
-/// [return mode]: ../salsa/index.html#return-modes
+/// [return mode]: https://docs.rs/salsa/latest/salsa/#return-modes
 /// [specifying query results in the Salsa book]: https://salsa-rs.github.io/salsa/overview.html#specify-the-result-of-tracked-functions-for-particular-structs
-/// [tracked functions in the `salsa` crate documentation]: ../salsa/index.html#tracked-functions-and-memoized-values
-/// [tracked structs in the `salsa` crate documentation]: ../salsa/index.html#tracked-structs
+/// [tracked functions in the `salsa` crate documentation]: https://docs.rs/salsa/latest/salsa/#tracked-functions-and-memoized-values
+/// [tracked structs in the `salsa` crate documentation]: https://docs.rs/salsa/latest/salsa/#tracked-structs
 #[proc_macro_attribute]
 pub fn tracked(args: TokenStream, input: TokenStream) -> TokenStream {
     tracked::tracked(args, input)
@@ -559,8 +562,8 @@ pub fn tracked(args: TokenStream, input: TokenStream) -> TokenStream {
 /// ```
 ///
 /// [`PartialEq`]: std::cmp::PartialEq
-/// [`salsa::Update`]: ../salsa/trait.Update.html
-/// [`salsa::update_fallback`]: ../salsa/fn.update_fallback.html
+/// [`salsa::Update`]: https://docs.rs/salsa/latest/salsa/trait.Update.html
+/// [`salsa::update_fallback`]: https://docs.rs/salsa/latest/salsa/fn.update_fallback.html
 #[proc_macro_derive(Update, attributes(update))]
 pub fn update(input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as syn::DeriveInput);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,242 @@
+//! A framework for writing incremental, on-demand computations.
+//!
+//! # Choosing a Salsa construct
+//!
+//! - [`input`] structs hold mutable state supplied from outside Salsa.
+//! - [`tracked`] structs represent derived entities owned by one query invocation.
+//! - [`interned`] structs canonicalize immutable values for structural equality and sharing.
+//! - [`tracked`] functions are memoized computations. They record the queries and fields read by
+//!   their body and act as incremental invalidation boundaries.
+//! - [`accumulator`] values are auxiliary outputs, such as diagnostics, that do not participate in
+//!   a tracked function's main result.
+//! - [`Supertype`] enums let one tracked function accept several different Salsa struct types as
+//!   its key.
+//!
+//! # Salsa structs
+//!
+//! Input, tracked, and interned structs are the three kinds of Salsa struct. All three are compact,
+//! [`Copy`] handles whose fields live in the database, but they intentionally use different notions
+//! of identity, equality, and ownership:
+//!
+//! | Kind | How identity is assigned | Lifecycle |
+//! |------|--------------------------|-----------|
+//! | [Input](#input-structs) | Each constructor call creates a distinct identity | Lives until the database is dropped |
+//! | [Tracked](#tracked-structs) | Producing query, identity fields, and occurrence | Owned by the producing query |
+//! | [Interned](#interned-structs) | All field values; equal fields share an identity | Shared; low-durability values may be reclaimed |
+//!
+//! The generated [`Eq`] and [`Hash`] implementations compare the compact ID for every kind of Salsa
+//! struct: two handles are equal exactly when they have the same Salsa identity. What differs is how
+//! Salsa assigns and preserves that identity.
+//!
+//! ## Input structs
+//!
+//! An [`input`] struct represents mutable state supplied from outside the incremental computation,
+//! such as the contents of a file. Inputs are the roots from which tracked computations read.
+//!
+//! ### Identity
+//!
+//! Every constructor call creates a distinct input identity. Two inputs with equal field values are
+//! therefore unequal, while updating a field preserves the input's identity.
+//!
+//! Dependencies are recorded per field. If a query reads only `file.text(db)`, changing another
+//! field does not invalidate that query. A setter always records its field as changed; Salsa does
+//! not compare the old and new values first. Each field also has a [`Durability`], which lets Salsa
+//! skip validation when only more durable inputs could have changed.
+//!
+//! ### Lifecycle
+//!
+//! An input handle has no `'db` parameter and can be copied across revisions. It must still be used
+//! with the database in which it was created. The input's data and memo entries keyed by it remain
+//! in that database until it is dropped; dropping every copy of the handle does not delete the
+//! input.
+//!
+//! References returned by getters such as `#[returns(ref)]` are tied to an immutable database
+//! borrow. They cannot overlap the mutable borrow required to call a setter and begin a new
+//! revision.
+//!
+//! See [input structs in the Salsa book] for examples of declaring, reading, and updating inputs,
+//! and the [durability reference] for choosing a durability.
+//!
+//! ## Tracked structs
+//!
+//! A [`tracked`] struct represents a derived entity created while a tracked function executes. It
+//! is a good fit for intermediate values whose identity belongs to one computation rather than
+//! being shared structurally across the entire database.
+//!
+//! ### Identity
+//!
+//! A tracked struct's identity consists of its producing query invocation, the values of every
+//! field not marked `#[tracked]`, and its occurrence among structs with the same identity created
+//! by that invocation. Equal-looking structs created by different queries, by different query
+//! keys, or twice by one invocation are distinct.
+//!
+//! When the producing query re-executes, Salsa matches newly created structs with the previous
+//! execution. Recreating the same identities in the same order preserves their IDs.
+//!
+//! A field marked `#[tracked]` is excluded from identity. When an entity is matched across
+//! executions, Salsa updates that field with [`Update`]. Only queries that read a changed tracked
+//! field are invalidated; reading an identity field depends on the entity as a whole.
+//!
+//! ### Lifecycle
+//!
+//! A tracked handle carries a `'db` lifetime tied to an immutable database borrow, so it cannot be
+//! used across the mutable borrow that starts a new revision. The handle must be obtained again in
+//! a later revision even when Salsa preserves the entity's identity.
+//!
+//! Tracked structs are outputs owned by their producing query. Validating that query also validates
+//! its outputs. When it re-executes, any previous tracked struct that is not recreated becomes
+//! stale; Salsa reclaims it and may reuse its storage.
+//!
+//! See [tracked structs in the Salsa book] for examples of tracked entities in an incremental IR.
+//!
+//! ## Interned structs
+//!
+//! An [`interned`] struct canonicalizes an immutable set of field values. Interning is useful when
+//! every occurrence of equal field values should share one database-wide identity, regardless of
+//! where or how often those values are created. Comparing the resulting handles is then a cheap ID
+//! comparison.
+//!
+//! ### Identity
+//!
+//! The complete set of fields determines an interned struct's identity. Interning the same field
+//! values again in the same revision returns the same handle and shares the stored data, regardless
+//! of which query performs the interning. Once interned, comparing two values is a cheap ID
+//! comparison.
+//!
+//! This database-wide sharing requires coordination through the interner. Prefer a tracked struct
+//! when the value is a derived entity owned by one query and does not need structural sharing.
+//!
+//! ### Lifecycle
+//!
+//! By default, an interned handle carries a `'db` lifetime tied to an immutable database borrow and
+//! cannot be used across a new revision. Create or retrieve the value again to obtain a handle for
+//! the new revision.
+//!
+//! Salsa may reclaim a low-durability interned value after it has not been used for the number of
+//! active revisions configured by the `revisions` option, which defaults to `3`. Reclaiming reuses
+//! its slot with a new ID generation so dependencies on the old value are invalidated. Values with
+//! higher durability are not reclaimed; `revisions = usize::MAX` disables reclamation for the
+//! interned type.
+//!
+//! See [interned structs in the Salsa book] for examples of canonicalizing names and other values.
+//!
+//! # Return modes
+//!
+//! Salsa struct field getters and tracked functions return cloned values by default. The
+//! `#[returns(MODE)]` field attribute and `returns(MODE)` tracked-function option select another
+//! mode:
+//!
+//! - `clone` returns an owned clone.
+//! - `copy` returns an owned copy.
+//! - `ref` returns a reference to the stored field or memoized result.
+//! - `deref` uses [`Deref`] and returns a reference to its `Target`.
+//! - `as_ref` uses [`SalsaAsRef`].
+//! - `as_deref` uses [`SalsaAsDeref`].
+//!
+//! Owned results can outlive the database borrow if their types permit it. Borrowed results are
+//! tied to the immutable database borrow and cannot be used across a revision in which Salsa may
+//! replace or reclaim the stored value.
+//!
+//! See [returning references in the Salsa book] for examples on fields and tracked functions.
+//!
+//! # Tracked functions and memoized values
+//!
+//! A [`tracked`] function is identified by the function and its non-database arguments. Those
+//! arguments select a memoized query but are not themselves dependencies: dependencies arise only
+//! when the body reads a Salsa field or calls another tracked function.
+//!
+//! A function without non-database arguments has one query key and one memoized result in each
+//! database. A function with one non-database argument uses that Salsa struct's ID directly as its
+//! query key. With multiple arguments, every call first interns the argument tuple to obtain a
+//! synthetic Salsa ID. This extra interning step lets Salsa use the tuple as a query key; the
+//! arguments' [`Eq`] and [`Hash`] implementations determine whether two calls resolve to the same
+//! ID and memo.
+//!
+//! If a query's dependencies have not changed, Salsa reuses its memoized result. After
+//! re-execution, Salsa compares the old and new results with [`PartialEq`]. If they are equal, Salsa
+//! preserves the memo's previous "changed at" revision. This optimization is called [backdating];
+//! it prevents invalidation from propagating to dependents when the result has not changed. The
+//! `no_eq` option disables this comparison.
+//!
+//! A memo stores one current result, not a history. By default, each key that remains in the
+//! database retains its result. Re-execution may update or replace the value; reclaiming the key or
+//! dropping the database removes it. The `lru` option additionally evicts least-recently-used
+//! results at the start of a new revision, but retains their memo entries so a later call can
+//! recompute the value.
+//!
+//! The [return mode](#return-modes) controls whether callers receive an owned result or borrow it
+//! from the memo.
+//!
+//! See [tracked functions in the Salsa book] for an introduction, the [red-green algorithm] for the
+//! full validation model, and [cache tuning] for controlling memo retention.
+//!
+//! ## Specifying results
+//!
+//! The `specify` option supports queries with both an on-demand incremental implementation and a
+//! batch implementation. The tracked function defines how to compute one result on demand. A
+//! query that creates many tracked structs can instead compute their results together and call
+//! `FUNCTION::specify(db, key, value)` for each one, avoiding the per-key implementation when those
+//! results are later requested. It can also provide special results for built-in entities or model
+//! a value initialized after a tracked struct is created.
+//!
+//! A specifiable function must take exactly one non-database argument, and that argument must be a
+//! tracked struct, not an input or interned struct. `specify` must be called during the same tracked
+//! query invocation that created the key. Salsa records the specified memo as an output of that
+//! creating query, so validating or re-executing the creator also validates or replaces the
+//! specified result. The `specify` and `lru` options cannot currently be combined.
+//!
+//! See [specifying query results in the Salsa book] for an example.
+//!
+//! # Accumulators
+//!
+//! An [`accumulator`] is a side channel for auxiliary outputs such as diagnostics. Accumulated
+//! values are stored with a memoized query execution but do not participate in the query's return
+//! value or result equality. Adding or removing one therefore does not by itself make the query's
+//! main result change. Values can only be accumulated while a tracked function is executing;
+//! attempting to accumulate outside one panics.
+//!
+//! Calling a tracked function's generated `accumulated` method first brings the query up to date,
+//! then returns references to values emitted by that query and its transitive callees. The
+//! references are tied to the database borrow. If the query re-executes, its new accumulated values
+//! replace the previous set; if Salsa reuses the memo, the existing values remain available without
+//! rerunning the function body.
+//!
+//! See [accumulators in the Salsa book] for a complete diagnostic-reporting example.
+//!
+//! # Supertypes
+//!
+//! A [`Supertype`] enum is a heterogeneous Salsa-struct key. It lets one tracked function operate
+//! on several input, tracked, or interned struct types. Salsa uses the wrapped struct's ID directly
+//! as the query key, while its concrete Salsa struct type determines the enum variant. Without a
+//! supertype, the query must be duplicated for every concrete type or callers must convert every
+//! value into some other common Salsa struct.
+//!
+//! The enum must be nonempty. Each variant must contain exactly one unnamed field wrapping a Salsa
+//! struct or another `Supertype`; nesting supertypes can build larger groups from smaller ones. A
+//! concrete Salsa struct must be reachable through only one variant, ensuring that Salsa can
+//! determine the variant unambiguously from the wrapped ID.
+//!
+//! A supertype has no storage of its own, so its validity and lifecycle follow the wrapped value.
+//!
+//! The [Salsa book](https://salsa-rs.github.io/salsa) develops these constructs as part of a
+//! complete incremental program. Its chapter on the [`'db` database lifetime] explains why tracked
+//! and interned values cannot cross revisions.
+//!
+//! [`Deref`]: std::ops::Deref
+//! [`Hash`]: std::hash::Hash
+//! [`'db` database lifetime]: https://salsa-rs.github.io/salsa/plumbing/db_lifetime.html
+//! [accumulators in the Salsa book]: https://salsa-rs.github.io/salsa/tutorial/accumulators.html
+//! [backdating]: https://salsa-rs.github.io/salsa/reference/algorithm.html#backdating-sometimes-we-can-be-smarter
+//! [cache tuning]: https://salsa-rs.github.io/salsa/tuning.html#cache-eviction-lru
+//! [durability reference]: https://salsa-rs.github.io/salsa/reference/durability.html
+//! [input structs in the Salsa book]: https://salsa-rs.github.io/salsa/overview.html#input-structs
+//! [interned structs in the Salsa book]: https://salsa-rs.github.io/salsa/overview.html#interned-structs
+//! [red-green algorithm]: https://salsa-rs.github.io/salsa/reference/algorithm.html
+//! [returning references in the Salsa book]: https://salsa-rs.github.io/salsa/tutorial/parser.html#the-returnsref-annotation
+//! [specifying query results in the Salsa book]: https://salsa-rs.github.io/salsa/overview.html#specify-the-result-of-tracked-functions-for-particular-structs
+//! [tracked functions in the Salsa book]: https://salsa-rs.github.io/salsa/overview.html#tracked-functions
+//! [tracked structs in the Salsa book]: https://salsa-rs.github.io/salsa/overview.html#tracked-structs
+
 #![deny(clippy::undocumented_unsafe_blocks)]
 #![forbid(unsafe_op_in_unsafe_fn)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,9 @@
 //!
 //! Dependencies are recorded per field. If a query reads only `file.text(db)`, changing another
 //! field does not invalidate that query. A setter always records its field as changed; Salsa does
-//! not compare the old and new values first. Each field also has a [`Durability`], which lets Salsa
-//! skip validation when only more durable inputs could have changed.
+//! not compare the old and new values first. Each field also has a [`Durability`]. If a revision
+//! changes only lower-durability inputs, Salsa can skip validating queries that depend exclusively
+//! on higher-durability inputs.
 //!
 //! ### Lifecycle
 //!
@@ -229,7 +230,7 @@
 //! [backdating]: https://salsa-rs.github.io/salsa/reference/algorithm.html#backdating-sometimes-we-can-be-smarter
 //! [cache tuning]: https://salsa-rs.github.io/salsa/tuning.html#cache-eviction-lru
 //! [durability reference]: https://salsa-rs.github.io/salsa/reference/durability.html
-//! [input structs in the Salsa book]: https://salsa-rs.github.io/salsa/overview.html#input-structs
+//! [input structs in the Salsa book]: https://salsa-rs.github.io/salsa/overview.html#inputs
 //! [interned structs in the Salsa book]: https://salsa-rs.github.io/salsa/overview.html#interned-structs
 //! [red-green algorithm]: https://salsa-rs.github.io/salsa/reference/algorithm.html
 //! [returning references in the Salsa book]: https://salsa-rs.github.io/salsa/tutorial/parser.html#the-returnsref-annotation


### PR DESCRIPTION
Document the public API and accepted options for Salsa's procedural macros, including field attributes, safety constraints, and examples.

Expand the crate-level guidance around Salsa struct identity, lifecycles, memoization, accumulators, supertypes, and relevant Salsa book references.

Testing: Ran workspace checks, rustdoc, doctests, formatting, and diff validation.
