### PR TITLE
refactor: simplify specify origin handling

### DIFF
--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -88,15 +88,11 @@ where
 
         if let Some(old_memo) = old_memo {
             if old_memo.header.verified_at.load() == revision && old_memo.value.is_some() {
-                let assigned_by_active_query = matches!(
-                    old_memo.header.origin(),
-                    QueryOriginRef::Assigned(owner) if owner == active_query_key
-                );
-
                 // A value produced by another query wins this revision.
-                if !assigned_by_active_query {
+                let QueryOriginRef::Assigned(owner) = old_memo.header.origin() else {
                     return;
-                }
+                };
+                debug_assert_eq!(owner, active_query_key);
 
                 let first_assignment_in_execution = zalsa_local.add_output(database_key_index);
                 // Outputs from a prior provisional iteration are seeded into the active query,


### PR DESCRIPTION
Specifiable queries can only be assigned by the query that owns their tracked input. Use that invariant directly when handling an existing current memo, while retaining a debug assertion for ownership.

Testing: Formatting, focused specify tests, and a no-default-features build pass.
