### PR TITLE
feat: return references by default

### DIFF
--- a/benches/accumulator.rs
+++ b/benches/accumulator.rs
@@ -22,7 +22,7 @@ struct Expression<'db> {
     number: usize,
 }
 
-#[salsa::tracked(returns(clone))]
+#[salsa::tracked(returns(deref))]
 #[inline(never)]
 fn root(db: &dyn salsa::Database, input: Input) -> Vec<usize> {
     (0..input.expressions(db))

--- a/benches/accumulator.rs
+++ b/benches/accumulator.rs
@@ -8,6 +8,7 @@ fn main() {
 
 #[salsa::input]
 struct Input {
+    #[returns(copy)]
     expressions: usize,
 }
 
@@ -17,10 +18,11 @@ struct Diagnostic(String);
 
 #[salsa::interned]
 struct Expression<'db> {
+    #[returns(copy)]
     number: usize,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(clone))]
 #[inline(never)]
 fn root(db: &dyn salsa::Database, input: Input) -> Vec<usize> {
     (0..input.expressions(db))
@@ -28,7 +30,7 @@ fn root(db: &dyn salsa::Database, input: Input) -> Vec<usize> {
         .collect()
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 #[inline(never)]
 fn infer_expression<'db>(db: &'db dyn salsa::Database, expression: Expression<'db>) -> usize {
     let number = expression.number(db);

--- a/benches/compare.rs
+++ b/benches/compare.rs
@@ -13,7 +13,7 @@ pub struct Input {
     pub text: String,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 #[inline(never)]
 pub fn length(db: &dyn salsa::Database, input: Input) -> usize {
     input.text(db).len()
@@ -31,13 +31,13 @@ enum SupertypeInput<'db> {
     Input(Input),
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 #[inline(never)]
 pub fn interned_length<'db>(db: &'db dyn salsa::Database, input: InternedInput<'db>) -> usize {
     input.text(db).len()
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 #[inline(never)]
 pub fn either_length<'db>(db: &'db dyn salsa::Database, input: SupertypeInput<'db>) -> usize {
     match input {
@@ -48,10 +48,11 @@ pub fn either_length<'db>(db: &'db dyn salsa::Database, input: SupertypeInput<'d
 
 #[salsa::tracked]
 pub struct Tracked<'db> {
+    #[returns(copy)]
     pub value: usize,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 pub fn make_tracked(db: &dyn salsa::Database, input: Input) -> Tracked<'_> {
     Tracked::new(db, input.text(db).len())
 }

--- a/benches/dataflow.rs
+++ b/benches/dataflow.rs
@@ -20,7 +20,9 @@ struct Use {
 /// A Definition of a symbol, either of the form `base + increment` or `0 + increment`.
 #[salsa::input]
 struct Definition {
+    #[returns(copy)]
     base: Option<Use>,
+    #[returns(copy)]
     increment: usize,
 }
 
@@ -52,7 +54,7 @@ impl Type {
     }
 }
 
-#[salsa::tracked(cycle_fn=use_cycle_recover, cycle_initial=use_cycle_initial)]
+#[salsa::tracked(returns(clone), cycle_fn=use_cycle_recover, cycle_initial=use_cycle_initial)]
 fn infer_use(db: &dyn Db, u: Use) -> Type {
     let defs = u.reaching_definitions(db);
     match defs[..] {
@@ -62,7 +64,7 @@ fn infer_use(db: &dyn Db, u: Use) -> Type {
     }
 }
 
-#[salsa::tracked(cycle_fn=def_cycle_recover, cycle_initial=def_cycle_initial)]
+#[salsa::tracked(returns(clone), cycle_fn=def_cycle_recover, cycle_initial=def_cycle_initial)]
 fn infer_definition(db: &dyn Db, def: Definition) -> Type {
     let increment_ty = Type::Values(Box::from([def.increment(db)]));
     if let Some(base) = def.base(db) {

--- a/benches/dataflow.rs
+++ b/benches/dataflow.rs
@@ -14,6 +14,7 @@ fn main() {
 /// A Use of a symbol.
 #[salsa::input]
 struct Use {
+    #[returns(clone)]
     reaching_definitions: Vec<Definition>,
 }
 

--- a/benches/incremental.rs
+++ b/benches/incremental.rs
@@ -8,11 +8,13 @@ fn main() {
 
 #[salsa::input]
 struct Input {
+    #[returns(copy)]
     field: usize,
 }
 
 #[salsa::tracked]
 struct Tracked<'db> {
+    #[returns(copy)]
     number: usize,
 }
 
@@ -22,7 +24,7 @@ fn index(db: &dyn salsa::Database, input: Input) -> Vec<Tracked<'_>> {
     (0..input.field(db)).map(|i| Tracked::new(db, i)).collect()
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 #[inline(never)]
 fn root(db: &dyn salsa::Database, input: Input) -> usize {
     let index = index(db, input);

--- a/benches/lru.rs
+++ b/benches/lru.rs
@@ -15,6 +15,7 @@ const SCATTERED_HOT_ITEMS: usize = EVICTION_CAPACITY * 2;
 
 #[salsa::input]
 struct Item {
+    #[returns(copy)]
     value: usize,
 }
 
@@ -27,7 +28,7 @@ impl Drop for Value {
     }
 }
 
-#[salsa::tracked(lru = 4096)]
+#[salsa::tracked(returns(clone), lru = 4096)]
 #[inline(never)]
 fn lru_value(db: &dyn salsa::Database, item: Item) -> Value {
     value(item.value(db))

--- a/benches/lru.rs
+++ b/benches/lru.rs
@@ -19,16 +19,10 @@ struct Item {
     value: usize,
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy)]
 struct Value(usize);
 
-impl Drop for Value {
-    fn drop(&mut self) {
-        black_box(self);
-    }
-}
-
-#[salsa::tracked(returns(clone), lru = 4096)]
+#[salsa::tracked(returns(copy), lru = 4096)]
 #[inline(never)]
 fn lru_value(db: &dyn salsa::Database, item: Item) -> Value {
     value(item.value(db))
@@ -65,7 +59,7 @@ fn expected_sum(items: &[Item], db: &dyn salsa::Database) -> Value {
 fn prewarm(db: &dyn salsa::Database, items: &[Item]) -> Value {
     let actual = access_all(db, items);
     let expected = expected_sum(items, db);
-    assert_eq!(black_box(actual.clone()), expected);
+    assert_eq!(black_box(actual), expected);
     actual
 }
 

--- a/book/src/overview.md
+++ b/book/src/overview.md
@@ -81,28 +81,28 @@ pub struct ProgramFile(salsa::Id);
 This means that, when you have a `ProgramFile`, you can easily copy it around and put it wherever you like.
 To actually read any of its fields, however, you will need to use the database and a getter method.
 
-### Reading fields and `returns(ref)`
+### Reading fields
 
 You can access the value of an input's fields by using the getter method.
 As this is only reading the field, it just needs a `&`-reference to the database:
 
 ```rust
-let contents: String = file.contents(&db);
+let contents: &str = file.contents(&db);
 ```
 
-Invoking the accessor clones the value from the database.
-Sometimes this is not what you want, so you can annotate fields with `#[returns(ref)]` to indicate that they should return a reference into the database instead:
+Field getters return a reference into the database by default. Use `#[returns(copy)]` for `Copy` fields or `#[returns(clone)]` to return an owned clone instead. `#[returns(deref)]` borrows through `Deref`, so a `String` field returns a `&str`. For optional and fallible values, `#[returns(as_ref)]` converts an `Option<T>` or `Result<T, E>` into references, while `#[returns(as_deref)]` also borrows through `Deref` (for example, converting `Option<String>` into `Option<&str>`).
 
 ```rust
 #[salsa::input]
 pub struct ProgramFile {
+    #[returns(clone)]
     pub path: PathBuf,
-    #[returns(ref)]
+    #[returns(deref)]
     pub contents: String,
 }
 ```
 
-Now `file.contents(&db)` will return an `&String`.
+Now `file.path(&db)` returns a `PathBuf`, while `file.contents(&db)` returns a `&str`.
 
 ### Writing input fields
 
@@ -143,7 +143,7 @@ Tracked functions have to follow a particular structure:
 - They may take no other arguments, one Salsa struct, or multiple arguments that implement `Eq` and `Hash`.
   A single Salsa struct can be used directly as the query key, whereas multiple arguments are interned together to create a key.
 
-By default, tracked functions return a clone of their memoized result. Tracked functions can instead be annotated with `#[salsa::tracked(returns(ref))]` if you would prefer to return a reference into the database (if `parse_file` were so annotated, then callers would actually get back an `&Ast<'_>`, for example).
+Tracked functions return a reference to their memoized value by default, so callers of `parse_file` receive an `&Ast<'_>`. Use `#[salsa::tracked(returns(clone))]` to clone the value out of the database instead.
 
 ## Tracked structs
 
@@ -157,10 +157,12 @@ Example:
 #[salsa::tracked]
 struct Ast<'db> {
     #[tracked]
-    #[returns(ref)]
+    #[returns(deref)]
     top_level_items: Vec<Item<'db>>,
 }
 ```
+
+The `#[returns(deref)]` annotation makes `ast.top_level_items(db)` return an `&[Item<'_>]`.
 
 Just as with an input, new values are created by invoking `Ast::new`. The `new` function on a tracked struct only requires a `&`-reference to the database:
 
@@ -236,7 +238,7 @@ Most compilers, for example, will define a type to represent a user identifier:
 ```rust
 #[salsa::interned]
 struct Word<'db> {
-    #[returns(ref)]
+    #[returns(deref)]
     pub text: String,
 }
 ```
@@ -253,7 +255,7 @@ let w3 = Word::new(db, "foo".to_string());
 
 When you create two interned structs with the same field values, you are guaranteed to get back the same integer id. So here, we know that `assert_eq!(w1, w3)` is true and `assert_ne!(w1, w2)`.
 
-You can access the fields of an interned struct using a getter, like `word.text(db)`. These getters respect the `#[returns(ref)]` annotation. Like tracked structs, the fields of interned structs are immutable.
+You can access the fields of an interned struct using a getter, like `word.text(db)`, which returns a `&str` because of the `#[returns(deref)]` annotation. The fields of interned structs are immutable.
 
 ## Accumulators
 

--- a/book/src/overview.md
+++ b/book/src/overview.md
@@ -81,7 +81,7 @@ pub struct ProgramFile(salsa::Id);
 This means that, when you have a `ProgramFile`, you can easily copy it around and put it wherever you like.
 To actually read any of its fields, however, you will need to use the database and a getter method.
 
-### Reading fields
+### Reading fields and `returns(mode)`
 
 You can access the value of an input's fields by using the getter method.
 As this is only reading the field, it just needs a `&`-reference to the database:
@@ -161,8 +161,6 @@ struct Ast<'db> {
     top_level_items: Vec<Item<'db>>,
 }
 ```
-
-The `#[returns(deref)]` annotation makes `ast.top_level_items(db)` return an `&[Item<'_>]`.
 
 Just as with an input, new values are created by invoking `Ast::new`. The `new` function on a tracked struct only requires a `&`-reference to the database:
 

--- a/book/src/reference/algorithm.md
+++ b/book/src/reference/algorithm.md
@@ -16,7 +16,7 @@ Here is a simple example, where the `parse_module` function reads the module's t
 ```rust
 #[salsa::input]
 struct Module {
-    #[returns(ref)]
+    #[returns(deref)]
     text: String,
 }
 
@@ -75,4 +75,3 @@ module
 ```
 
 For each durability, we track the revision in which _some input_ with that durability changed. If a tracked function depends (transitively) only on high durability inputs, and you change a low durability input, then we can very easily determine that the tracked function result is still valid, avoiding the need to traverse the input edges one by one.
-

--- a/book/src/tutorial/debug.md
+++ b/book/src/tutorial/debug.md
@@ -7,20 +7,14 @@ Before we can do that, though, we have to address one question: how do we inspec
 ## Generated `Debug` implementations
 
 The `debug` option on Salsa struct attributes generates an ordinary `Debug` implementation.
-The `FunctionId` definition already enables this option:
-
-```rust
-{{#include ../../../examples/calc/ir.rs:interned_ids}}
-```
-
 Tracked functions attach the database automatically; other code can use `salsa::Database::attach` to include field values:
 
 ```rust
 use salsa::Database as _;
 
 db.attach(|db| {
-    let function_id = FunctionId::new(db, "area_circle".to_string());
-    eprintln!("FunctionId = {function_id:?}");
+    let function = FunctionId::new(db, "area_circle".to_string());
+    eprintln!("Function = {function:?}");
 });
 ```
 

--- a/book/src/tutorial/debug.md
+++ b/book/src/tutorial/debug.md
@@ -7,14 +7,20 @@ Before we can do that, though, we have to address one question: how do we inspec
 ## Generated `Debug` implementations
 
 The `debug` option on Salsa struct attributes generates an ordinary `Debug` implementation.
+The `FunctionId` definition already enables this option:
+
+```rust
+{{#include ../../../examples/calc/ir.rs:interned_ids}}
+```
+
 Tracked functions attach the database automatically; other code can use `salsa::Database::attach` to include field values:
 
 ```rust
 use salsa::Database as _;
 
 db.attach(|db| {
-    let function = FunctionId::new(db, "area_circle".to_string());
-    eprintln!("Function = {function:?}");
+    let function_id = FunctionId::new(db, "area_circle".to_string());
+    eprintln!("FunctionId = {function_id:?}");
 });
 ```
 

--- a/book/src/tutorial/ir.md
+++ b/book/src/tutorial/ir.md
@@ -57,7 +57,8 @@ use salsa::Setter as _;
 let source = SourceProgram::new(&db, "print 11 + 11".to_string());
 ```
 
-You can read the value of the field with `source.text(&db)`,
+The `#[returns(deref)]` annotation makes `source.text(&db)` return a `&str`.
+You can read the value of the field with that getter,
 and you can set the value of the field with `source.set_text(&mut db).to("print 11 * 2".to_string())`.
 
 ### Database revisions
@@ -92,7 +93,7 @@ Apart from having no setters, the API for working with a tracked struct is quite
 
 - You can create a new value by using `new`: e.g., `Program::new(&db, some_statements)`
 - You use a getter to read the value of a field, just like with an input (e.g., `my_func.statements(db)` to read the `statements` field).
-  - In this case, the field is tagged as `#[returns(ref)]`, which means that the getter will return a `&Vec<Statement>`, instead of cloning the vector.
+  - The `#[returns(deref)]` annotation makes this getter return a `&[Statement]`.
 
 ### The `'db` lifetime
 
@@ -120,6 +121,7 @@ Apart from having no setters, the API for working with a tracked struct is quite
 
 - You can create a new value by using `new`: e.g., `Function::new(&db, some_name, some_name_span, some_args, some_body)`
 - You use a getter to read the value of a field, just like with an input (e.g., `my_func.args(db)` to read the `args` field).
+  - The `#[returns(deref)]` annotation makes this getter return a `&[VariableId]`.
 
 ### Identity fields and tracked fields
 
@@ -145,6 +147,8 @@ Therefore, we define two interned structs, `FunctionId` and `VariableId`, each w
 ```rust
 {{#include ../../../examples/calc/ir.rs:interned_ids}}
 ```
+
+The `#[returns(deref)]` annotations make the `text` getters return `&str` values.
 
 When you invoke e.g. `FunctionId::new(&db, "my_string".to_string())`, you will get back a `FunctionId` that is just a newtype'd integer.
 But if you invoke the same call to `new` again, you get back the same integer:

--- a/book/src/tutorial/ir.md
+++ b/book/src/tutorial/ir.md
@@ -57,8 +57,7 @@ use salsa::Setter as _;
 let source = SourceProgram::new(&db, "print 11 + 11".to_string());
 ```
 
-The `#[returns(deref)]` annotation makes `source.text(&db)` return a `&str`.
-You can read the value of the field with that getter,
+You can read the value of the field with `source.text(&db)`,
 and you can set the value of the field with `source.set_text(&mut db).to("print 11 * 2".to_string())`.
 
 ### Database revisions
@@ -93,7 +92,7 @@ Apart from having no setters, the API for working with a tracked struct is quite
 
 - You can create a new value by using `new`: e.g., `Program::new(&db, some_statements)`
 - You use a getter to read the value of a field, just like with an input (e.g., `my_func.statements(db)` to read the `statements` field).
-  - The `#[returns(deref)]` annotation makes this getter return a `&[Statement]`.
+    - In this case, the field is tagged as `#[returns(deref)]`, which means that the getter will return a `&[Statement]`, instead of a `&Vec<Statement>`.
 
 ### The `'db` lifetime
 
@@ -121,7 +120,7 @@ Apart from having no setters, the API for working with a tracked struct is quite
 
 - You can create a new value by using `new`: e.g., `Function::new(&db, some_name, some_name_span, some_args, some_body)`
 - You use a getter to read the value of a field, just like with an input (e.g., `my_func.args(db)` to read the `args` field).
-  - The `#[returns(deref)]` annotation makes this getter return a `&[VariableId]`.
+    - The `#[returns(deref)]` annotation makes this getter return a `&[VariableId]`.
 
 ### Identity fields and tracked fields
 
@@ -147,8 +146,6 @@ Therefore, we define two interned structs, `FunctionId` and `VariableId`, each w
 ```rust
 {{#include ../../../examples/calc/ir.rs:interned_ids}}
 ```
-
-The `#[returns(deref)]` annotations make the `text` getters return `&str` values.
 
 When you invoke e.g. `FunctionId::new(&db, "my_string".to_string())`, you will get back a `FunctionId` that is just a newtype'd integer.
 But if you invoke the same call to `new` again, you get back the same integer:

--- a/book/src/tutorial/parser.md
+++ b/book/src/tutorial/parser.md
@@ -24,12 +24,12 @@ This function is annotated as `#[salsa::tracked]`.
 That means that, when it is called, Salsa will track what inputs it reads as well as what value it returns.
 The return value is _memoized_,
 which means that if you call this function again without changing the inputs,
-Salsa will just clone the result rather than re-execute it.
+Salsa will reuse the result rather than re-execute it.
 
 ### Tracked functions are the unit of reuse
 
 Tracked functions are the core part of how Salsa enables incremental reuse.
-The goal of the framework is to avoid re-executing tracked functions and instead to clone their result.
+The goal of the framework is to avoid re-executing tracked functions and instead to reuse their result.
 Salsa uses the [red-green algorithm](../reference/algorithm.md) to decide when to re-execute a function.
 The short version is that a tracked function is re-executed if either (a) it directly reads an input, and that input has changed,
 or (b) it directly invokes another tracked function and that function's return value has changed.
@@ -56,12 +56,15 @@ A single Salsa struct can be used directly as the query key.
 When a function has multiple parameters, Salsa interns their tuple to obtain a key, adding an interning step to each call.
 Our `parse_statements` function takes one Salsa struct, the `SourceProgram` input.
 
-### The `returns(ref)` annotation
+### The `returns(copy)` annotation
 
-By default, when you call a tracked function, its result is cloned out of the database.
-Adding the `returns(ref)` option to the tracked attribute returns a reference into the database instead.
-For return types that implement `Deref`, `returns(deref)` returns a reference to the dereferenced target.
-For example, it can return a slice instead of a reference to a vector:
+You may have noticed that `parse_statements` is tagged with `#[salsa::tracked(returns(copy))]`.
+Tracked functions ordinarily return a reference to their memoized value. The `returns(copy)`
+attribute copies the value out of the database instead. This is a good fit for `Program`, which is
+a small `Copy` handle to a tracked struct.
+
+For return types that implement `Deref`, `returns(deref)` returns a reference to the dereferenced
+target. For example, it can return a slice instead of a reference to a vector:
 
 ```rust
 #[salsa::tracked(returns(deref))]
@@ -70,9 +73,11 @@ fn source_lines(db: &dyn crate::Db, source: SourceProgram) -> Vec<String> {
 }
 ```
 
-Calling `source_lines` returns an `&[String]` rather than cloning the `Vec`.
-Using `returns(ref)` would return an `&Vec<String>` instead.
+Calling `source_lines` returns an `&[String]` rather than the default `&Vec<String>`.
 That reference is tied to the database borrow and cannot be held across a new revision.
-The current `parse_statements` function returns the `Copy` `Program` handle, so it does not need this option.
-(You may recall the `returns(ref)` annotation from the [ir](./ir.md) section of the tutorial,
-where it was placed on struct fields, with roughly the same meaning.)
+Use `returns(clone)` when returning an owned clone is more convenient and the clone is known to be
+inexpensive.
+
+(You may recall the `returns(deref)` annotation from the [IR](./ir.md) section of the tutorial,
+where it was placed on struct fields. Return-mode annotations work the same way for fields and
+tracked functions.)

--- a/components/salsa-macros/src/lib.rs
+++ b/components/salsa-macros/src/lib.rs
@@ -76,7 +76,7 @@ mod xform;
 /// #[salsa::accumulator]
 /// struct Diagnostic(String);
 ///
-/// #[salsa::tracked(returns(copy))]
+/// #[salsa::tracked]
 /// fn check(db: &dyn salsa::Database) {
 ///     salsa::Accumulator::accumulate(Diagnostic("something went wrong".into()), db);
 /// }

--- a/components/salsa-macros/src/lib.rs
+++ b/components/salsa-macros/src/lib.rs
@@ -76,7 +76,7 @@ mod xform;
 /// #[salsa::accumulator]
 /// struct Diagnostic(String);
 ///
-/// #[salsa::tracked]
+/// #[salsa::tracked(returns(copy))]
 /// fn check(db: &dyn salsa::Database) {
 ///     salsa::Accumulator::accumulate(Diagnostic("something went wrong".into()), db);
 /// }
@@ -185,9 +185,9 @@ pub fn db(args: TokenStream, input: TokenStream) -> TokenStream {
 /// Every field generates a getter with the same name and visibility as the field. These helper
 /// attributes configure that getter:
 ///
-/// - `#[returns(MODE)]` selects how the getter returns the field. `clone` (the default) returns an
-///   owned `FieldTy` using [`Clone`]; `copy` returns an owned `FieldTy` using [`Copy`]; `ref`
-///   returns `&FieldTy`; and `deref` uses [`Deref`] to return
+/// - `#[returns(MODE)]` selects how the getter returns the field. `ref` (the default) returns
+///   `&FieldTy`; `clone` returns an owned `FieldTy` using [`Clone`]; `copy` returns an owned
+///   `FieldTy` using [`Copy`]; and `deref` uses [`Deref`] to return
 ///   `&<FieldTy as Deref>::Target`. `as_ref` and `as_deref` use [`salsa::SalsaAsRef`] and
 ///   [`salsa::SalsaAsDeref`] to return borrowed forms such as `Option<&T>` and
 ///   `Option<&T::Target>`. Every borrowed result is tied to the database borrow.
@@ -201,8 +201,9 @@ pub fn db(args: TokenStream, input: TokenStream) -> TokenStream {
 /// ```ignore
 /// #[salsa::interned(debug)]
 /// struct Name<'db> {
-///     #[returns(ref)]
+///     #[returns(deref)]
 ///     text: String,
+///     #[returns(copy)]
 ///     #[get(disambiguator)]
 ///     index: u32,
 /// }
@@ -241,13 +242,13 @@ pub fn interned(args: TokenStream, input: TokenStream) -> TokenStream {
 /// ```ignore
 /// #[salsa::input]
 /// struct File {
-///     #[returns(ref)]
+///     #[returns(deref)]
 ///     path: String,
 /// }
 ///
 /// #[salsa::interned]
 /// struct Symbol<'db> {
-///     #[returns(ref)]
+///     #[returns(deref)]
 ///     name: String,
 /// }
 ///
@@ -257,13 +258,13 @@ pub fn interned(args: TokenStream, input: TokenStream) -> TokenStream {
 ///     Symbol(Symbol<'db>),
 /// }
 ///
-/// #[salsa::tracked(returns(ref))]
+/// #[salsa::tracked(returns(deref))]
 /// fn display_name<'db>(db: &'db dyn salsa::Database, source: Source<'db>) -> String {
 ///     let name = match source {
 ///         Source::File(file) => file.path(db),
 ///         Source::Symbol(symbol) => symbol.name(db),
 ///     };
-///     name.clone()
+///     name.to_owned()
 /// }
 /// ```
 ///
@@ -309,9 +310,9 @@ pub fn supertype(input: TokenStream) -> TokenStream {
 /// Every field generates getter and setter methods with the same name and visibility as the field.
 /// These helper attributes configure those methods:
 ///
-/// - `#[returns(MODE)]` selects how the getter returns the field. `clone` (the default) returns an
-///   owned `FieldTy` using [`Clone`]; `copy` returns an owned `FieldTy` using [`Copy`]; `ref`
-///   returns `&FieldTy`; and `deref` uses [`Deref`] to return
+/// - `#[returns(MODE)]` selects how the getter returns the field. `ref` (the default) returns
+///   `&FieldTy`; `clone` returns an owned `FieldTy` using [`Clone`]; `copy` returns an owned
+///   `FieldTy` using [`Copy`]; and `deref` uses [`Deref`] to return
 ///   `&<FieldTy as Deref>::Target`. `as_ref` and `as_deref` use [`salsa::SalsaAsRef`] and
 ///   [`salsa::SalsaAsDeref`] to return borrowed forms such as `Option<&T>` and
 ///   `Option<&T::Target>`. Every borrowed result is tied to the database borrow.
@@ -373,9 +374,9 @@ pub fn input(args: TokenStream, input: TokenStream) -> TokenStream {
 ///   creating a new one. Reads of the field are tracked separately, so changing it invalidates only
 ///   queries that read that field. Use this for properties that may change while the conceptual
 ///   entity remains the same.
-/// - `#[returns(MODE)]` selects how the getter returns the field. `clone` (the default) returns an
-///   owned `FieldTy` using [`Clone`]; `copy` returns an owned `FieldTy` using [`Copy`]; `ref`
-///   returns `&FieldTy`; and `deref` uses [`Deref`] to return
+/// - `#[returns(MODE)]` selects how the getter returns the field. `ref` (the default) returns
+///   `&FieldTy`; `clone` returns an owned `FieldTy` using [`Clone`]; `copy` returns an owned
+///   `FieldTy` using [`Copy`]; and `deref` uses [`Deref`] to return
 ///   `&<FieldTy as Deref>::Target`. `as_ref` and `as_deref` use [`salsa::SalsaAsRef`] and
 ///   [`salsa::SalsaAsDeref`] to return borrowed forms such as `Option<&T>` and
 ///   `Option<&T::Target>`. Every borrowed result is tied to the database borrow.
@@ -410,9 +411,9 @@ pub fn input(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// ## Function options
 ///
-/// - `returns(MODE)` selects how callers receive the memoized result. `clone` (the default) returns
-///   an owned `Output` using [`Clone`]; `copy` returns an owned `Output` using [`Copy`]; `ref`
-///   returns `&Output`; and `deref` uses [`Deref`] to return `&<Output as Deref>::Target`.
+/// - `returns(MODE)` selects how callers receive the memoized result. `ref` (the default) returns
+///   `&Output`; `clone` returns an owned `Output` using [`Clone`]; `copy` returns an owned `Output`
+///   using [`Copy`]; and `deref` uses [`Deref`] to return `&<Output as Deref>::Target`.
 ///   `as_ref` and `as_deref` use [`salsa::SalsaAsRef`] and [`salsa::SalsaAsDeref`] to return
 ///   borrowed forms such as `Option<&T>` and `Option<&T::Target>`. Every borrowed result is tied to
 ///   the database borrow and remains stored in the query's memo.
@@ -464,18 +465,18 @@ pub fn input(args: TokenStream, input: TokenStream) -> TokenStream {
 /// ```ignore
 /// #[salsa::input]
 /// struct File {
-///     #[returns(ref)]
+///     #[returns(deref)]
 ///     text: String,
 /// }
 ///
-/// #[salsa::tracked]
+/// #[salsa::tracked(returns(copy))]
 /// fn word_count(db: &dyn salsa::Database, file: File) -> usize {
 ///     file.text(db).split_whitespace().count()
 /// }
 ///
 /// #[salsa::tracked]
 /// impl File {
-///     #[salsa::tracked]
+///     #[salsa::tracked(returns(copy))]
 ///     fn line_count(self, db: &dyn salsa::Database) -> usize {
 ///         self.text(db).lines().count()
 ///     }

--- a/components/salsa-macros/src/options.rs
+++ b/components/salsa-macros/src/options.rs
@@ -12,6 +12,7 @@ use syn::{parenthesized, token};
 #[derive(Debug)]
 pub(crate) struct Options<A: AllowedOptions> {
     /// The `returns` option is used to configure the "return mode" for the field/function.
+    /// Fields and tracked functions default to `ref`.
     /// This may be one of `copy`, `clone`, `ref`, `as_ref`, `as_deref`.
     ///
     /// If this is `Some`, the value is the ident representing the selected mode.

--- a/components/salsa-macros/src/salsa_struct.rs
+++ b/components/salsa-macros/src/salsa_struct.rs
@@ -476,7 +476,7 @@ impl<'s> SalsaField<'s> {
 
         let get_name = Ident::new(&field_name_str, field_name.span());
         let set_name = Ident::new(&format!("set_{field_name_str}",), field_name.span());
-        let returns = Ident::new("clone", field.span());
+        let returns = Ident::new("ref", field.span());
         let mut result = SalsaField {
             field,
             has_tracked_attr: false,

--- a/components/salsa-macros/src/tracked_fn.rs
+++ b/components/salsa-macros/src/tracked_fn.rs
@@ -179,7 +179,7 @@ impl Macro {
             .args
             .returns
             .clone()
-            .unwrap_or(Ident::new("clone", Span::call_site()));
+            .unwrap_or(Ident::new("ref", Span::call_site()));
 
         // Validate return mode
         if !ALLOWED_RETURN_MODES

--- a/components/salsa-macros/src/tracked_impl.rs
+++ b/components/salsa-macros/src/tracked_impl.rs
@@ -545,7 +545,7 @@ impl Macro {
         if let Some(returns) = &args.returns {
             returns == "ref" || returns == "deref" || returns == "as_ref" || returns == "as_deref"
         } else {
-            false
+            true
         }
     }
 
@@ -571,6 +571,9 @@ impl Macro {
         if let Some(returns) = &args.returns {
             if let syn::ReturnType::Type(_, t) = &mut sig.output {
                 if returns == "copy" || returns == "clone" {
+                    if let Some(db_lt) = db_lt {
+                        **t = ChangeLt::elided_to(db_lt).in_type(t);
+                    }
                 } else if returns == "ref" {
                     let ty = db_lt
                         .map(|db_lt| ChangeLt::elided_to(db_lt).in_type(t))
@@ -602,9 +605,15 @@ impl Macro {
                     returns,
                     "returns attribute requires explicit return type",
                 ));
-            };
-        } else if let (Some(db_lt), syn::ReturnType::Type(_, t)) = (db_lt, &mut sig.output) {
-            **t = ChangeLt::elided_to(db_lt).in_type(t);
+            }
+        } else {
+            let db_lt = db_lt.expect("the default ref return mode uses the database lifetime");
+            if let syn::ReturnType::Type(_, t) = &mut sig.output {
+                let ty = ChangeLt::elided_to(db_lt).in_type(t);
+                **t = parse_quote!(& #db_lt #ty);
+            } else {
+                sig.output = parse_quote!(-> & #db_lt ());
+            }
         }
         Ok(())
     }

--- a/examples/calc/compile.rs
+++ b/examples/calc/compile.rs
@@ -2,7 +2,7 @@ use crate::ir::SourceProgram;
 use crate::parser::parse_statements;
 use crate::type_check::type_check_program;
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 pub fn compile(db: &dyn crate::Db, source_program: SourceProgram) {
     let program = parse_statements(db, source_program);
     type_check_program(db, program);

--- a/examples/calc/ir.rs
+++ b/examples/calc/ir.rs
@@ -5,7 +5,7 @@ use ordered_float::OrderedFloat;
 // ANCHOR: input
 #[salsa::input(debug)]
 pub struct SourceProgram {
-    #[returns(ref)]
+    #[returns(deref)]
     pub text: String,
 }
 // ANCHOR_END: input
@@ -13,13 +13,13 @@ pub struct SourceProgram {
 // ANCHOR: interned_ids
 #[salsa::interned(debug)]
 pub struct VariableId<'db> {
-    #[returns(ref)]
+    #[returns(deref)]
     pub text: String,
 }
 
 #[salsa::interned(debug)]
 pub struct FunctionId<'db> {
-    #[returns(ref)]
+    #[returns(deref)]
     pub text: String,
 }
 // ANCHOR_END: interned_ids
@@ -28,7 +28,7 @@ pub struct FunctionId<'db> {
 #[salsa::tracked(debug)]
 pub struct Program<'db> {
     #[tracked]
-    #[returns(ref)]
+    #[returns(deref)]
     pub statements: Vec<Statement<'db>>,
 }
 // ANCHOR_END: program
@@ -88,16 +88,17 @@ pub enum Op {
 // ANCHOR: functions
 #[salsa::tracked(debug)]
 pub struct Function<'db> {
+    #[returns(copy)]
     pub name: FunctionId<'db>,
 
+    #[returns(copy)]
     name_span: Span<'db>,
 
     #[tracked]
-    #[returns(ref)]
+    #[returns(deref)]
     pub args: Vec<VariableId<'db>>,
 
     #[tracked]
-    #[returns(ref)]
     pub body: Expression<'db>,
 }
 // ANCHOR_END: functions
@@ -105,8 +106,10 @@ pub struct Function<'db> {
 #[salsa::tracked(debug)]
 pub struct Span<'db> {
     #[tracked]
+    #[returns(copy)]
     pub start: usize,
     #[tracked]
+    #[returns(copy)]
     pub end: usize,
 }
 

--- a/examples/calc/parser.rs
+++ b/examples/calc/parser.rs
@@ -7,7 +7,7 @@ use crate::ir::{
 };
 
 // ANCHOR: parse_statements
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 pub fn parse_statements(db: &dyn crate::Db, source: SourceProgram) -> Program<'_> {
     // Get the source text from the database
     let source_text = source.text(db);

--- a/examples/calc/type_check.rs
+++ b/examples/calc/type_check.rs
@@ -9,7 +9,7 @@ use crate::ir::{
 };
 
 // ANCHOR: parse_statements
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 pub fn type_check_program<'db>(db: &'db dyn crate::Db, program: Program<'db>) {
     for statement in program.statements(db) {
         match &statement.data {
@@ -19,7 +19,7 @@ pub fn type_check_program<'db>(db: &'db dyn crate::Db, program: Program<'db>) {
     }
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 pub fn type_check_function<'db>(
     db: &'db dyn crate::Db,
     function: Function<'db>,
@@ -28,7 +28,7 @@ pub fn type_check_function<'db>(
     CheckExpression::new(db, program, function.args(db)).check(function.body(db))
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 pub fn find_function<'db>(
     db: &'db dyn crate::Db,
     program: Program<'db>,

--- a/examples/lazy-input/main.rs
+++ b/examples/lazy-input/main.rs
@@ -66,8 +66,9 @@ fn main() -> Result<()> {
 // ANCHOR: db
 #[salsa::input]
 struct File {
+    #[returns(deref)]
     path: PathBuf,
-    #[returns(ref)]
+    #[returns(deref)]
     contents: String,
 }
 
@@ -160,18 +161,19 @@ impl Diagnostic {
 
 #[salsa::tracked]
 struct ParsedFile<'db> {
+    #[returns(copy)]
     value: u32,
-    #[returns(ref)]
+    #[returns(deref)]
     links: Vec<ParsedFile<'db>>,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn compile(db: &dyn Db, input: File) -> u32 {
     let parsed = parse(db, input);
     sum(db, parsed)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn parse(db: &dyn Db, input: File) -> ParsedFile<'_> {
     let mut lines = input.contents(db).lines();
     let value = match lines.next().map(|line| (line.parse::<u32>(), line)) {
@@ -217,7 +219,7 @@ fn parse(db: &dyn Db, input: File) -> ParsedFile<'_> {
     ParsedFile::new(db, value, links)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn sum<'db>(db: &'db dyn Db, input: ParsedFile<'db>) -> u32 {
     input.value(db)
         + input

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,9 +51,8 @@
 //! in that database until it is dropped; dropping every copy of the handle does not delete the
 //! input.
 //!
-//! References returned by getters such as `#[returns(ref)]` are tied to an immutable database
-//! borrow. They cannot overlap the mutable borrow required to call a setter and begin a new
-//! revision.
+//! References returned by field getters are tied to an immutable database borrow. They cannot
+//! overlap the mutable borrow required to call a setter and begin a new revision.
 //!
 //! See [input structs in the Salsa book] for examples of declaring, reading, and updating inputs,
 //! and the [durability reference] for choosing a durability.
@@ -123,13 +122,13 @@
 //!
 //! # Return modes
 //!
-//! Salsa struct field getters and tracked functions return cloned values by default. The
+//! Salsa struct field getters and tracked functions return references by default. The
 //! `#[returns(MODE)]` field attribute and `returns(MODE)` tracked-function option select another
 //! mode:
 //!
+//! - `ref` returns a reference to the stored field or memoized result. This is the default.
 //! - `clone` returns an owned clone.
 //! - `copy` returns an owned copy.
-//! - `ref` returns a reference to the stored field or memoized result.
 //! - `deref` uses [`Deref`] and returns a reference to its `Target`.
 //! - `as_ref` uses [`SalsaAsRef`].
 //! - `as_deref` uses [`SalsaAsDeref`].
@@ -233,7 +232,7 @@
 //! [input structs in the Salsa book]: https://salsa-rs.github.io/salsa/overview.html#inputs
 //! [interned structs in the Salsa book]: https://salsa-rs.github.io/salsa/overview.html#interned-structs
 //! [red-green algorithm]: https://salsa-rs.github.io/salsa/reference/algorithm.html
-//! [returning references in the Salsa book]: https://salsa-rs.github.io/salsa/tutorial/parser.html#the-returnsref-annotation
+//! [returning references in the Salsa book]: https://salsa-rs.github.io/salsa/tutorial/parser.html#the-returnscopy-annotation
 //! [specifying query results in the Salsa book]: https://salsa-rs.github.io/salsa/overview.html#specify-the-result-of-tracked-functions-for-particular-structs
 //! [tracked functions in the Salsa book]: https://salsa-rs.github.io/salsa/overview.html#tracked-functions
 //! [tracked structs in the Salsa book]: https://salsa-rs.github.io/salsa/overview.html#tracked-structs

--- a/tests/accumulate-behind-tracked-fn.rs
+++ b/tests/accumulate-behind-tracked-fn.rs
@@ -12,7 +12,9 @@ use test_log::test;
 
 #[salsa::input(debug)]
 struct List {
+    #[returns(copy)]
     value: u32,
+    #[returns(copy)]
     next: Option<List>,
 }
 
@@ -22,7 +24,7 @@ struct List {
 struct Integers(u32);
 
 /// Outer tracked fn: iterates the list and delegates accumulation to `compute_single`.
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn compute(db: &dyn salsa::Database, input: List) {
     compute_single(db, input);
     if let Some(next) = input.next(db) {
@@ -31,7 +33,7 @@ fn compute(db: &dyn salsa::Database, input: List) {
 }
 
 /// Inner tracked fn: performs the actual accumulation.
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn compute_single(db: &dyn salsa::Database, input: List) {
     Integers(input.value(db)).accumulate(db);
 }

--- a/tests/accumulate-chain.rs
+++ b/tests/accumulate-chain.rs
@@ -13,30 +13,30 @@ use test_log::test;
 #[derive(Debug)]
 struct Log(#[allow(dead_code)] String);
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn push_logs(db: &dyn Database) {
     push_a_logs(db);
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn push_a_logs(db: &dyn Database) {
     Log("log a".to_string()).accumulate(db);
     push_b_logs(db);
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn push_b_logs(db: &dyn Database) {
     // No logs
     push_c_logs(db);
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn push_c_logs(db: &dyn Database) {
     // No logs
     push_d_logs(db);
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn push_d_logs(db: &dyn Database) {
     Log("log d".to_string()).accumulate(db);
 }

--- a/tests/accumulate-custom-debug.rs
+++ b/tests/accumulate-custom-debug.rs
@@ -8,6 +8,7 @@ use test_log::test;
 
 #[salsa::input(debug)]
 struct MyInput {
+    #[returns(copy)]
     count: u32,
 }
 
@@ -20,7 +21,7 @@ impl std::fmt::Debug for Log {
     }
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn push_logs(db: &dyn salsa::Database, input: MyInput) {
     for i in 0..input.count(db) {
         Log(format!("#{i}")).accumulate(db);

--- a/tests/accumulate-dag.rs
+++ b/tests/accumulate-dag.rs
@@ -8,7 +8,9 @@ use test_log::test;
 
 #[salsa::input(debug)]
 struct MyInput {
+    #[returns(copy)]
     field_a: u32,
+    #[returns(copy)]
     field_b: u32,
 }
 
@@ -16,13 +18,13 @@ struct MyInput {
 #[derive(Debug)]
 struct Log(#[allow(dead_code)] String);
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn push_logs(db: &dyn Database, input: MyInput) {
     push_a_logs(db, input);
     push_b_logs(db, input);
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn push_a_logs(db: &dyn Database, input: MyInput) {
     let count = input.field_a(db);
     for i in 0..count {
@@ -30,7 +32,7 @@ fn push_a_logs(db: &dyn Database, input: MyInput) {
     }
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn push_b_logs(db: &dyn Database, input: MyInput) {
     // Note that b calls a
     push_a_logs(db, input);

--- a/tests/accumulate-execution-order.rs
+++ b/tests/accumulate-execution-order.rs
@@ -13,12 +13,12 @@ use test_log::test;
 #[derive(Debug)]
 struct Log(#[allow(dead_code)] String);
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn push_logs(db: &dyn Database) {
     push_a_logs(db);
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn push_a_logs(db: &dyn Database) {
     Log("log a".to_string()).accumulate(db);
     push_b_logs(db);
@@ -26,18 +26,18 @@ fn push_a_logs(db: &dyn Database) {
     push_d_logs(db);
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn push_b_logs(db: &dyn Database) {
     Log("log b".to_string()).accumulate(db);
     push_d_logs(db);
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn push_c_logs(db: &dyn Database) {
     Log("log c".to_string()).accumulate(db);
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn push_d_logs(db: &dyn Database) {
     Log("log d".to_string()).accumulate(db);
 }

--- a/tests/accumulate-from-tracked-fn.rs
+++ b/tests/accumulate-from-tracked-fn.rs
@@ -10,7 +10,9 @@ use test_log::test;
 
 #[salsa::input(debug)]
 struct List {
+    #[returns(copy)]
     value: u32,
+    #[returns(copy)]
     next: Option<List>,
 }
 
@@ -18,7 +20,7 @@ struct List {
 #[derive(Copy, Clone, Debug)]
 struct Integers(u32);
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn compute(db: &dyn salsa::Database, input: List) {
     eprintln!(
         "{:?}(value={:?}, next={:?})",

--- a/tests/accumulate-no-duplicates.rs
+++ b/tests/accumulate-no-duplicates.rs
@@ -29,15 +29,16 @@ struct Log(#[allow(dead_code)] String);
 
 #[salsa::input(debug)]
 struct MyInput {
+    #[returns(copy)]
     n: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn push_logs(db: &dyn Database) {
     push_a_logs(db, MyInput::new(db, 1));
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn push_a_logs(db: &dyn Database, input: MyInput) {
     Log("log a".to_string()).accumulate(db);
     if input.n(db) == 1 {
@@ -50,12 +51,12 @@ fn push_a_logs(db: &dyn Database, input: MyInput) {
     }
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn push_b_logs(db: &dyn Database) {
     Log("log b".to_string()).accumulate(db);
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn push_c_logs(db: &dyn Database) {
     Log("log c".to_string()).accumulate(db);
     push_d_logs(db);
@@ -69,7 +70,7 @@ fn push_d_logs(db: &dyn Database) {
     push_b_logs(db);
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn push_e_logs(db: &dyn Database) {
     Log("log e".to_string()).accumulate(db);
 }

--- a/tests/accumulate-reuse-workaround.rs
+++ b/tests/accumulate-reuse-workaround.rs
@@ -12,7 +12,9 @@ use test_log::test;
 
 #[salsa::input(debug)]
 struct List {
+    #[returns(copy)]
     value: u32,
+    #[returns(copy)]
     next: Option<List>,
 }
 
@@ -20,7 +22,7 @@ struct List {
 #[derive(Copy, Clone, Debug)]
 struct Integers(u32);
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn compute(db: &dyn LogDatabase, input: List) -> u32 {
     db.push_log(format!("compute({input:?})",));
 

--- a/tests/accumulate-reuse.rs
+++ b/tests/accumulate-reuse.rs
@@ -13,14 +13,16 @@ use test_log::test;
 
 #[salsa::input(debug)]
 struct List {
+    #[returns(copy)]
     value: u32,
+    #[returns(copy)]
     next: Option<List>,
 }
 
 #[salsa::accumulator]
 struct Integers(u32);
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn compute(db: &dyn LogDatabase, input: List) -> u32 {
     db.push_log(format!("compute({input:?})",));
 

--- a/tests/accumulate-shallow-verify.rs
+++ b/tests/accumulate-shallow-verify.rs
@@ -7,19 +7,21 @@ use salsa::{Accumulator, Setter};
 
 #[salsa::input]
 struct List {
+    #[returns(copy)]
     value: u32,
+    #[returns(copy)]
     next: Option<List>,
 }
 
 #[salsa::accumulator]
 struct Values(u32);
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn compute_single(db: &dyn LogDatabase, input: List) {
     Values(input.value(db)).accumulate(db);
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn compute(db: &dyn LogDatabase, input: List) {
     compute_single(db, input);
     if let Some(next) = input.next(db) {

--- a/tests/accumulate.rs
+++ b/tests/accumulate.rs
@@ -8,7 +8,9 @@ use test_log::test;
 
 #[salsa::input(debug)]
 struct MyInput {
+    #[returns(copy)]
     field_a: u32,
+    #[returns(copy)]
     field_b: u32,
 }
 
@@ -16,7 +18,7 @@ struct MyInput {
 #[derive(Debug)]
 struct Log(#[allow(dead_code)] String);
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn push_logs(db: &dyn LogDatabase, input: MyInput) {
     db.push_log(format!(
         "push_logs(a = {}, b = {})",
@@ -35,7 +37,7 @@ fn push_logs(db: &dyn LogDatabase, input: MyInput) {
     }
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn push_a_logs(db: &dyn LogDatabase, input: MyInput) {
     let field_a = input.field_a(db);
     db.push_log(format!("push_a_logs({field_a})"));
@@ -45,7 +47,7 @@ fn push_a_logs(db: &dyn LogDatabase, input: MyInput) {
     }
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn push_b_logs(db: &dyn LogDatabase, input: MyInput) {
     let field_a = input.field_b(db);
     db.push_log(format!("push_b_logs({field_a})"));

--- a/tests/accumulated_backdate.rs
+++ b/tests/accumulated_backdate.rs
@@ -18,12 +18,12 @@ struct File {
 #[derive(Debug)]
 struct Log(#[allow(dead_code)] String);
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn compile(db: &dyn LogDatabase, input: File) -> u32 {
     parse(db, input)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn parse(db: &dyn LogDatabase, input: File) -> u32 {
     let value: Result<u32, _> = input.content(db).parse();
 

--- a/tests/backdate_untracked_db_field.rs
+++ b/tests/backdate_untracked_db_field.rs
@@ -4,6 +4,7 @@ use salsa::Setter;
 
 #[salsa::input(debug)]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
@@ -36,17 +37,17 @@ impl ExtraFieldDatabase {
     }
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn dep_a_db(db: &dyn Db, input: MyInput) -> u32 {
     input.field(db)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn dep_b_db(db: &dyn Db, input: MyInput) -> u32 {
     input.field(db)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn db_field_branch_query(db: &dyn Db, a: MyInput, b: MyInput) -> u32 {
     if db.extra() == 0 {
         dep_a_db(db, a)

--- a/tests/backtrace.rs
+++ b/tests/backtrace.rs
@@ -6,30 +6,31 @@ use test_log::test;
 
 #[salsa::input(debug)]
 struct Thing {
+    #[returns(copy)]
     detailed: bool,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(clone))]
 fn query_a(db: &dyn Database, thing: Thing) -> String {
     query_b(db, thing)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(clone))]
 fn query_b(db: &dyn Database, thing: Thing) -> String {
     query_c(db, thing)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(clone))]
 fn query_c(db: &dyn Database, thing: Thing) -> String {
     query_d(db, thing)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(clone))]
 fn query_d(db: &dyn Database, thing: Thing) -> String {
     query_e(db, thing)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(clone))]
 fn query_e(db: &dyn Database, thing: Thing) -> String {
     if thing.detailed(db) {
         format!("{:#}", Backtrace::capture().unwrap())
@@ -37,12 +38,12 @@ fn query_e(db: &dyn Database, thing: Thing) -> String {
         format!("{}", Backtrace::capture().unwrap())
     }
 }
-#[salsa::tracked]
+#[salsa::tracked(returns(clone))]
 fn query_f(db: &dyn Database, thing: Thing) -> String {
     query_cycle(db, thing)
 }
 
-#[salsa::tracked(cycle_initial=cycle_initial)]
+#[salsa::tracked(returns(clone), cycle_initial=cycle_initial)]
 fn query_cycle(db: &dyn Database, thing: Thing) -> String {
     let backtrace = query_cycle(db, thing);
     if backtrace.is_empty() {
@@ -64,15 +65,15 @@ fn backtrace_works() {
     expect![[r#"
         query stacktrace:
            0: query_e(Id(0))
-                     at tests/backtrace.rs:32
+                     at tests/backtrace.rs:33
            1: query_d(Id(0))
-                     at tests/backtrace.rs:27
+                     at tests/backtrace.rs:28
            2: query_c(Id(0))
-                     at tests/backtrace.rs:22
+                     at tests/backtrace.rs:23
            3: query_b(Id(0))
-                     at tests/backtrace.rs:17
+                     at tests/backtrace.rs:18
            4: query_a(Id(0))
-                     at tests/backtrace.rs:12
+                     at tests/backtrace.rs:13
     "#]]
     .assert_eq(&backtrace);
 
@@ -80,15 +81,15 @@ fn backtrace_works() {
     expect![[r#"
         query stacktrace:
            0: query_e(Id(1)) -> (R1, Durability::LOW)
-                     at tests/backtrace.rs:32
+                     at tests/backtrace.rs:33
            1: query_d(Id(1)) -> (R1, Durability::NEVER_CHANGE)
-                     at tests/backtrace.rs:27
+                     at tests/backtrace.rs:28
            2: query_c(Id(1)) -> (R1, Durability::NEVER_CHANGE)
-                     at tests/backtrace.rs:22
+                     at tests/backtrace.rs:23
            3: query_b(Id(1)) -> (R1, Durability::NEVER_CHANGE)
-                     at tests/backtrace.rs:17
+                     at tests/backtrace.rs:18
            4: query_a(Id(1)) -> (R1, Durability::NEVER_CHANGE)
-                     at tests/backtrace.rs:12
+                     at tests/backtrace.rs:13
     "#]]
     .assert_eq(&backtrace);
 
@@ -96,12 +97,12 @@ fn backtrace_works() {
     expect![[r#"
         query stacktrace:
            0: query_e(Id(2))
-                     at tests/backtrace.rs:32
+                     at tests/backtrace.rs:33
            1: query_cycle(Id(2))
-                     at tests/backtrace.rs:45
+                     at tests/backtrace.rs:46
                      cycle heads: query_cycle(Id(2)) -> iteration = 0
            2: query_f(Id(2))
-                     at tests/backtrace.rs:40
+                     at tests/backtrace.rs:41
     "#]]
     .assert_eq(&backtrace);
 
@@ -109,12 +110,12 @@ fn backtrace_works() {
     expect![[r#"
         query stacktrace:
            0: query_e(Id(3)) -> (R1, Durability::LOW)
-                     at tests/backtrace.rs:32
+                     at tests/backtrace.rs:33
            1: query_cycle(Id(3)) -> (R1, Durability::NEVER_CHANGE)
-                     at tests/backtrace.rs:45
+                     at tests/backtrace.rs:46
                      cycle heads: query_cycle(Id(3)) -> iteration = 0
            2: query_f(Id(3)) -> (R1, Durability::NEVER_CHANGE)
-                     at tests/backtrace.rs:40
+                     at tests/backtrace.rs:41
     "#]]
     .assert_eq(&backtrace);
 }

--- a/tests/cancellation-event-panic.rs
+++ b/tests/cancellation-event-panic.rs
@@ -31,10 +31,11 @@ impl Database for TestDatabase {}
 
 #[salsa::input]
 struct Input {
+    #[returns(copy)]
     value: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn read(db: &dyn Database, input: Input) -> u32 {
     input.value(db)
 }

--- a/tests/cancellation_token.rs
+++ b/tests/cancellation_token.rs
@@ -16,31 +16,32 @@ use crate::common::LogDatabase;
 
 #[salsa::input(debug)]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn a(db: &dyn Database, input: MyInput) -> u32 {
     BARRIER.wait();
     BARRIER2.wait();
     b(db, input)
 }
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn b(db: &dyn Database, input: MyInput) -> u32 {
     input.field(db)
 }
 
-#[salsa::tracked(cycle_initial = |_, _| 0)]
+#[salsa::tracked(returns(copy), cycle_initial = |_, _| 0)]
 fn panicking_cycle_query(_db: &dyn Database) -> u32 {
     panic!("boom")
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn uncancelled_query(_db: &dyn Database) -> u32 {
     1
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn cancel_after_cycle_panic(db: &dyn Database) -> u32 {
     assert!(catch_unwind(AssertUnwindSafe(|| panicking_cycle_query(db))).is_err());
     db.cancellation_token().cancel();

--- a/tests/check_auto_traits.rs
+++ b/tests/check_auto_traits.rs
@@ -14,6 +14,7 @@ struct MyInput {
 
 #[salsa::tracked]
 struct MyTracked<'db> {
+    #[returns(copy)]
     field: MyInterned<'db>,
 }
 
@@ -22,7 +23,7 @@ struct MyInterned<'db> {
     field: String,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn test(db: &dyn Database, input: MyInput) {
     let input = is_send(is_sync(input));
     let interned = is_send(is_sync(MyInterned::new(db, input.field(db).clone())));

--- a/tests/compile-fail/invalid_persist_options.rs
+++ b/tests/compile-fail/invalid_persist_options.rs
@@ -40,17 +40,17 @@ struct InvalidInput3 {
 
 #[salsa::tracked(persist)]
 fn tracked_fn(db: &dyn salsa::Database, input: Input) -> String {
-    input.text(db)
+    input.text(db).clone()
 }
 
 #[salsa::tracked(persist())]
 fn tracked_fn2(db: &dyn salsa::Database, input: Input) -> String {
-    input.text(db)
+    input.text(db).clone()
 }
 
 #[salsa::tracked(persist(serialize = serde::Serialize::serialize, deserialize = serde::Deserialize::deserialize))]
 fn invalid_tracked_fn(db: &dyn salsa::Database, input: Input) -> String {
-    input.text(db)
+    input.text(db).clone()
 }
 
 fn main() {}

--- a/tests/compile-fail/lru_can_not_be_used_with_specify.rs
+++ b/tests/compile-fail/lru_can_not_be_used_with_specify.rs
@@ -1,5 +1,6 @@
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 

--- a/tests/compile-fail/lru_can_not_be_used_with_specify.stderr
+++ b/tests/compile-fail/lru_can_not_be_used_with_specify.stderr
@@ -1,5 +1,5 @@
 error: the `specify` and `lru` options cannot be used together
- --> tests/compile-fail/lru_can_not_be_used_with_specify.rs:6:27
+ --> tests/compile-fail/lru_can_not_be_used_with_specify.rs:7:27
   |
-6 | #[salsa::tracked(lru = 3, specify)]
+7 | #[salsa::tracked(lru = 3, specify)]
   |                           ^^^^^^^

--- a/tests/compile-fail/singleton_only_for_input.rs
+++ b/tests/compile-fail/singleton_only_for_input.rs
@@ -4,6 +4,7 @@
 
 #[salsa::input(singleton)]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 

--- a/tests/compile-fail/singleton_only_for_input.stderr
+++ b/tests/compile-fail/singleton_only_for_input.stderr
@@ -1,23 +1,23 @@
 error: `singleton` option not allowed here
-  --> tests/compile-fail/singleton_only_for_input.rs:10:18
+  --> tests/compile-fail/singleton_only_for_input.rs:11:18
    |
-10 | #[salsa::tracked(singleton)]
+11 | #[salsa::tracked(singleton)]
    |                  ^^^^^^^^^
 
 error: `singleton` option not allowed here
-  --> tests/compile-fail/singleton_only_for_input.rs:15:19
+  --> tests/compile-fail/singleton_only_for_input.rs:16:19
    |
-15 | #[salsa::interned(singleton)]
+16 | #[salsa::interned(singleton)]
    |                   ^^^^^^^^^
 
 error: `singleton` option not allowed here
-  --> tests/compile-fail/singleton_only_for_input.rs:20:18
+  --> tests/compile-fail/singleton_only_for_input.rs:21:18
    |
-20 | #[salsa::tracked(singleton)]
+21 | #[salsa::tracked(singleton)]
    |                  ^^^^^^^^^
 
 error: `singleton` option not allowed here
-  --> tests/compile-fail/singleton_only_for_input.rs:25:22
+  --> tests/compile-fail/singleton_only_for_input.rs:26:22
    |
-25 | #[salsa::accumulator(singleton)]
+26 | #[salsa::accumulator(singleton)]
    |                      ^^^^^^^^^

--- a/tests/compile-pass/input-impl-trait-redundant-captures.rs
+++ b/tests/compile-pass/input-impl-trait-redundant-captures.rs
@@ -2,6 +2,7 @@
 
 #[salsa::input]
 struct Input {
+    #[returns(copy)]
     field: u32,
 }
 

--- a/tests/compile-pass/redefine-result-input-struct-derive.rs
+++ b/tests/compile-pass/redefine-result-input-struct-derive.rs
@@ -5,7 +5,7 @@
 
 type Result<T> = std::result::Result<T, String>;
 
-#[salsa::tracked]
+#[salsa::tracked(returns(clone))]
 fn example_query(_db: &dyn salsa::Database) -> Result<()> {
     Ok(())
 }

--- a/tests/compile-pass/tracked-methods.rs
+++ b/tests/compile-pass/tracked-methods.rs
@@ -5,18 +5,19 @@ pub struct Things<'db> {
 
 #[salsa::interned]
 struct Other {
+    #[returns(copy)]
     b: bool,
 }
 
 #[salsa::tracked]
 impl Things<'_> {
-    #[salsa::tracked(returns(ref))]
+    #[salsa::tracked]
     pub fn implicit(db: &dyn salsa::Database, _: Other<'_>) -> Things<'_> {
         _ = db;
         todo!()
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     pub fn implicit2(db: &dyn salsa::Database, _: Other<'_>) -> Things<'_> {
         _ = db;
         todo!()
@@ -25,25 +26,25 @@ impl Things<'_> {
 
 #[salsa::tracked]
 impl<'db> Things<'db> {
-    #[salsa::tracked(returns(ref))]
+    #[salsa::tracked]
     pub fn explicit(db: &'db dyn salsa::Database, _: Other<'db>) -> Things<'db> {
         _ = db;
         todo!()
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     pub fn explicit2(db: &'db dyn salsa::Database, _: Other<'db>) -> Things<'db> {
         _ = db;
         todo!()
     }
 
-    #[salsa::tracked(returns(ref))]
+    #[salsa::tracked]
     pub fn implicit3(db: &dyn salsa::Database, _: Other<'_>) -> Things<'_> {
         _ = db;
         todo!()
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     pub fn implicit4(db: &dyn salsa::Database, _: Other<'_>) -> Things<'_> {
         _ = db;
         todo!()
@@ -55,7 +56,7 @@ impl<'db> Things<'db> {
         "test"
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     pub fn static_value2(db: &dyn salsa::Database) -> &'static str {
         _ = db;
         "test"
@@ -66,7 +67,7 @@ impl<'db> Things<'db> {
 impl<'a> Things<'a> {
     // The body refers to the impl's lifetime by name; the generated signature
     // must keep using that same name.
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn body_annotation(db: &'a dyn salsa::Database) -> u32 {
         let _: &'a dyn salsa::Database = db;
         0
@@ -75,7 +76,7 @@ impl<'a> Things<'a> {
     // A higher-ranked function pointer return whose binder reuses `'db`; the db
     // lifetime must not be renamed into the binder. `no_eq` avoids comparing fn
     // pointers (which is unpredictable and only incidental to this test).
-    #[salsa::tracked(no_eq, unsafe(non_update_types))]
+    #[salsa::tracked(returns(copy), no_eq, unsafe(non_update_types))]
     fn hrtb(db: &'a dyn salsa::Database) -> for<'db> fn(&'a (), &'db ()) {
         _ = db;
         unimplemented!()
@@ -83,7 +84,7 @@ impl<'a> Things<'a> {
 
     // An elided, independent input lifetime (`Other<'_>`) must be tied to the db
     // lifetime on the outer signature so the call to the inner fn type-checks.
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn named_return(db: &'a dyn salsa::Database, other: Other<'_>) -> Things<'a> {
         _ = (db, other);
         unimplemented!()

--- a/tests/cycle.rs
+++ b/tests/cycle.rs
@@ -169,7 +169,7 @@ where
 }
 
 /// Query minimum value of inputs, with cycle recovery.
-#[salsa::tracked(cycle_fn=cycle_recover, cycle_initial=min_initial)]
+#[salsa::tracked(returns(copy), cycle_fn=cycle_recover, cycle_initial=min_initial)]
 fn min_iterate(db: &dyn Db, inputs: Inputs) -> Value {
     fold_values(inputs.values(db), u8::min)
 }
@@ -179,7 +179,7 @@ fn min_initial(_db: &dyn Db, _id: salsa::Id, _inputs: Inputs) -> Value {
 }
 
 /// Query maximum value of inputs, with cycle recovery.
-#[salsa::tracked(cycle_fn=cycle_recover, cycle_initial=max_initial)]
+#[salsa::tracked(returns(copy), cycle_fn=cycle_recover, cycle_initial=max_initial)]
 fn max_iterate(db: &dyn Db, inputs: Inputs) -> Value {
     fold_values(inputs.values(db), u8::max)
 }
@@ -189,13 +189,13 @@ fn max_initial(_db: &dyn Db, _id: salsa::Id, _inputs: Inputs) -> Value {
 }
 
 /// Query minimum value of inputs, without cycle recovery.
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn min_panic(db: &dyn Db, inputs: Inputs) -> Value {
     fold_values(inputs.values(db), u8::min)
 }
 
 /// Query maximum value of inputs, without cycle recovery.
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn max_panic(db: &dyn Db, inputs: Inputs) -> Value {
     fold_values(inputs.values(db), u8::max)
 }
@@ -1167,16 +1167,19 @@ fn repeat_provisional_query_incremental() {
 fn repeat_query_participating_in_cycle() {
     #[salsa::input]
     struct Input {
+        #[returns(copy)]
         value: u32,
+        #[returns(copy)]
         stable: u32,
     }
 
     #[salsa::interned]
     struct Interned {
+        #[returns(copy)]
         value: u32,
     }
 
-    #[salsa::tracked(cycle_initial=initial)]
+    #[salsa::tracked(returns(copy), cycle_initial=initial)]
     fn head(db: &dyn Db, input: Input) -> u32 {
         let a = query_a(db, input);
 
@@ -1187,33 +1190,33 @@ fn repeat_query_participating_in_cycle() {
         0
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn query_a(db: &dyn Db, input: Input) -> u32 {
         let _ = query_b(db, input);
 
         query_hot(db, input)
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn query_b(db: &dyn Db, input: Input) -> u32 {
         let _ = query_c(db, input);
 
         query_hot(db, input)
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn query_c(db: &dyn Db, input: Input) -> u32 {
         let _ = query_d(db, input);
 
         query_hot(db, input)
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn query_d(db: &dyn Db, input: Input) -> u32 {
         query_hot(db, input)
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn query_hot(db: &dyn Db, input: Input) -> u32 {
         let value = head(db, input);
 
@@ -1276,16 +1279,19 @@ fn repeat_query_participating_in_cycle() {
 fn repeat_query_participating_in_cycle2() {
     #[salsa::input]
     struct Input {
+        #[returns(copy)]
         value: u32,
+        #[returns(copy)]
         stable: u32,
     }
 
     #[salsa::interned]
     struct Interned {
+        #[returns(copy)]
         value: u32,
     }
 
-    #[salsa::tracked(cycle_initial=initial)]
+    #[salsa::tracked(returns(copy), cycle_initial=initial)]
     fn head(db: &dyn Db, input: Input) -> u32 {
         let a = query_a(db, input);
 
@@ -1296,25 +1302,25 @@ fn repeat_query_participating_in_cycle2() {
         0
     }
 
-    #[salsa::tracked(cycle_initial=initial)]
+    #[salsa::tracked(returns(copy), cycle_initial=initial)]
     fn query_a(db: &dyn Db, input: Input) -> u32 {
         let _ = query_hot(db, input);
         query_b(db, input)
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn query_b(db: &dyn Db, input: Input) -> u32 {
         let _ = query_hot(db, input);
         query_c(db, input)
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn query_c(db: &dyn Db, input: Input) -> u32 {
         let _ = query_hot(db, input);
         query_d(db, input)
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn query_d(db: &dyn Db, input: Input) -> u32 {
         let _ = query_hot(db, input);
 
@@ -1324,7 +1330,7 @@ fn repeat_query_participating_in_cycle2() {
         value + 1
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn query_hot(db: &dyn Db, input: Input) -> u32 {
         let _ = input.stable(db);
 

--- a/tests/cycle_accumulate.rs
+++ b/tests/cycle_accumulate.rs
@@ -43,7 +43,7 @@ struct File {
 #[derive(Debug)]
 struct Diagnostic(#[allow(dead_code)] String);
 
-#[salsa::tracked(cycle_fn = cycle_fn, cycle_initial = cycle_initial)]
+#[salsa::tracked(returns(clone), cycle_fn = cycle_fn, cycle_initial = cycle_initial)]
 fn check_file(db: &dyn LogDatabase, file: File) -> Vec<u32> {
     db.push_log(format!(
         "check_file(name = {}, issues = {:?})",
@@ -53,7 +53,7 @@ fn check_file(db: &dyn LogDatabase, file: File) -> Vec<u32> {
 
     let mut collected_issues = HashSet::<u32>::from_iter(file.issues(db).iter().copied());
 
-    for dep in file.dependencies(db) {
+    for &dep in file.dependencies(db) {
         let issues = check_file(db, dep);
         collected_issues.extend(issues);
     }

--- a/tests/cycle_dependency_order_different_entry_queries.rs
+++ b/tests/cycle_dependency_order_different_entry_queries.rs
@@ -6,7 +6,7 @@ use salsa::{Database, Durability};
 
 mod common;
 
-#[salsa::tracked(cycle_initial=a_cycle_initial)]
+#[salsa::tracked(returns(copy), cycle_initial=a_cycle_initial)]
 fn query_a(db: &dyn Database) {
     let b = query_b(db);
     query_d(db, b);
@@ -16,15 +16,17 @@ fn a_cycle_initial(_db: &dyn Database, _id: salsa::Id) {}
 
 #[salsa::interned]
 struct Interned {
+    #[returns(copy)]
     value: u32,
 }
 
 #[salsa::input(singleton)]
 struct StableInput {
+    #[returns(copy)]
     value: (),
 }
 
-#[salsa::tracked(cycle_initial=|db, _| Interned::new(db, 0))]
+#[salsa::tracked(returns(copy), cycle_initial=|db, _| Interned::new(db, 0))]
 fn query_b(db: &dyn Database) -> Interned<'_> {
     query_c(db);
     // Keep this value reusable so the test still covers validation ordering.
@@ -32,12 +34,12 @@ fn query_b(db: &dyn Database) -> Interned<'_> {
     Interned::new(db, 2)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn query_c(db: &dyn Database) {
     query_a(db);
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn query_d<'db>(db: &'db dyn Database, _i: Interned<'db>) {
     StableInput::get(db).value(db);
 }

--- a/tests/cycle_fallback_immediate.rs
+++ b/tests/cycle_fallback_immediate.rs
@@ -3,7 +3,7 @@
 //! It is possible to omit the `cycle_fn`, only specifying `cycle_result` in which case
 //! an immediate fallback value is used as the cycle handling opposed to doing a fixpoint resolution.
 
-#[salsa::tracked(cycle_result=cycle_result)]
+#[salsa::tracked(returns(copy), cycle_result=cycle_result)]
 fn one_o_one(db: &dyn salsa::Database) -> u32 {
     let val = one_o_one(db);
     val + 1
@@ -20,12 +20,12 @@ fn simple() {
     assert_eq!(one_o_one(&db), 100);
 }
 
-#[salsa::tracked(cycle_result=two_queries_cycle_result)]
+#[salsa::tracked(returns(copy), cycle_result=two_queries_cycle_result)]
 fn two_queries1(db: &dyn salsa::Database) -> i32 {
     two_queries2(db) + 1
 }
 
-#[salsa::tracked(cycle_result=two_queries_cycle_result)]
+#[salsa::tracked(returns(copy), cycle_result=two_queries_cycle_result)]
 fn two_queries2(db: &dyn salsa::Database) -> i32 {
     two_queries1(db)
 }

--- a/tests/cycle_initial_call_back_into_cycle.rs
+++ b/tests/cycle_initial_call_back_into_cycle.rs
@@ -2,12 +2,12 @@
 
 //! Calling back into the same cycle from your cycle initial function will trigger another cycle.
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn initial_value(db: &dyn salsa::Database) -> u32 {
     query(db)
 }
 
-#[salsa::tracked(cycle_initial=cycle_initial)]
+#[salsa::tracked(returns(copy), cycle_initial=cycle_initial)]
 fn query(db: &dyn salsa::Database) -> u32 {
     let val = query(db);
     if val < 5 { val + 1 } else { val }

--- a/tests/cycle_initial_call_query.rs
+++ b/tests/cycle_initial_call_query.rs
@@ -2,12 +2,12 @@
 
 //! It's possible to call a Salsa query from within a cycle initial fn.
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn initial_value(_db: &dyn salsa::Database) -> u32 {
     0
 }
 
-#[salsa::tracked(cycle_initial= |db, _| initial_value(db))]
+#[salsa::tracked(returns(copy), cycle_initial= |db, _| initial_value(db))]
 fn query(db: &dyn salsa::Database) -> u32 {
     let val = query(db);
     if val < 5 { val + 1 } else { val }

--- a/tests/cycle_input_different_cycle_head.rs
+++ b/tests/cycle_input_different_cycle_head.rs
@@ -21,6 +21,7 @@ fn low_durability_cycle_enter_from_different_head() {
 
 #[salsa::input]
 struct Input {
+    #[returns(copy)]
     value: u32,
 }
 
@@ -46,7 +47,7 @@ impl MyDb for MyDbImpl {
     }
 }
 
-#[salsa::tracked(cycle_initial=cycle_initial)]
+#[salsa::tracked(returns(copy), cycle_initial=cycle_initial)]
 fn query_a(db: &dyn MyDb) -> u32 {
     query_b(db);
     db.input().value(db)
@@ -58,15 +59,16 @@ fn cycle_initial(_db: &dyn MyDb, _id: salsa::Id) -> u32 {
 
 #[salsa::interned]
 struct Interned {
+    #[returns(copy)]
     value: u32,
 }
 
-#[salsa::tracked(cycle_initial=cycle_initial)]
+#[salsa::tracked(returns(copy), cycle_initial=cycle_initial)]
 fn query_b(db: &dyn MyDb) -> u32 {
     query_c(db)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn query_c(db: &dyn MyDb) -> u32 {
     query_a(db)
 }

--- a/tests/cycle_left_recursive_query.rs
+++ b/tests/cycle_left_recursive_query.rs
@@ -6,7 +6,7 @@ use salsa::{Database, Durability, Id};
 
 mod common;
 
-#[salsa::tracked(cycle_initial=cycle_initial)]
+#[salsa::tracked(returns(copy), cycle_initial=cycle_initial)]
 fn query_a(db: &dyn salsa::Database) -> Interned<'_> {
     let interned = query_b(db);
     let value = interned.value(db);
@@ -18,14 +18,14 @@ fn query_a(db: &dyn salsa::Database) -> Interned<'_> {
     }
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn query_b(db: &dyn Database) -> Interned<'_> {
     let interned = query_a(db);
     query_x(db, interned);
     interned
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn query_x<'db>(db: &'db dyn Database, _i: Interned<'db>) {
     StableInput::get(db).value(db);
 }
@@ -38,11 +38,13 @@ fn cycle_initial(db: &dyn Database, _id: Id) -> Interned<'_> {
 
 #[salsa::interned]
 struct Interned {
+    #[returns(copy)]
     value: u32,
 }
 
 #[salsa::input(singleton)]
 struct StableInput {
+    #[returns(copy)]
     value: (),
 }
 

--- a/tests/cycle_maybe_changed_after.rs
+++ b/tests/cycle_maybe_changed_after.rs
@@ -8,21 +8,24 @@ use salsa::{Database, Durability, Setter};
 
 #[salsa::input(debug)]
 struct Input {
+    #[returns(copy)]
     value: u32,
+    #[returns(copy)]
     max: u32,
 }
 
 #[salsa::interned(debug)]
 struct Output<'db> {
+    #[returns(copy)]
     value: u32,
 }
 
-#[salsa::tracked(cycle_initial=query_a_initial)]
+#[salsa::tracked(returns(copy), cycle_initial=query_a_initial)]
 fn query_c(db: &dyn salsa::Database, input: Input) -> u32 {
     query_d(db, input)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn query_d(db: &dyn salsa::Database, input: Input) -> u32 {
     let value = query_c(db, input);
     if value < input.max(db) * 2 {
@@ -45,12 +48,12 @@ fn query_a_initial(_db: &dyn Database, _id: salsa::Id, _input: Input) -> u32 {
 /// from the previous iteration.
 #[test_log::test]
 fn first_iteration_input_only() {
-    #[salsa::tracked(cycle_initial=query_a_initial)]
+    #[salsa::tracked(returns(copy), cycle_initial=query_a_initial)]
     fn query_a(db: &dyn salsa::Database, input: Input) -> u32 {
         query_b(db, input)
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn query_b(db: &dyn salsa::Database, input: Input) -> u32 {
         let value = query_a(db, input);
 
@@ -88,12 +91,13 @@ fn first_iteration_input_only() {
 fn nested_cycle_fewer_dependencies_in_first_iteration() {
     #[salsa::interned(debug)]
     struct ClassLiteral<'db> {
+        #[returns(copy)]
         scope: Scope<'db>,
     }
 
     #[salsa::tracked]
     impl<'db> ClassLiteral<'db> {
-        #[salsa::tracked]
+        #[salsa::tracked(returns(copy))]
         fn context(self, db: &'db dyn salsa::Database) -> u32 {
             let scope = self.scope(db);
 
@@ -104,10 +108,11 @@ fn nested_cycle_fewer_dependencies_in_first_iteration() {
 
     #[salsa::tracked(debug)]
     struct Scope<'db> {
+        #[returns(copy)]
         field: u32,
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn create_interned<'db>(db: &'db dyn salsa::Database, scope: Scope<'db>) -> ClassLiteral<'db> {
         ClassLiteral::new(db, scope)
     }
@@ -117,7 +122,7 @@ fn nested_cycle_fewer_dependencies_in_first_iteration() {
         scope: Scope<'db>,
     }
 
-    #[salsa::tracked(cycle_initial=head_initial)]
+    #[salsa::tracked(returns(copy), cycle_initial=head_initial)]
     fn cycle_head(db: &dyn salsa::Database, input: Input) -> Option<ClassLiteral<'_>> {
         let b = cycle_outer(db, input);
         tracing::info!("query_b = {b:?}");
@@ -132,12 +137,12 @@ fn nested_cycle_fewer_dependencies_in_first_iteration() {
         None
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn cycle_outer(db: &dyn salsa::Database, input: Input) -> Option<ClassLiteral<'_>> {
         cycle_participant(db, input)
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn cycle_participant(db: &dyn salsa::Database, input: Input) -> Option<ClassLiteral<'_>> {
         let value = cycle_head(db, input);
         tracing::info!("cycle_head = {value:?}");
@@ -157,7 +162,7 @@ fn nested_cycle_fewer_dependencies_in_first_iteration() {
         }
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn entry(db: &dyn salsa::Database, input: Input) -> u32 {
         let _ = input.value(db);
         let head = cycle_head(db, input);

--- a/tests/cycle_nested_converge_early.rs
+++ b/tests/cycle_nested_converge_early.rs
@@ -21,7 +21,7 @@ impl std::ops::Add for CycleValue {
 const MIN: CycleValue = CycleValue(0);
 const MAX: CycleValue = CycleValue(3);
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_a(db: &dyn salsa::Database) -> CycleValue {
     let b = query_b(db);
     let c = query_d(db);
@@ -29,7 +29,7 @@ fn query_a(db: &dyn salsa::Database) -> CycleValue {
     (b + c).min(MAX)
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_b(db: &dyn salsa::Database) -> CycleValue {
     let c_value = query_c(db);
 
@@ -40,7 +40,7 @@ fn query_b(db: &dyn salsa::Database) -> CycleValue {
     }
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_c(db: &dyn salsa::Database) -> CycleValue {
     let b_value = query_b(db);
 
@@ -51,7 +51,7 @@ fn query_c(db: &dyn salsa::Database) -> CycleValue {
     }
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_d(db: &dyn salsa::Database) -> CycleValue {
     let a_value = query_a(db);
 

--- a/tests/cycle_nested_converges_never.rs
+++ b/tests/cycle_nested_converges_never.rs
@@ -20,7 +20,7 @@ impl std::ops::Add for CycleValue {
 
 const MIN: CycleValue = CycleValue(0);
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_a(db: &dyn salsa::Database) -> CycleValue {
     let b = query_b(db);
 
@@ -28,12 +28,12 @@ fn query_a(db: &dyn salsa::Database) -> CycleValue {
     if b < CycleValue(1) { query_c(db) } else { b }
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_b(db: &dyn salsa::Database) -> CycleValue {
     query_a(db)
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_c(db: &dyn salsa::Database) -> CycleValue {
     let a_value = query_a(db);
     let d_value = query_d(db);
@@ -41,7 +41,7 @@ fn query_c(db: &dyn salsa::Database) -> CycleValue {
     a_value + d_value + CycleValue(1)
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_d(db: &dyn salsa::Database) -> CycleValue {
     query_c(db)
 }

--- a/tests/cycle_output.rs
+++ b/tests/cycle_output.rs
@@ -8,26 +8,29 @@ use salsa::{Setter, Storage};
 
 #[salsa::tracked]
 struct Output<'db> {
+    #[returns(copy)]
     value: u32,
 }
 
 #[salsa::input]
 struct InputValue {
+    #[returns(copy)]
     value: u32,
 }
 
 #[salsa::input(singleton)]
 struct StableInput {
+    #[returns(copy)]
     value: (),
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn read_value<'db>(db: &'db dyn Db, output: Output<'db>) -> u32 {
     StableInput::get(db).value(db);
     output.value(db)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn query_a(db: &dyn Db, input: InputValue) -> u32 {
     let val = query_b(db, input);
     let output = Output::new(db, val);
@@ -37,7 +40,7 @@ fn query_a(db: &dyn Db, input: InputValue) -> u32 {
     if val > 2 { val } else { val + input.value(db) }
 }
 
-#[salsa::tracked(cycle_initial=cycle_initial)]
+#[salsa::tracked(returns(copy), cycle_initial=cycle_initial)]
 fn query_b(db: &dyn Db, input: InputValue) -> u32 {
     query_a(db, input)
 }
@@ -46,12 +49,12 @@ fn cycle_initial(_db: &dyn Db, _id: salsa::Id, _input: InputValue) -> u32 {
     0
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn query_c(db: &dyn Db, input: InputValue) -> u32 {
     input.value(db)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn query_d(db: &dyn Db) -> u32 {
     StableInput::get(db).value(db);
     db.get_input().map(|input| input.value(db)).unwrap_or(0)

--- a/tests/cycle_recovery_call_back_into_cycle.rs
+++ b/tests/cycle_recovery_call_back_into_cycle.rs
@@ -6,12 +6,12 @@
 mod common;
 use common::{DatabaseWithValue, ValueDatabase};
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn fallback_value(db: &dyn ValueDatabase) -> u32 {
     query(db) + db.get_value()
 }
 
-#[salsa::tracked(cycle_fn=cycle_fn, cycle_initial=cycle_initial)]
+#[salsa::tracked(returns(copy), cycle_fn=cycle_fn, cycle_initial=cycle_initial)]
 fn query(db: &dyn ValueDatabase) -> u32 {
     let val = query(db);
     if val < 5 { val + 1 } else { val }

--- a/tests/cycle_recovery_call_query.rs
+++ b/tests/cycle_recovery_call_query.rs
@@ -2,12 +2,12 @@
 
 //! It's possible to call a Salsa query from within a cycle recovery fn.
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn fallback_value(_db: &dyn salsa::Database) -> u32 {
     10
 }
 
-#[salsa::tracked(cycle_fn = |db, _, _, _| fallback_value(db), cycle_initial = |_, _| 0)]
+#[salsa::tracked(returns(copy), cycle_fn = |db, _, _, _| fallback_value(db), cycle_initial = |_, _| 0)]
 fn query(db: &dyn salsa::Database) -> u32 {
     let val = query(db);
     if val < 5 { val + 1 } else { val }

--- a/tests/cycle_recovery_dependencies.rs
+++ b/tests/cycle_recovery_dependencies.rs
@@ -13,15 +13,16 @@ mod common;
 
 #[salsa::input]
 struct Input {
+    #[returns(copy)]
     value: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn entry(db: &dyn salsa::Database, input: Input) -> u32 {
     query(db, input)
 }
 
-#[salsa::tracked(cycle_fn=cycle_fn, cycle_initial=cycle_initial)]
+#[salsa::tracked(returns(copy), cycle_fn=cycle_fn, cycle_initial=cycle_initial)]
 fn query(db: &dyn salsa::Database, input: Input) -> u32 {
     let val = query(db, input);
     if val < 5 { val + 1 } else { val }

--- a/tests/cycle_regression_455.rs
+++ b/tests/cycle_regression_455.rs
@@ -2,12 +2,12 @@
 
 use salsa::{Database, Setter};
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn memoized(db: &dyn Database, input: MyInput) -> u32 {
     memoized_a(db, MyTracked::new(db, input.field(db)))
 }
 
-#[salsa::tracked(cycle_initial=cycle_initial)]
+#[salsa::tracked(returns(copy), cycle_initial=cycle_initial)]
 fn memoized_a<'db>(db: &'db dyn Database, tracked: MyTracked<'db>) -> u32 {
     MyTracked::new(db, 0);
     memoized_b(db, tracked)
@@ -16,7 +16,7 @@ fn cycle_initial(_db: &dyn Database, _id: salsa::Id, _input: MyTracked) -> u32 {
     0
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn memoized_b<'db>(db: &'db dyn Database, tracked: MyTracked<'db>) -> u32 {
     let incr = tracked.field(db);
     let a = memoized_a(db, tracked);
@@ -25,11 +25,13 @@ fn memoized_b<'db>(db: &'db dyn Database, tracked: MyTracked<'db>) -> u32 {
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
 #[salsa::tracked]
 struct MyTracked<'db> {
+    #[returns(copy)]
     field: u32,
 }
 

--- a/tests/cycle_result_dependencies.rs
+++ b/tests/cycle_result_dependencies.rs
@@ -4,10 +4,11 @@ use salsa::{Database, Setter};
 
 #[salsa::input]
 struct Input {
+    #[returns(copy)]
     value: i32,
 }
 
-#[salsa::tracked(cycle_result=cycle_result)]
+#[salsa::tracked(returns(copy), cycle_result=cycle_result)]
 fn has_cycle(db: &dyn Database, input: Input) -> i32 {
     has_cycle(db, input)
 }

--- a/tests/cycle_specify.rs
+++ b/tests/cycle_specify.rs
@@ -9,21 +9,22 @@ use expect_test::expect;
 
 #[salsa::tracked]
 struct Item<'db> {
+    #[returns(copy)]
     value: (),
 }
 
-#[salsa::tracked(specify)]
+#[salsa::tracked(returns(copy), specify)]
 fn specified(db: &dyn salsa::Database, item: Item<'_>) -> u32 {
     item.value(db);
     0
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn read_specified(db: &dyn salsa::Database, item: Item<'_>) -> u32 {
     specified(db, item)
 }
 
-#[salsa::tracked(cycle_initial = initial)]
+#[salsa::tracked(returns(copy), cycle_initial = initial)]
 fn cycle(db: &dyn salsa::Database) -> Option<Item<'_>> {
     let item = cycle(db).unwrap_or_else(|| Item::new(db, ()));
 

--- a/tests/cycle_stale_cycle_heads.rs
+++ b/tests/cycle_stale_cycle_heads.rs
@@ -22,11 +22,12 @@
 
 #[salsa::input]
 struct Input {
+    #[returns(copy)]
     value: u32,
 }
 
 // Outer cycle head - should iterate
-#[salsa::tracked(cycle_initial = initial_zero)]
+#[salsa::tracked(returns(copy), cycle_initial = initial_zero)]
 fn query_e(db: &dyn salsa::Database, input: Input) -> u32 {
     // First call C to establish the nested cycles
     let c_val = query_c(db, input);
@@ -39,12 +40,12 @@ fn query_e(db: &dyn salsa::Database, input: Input) -> u32 {
     c_val.min(x_val)
 }
 
-#[salsa::tracked(cycle_initial = initial_zero)]
+#[salsa::tracked(returns(copy), cycle_initial = initial_zero)]
 fn query_c(db: &dyn salsa::Database, input: Input) -> u32 {
     query_d(db, input)
 }
 
-#[salsa::tracked(cycle_initial = initial_zero)]
+#[salsa::tracked(returns(copy), cycle_initial = initial_zero)]
 fn query_d(db: &dyn salsa::Database, input: Input) -> u32 {
     let b_val = query_b(db, input);
 
@@ -54,7 +55,7 @@ fn query_d(db: &dyn salsa::Database, input: Input) -> u32 {
     b_val.min(e_val)
 }
 
-#[salsa::tracked(cycle_initial = initial_zero)]
+#[salsa::tracked(returns(copy), cycle_initial = initial_zero)]
 fn query_b(db: &dyn salsa::Database, input: Input) -> u32 {
     // First call A - this will detect A<->B cycle and A will complete
     let a_val = query_a(db, input);
@@ -66,7 +67,7 @@ fn query_b(db: &dyn salsa::Database, input: Input) -> u32 {
     (a_val + d_val + c_val).min(50)
 }
 
-#[salsa::tracked(cycle_initial = initial_zero)]
+#[salsa::tracked(returns(copy), cycle_initial = initial_zero)]
 fn query_a(db: &dyn salsa::Database, input: Input) -> u32 {
     // Read B to create A<->B cycle
     let b_val = query_b(db, input);
@@ -77,7 +78,7 @@ fn query_a(db: &dyn salsa::Database, input: Input) -> u32 {
     b_val.max(val)
 }
 
-#[salsa::tracked(cycle_initial = initial_zero)]
+#[salsa::tracked(returns(copy), cycle_initial = initial_zero)]
 fn query_x(db: &dyn salsa::Database, input: Input) -> u32 {
     // This reads A's memoized result which has stale cycle_heads
     query_a(db, input)

--- a/tests/cycle_tracked.rs
+++ b/tests/cycle_tracked.rs
@@ -36,12 +36,15 @@ struct Node<'db> {
     #[tracked]
     edges: Vec<Edge>,
 
+    #[returns(copy)]
     graph: GraphInput,
 }
 
 #[salsa::input(debug)]
 struct GraphInput {
+    #[returns(copy)]
     simple: bool,
+    #[returns(copy)]
     fixpoint_variant: usize,
 }
 
@@ -86,7 +89,7 @@ fn create_graph(db: &dyn salsa::Database, input: GraphInput) -> Graph<'_> {
 }
 
 /// Computes the minimum cost from the node with offset `0` to the given node.
-#[salsa::tracked(cycle_initial=max_initial)]
+#[salsa::tracked(returns(copy), cycle_initial=max_initial)]
 fn cost_to_start<'db>(db: &'db dyn Database, node: Node<'db>) -> usize {
     let mut min_cost = usize::MAX;
     let graph = create_graph(db, node.graph(db));
@@ -188,6 +191,7 @@ fn main() {
 struct IterationNode<'db> {
     #[returns(ref)]
     name: String,
+    #[returns(copy)]
     iteration: usize,
 }
 
@@ -206,7 +210,7 @@ struct IterationNode<'db> {
 /// 3. Second iteration: returns `[iter_0, iter_1]`
 /// 4. Third iteration (only for variant=1): returns `[iter_0, iter_1, iter_2]`
 /// 5. Further iterations: no change, fixpoint reached
-#[salsa::tracked(cycle_initial=initial_with_structs)]
+#[salsa::tracked(returns(clone), cycle_initial=initial_with_structs)]
 fn create_tracked_in_cycle(db: &dyn Database, input: GraphInput) -> Vec<IterationNode<'_>> {
     // Check if we should create more nodes based on the input.
     let variant = input.fixpoint_variant(db);
@@ -304,12 +308,13 @@ struct NameWithOffset<'db> {
     name: String,
 
     #[tracked]
+    #[returns(copy)]
     offset: u32,
 }
 
 #[test]
 fn cycle_tracked_struct_with_tracked_field() {
-    #[salsa::tracked(cycle_initial=|_,_| 0)]
+    #[salsa::tracked(returns(copy), cycle_initial=|_,_| 0)]
     fn query_a(db: &dyn salsa::Database) -> u32 {
         let offset = query_b(db);
 
@@ -318,7 +323,7 @@ fn cycle_tracked_struct_with_tracked_field() {
         tracked.offset(db)
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn query_b(db: &dyn salsa::Database) -> u32 {
         let base_offset = query_a(db);
 

--- a/tests/cycle_tracked_own_input.rs
+++ b/tests/cycle_tracked_own_input.rs
@@ -16,24 +16,28 @@ use salsa::{Database, Setter};
 #[salsa::input(debug)]
 struct ClassNode {
     name: String,
+    #[returns(copy)]
     type_params: Option<TypeParamNode>,
 }
 
 #[salsa::input(debug)]
 struct TypeParamNode {
     name: String,
+    #[returns(copy)]
     constraint: Option<ClassNode>,
 }
 
 #[salsa::interned(debug)]
 struct Class<'db> {
     name: String,
+    #[returns(copy)]
     type_params: Option<TypeParam<'db>>,
 }
 
 #[salsa::tracked(debug)]
 struct TypeParam<'db> {
     name: String,
+    #[returns(copy)]
     constraint: Option<Type<'db>>,
 }
 
@@ -52,7 +56,7 @@ impl Type<'_> {
     }
 }
 
-#[salsa::tracked(cycle_initial=infer_class_initial)]
+#[salsa::tracked(returns(copy), cycle_initial=infer_class_initial)]
 fn infer_class(db: &dyn salsa::Database, node: ClassNode) -> Type<'_> {
     Type::Class(Class::new(
         db,
@@ -61,7 +65,7 @@ fn infer_class(db: &dyn salsa::Database, node: ClassNode) -> Type<'_> {
     ))
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn infer_type_param(db: &dyn salsa::Database, node: TypeParamNode) -> TypeParam<'_> {
     if let Some(constraint) = node.constraint(db) {
         // Reuse the type param from the class if any.
@@ -73,11 +77,11 @@ fn infer_type_param(db: &dyn salsa::Database, node: TypeParamNode) -> TypeParam<
         match infer_class(db, constraint) {
             Type::Class(class) => class
                 .type_params(db)
-                .unwrap_or_else(|| TypeParam::new(db, node.name(db), Some(Type::Unknown))),
-            Type::Unknown => TypeParam::new(db, node.name(db), Some(Type::Unknown)),
+                .unwrap_or_else(|| TypeParam::new(db, node.name(db).clone(), Some(Type::Unknown))),
+            Type::Unknown => TypeParam::new(db, node.name(db).clone(), Some(Type::Unknown)),
         }
     } else {
-        TypeParam::new(db, node.name(db), None)
+        TypeParam::new(db, node.name(db).clone(), None)
     }
 }
 

--- a/tests/dataflow.rs
+++ b/tests/dataflow.rs
@@ -18,7 +18,9 @@ struct Use {
 /// A Definition of a symbol, either of the form `base + increment` or `0 + increment`.
 #[salsa::input]
 struct Definition {
+    #[returns(copy)]
     base: Option<Use>,
+    #[returns(copy)]
     increment: usize,
 }
 
@@ -50,7 +52,7 @@ impl Type {
     }
 }
 
-#[salsa::tracked(cycle_fn=use_cycle_recover, cycle_initial=use_cycle_initial)]
+#[salsa::tracked(returns(clone), cycle_fn=use_cycle_recover, cycle_initial=use_cycle_initial)]
 fn infer_use(db: &dyn Db, u: Use) -> Type {
     let defs = u.reaching_definitions(db);
     match defs[..] {
@@ -60,7 +62,7 @@ fn infer_use(db: &dyn Db, u: Use) -> Type {
     }
 }
 
-#[salsa::tracked(cycle_fn=def_cycle_recover, cycle_initial=def_cycle_initial)]
+#[salsa::tracked(returns(clone), cycle_fn=def_cycle_recover, cycle_initial=def_cycle_initial)]
 fn infer_definition(db: &dyn Db, def: Definition) -> Type {
     let increment_ty = Type::Values(Box::from([def.increment(db)]));
     if let Some(base) = def.base(db) {

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -7,6 +7,7 @@ use salsa::{Database, Setter};
 
 #[salsa::input(debug)]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
@@ -17,6 +18,7 @@ struct NotSalsa {
 
 #[salsa::input(debug)]
 struct ComplexStruct {
+    #[returns(copy)]
     my_input: MyInput,
     not_salsa: NotSalsa,
 }
@@ -37,7 +39,7 @@ fn input() {
     })
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(clone))]
 fn leak_debug_string(_db: &dyn salsa::Database, input: MyInput) -> String {
     format!("{input:?}")
 }
@@ -65,17 +67,17 @@ fn untracked_dependencies() {
     assert!(s.contains(", field: 22 }"));
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn dep_a(db: &dyn salsa::Database, input: MyInput) -> u32 {
     input.field(db)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn dep_b(db: &dyn salsa::Database, input: MyInput) -> u32 {
     input.field(db)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn debug_branch_query(db: &dyn salsa::Database, selector: MyInput, a: MyInput, b: MyInput) -> u32 {
     // `Debug` for salsa structs is explicitly untracked; branching on it is unsound.
     // This test demonstrates it can break the backdate invariant.
@@ -119,7 +121,9 @@ fn debug_branch_can_trip_backdate_assertion() {
 
 #[salsa::tracked]
 struct DerivedCustom<'db> {
+    #[returns(copy)]
     my_input: MyInput,
+    #[returns(copy)]
     value: u32,
 }
 
@@ -132,7 +136,7 @@ impl std::fmt::Debug for DerivedCustom<'_> {
     }
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(clone))]
 fn leak_derived_custom(db: &dyn salsa::Database, input: MyInput, value: u32) -> String {
     let c = DerivedCustom::new(db, input, value);
     format!("{c:?}")

--- a/tests/debug_bounds.rs
+++ b/tests/debug_bounds.rs
@@ -9,41 +9,49 @@ struct Debug;
 
 #[salsa::input(debug)]
 struct DebugInput {
+    #[returns(copy)]
     field: Debug,
 }
 
 #[salsa::input]
 struct NotDebugInput {
+    #[returns(copy)]
     field: NotDebug,
 }
 
 #[salsa::interned(debug)]
 struct DebugInterned {
+    #[returns(copy)]
     field: Debug,
 }
 
 #[salsa::interned]
 struct NotDebugInterned {
+    #[returns(copy)]
     field: NotDebug,
 }
 
 #[salsa::interned(no_lifetime, debug)]
 struct DebugInternedNoLifetime {
+    #[returns(copy)]
     field: Debug,
 }
 
 #[salsa::interned(no_lifetime)]
 struct NotDebugInternedNoLifetime {
+    #[returns(copy)]
     field: NotDebug,
 }
 
 #[salsa::tracked(debug)]
 struct DebugTracked<'db> {
+    #[returns(copy)]
     field: Debug,
 }
 
 #[salsa::tracked]
 struct NotDebugTracked<'db> {
+    #[returns(copy)]
     field: NotDebug,
 }
 

--- a/tests/debug_db_contents.rs
+++ b/tests/debug_db_contents.rs
@@ -7,15 +7,17 @@ struct InternedStruct<'db> {
 
 #[salsa::input(debug)]
 struct InputStruct {
+    #[returns(copy)]
     field: u32,
 }
 
 #[salsa::tracked(debug)]
 struct TrackedStruct<'db> {
+    #[returns(copy)]
     field: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn tracked_fn(db: &dyn salsa::Database, input: InputStruct) -> TrackedStruct<'_> {
     TrackedStruct::new(db, input.field(db) * 2)
 }

--- a/tests/deletion-cascade.rs
+++ b/tests/deletion-cascade.rs
@@ -12,10 +12,11 @@ use test_log::test;
 
 #[salsa::input(singleton, debug)]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn final_result(db: &dyn LogDatabase, input: MyInput) -> u32 {
     db.push_log(format!("final_result({input:?})"));
     let mut sum = 0;
@@ -27,10 +28,11 @@ fn final_result(db: &dyn LogDatabase, input: MyInput) -> u32 {
 
 #[salsa::tracked]
 struct MyTracked<'db> {
+    #[returns(copy)]
     field: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(clone))]
 fn create_tracked_structs(db: &dyn LogDatabase, input: MyInput) -> Vec<MyTracked<'_>> {
     db.push_log(format!("intermediate_result({input:?})"));
     (0..input.field(db))
@@ -38,13 +40,13 @@ fn create_tracked_structs(db: &dyn LogDatabase, input: MyInput) -> Vec<MyTracked
         .collect()
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn contribution_from_struct<'db>(db: &'db dyn LogDatabase, tracked: MyTracked<'db>) -> u32 {
     let m = MyTracked::new(db, tracked.field(db));
     copy_field(db, m) * 2
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn copy_field<'db>(db: &'db dyn LogDatabase, tracked: MyTracked<'db>) -> u32 {
     tracked.field(db)
 }

--- a/tests/deletion-drops.rs
+++ b/tests/deletion-drops.rs
@@ -11,11 +11,13 @@ use test_log::test;
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     identity: u32,
 }
 
 #[salsa::tracked]
 struct MyTracked<'db> {
+    #[returns(copy)]
     identifier: u32,
 
     #[tracked]
@@ -44,7 +46,7 @@ impl Drop for Bomb {
 
 #[salsa::tracked]
 impl MyInput {
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn create_tracked_struct(self, db: &dyn Database) -> MyTracked<'_> {
         MyTracked::new(
             db,

--- a/tests/deletion.rs
+++ b/tests/deletion.rs
@@ -12,10 +12,11 @@ use test_log::test;
 
 #[salsa::input(debug)]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn final_result(db: &dyn LogDatabase, input: MyInput) -> u32 {
     db.push_log(format!("final_result({input:?})"));
     let mut sum = 0;
@@ -27,10 +28,11 @@ fn final_result(db: &dyn LogDatabase, input: MyInput) -> u32 {
 
 #[salsa::tracked]
 struct MyTracked<'db> {
+    #[returns(copy)]
     field: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(clone))]
 fn create_tracked_structs(db: &dyn LogDatabase, input: MyInput) -> Vec<MyTracked<'_>> {
     db.push_log(format!("intermediate_result({input:?})"));
     (0..input.field(db))
@@ -38,7 +40,7 @@ fn create_tracked_structs(db: &dyn LogDatabase, input: MyInput) -> Vec<MyTracked
         .collect()
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn contribution_from_struct<'db>(db: &'db dyn LogDatabase, tracked: MyTracked<'db>) -> u32 {
     tracked.field(db) * 2
 }

--- a/tests/durability.rs
+++ b/tests/durability.rs
@@ -7,15 +7,16 @@ use test_log::test;
 
 #[salsa::input]
 struct N {
+    #[returns(copy)]
     value: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn add3(db: &dyn Database, a: N, b: N, c: N) -> u32 {
     add(db, a, b) + c.value(db)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn add(db: &dyn Database, a: N, b: N) -> u32 {
     a.value(db) + b.value(db)
 }

--- a/tests/elided-lifetime-in-tracked-fn.rs
+++ b/tests/elided-lifetime-in-tracked-fn.rs
@@ -11,10 +11,11 @@ use test_log::test;
 
 #[salsa::input(debug)]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn final_result(db: &dyn LogDatabase, input: MyInput) -> u32 {
     db.push_log(format!("final_result({input:?})"));
     intermediate_result(db, input).field(db) * 2
@@ -22,10 +23,11 @@ fn final_result(db: &dyn LogDatabase, input: MyInput) -> u32 {
 
 #[salsa::tracked]
 struct MyTracked<'db> {
+    #[returns(copy)]
     field: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn intermediate_result(db: &dyn LogDatabase, input: MyInput) -> MyTracked<'_> {
     db.push_log(format!("intermediate_result({input:?})"));
     MyTracked::new(db, input.field(db) / 2)

--- a/tests/expect_reuse_field_x_of_a_tracked_struct_changes_but_fn_depends_on_field_y.rs
+++ b/tests/expect_reuse_field_x_of_a_tracked_struct_changes_but_fn_depends_on_field_y.rs
@@ -12,16 +12,17 @@ use salsa::Setter;
 
 #[salsa::input(debug)]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn final_result_depends_on_x(db: &dyn LogDatabase, input: MyInput) -> u32 {
     db.push_log(format!("final_result_depends_on_x({input:?})"));
     intermediate_result(db, input).x(db) * 2
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn final_result_depends_on_y(db: &dyn LogDatabase, input: MyInput) -> u32 {
     db.push_log(format!("final_result_depends_on_y({input:?})"));
     intermediate_result(db, input).y(db) * 2
@@ -30,12 +31,14 @@ fn final_result_depends_on_y(db: &dyn LogDatabase, input: MyInput) -> u32 {
 #[salsa::tracked]
 struct MyTracked<'db> {
     #[tracked]
+    #[returns(copy)]
     x: u32,
     #[tracked]
+    #[returns(copy)]
     y: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn intermediate_result(db: &dyn LogDatabase, input: MyInput) -> MyTracked<'_> {
     MyTracked::new(db, input.field(db).div_ceil(2), input.field(db) / 2)
 }

--- a/tests/expect_reuse_field_x_of_an_input_changes_but_fn_depends_on_field_y.rs
+++ b/tests/expect_reuse_field_x_of_an_input_changes_but_fn_depends_on_field_y.rs
@@ -12,17 +12,19 @@ use salsa::Setter;
 
 #[salsa::input(debug)]
 struct MyInput {
+    #[returns(copy)]
     x: u32,
+    #[returns(copy)]
     y: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn result_depends_on_x(db: &dyn LogDatabase, input: MyInput) -> u32 {
     db.push_log(format!("result_depends_on_x({input:?})"));
     input.x(db) + 1
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn result_depends_on_y(db: &dyn LogDatabase, input: MyInput) -> u32 {
     db.push_log(format!("result_depends_on_y({input:?})"));
     input.y(db) - 1

--- a/tests/hash_collision.rs
+++ b/tests/hash_collision.rs
@@ -8,6 +8,7 @@ fn hello() {
 
     #[salsa::input]
     struct Bool {
+        #[returns(copy)]
         value: bool,
     }
 
@@ -17,7 +18,7 @@ fn hello() {
     #[salsa::tracked]
     struct False<'db> {}
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn hello(db: &dyn Database, bool: Bool) {
         if bool.value(db) {
             True::new(db);

--- a/tests/hello_world.rs
+++ b/tests/hello_world.rs
@@ -11,10 +11,11 @@ use test_log::test;
 
 #[salsa::input(debug)]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn final_result(db: &dyn LogDatabase, input: MyInput) -> u32 {
     db.push_log(format!("final_result({input:?})"));
     intermediate_result(db, input).field(db) * 2
@@ -22,10 +23,11 @@ fn final_result(db: &dyn LogDatabase, input: MyInput) -> u32 {
 
 #[salsa::tracked]
 struct MyTracked<'db> {
+    #[returns(copy)]
     field: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn intermediate_result(db: &dyn LogDatabase, input: MyInput) -> MyTracked<'_> {
     db.push_log(format!("intermediate_result({input:?})"));
     MyTracked::new(db, input.field(db) / 2)

--- a/tests/input_default.rs
+++ b/tests/input_default.rs
@@ -7,8 +7,10 @@ use test_log::test;
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     required: bool,
     #[default]
+    #[returns(copy)]
     optional: usize,
 }
 

--- a/tests/input_field_durability.rs
+++ b/tests/input_field_durability.rs
@@ -7,9 +7,11 @@ use test_log::test;
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     required_field: bool,
 
     #[default]
+    #[returns(copy)]
     optional_field: usize,
 }
 

--- a/tests/input_setter_preserves_durability.rs
+++ b/tests/input_setter_preserves_durability.rs
@@ -6,9 +6,11 @@ use test_log::test;
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     required_field: bool,
 
     #[default]
+    #[returns(copy)]
     optional_field: usize,
 }
 

--- a/tests/intern_access_in_different_revision.rs
+++ b/tests/intern_access_in_different_revision.rs
@@ -4,11 +4,13 @@ use salsa::{Durability, Setter};
 
 #[salsa::interned(no_lifetime)]
 struct Interned {
+    #[returns(copy)]
     field: u32,
 }
 
 #[salsa::input]
 struct Input {
+    #[returns(copy)]
     field: i32,
 }
 

--- a/tests/interned-revisions.rs
+++ b/tests/interned-revisions.rs
@@ -11,6 +11,7 @@ use test_log::test;
 
 #[salsa::input]
 struct Input {
+    #[returns(copy)]
     field1: usize,
 }
 
@@ -61,7 +62,7 @@ struct PanickingInterned<'db> {
     value: BadHash,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn intern_panicking(db: &dyn Database, input: Input) -> PanickingInterned<'_> {
     PanickingInterned::new(db, PanickingLookup(input.field1(db)))
 }
@@ -92,12 +93,13 @@ fn panic_during_reuse_does_not_orphan_slot() {
 #[salsa::interned]
 #[derive(Debug)]
 struct NestedInterned<'db> {
+    #[returns(copy)]
     interned: Interned<'db>,
 }
 
 #[test]
 fn test_intern_new() {
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn function(db: &dyn Database, input: Input) -> Interned<'_> {
         Interned::new(db, BadHash(input.field1(db)))
     }
@@ -128,7 +130,7 @@ fn test_intern_new() {
 
 #[test]
 fn test_reintern() {
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn function(db: &dyn Database, input: Input) -> Interned<'_> {
         let _ = input.field1(db);
         Interned::new(db, BadHash(0))
@@ -164,7 +166,7 @@ fn test_reintern() {
 
 #[test]
 fn test_durability() {
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn function(db: &dyn Database, _input: Input) -> Interned<'_> {
         Interned::new(db, BadHash(0))
     }
@@ -195,7 +197,7 @@ fn test_durability() {
 
 #[test]
 fn test_non_reusable_new_value_does_not_record_dependency() {
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn function(db: &dyn Database, input: Input) -> Interned<'_> {
         let _ = input.field1(db);
         Interned::new(db, BadHash(0))
@@ -222,7 +224,7 @@ fn test_non_reusable_new_value_does_not_record_dependency() {
 
 #[test]
 fn test_non_reusable_existing_value_does_not_record_dependency() {
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn function(db: &dyn Database, input: Input) -> Interned<'_> {
         let _ = input.field1(db);
         Interned::new(db, BadHash(0))
@@ -251,14 +253,14 @@ fn test_non_reusable_existing_value_does_not_record_dependency() {
 
 #[test]
 fn test_non_reusable_value_still_updates_query_stamp() {
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn outer(db: &dyn Database, input: Input) -> bool {
         let _ = input.field1(db);
         let _ = Interned::new(db, BadHash(0));
         true
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn intern_from_input(db: &dyn Database, input: Input) -> Interned<'_> {
         Interned::new(db, BadHash(input.field1(db)))
     }
@@ -299,7 +301,7 @@ struct SpilledInterned<'db> {
 
 #[test]
 fn test_revisions_above_inline_capacity() {
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn function(db: &dyn Database, input: Input) -> SpilledInterned<'_> {
         SpilledInterned::new(db, BadHash(input.field1(db)))
     }
@@ -327,7 +329,7 @@ fn test_revisions_above_inline_capacity() {
 
 #[test]
 fn test_immortal() {
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn function(db: &dyn Database, input: Input) -> Immortal<'_> {
         Immortal::new(db, BadHash(input.field1(db)))
     }
@@ -351,7 +353,7 @@ fn test_immortal() {
 
 #[test]
 fn test_reuse() {
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn function(db: &dyn Database, input: Input) -> Interned<'_> {
         Interned::new(db, BadHash(input.field1(db)))
     }
@@ -453,12 +455,12 @@ fn test_reuse() {
 fn reuse_discards_memos_for_old_generation() {
     use salsa::plumbing::AsId;
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn intern(db: &dyn Database, input: Input) -> Interned<'_> {
         Interned::new(db, BadHash(input.field1(db)))
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn read(db: &dyn Database, interned: Interned<'_>) -> usize {
         interned.field1(db).0
     }
@@ -488,12 +490,12 @@ fn reuse_discards_memos_for_old_generation() {
 
 #[test]
 fn test_reuse_indirect() {
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn intern(db: &dyn Database, input: Input, value: usize) -> Interned<'_> {
         intern_inner(db, input, value)
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn intern_inner(db: &dyn Database, input: Input, value: usize) -> Interned<'_> {
         let _i = input.field1(db); // Only low durability interned values are garbage collected.
         Interned::new(db, BadHash(value))
@@ -534,12 +536,12 @@ fn test_reuse_indirect() {
 #[test]
 fn test_reuse_interned_input() {
     // A query that creates an interned value.
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn create_interned(db: &dyn Database, input: Input) -> Interned<'_> {
         Interned::new(db, BadHash(input.field1(db)))
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn use_interned<'db>(db: &'db dyn Database, interned: Interned<'db>) -> usize {
         interned.field1(db).0
     }
@@ -576,13 +578,13 @@ fn test_reuse_interned_input() {
 #[test]
 fn test_reuse_multiple_interned_input() {
     // A query that creates an interned value.
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn create_interned(db: &dyn Database, input: Input) -> Interned<'_> {
         Interned::new(db, BadHash(input.field1(db)))
     }
 
     // A query that creates an interned value.
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn create_nested_interned<'db>(
         db: &'db dyn Database,
         interned: Interned<'db>,
@@ -590,13 +592,13 @@ fn test_reuse_multiple_interned_input() {
         NestedInterned::new(db, interned)
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn use_interned<'db>(db: &'db dyn Database, interned: Interned<'db>) -> usize {
         interned.field1(db).0
     }
 
     // A query that reads an interned value.
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn use_nested_interned<'db>(
         db: &'db dyn Database,
         nested_interned: NestedInterned<'db>,
@@ -643,7 +645,7 @@ fn test_reuse_multiple_interned_input() {
 
 #[test]
 fn test_durability_increase() {
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn intern(db: &dyn Database, input: Input, value: usize) -> Interned<'_> {
         let _f = input.field1(db);
         Interned::new(db, BadHash(value))

--- a/tests/interned-structs.rs
+++ b/tests/interned-structs.rs
@@ -22,6 +22,7 @@ struct InternedString<'db> {
 
 #[salsa::interned(debug)]
 struct InternedPair<'db> {
+    #[returns(copy)]
     data: (InternedString<'db>, InternedString<'db>),
 }
 
@@ -92,7 +93,7 @@ struct InternedOverGeneric {
     value: Generic<String>,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(clone))]
 fn intern_stuff(db: &dyn salsa::Database) -> String {
     let s1 = InternedString::new(db, "Hello, ".to_string());
     let s2 = InternedString::new(db, "World, ");

--- a/tests/lru.rs
+++ b/tests/lru.rs
@@ -34,16 +34,17 @@ impl Drop for HotPotato {
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
-#[salsa::tracked(lru = 8)]
+#[salsa::tracked(returns(clone), lru = 8)]
 fn get_hot_potato(db: &dyn LogDatabase, input: MyInput) -> Arc<HotPotato> {
     db.push_log(format!("get_hot_potato({:?})", input.field(db)));
     Arc::new(HotPotato::new(input.field(db)))
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn get_hot_potato2(db: &dyn LogDatabase, input: MyInput) -> u32 {
     db.push_log(format!("get_hot_potato2({:?})", input.field(db)));
     get_hot_potato(db, input).0

--- a/tests/manual_registration.rs
+++ b/tests/manual_registration.rs
@@ -3,25 +3,28 @@
 mod ingredients {
     #[salsa::input]
     pub(super) struct MyInput {
+        #[returns(copy)]
         field: u32,
     }
 
     #[salsa::tracked]
     pub(super) struct MyTracked<'db> {
+        #[returns(copy)]
         pub(super) field: u32,
     }
 
     #[salsa::interned]
     pub(super) struct MyInterned<'db> {
+        #[returns(copy)]
         pub(super) field: u32,
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     pub(super) fn intern<'db>(db: &'db dyn salsa::Database, input: MyInput) -> MyInterned<'db> {
         MyInterned::new(db, input.field(db))
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     pub(super) fn track<'db>(db: &'db dyn salsa::Database, input: MyInput) -> MyTracked<'db> {
         MyTracked::new(db, input.field(db))
     }

--- a/tests/memory-usage.rs
+++ b/tests/memory-usage.rs
@@ -6,6 +6,7 @@ use salsa::{Database as _, Setter as _};
 
 #[salsa::input(heap_size = string_tuple_size_of)]
 struct MyInput {
+    #[returns(clone)]
     field: String,
 }
 
@@ -19,38 +20,38 @@ struct MyInterned<'db> {
     field: String,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(clone))]
 fn input_to_interned(db: &dyn salsa::Database, input: MyInput) -> MyInterned<'_> {
     MyInterned::new(db, input.field(db))
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn input_to_tracked(db: &dyn salsa::Database, input: MyInput) -> MyTracked<'_> {
     MyTracked::new(db, input.field(db))
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn maybe_input_to_tracked(db: &dyn salsa::Database, input: MyInput) -> Option<MyTracked<'_>> {
     let field = input.field(db);
     (!field.is_empty()).then(|| MyTracked::new(db, field))
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(clone))]
 fn input_to_string(_db: &dyn salsa::Database) -> String {
     "a".repeat(1000)
 }
 
-#[salsa::tracked(heap_size = string_size_of)]
+#[salsa::tracked(returns(clone), heap_size = string_size_of)]
 fn input_to_string_get_size(_db: &dyn salsa::Database) -> String {
     "a".repeat(1000)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn input_to_length(db: &dyn salsa::Database, input: MyInput) -> usize {
     input.field(db).len()
 }
 
-#[salsa::tracked(cycle_fn = cycle_recover_length, cycle_initial = cycle_initial_length)]
+#[salsa::tracked(returns(copy), cycle_fn = cycle_recover_length, cycle_initial = cycle_initial_length)]
 fn cycle_input_to_length(db: &dyn salsa::Database, input: MyInput) -> usize {
     cycle_input_to_length(db, input).max(input.field(db).len())
 }
@@ -77,7 +78,7 @@ fn string_tuple_size_of((x,): &(String,)) -> usize {
     x.capacity()
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn input_to_tracked_tuple(
     db: &dyn salsa::Database,
     input: MyInput,

--- a/tests/never_change.rs
+++ b/tests/never_change.rs
@@ -11,32 +11,33 @@ use test_log::test;
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     value: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn immutable_value(db: &dyn Database, input: MyInput) -> u32 {
     input.value(db)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn mixed_value(db: &dyn Database, immutable_input: MyInput, mutable_input: MyInput) -> u32 {
     immutable_value(db, immutable_input) + mutable_input.value(db)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn mixed_input_value(db: &dyn Database, immutable_input: MyInput, mutable_input: MyInput) -> u32 {
     immutable_input.value(db) + mutable_input.value(db)
 }
 
-#[salsa::tracked(lru = 1)]
+#[salsa::tracked(returns(copy), lru = 1)]
 #[cfg(not(feature = "persistence"))]
 fn immutable_value_with_lru(db: &dyn LogDatabase, input: MyInput) -> u32 {
     db.push_log(format!("immutable_value_with_lru({})", input.value(db)));
     input.value(db)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 #[cfg(not(feature = "persistence"))]
 fn value_from_lru(db: &dyn LogDatabase, input: MyInput) -> u32 {
     db.push_log(format!("value_from_lru({})", input.value(db)));
@@ -45,24 +46,25 @@ fn value_from_lru(db: &dyn LogDatabase, input: MyInput) -> u32 {
 
 #[salsa::tracked]
 struct Output<'db> {
+    #[returns(copy)]
     value: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn output(db: &dyn Database, input: MyInput) -> Output<'_> {
     let output = Output::new(db, input.value(db));
     specified::specify(db, output, input.value(db) + 1);
     output
 }
 
-#[salsa::tracked(lru = 1)]
+#[salsa::tracked(returns(copy), lru = 1)]
 fn output_with_lru(db: &dyn Database, input: MyInput) -> Output<'_> {
     let output = Output::new(db, input.value(db));
     specified::specify(db, output, input.value(db) + 1);
     output
 }
 
-#[salsa::tracked(specify)]
+#[salsa::tracked(returns(copy), specify)]
 fn specified<'db>(_db: &'db dyn Database, _output: Output<'db>) -> u32 {
     0
 }

--- a/tests/never_change_accumulate.rs
+++ b/tests/never_change_accumulate.rs
@@ -6,6 +6,7 @@ use test_log::test;
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     value: u32,
 }
 
@@ -13,12 +14,12 @@ struct MyInput {
 #[derive(Debug)]
 struct Log(#[allow(dead_code)] u32);
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn push_log(db: &dyn Database, input: MyInput) {
     Log(input.value(db)).accumulate(db);
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn outer(db: &dyn Database, input: MyInput) {
     push_log(db, input);
 }

--- a/tests/override_new_get_set.rs
+++ b/tests/override_new_get_set.rs
@@ -25,7 +25,7 @@ impl MyInput {
     }
 
     pub fn field(self, db: &dyn Db) -> String {
-        self.text(db)
+        self.text(db).clone()
     }
 
     pub fn set_field(self, db: &mut dyn Db, id: String) {
@@ -62,7 +62,7 @@ impl<'db> MyTracked<'db> {
     }
 
     pub fn field(self, db: &'db dyn Db) -> String {
-        self.text(db)
+        self.text(db).clone()
     }
 }
 

--- a/tests/panic-when-creating-tracked-struct-outside-of-tracked-fn.rs
+++ b/tests/panic-when-creating-tracked-struct-outside-of-tracked-fn.rs
@@ -5,6 +5,7 @@
 
 #[salsa::tracked]
 struct MyTracked<'db> {
+    #[returns(copy)]
     field: u32,
 }
 

--- a/tests/parallel/cancellation_token_cycle_nested.rs
+++ b/tests/parallel/cancellation_token_cycle_nested.rs
@@ -17,18 +17,18 @@ struct CycleValue(u32);
 const MIN: CycleValue = CycleValue(0);
 const MAX: CycleValue = CycleValue(3);
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_a(db: &dyn KnobsDatabase) -> CycleValue {
     query_b(db)
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_b(db: &dyn KnobsDatabase) -> CycleValue {
     let c_value = query_c(db);
     CycleValue(c_value.0 + 1).min(MAX)
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_c(db: &dyn KnobsDatabase) -> CycleValue {
     let d_value = query_d(db);
     let e_value = query_e(db);
@@ -37,17 +37,17 @@ fn query_c(db: &dyn KnobsDatabase) -> CycleValue {
     CycleValue(d_value.0.max(e_value.0).max(b_value.0).max(a_value.0))
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_d(db: &dyn KnobsDatabase) -> CycleValue {
     query_c(db)
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_e(db: &dyn KnobsDatabase) -> CycleValue {
     query_c(db)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn query_f(db: &dyn KnobsDatabase) -> CycleValue {
     let c = query_c(db);
     // this should trigger cancellation again
@@ -55,7 +55,7 @@ fn query_f(db: &dyn KnobsDatabase) -> CycleValue {
     c
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn query_h(db: &dyn KnobsDatabase) {
     _ = db;
 }

--- a/tests/parallel/cancellation_token_multi_blocked.rs
+++ b/tests/parallel/cancellation_token_multi_blocked.rs
@@ -10,12 +10,12 @@ use salsa::{Cancelled, Database};
 
 use crate::setup::{Knobs, KnobsDatabase};
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn query_a(db: &dyn KnobsDatabase) -> u32 {
     query_b(db)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn query_b(db: &dyn KnobsDatabase) -> u32 {
     // Signal that t1 has started computing query_b
     db.signal(1);
@@ -26,7 +26,7 @@ fn query_b(db: &dyn KnobsDatabase) -> u32 {
     query_c(db)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn query_c(_db: &dyn KnobsDatabase) -> u32 {
     42
 }

--- a/tests/parallel/cancellation_token_recomputes.rs
+++ b/tests/parallel/cancellation_token_recomputes.rs
@@ -6,19 +6,19 @@ use salsa::{Cancelled, Database};
 
 use crate::setup::{Knobs, KnobsDatabase};
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn query_a(db: &dyn KnobsDatabase) -> u32 {
     query_b(db)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn query_b(db: &dyn KnobsDatabase) -> u32 {
     db.signal(1);
     db.wait_for(3);
     query_c(db)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn query_c(_db: &dyn KnobsDatabase) -> u32 {
     1
 }

--- a/tests/parallel/cycle_a_t1_b_t2.rs
+++ b/tests/parallel/cycle_a_t1_b_t2.rs
@@ -24,7 +24,7 @@ const MAX: CycleValue = CycleValue(3);
 // Signal 1: T1 has entered `query_a`
 // Signal 2: T2 has entered `query_b`
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_a(db: &dyn KnobsDatabase) -> CycleValue {
     db.signal(1);
 
@@ -34,7 +34,7 @@ fn query_a(db: &dyn KnobsDatabase) -> CycleValue {
     query_b(db)
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_b(db: &dyn KnobsDatabase) -> CycleValue {
     // Wait for Thread T1 to enter `query_a` before we continue.
     db.wait_for(1);

--- a/tests/parallel/cycle_a_t1_b_t2_fallback.rs
+++ b/tests/parallel/cycle_a_t1_b_t2_fallback.rs
@@ -21,7 +21,7 @@ const OFFSET_B: u32 = 0b1000;
 // Signal 1: T1 has entered `query_a`
 // Signal 2: T2 has entered `query_b`
 
-#[salsa::tracked(cycle_result=cycle_result_a)]
+#[salsa::tracked(returns(copy), cycle_result=cycle_result_a)]
 fn query_a(db: &dyn KnobsDatabase) -> u32 {
     db.signal(1);
 
@@ -31,7 +31,7 @@ fn query_a(db: &dyn KnobsDatabase) -> u32 {
     query_b(db) | OFFSET_A
 }
 
-#[salsa::tracked(cycle_result=cycle_result_b)]
+#[salsa::tracked(returns(copy), cycle_result=cycle_result_b)]
 fn query_b(db: &dyn KnobsDatabase) -> u32 {
     // Wait for Thread T1 to enter `query_a` before we continue.
     db.wait_for(1);

--- a/tests/parallel/cycle_ab_peeping_c.rs
+++ b/tests/parallel/cycle_ab_peeping_c.rs
@@ -16,7 +16,7 @@ const MIN: CycleValue = CycleValue(0);
 const MID: CycleValue = CycleValue(5);
 const MAX: CycleValue = CycleValue(10);
 
-#[salsa::tracked(cycle_initial=cycle_initial)]
+#[salsa::tracked(returns(copy), cycle_initial=cycle_initial)]
 fn query_a(db: &dyn KnobsDatabase) -> CycleValue {
     let b_value = query_b(db);
 
@@ -34,14 +34,14 @@ fn cycle_initial(_db: &dyn KnobsDatabase, _id: salsa::Id) -> CycleValue {
     MIN
 }
 
-#[salsa::tracked(cycle_initial=cycle_initial)]
+#[salsa::tracked(returns(copy), cycle_initial=cycle_initial)]
 fn query_b(db: &dyn KnobsDatabase) -> CycleValue {
     let a_value = query_a(db);
 
     CycleValue(a_value.0 + 1).min(MAX)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn query_c(db: &dyn KnobsDatabase) -> CycleValue {
     // Wait until T1 has reached MID then execute `query_b`.
     // This should block and (due to the configuration on our database) signal stage 2.

--- a/tests/parallel/cycle_iteration_mismatch.rs
+++ b/tests/parallel/cycle_iteration_mismatch.rs
@@ -15,14 +15,14 @@ const MIN: CycleValue = CycleValue(0);
 const MAX: CycleValue = CycleValue(5);
 
 // Query A: First cycle head - will iterate multiple times
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_a(db: &dyn KnobsDatabase) -> CycleValue {
     let b = query_b(db);
     CycleValue(b.0 + 1).min(MAX)
 }
 
 // Query B: Depends on C and D, creating complex dependencies
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_b(db: &dyn KnobsDatabase) -> CycleValue {
     let c = query_c(db);
     let d = query_d(db);
@@ -30,7 +30,7 @@ fn query_b(db: &dyn KnobsDatabase) -> CycleValue {
 }
 
 // Query C: Creates a cycle back to A
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_c(db: &dyn KnobsDatabase) -> CycleValue {
     let a = query_a(db);
     // Also depends on E to create more complex cycle structure
@@ -39,14 +39,14 @@ fn query_c(db: &dyn KnobsDatabase) -> CycleValue {
 }
 
 // Query D: Part of a separate cycle with E
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_d(db: &dyn KnobsDatabase) -> CycleValue {
     let e = query_e(db);
     CycleValue(e.0 + 1).min(MAX)
 }
 
 // Query E: Depends back on D and F
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_e(db: &dyn KnobsDatabase) -> CycleValue {
     let d = query_d(db);
     let f = query_f(db);
@@ -54,7 +54,7 @@ fn query_e(db: &dyn KnobsDatabase) -> CycleValue {
 }
 
 // Query F: Creates another cycle that might have different iteration count
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_f(db: &dyn KnobsDatabase) -> CycleValue {
     // Create a cycle that depends on earlier queries
     let b = query_b(db);

--- a/tests/parallel/cycle_nested_deep.rs
+++ b/tests/parallel/cycle_nested_deep.rs
@@ -15,18 +15,18 @@ struct CycleValue(u32);
 const MIN: CycleValue = CycleValue(0);
 const MAX: CycleValue = CycleValue(3);
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_a(db: &dyn KnobsDatabase) -> CycleValue {
     query_b(db)
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_b(db: &dyn KnobsDatabase) -> CycleValue {
     let c_value = query_c(db);
     CycleValue(c_value.0 + 1).min(MAX)
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_c(db: &dyn KnobsDatabase) -> CycleValue {
     let d_value = query_d(db);
     let e_value = query_e(db);
@@ -36,12 +36,12 @@ fn query_c(db: &dyn KnobsDatabase) -> CycleValue {
     CycleValue(d_value.0.max(e_value.0).max(b_value.0).max(a_value.0))
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_d(db: &dyn KnobsDatabase) -> CycleValue {
     query_c(db)
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_e(db: &dyn KnobsDatabase) -> CycleValue {
     query_c(db)
 }

--- a/tests/parallel/cycle_nested_deep_conditional.rs
+++ b/tests/parallel/cycle_nested_deep_conditional.rs
@@ -20,18 +20,18 @@ struct CycleValue(u32);
 const MIN: CycleValue = CycleValue(0);
 const MAX: CycleValue = CycleValue(3);
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_a(db: &dyn KnobsDatabase) -> CycleValue {
     query_b(db)
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_b(db: &dyn KnobsDatabase) -> CycleValue {
     let c_value = query_c(db);
     CycleValue(c_value.0 + 1).min(MAX)
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_c(db: &dyn KnobsDatabase) -> CycleValue {
     let d_value = query_d(db);
 
@@ -45,12 +45,12 @@ fn query_c(db: &dyn KnobsDatabase) -> CycleValue {
     }
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_d(db: &dyn KnobsDatabase) -> CycleValue {
     query_c(db)
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_e(db: &dyn KnobsDatabase) -> CycleValue {
     query_c(db)
 }

--- a/tests/parallel/cycle_nested_deep_conditional_changed.rs
+++ b/tests/parallel/cycle_nested_deep_conditional_changed.rs
@@ -23,21 +23,22 @@ const MAX: CycleValue = CycleValue(3);
 
 #[salsa::input]
 struct Input {
+    #[returns(copy)]
     value: u32,
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_a(db: &dyn salsa::Database, input: Input) -> CycleValue {
     query_b(db, input)
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_b(db: &dyn salsa::Database, input: Input) -> CycleValue {
     let c_value = query_c(db, input);
     CycleValue(c_value.0 + input.value(db).max(1)).min(MAX)
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_c(db: &dyn salsa::Database, input: Input) -> CycleValue {
     let d_value = query_d(db, input);
 
@@ -51,12 +52,12 @@ fn query_c(db: &dyn salsa::Database, input: Input) -> CycleValue {
     }
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_d(db: &dyn salsa::Database, input: Input) -> CycleValue {
     query_c(db, input)
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_e(db: &dyn salsa::Database, input: Input) -> CycleValue {
     query_c(db, input)
 }

--- a/tests/parallel/cycle_nested_deep_panic.rs
+++ b/tests/parallel/cycle_nested_deep_panic.rs
@@ -14,18 +14,18 @@ struct CycleValue(u32);
 const MIN: CycleValue = CycleValue(0);
 const MAX: CycleValue = CycleValue(3);
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_a(db: &dyn KnobsDatabase) -> CycleValue {
     query_b(db)
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_b(db: &dyn KnobsDatabase) -> CycleValue {
     let c_value = query_c(db);
     CycleValue(c_value.0 + 1).min(MAX)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn query_c(db: &dyn KnobsDatabase) -> CycleValue {
     let d_value = query_d(db);
 
@@ -39,12 +39,12 @@ fn query_c(db: &dyn KnobsDatabase) -> CycleValue {
     }
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_d(db: &dyn KnobsDatabase) -> CycleValue {
     query_b(db)
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_e(db: &dyn KnobsDatabase) -> CycleValue {
     query_c(db)
 }

--- a/tests/parallel/cycle_nested_three_threads.rs
+++ b/tests/parallel/cycle_nested_three_threads.rs
@@ -27,7 +27,7 @@ const MAX: CycleValue = CycleValue(3);
 // Signal 2: T2 has entered `query_b`
 // Signal 3: T3 has entered `query_c`
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_a(db: &dyn KnobsDatabase) -> CycleValue {
     db.signal(1);
     db.wait_for(3);
@@ -35,7 +35,7 @@ fn query_a(db: &dyn KnobsDatabase) -> CycleValue {
     query_b(db)
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_b(db: &dyn KnobsDatabase) -> CycleValue {
     db.wait_for(1);
     db.signal(2);
@@ -45,7 +45,7 @@ fn query_b(db: &dyn KnobsDatabase) -> CycleValue {
     CycleValue(c_value.0 + 1).min(MAX)
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_c(db: &dyn KnobsDatabase) -> CycleValue {
     db.wait_for(2);
     db.signal(3);

--- a/tests/parallel/cycle_nested_three_threads_changed.rs
+++ b/tests/parallel/cycle_nested_three_threads_changed.rs
@@ -29,6 +29,7 @@ const MAX: CycleValue = CycleValue(3);
 
 #[salsa::input]
 struct Input {
+    #[returns(copy)]
     value: u32,
 }
 
@@ -36,18 +37,18 @@ struct Input {
 // Signal 2: T2 has entered `query_b`
 // Signal 3: T3 has entered `query_c`
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_a(db: &dyn salsa::Database, input: Input) -> CycleValue {
     query_b(db, input)
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_b(db: &dyn salsa::Database, input: Input) -> CycleValue {
     let c_value = query_c(db, input);
     CycleValue(c_value.0 + input.value(db)).min(MAX)
 }
 
-#[salsa::tracked(cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_initial=initial)]
 fn query_c(db: &dyn salsa::Database, input: Input) -> CycleValue {
     let a_value = query_a(db, input);
     let b_value = query_b(db, input);

--- a/tests/parallel/cycle_panic.rs
+++ b/tests/parallel/cycle_panic.rs
@@ -4,14 +4,14 @@
 //! Test for panic in cycle recovery function, in cross-thread cycle.
 use crate::setup::{Knobs, KnobsDatabase};
 
-#[salsa::tracked(cycle_fn=cycle_fn, cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_fn=cycle_fn, cycle_initial=initial)]
 fn query_a(db: &dyn KnobsDatabase) -> u32 {
     db.signal(1);
     db.wait_for(2);
     query_b(db)
 }
 
-#[salsa::tracked(cycle_fn=cycle_fn, cycle_initial=initial)]
+#[salsa::tracked(returns(copy), cycle_fn=cycle_fn, cycle_initial=initial)]
 fn query_b(db: &dyn KnobsDatabase) -> u32 {
     db.wait_for(1);
     db.signal(2);

--- a/tests/parallel/cycle_provisional_depending_on_itself.rs
+++ b/tests/parallel/cycle_provisional_depending_on_itself.rs
@@ -28,12 +28,12 @@ struct CycleValue(u32);
 const MIN: CycleValue = CycleValue(0);
 const MAX: CycleValue = CycleValue(1);
 
-#[salsa::tracked(cycle_initial=cycle_initial)]
+#[salsa::tracked(returns(copy), cycle_initial=cycle_initial)]
 fn query_a(db: &dyn KnobsDatabase) -> CycleValue {
     query_b(db)
 }
 
-#[salsa::tracked(cycle_initial=cycle_initial)]
+#[salsa::tracked(returns(copy), cycle_initial=cycle_initial)]
 fn query_b(db: &dyn KnobsDatabase) -> CycleValue {
     // Wait for thread 2 to have entered `query_c`.
     tracing::debug!("Wait for signal 1 from thread 2");
@@ -54,7 +54,7 @@ fn query_b(db: &dyn KnobsDatabase) -> CycleValue {
     CycleValue(a_value.0 + 1).min(MAX)
 }
 
-#[salsa::tracked(cycle_initial=cycle_initial)]
+#[salsa::tracked(returns(copy), cycle_initial=cycle_initial)]
 fn query_c(db: &dyn KnobsDatabase) -> CycleValue {
     tracing::debug!("query_c: signaling thread1 to call c");
     db.signal(1);

--- a/tests/parallel/lru_eviction_cancels_cycle.rs
+++ b/tests/parallel/lru_eviction_cancels_cycle.rs
@@ -10,13 +10,14 @@ use crate::sync::thread;
 
 #[salsa::input]
 struct Input {
+    #[returns(copy)]
     value: u32,
 }
 
 /// A query with cycle recovery that will be interrupted by LRU eviction.
 /// This uses `cycle_initial` which gives it `FallbackImmediate` cycle recovery strategy,
 /// meaning it goes through `execute_maybe_iterate` and has `PoisonProvisionalIfPanicking`.
-#[salsa::tracked(cycle_initial = cycle_initial)]
+#[salsa::tracked(returns(copy), cycle_initial = cycle_initial)]
 fn cycle_query(db: &dyn KnobsDatabase, input: Input) -> u32 {
     // Signal that we've started the cycle query
     db.signal(1);
@@ -26,7 +27,7 @@ fn cycle_query(db: &dyn KnobsDatabase, input: Input) -> u32 {
     inner_query(db, input)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn inner_query(db: &dyn KnobsDatabase, input: Input) -> u32 {
     input.value(db)
 }

--- a/tests/parallel/memo_table_first_insert.rs
+++ b/tests/parallel/memo_table_first_insert.rs
@@ -3,17 +3,18 @@ use crate::{Knobs, KnobsDatabase};
 
 #[salsa::input]
 struct Input {
+    #[returns(copy)]
     value: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn query_a(db: &dyn KnobsDatabase, input: Input) -> u32 {
     db.signal(1);
     db.wait_for(2);
     input.value(db)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn query_b(db: &dyn KnobsDatabase, input: Input) -> u32 {
     db.wait_for(1);
     db.signal(2);

--- a/tests/persistence.rs
+++ b/tests/persistence.rs
@@ -9,11 +9,13 @@ use expect_test::expect;
 
 #[salsa::input(persist)]
 struct MyInput {
+    #[returns(copy)]
     field: usize,
 }
 
 #[salsa::input(persist, singleton)]
 struct MySingleton {
+    #[returns(copy)]
     field: usize,
 }
 
@@ -27,17 +29,17 @@ struct MyTracked<'db> {
     field: String,
 }
 
-#[salsa::tracked(persist)]
+#[salsa::tracked(returns(copy), persist)]
 fn unit_to_interned(db: &dyn salsa::Database) -> MyInterned<'_> {
     MyInterned::new(db, "a".repeat(50))
 }
 
-#[salsa::tracked(persist)]
+#[salsa::tracked(returns(copy), persist)]
 fn input_to_tracked(db: &dyn salsa::Database, input: MyInput) -> MyTracked<'_> {
     MyTracked::new(db, "a".repeat(input.field(db)))
 }
 
-#[salsa::tracked(persist)]
+#[salsa::tracked(returns(clone), persist)]
 fn input_pair_to_string(db: &dyn salsa::Database, input1: MyInput, input2: MyInput) -> String {
     "a".repeat(input1.field(db) + input2.field(db))
 }
@@ -310,13 +312,13 @@ fn everything() {
 fn partial_query() {
     use salsa::plumbing::ZalsaDatabase;
 
-    #[salsa::tracked(persist)]
+    #[salsa::tracked(returns(copy), persist)]
     fn query(db: &dyn salsa::Database, input: MyInput) -> usize {
         inner_query(db, input) + 1
     }
 
     // Note that the inner query is not persisted, but we should still preserve the dependency on `input.field`.
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn inner_query(db: &dyn salsa::Database, input: MyInput) -> usize {
         input.field(db)
     }
@@ -420,13 +422,13 @@ fn partial_query() {
 fn partial_query_interned() {
     use salsa::plumbing::{AsId, ZalsaDatabase};
 
-    #[salsa::tracked(persist)]
+    #[salsa::tracked(returns(copy), persist)]
     fn intern(db: &dyn salsa::Database, input: MyInput, value: usize) -> MyInterned<'_> {
         do_intern(db, input, value)
     }
 
     // Note that the inner query is not persisted, but we should still preserve the dependency on `MyInterned`.
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn do_intern(db: &dyn salsa::Database, input: MyInput, value: usize) -> MyInterned<'_> {
         let _i = input.field(db); // Only low durability interned values are garbage collected.
         MyInterned::new(db, value.to_string())
@@ -561,13 +563,13 @@ fn partial_query_interned() {
 #[test]
 #[should_panic(expected = "must be persistable")]
 fn invalid_specified_dependency() {
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn specify(db: &dyn salsa::Database) {
         let tracked = MyTracked::new(db, "a".to_string());
         specified_query::specify(db, tracked, 2222);
     }
 
-    #[salsa::tracked(specify, persist)]
+    #[salsa::tracked(returns(copy), specify, persist)]
     fn specified_query<'db>(_db: &'db dyn salsa::Database, _tracked: MyTracked<'db>) -> u32 {
         0
     }

--- a/tests/persistence_never_change.rs
+++ b/tests/persistence_never_change.rs
@@ -6,10 +6,11 @@ use salsa::Durability;
 
 #[salsa::input(singleton)]
 struct NonPersistedInput {
+    #[returns(copy)]
     value: usize,
 }
 
-#[salsa::tracked(persist)]
+#[salsa::tracked(returns(copy), persist)]
 fn query(db: &dyn salsa::Database) -> usize {
     NonPersistedInput::get(db).value(db)
 }

--- a/tests/preverify-struct-with-leaked-data-2.rs
+++ b/tests/preverify-struct-with-leaked-data-2.rs
@@ -17,17 +17,20 @@ thread_local! {
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field1: u32,
+    #[returns(copy)]
     field2: u32,
 }
 
 #[salsa::tracked]
 struct MyTracked<'db> {
     #[tracked]
+    #[returns(copy)]
     counter: usize,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn function(db: &dyn Database, input: MyInput) -> (usize, usize) {
     // Read input 1
     let _field1 = input.field1(db);
@@ -48,7 +51,7 @@ fn function(db: &dyn Database, input: MyInput) -> (usize, usize) {
     (result, tracked.counter(db))
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn counter_field<'db>(db: &'db dyn Database, input: MyInput, tracked: MyTracked<'db>) -> usize {
     // Read input 2. This will cause us to re-execute on revision 2.
     let _field2 = input.field2(db);

--- a/tests/preverify-struct-with-leaked-data.rs
+++ b/tests/preverify-struct-with-leaked-data.rs
@@ -17,17 +17,20 @@ thread_local! {
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field1: u32,
+    #[returns(copy)]
     field2: u32,
 }
 
 #[salsa::tracked]
 struct MyTracked<'db> {
     #[tracked]
+    #[returns(copy)]
     counter: usize,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn function(db: &dyn Database, input: MyInput) -> (usize, usize) {
     // Read input 1
     let _field1 = input.field1(db);
@@ -48,7 +51,7 @@ fn function(db: &dyn Database, input: MyInput) -> (usize, usize) {
     (result, tracked.counter(db))
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn counter_field<'db>(db: &'db dyn Database, tracked: MyTracked<'db>) -> usize {
     tracked.counter(db)
 }

--- a/tests/return_mode.rs
+++ b/tests/return_mode.rs
@@ -7,21 +7,39 @@ struct DefaultInput {
     text: String,
 }
 
+#[salsa::interned]
+struct DefaultInterned<'db> {
+    text: String,
+}
+
+#[salsa::tracked]
+struct DefaultTracked<'db> {
+    text: String,
+}
+
 #[salsa::tracked]
 fn default_fn(db: &dyn Database, input: DefaultInput) -> String {
-    let input: String = input.text(db);
-    input
+    let input: &String = input.text(db);
+
+    let interned = DefaultInterned::new(db, input.clone());
+    let _: &String = interned.text(db);
+
+    let tracked = DefaultTracked::new(db, input.clone());
+    let _: &String = tracked.text(db);
+
+    input.clone()
 }
 
 #[test]
 fn default_test() {
     salsa::DatabaseImpl::new().attach(|db| {
         let input = DefaultInput::new(db, "Test".into());
-        let x: String = default_fn(db, input);
+        let _: &String = input.text(db);
+        let x: &String = default_fn(db, input);
         expect_test::expect![[r#"
             "Test"
         "#]]
-        .assert_debug_eq(&x);
+        .assert_debug_eq(x);
     })
 }
 

--- a/tests/singleton.rs
+++ b/tests/singleton.rs
@@ -10,7 +10,9 @@ use test_log::test;
 
 #[salsa::input(singleton, debug)]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
+    #[returns(copy)]
     id_field: u16,
 }
 

--- a/tests/specify-discards-derived-tracked-outputs.rs
+++ b/tests/specify-discards-derived-tracked-outputs.rs
@@ -41,25 +41,28 @@ impl Database for EventDatabase {}
 
 #[salsa::tracked]
 struct Owner<'db> {
+    #[returns(copy)]
     value: u32,
 }
 
 #[salsa::input]
 struct Input {
+    #[returns(copy)]
     specify: bool,
 }
 
 #[salsa::tracked]
 struct Child<'db> {
+    #[returns(copy)]
     value: u32,
 }
 
-#[salsa::tracked(specify)]
+#[salsa::tracked(returns(copy), specify)]
 fn overridable<'db>(db: &'db dyn Database, owner: Owner<'db>) -> Child<'db> {
     Child::new(db, owner.value(db) + 10)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn specify_over_derived_memo(db: &dyn Database, input: Input) -> Child<'_> {
     let owner = Owner::new(db, 1);
     if input.specify(db) {

--- a/tests/specify-only-works-if-the-key-is-created-in-the-current-query.rs
+++ b/tests/specify-only-works-if-the-key-is-created-in-the-current-query.rs
@@ -6,15 +6,17 @@
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
 #[salsa::tracked]
 struct MyTracked<'db> {
+    #[returns(copy)]
     field: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn tracked_struct_created_in_another_query<'db>(
     db: &'db dyn salsa::Database,
     input: MyInput,
@@ -22,7 +24,7 @@ fn tracked_struct_created_in_another_query<'db>(
     MyTracked::new(db, input.field(db) * 2)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn tracked_fn<'db>(db: &'db dyn salsa::Database, input: MyInput) -> MyTracked<'db> {
     let t = tracked_struct_created_in_another_query(db, input);
     if input.field(db) != 0 {
@@ -31,7 +33,7 @@ fn tracked_fn<'db>(db: &'db dyn salsa::Database, input: MyInput) -> MyTracked<'d
     t
 }
 
-#[salsa::tracked(specify)]
+#[salsa::tracked(returns(copy), specify)]
 fn tracked_fn_extra<'db>(_db: &'db dyn salsa::Database, _input: MyTracked<'db>) -> u32 {
     0
 }

--- a/tests/specify-preserves-current-memo.rs
+++ b/tests/specify-preserves-current-memo.rs
@@ -8,30 +8,34 @@ use salsa::{Database, Setter};
 
 #[salsa::tracked]
 struct Owner<'db> {
+    #[returns(copy)]
     value: u32,
 }
 
 #[salsa::input]
 struct Input {
+    #[returns(copy)]
     specify: bool,
 }
 
 #[salsa::input]
 struct AssignInput {
+    #[returns(copy)]
     later: u32,
 }
 
 #[salsa::tracked]
 struct Child<'db> {
+    #[returns(copy)]
     value: u32,
 }
 
-#[salsa::tracked(specify)]
+#[salsa::tracked(returns(copy), specify)]
 fn overridable<'db>(db: &'db dyn Database, owner: Owner<'db>) -> Child<'db> {
     Child::new(db, owner.value(db) + 10)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn specify_over_derived_memo(db: &dyn Database, input: Input) -> (Child<'_>, Child<'_>) {
     let owner = Owner::new(db, 1);
     let derived = overridable(db, owner);
@@ -44,7 +48,7 @@ fn specify_over_derived_memo(db: &dyn Database, input: Input) -> (Child<'_>, Chi
     }
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn assign_before_later_input(db: &dyn Database, input: AssignInput) -> (Owner<'_>, Child<'_>) {
     let owner = Owner::new(db, 2);
     let child = Child::new(db, 77);

--- a/tests/supertype_overlap.rs
+++ b/tests/supertype_overlap.rs
@@ -10,11 +10,13 @@ struct Name {
 
 #[salsa::interned(no_lifetime, debug)]
 struct Age {
+    #[returns(copy)]
     value: u32,
 }
 
 #[salsa::input(debug)]
 struct Input {
+    #[returns(copy)]
     data: u32,
 }
 

--- a/tests/synthetic_write.rs
+++ b/tests/synthetic_write.rs
@@ -12,10 +12,11 @@ use salsa::{Database, DatabaseImpl, Durability, Event, EventKind};
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn tracked_fn(db: &dyn Database, input: MyInput) -> u32 {
     input.field(db) * 2
 }

--- a/tests/tracked-struct-entries-persistence.rs
+++ b/tests/tracked-struct-entries-persistence.rs
@@ -6,6 +6,7 @@ const DELETED_VALUE: &str = "deleted tracked entry sentinel";
 
 #[salsa::input(persist)]
 struct Input {
+    #[returns(copy)]
     enabled: bool,
 }
 
@@ -14,14 +15,14 @@ struct Entity<'db> {
     value: String,
 }
 
-#[salsa::tracked(persist)]
+#[salsa::tracked(returns(copy), persist)]
 fn maybe_entity(db: &dyn salsa::Database, input: Input) -> Option<Entity<'_>> {
     input
         .enabled(db)
         .then(|| Entity::new(db, DELETED_VALUE.to_owned()))
 }
 
-#[salsa::tracked(persist)]
+#[salsa::tracked(returns(copy), persist)]
 fn consume(db: &dyn salsa::Database, entity: Entity<'_>) -> usize {
     entity.value(db).len()
 }

--- a/tests/tracked-struct-entries.rs
+++ b/tests/tracked-struct-entries.rs
@@ -8,15 +8,17 @@ mod deleted {
 
     #[salsa::input]
     struct Input {
+        #[returns(copy)]
         enabled: bool,
     }
 
     #[salsa::tracked]
     struct Entity<'db> {
+        #[returns(copy)]
         value: u32,
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn maybe_entity(db: &dyn salsa::Database, input: Input) -> Option<Entity<'_>> {
         input.enabled(db).then(|| Entity::new(db, 22))
     }
@@ -39,15 +41,17 @@ mod stale {
 
     #[salsa::input]
     struct Input {
+        #[returns(copy)]
         value: u32,
     }
 
     #[salsa::tracked]
     struct Entity<'db> {
+        #[returns(copy)]
         value: u32,
     }
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn make_entity(db: &dyn salsa::Database, input: Input) -> Entity<'_> {
         Entity::new(db, input.value(db))
     }

--- a/tests/tracked-struct-id-field-bad-eq.rs
+++ b/tests/tracked-struct-id-field-bad-eq.rs
@@ -7,6 +7,7 @@ use test_log::test;
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field: bool,
 }
 
@@ -33,7 +34,7 @@ struct MyTracked<'db> {
     field: BadEq,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn the_fn(db: &dyn Database, input: MyInput) {
     let tracked0 = MyTracked::new(db, BadEq::from(input.field(db)));
     assert_eq!(tracked0.field(db).field, input.field(db));

--- a/tests/tracked-struct-id-field-bad-hash.rs
+++ b/tests/tracked-struct-id-field-bad-hash.rs
@@ -13,6 +13,7 @@ use test_log::test;
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field: u64,
 }
 
@@ -38,7 +39,7 @@ struct MyTracked<'db> {
     field: BadHash,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn the_fn(db: &dyn Db, input: MyInput) {
     let tracked0 = MyTracked::new(db, BadHash::from(input.field(db)));
     assert_eq!(tracked0.field(db).field, input.field(db));
@@ -54,12 +55,12 @@ fn execute() {
     the_fn(&db, input);
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn create_tracked(db: &dyn Db, input: MyInput) -> MyTracked<'_> {
     MyTracked::new(db, BadHash::from(input.field(db)))
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn with_tracked<'db>(db: &'db dyn Db, tracked: MyTracked<'db>) -> u64 {
     tracked.field(db).field
 }

--- a/tests/tracked-struct-unchanged-in-new-rev.rs
+++ b/tests/tracked-struct-unchanged-in-new-rev.rs
@@ -5,15 +5,17 @@ use test_log::test;
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
 #[salsa::tracked]
 struct MyTracked<'db> {
+    #[returns(copy)]
     field: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn tracked_fn(db: &dyn Db, input: MyInput) -> MyTracked<'_> {
     MyTracked::new(db, input.field(db) / 2)
 }

--- a/tests/tracked-struct-value-field-bad-eq.rs
+++ b/tests/tracked-struct-value-field-bad-eq.rs
@@ -12,6 +12,7 @@ use test_log::test;
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field: bool,
 }
 
@@ -39,18 +40,18 @@ struct MyTracked<'db> {
     field: BadEq,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn the_fn(db: &dyn Database, input: MyInput) -> bool {
     let tracked = make_tracked_struct(db, input);
     read_tracked_struct(db, tracked)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn make_tracked_struct(db: &dyn Database, input: MyInput) -> MyTracked<'_> {
     MyTracked::new(db, BadEq::from(input.field(db)))
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn read_tracked_struct<'db>(db: &'db dyn Database, tracked: MyTracked<'db>) -> bool {
     tracked.field(db).field
 }

--- a/tests/tracked-struct-value-field-not-eq.rs
+++ b/tests/tracked-struct-value-field-not-eq.rs
@@ -9,6 +9,7 @@ use test_log::test;
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field: bool,
 }
 
@@ -30,7 +31,7 @@ struct MyTracked<'db> {
     field: NotEq,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn the_fn(db: &dyn Database, input: MyInput) {
     let tracked0 = MyTracked::new(db, NotEq::from(input.field(db)));
     assert_eq!(tracked0.field(db).field, input.field(db));

--- a/tests/tracked_assoc_fn.rs
+++ b/tests/tracked_assoc_fn.rs
@@ -17,17 +17,19 @@ trait TrackedTrait<'db> {
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
 #[salsa::tracked]
 struct MyOutput<'db> {
+    #[returns(copy)]
     field: u32,
 }
 
 #[salsa::tracked]
 impl MyInput {
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn tracked_fn(db: &dyn salsa::Database, input: MyInput) -> Self {
         Self::new(db, 2 * input.field(db))
     }
@@ -42,7 +44,7 @@ impl MyInput {
 impl<'db> TrackedTrait<'db> for MyOutput<'db> {
     type Output = Self;
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn tracked_trait_fn(db: &'db dyn salsa::Database, input: MyInput) -> Self::Output {
         Self::new(db, 4 * input.field(db))
     }
@@ -55,7 +57,7 @@ struct UntrackedHelper;
 impl<'db> TrackedTrait<'db> for UntrackedHelper {
     type Output = MyOutput<'db>;
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn tracked_trait_fn(db: &'db dyn salsa::Database, input: MyInput) -> Self::Output {
         MyOutput::tracked_trait_fn(db, input)
     }

--- a/tests/tracked_fn_constant.rs
+++ b/tests/tracked_fn_constant.rs
@@ -8,12 +8,12 @@ use crate::common::LogDatabase;
 
 mod common;
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn tracked_fn(db: &dyn salsa::Database) -> u32 {
     44
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn tracked_custom_db(db: &dyn LogDatabase) -> u32 {
     44
 }

--- a/tests/tracked_fn_high_durability_dependency.rs
+++ b/tests/tracked_fn_high_durability_dependency.rs
@@ -7,10 +7,11 @@ use salsa::{Database, Durability, Setter};
 mod common;
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn tracked_fn(db: &dyn salsa::Database, input: MyInput) -> u32 {
     input.field(db) * 2
 }

--- a/tests/tracked_fn_interned_lifetime.rs
+++ b/tests/tracked_fn_interned_lifetime.rs
@@ -2,10 +2,11 @@
 
 #[salsa::interned]
 struct Interned<'db> {
+    #[returns(copy)]
     field: i32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn foo<'a>(_db: &'a dyn salsa::Database, _: Interned<'_>, _: Interned<'a>) {}
 
 #[test]

--- a/tests/tracked_fn_multiple_args.rs
+++ b/tests/tracked_fn_multiple_args.rs
@@ -5,15 +5,17 @@
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
 #[salsa::interned]
 struct MyInterned<'db> {
+    #[returns(copy)]
     field: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn tracked_fn<'db>(db: &'db dyn salsa::Database, input: MyInput, interned: MyInterned<'db>) -> u32 {
     input.field(db) + interned.field(db)
 }

--- a/tests/tracked_fn_no_eq.rs
+++ b/tests/tracked_fn_no_eq.rs
@@ -8,10 +8,11 @@ use salsa::Setter as _;
 
 #[salsa::input]
 struct Input {
+    #[returns(copy)]
     number: i16,
 }
 
-#[salsa::tracked(no_eq)]
+#[salsa::tracked(returns(copy), no_eq)]
 fn abs_float(db: &dyn LogDatabase, input: Input) -> f32 {
     let number = input.number(db);
 
@@ -19,7 +20,7 @@ fn abs_float(db: &dyn LogDatabase, input: Input) -> f32 {
     number.abs() as f32
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn derived(db: &dyn LogDatabase, input: Input) -> u32 {
     let x = abs_float(db, input);
     db.push_log("derived".to_string());

--- a/tests/tracked_fn_on_input.rs
+++ b/tests/tracked_fn_on_input.rs
@@ -6,10 +6,11 @@
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn tracked_fn(db: &dyn salsa::Database, input: MyInput) -> u32 {
     input.field(db) * 2
 }

--- a/tests/tracked_fn_on_input_with_high_durability.rs
+++ b/tests/tracked_fn_on_input_with_high_durability.rs
@@ -9,10 +9,11 @@ use salsa::{Database, Durability, Event, EventKind, Setter};
 mod common;
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn tracked_fn(db: &dyn salsa::Database, input: MyInput) -> u32 {
     input.field(db) * 2
 }

--- a/tests/tracked_fn_on_interned.rs
+++ b/tests/tracked_fn_on_interned.rs
@@ -8,7 +8,7 @@ struct Name<'db> {
     name: String,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(clone))]
 fn tracked_fn<'db>(db: &'db dyn salsa::Database, name: Name<'db>) -> String {
     name.name(db).clone()
 }

--- a/tests/tracked_fn_on_interned_enum.rs
+++ b/tests/tracked_fn_on_interned_enum.rs
@@ -15,6 +15,7 @@ struct NameAndAge<'db> {
 
 #[salsa::interned(no_lifetime, debug)]
 struct Age {
+    #[returns(copy)]
     age: u32,
 }
 
@@ -36,20 +37,20 @@ enum EnumOfEnum<'db> {
     Input(Input),
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(clone))]
 fn tracked_fn<'db>(db: &'db dyn salsa::Database, enum_: Enum<'db>) -> String {
     match enum_ {
-        Enum::Name(name) => name.name(db),
-        Enum::NameAndAge(name_and_age) => name_and_age.name_and_age(db),
+        Enum::Name(name) => name.name(db).clone(),
+        Enum::NameAndAge(name_and_age) => name_and_age.name_and_age(db).clone(),
         Enum::Age(age) => age.age(db).to_string(),
     }
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(clone))]
 fn tracked_fn2<'db>(db: &'db dyn salsa::Database, enum_: EnumOfEnum<'db>) -> String {
     match enum_ {
         EnumOfEnum::Enum(enum_) => tracked_fn(db, enum_),
-        EnumOfEnum::Input(input) => input.value(db),
+        EnumOfEnum::Input(input) => input.value(db).clone(),
     }
 }
 

--- a/tests/tracked_fn_on_tracked.rs
+++ b/tests/tracked_fn_on_tracked.rs
@@ -5,15 +5,17 @@
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
 #[salsa::tracked]
 struct MyTracked<'db> {
+    #[returns(copy)]
     field: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn tracked_fn(db: &dyn salsa::Database, input: MyInput) -> MyTracked<'_> {
     MyTracked::new(db, input.field(db) * 2)
 }

--- a/tests/tracked_fn_on_tracked_specify.rs
+++ b/tests/tracked_fn_on_tracked_specify.rs
@@ -6,15 +6,17 @@
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
 #[salsa::tracked]
 struct MyTracked<'db> {
+    #[returns(copy)]
     field: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn tracked_fn<'db>(db: &'db dyn salsa::Database, input: MyInput) -> MyTracked<'db> {
     let t = MyTracked::new(db, input.field(db) * 2);
     if input.field(db) != 0 {
@@ -23,7 +25,7 @@ fn tracked_fn<'db>(db: &'db dyn salsa::Database, input: MyInput) -> MyTracked<'d
     t
 }
 
-#[salsa::tracked(specify)]
+#[salsa::tracked(returns(copy), specify)]
 fn tracked_fn_extra<'db>(_db: &'db dyn salsa::Database, _input: MyTracked<'db>) -> u32 {
     0
 }

--- a/tests/tracked_fn_orphan_escape_hatch.rs
+++ b/tests/tracked_fn_orphan_escape_hatch.rs
@@ -8,13 +8,14 @@ use std::marker::PhantomData;
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct NotUpdate<'a>(PhantomData<fn() -> &'a ()>);
 
-#[salsa::tracked(unsafe(non_update_types))]
+#[salsa::tracked(returns(copy), unsafe(non_update_types))]
 fn tracked_fn(db: &dyn salsa::Database, input: MyInput) -> NotUpdate<'_> {
     NotUpdate(PhantomData)
 }

--- a/tests/tracked_fn_read_own_entity.rs
+++ b/tests/tracked_fn_read_own_entity.rs
@@ -11,10 +11,11 @@ use test_log::test;
 
 #[salsa::input(debug)]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn final_result(db: &dyn LogDatabase, input: MyInput) -> u32 {
     db.push_log(format!("final_result({input:?})"));
     intermediate_result(db, input).field(db) * 2
@@ -22,10 +23,11 @@ fn final_result(db: &dyn LogDatabase, input: MyInput) -> u32 {
 
 #[salsa::tracked]
 struct MyTracked<'db> {
+    #[returns(copy)]
     field: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn intermediate_result(db: &dyn LogDatabase, input: MyInput) -> MyTracked<'_> {
     db.push_log(format!("intermediate_result({input:?})"));
     let tracked = MyTracked::new(db, input.field(db) / 2);

--- a/tests/tracked_fn_read_own_specify.rs
+++ b/tests/tracked_fn_read_own_specify.rs
@@ -7,15 +7,17 @@ use salsa::Database;
 
 #[salsa::input(debug)]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
 #[salsa::tracked(debug)]
 struct MyTracked<'db> {
+    #[returns(copy)]
     field: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn tracked_fn(db: &dyn LogDatabase, input: MyInput) -> u32 {
     db.push_log(format!("tracked_fn({input:?})"));
     let t = MyTracked::new(db, input.field(db) * 2);
@@ -23,14 +25,14 @@ fn tracked_fn(db: &dyn LogDatabase, input: MyInput) -> u32 {
     tracked_fn_extra(db, t)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn tracked_fn_specify_twice(db: &dyn LogDatabase, input: MyInput) {
     let t = MyTracked::new(db, input.field(db) * 2);
     tracked_fn_extra::specify(db, t, 1111);
     tracked_fn_extra::specify(db, t, 2222);
 }
 
-#[salsa::tracked(specify)]
+#[salsa::tracked(returns(copy), specify)]
 fn tracked_fn_extra<'db>(db: &'db dyn LogDatabase, input: MyTracked<'db>) -> u32 {
     db.push_log(format!("tracked_fn_extra({input:?})"));
     0

--- a/tests/tracked_fn_return_ref.rs
+++ b/tests/tracked_fn_return_ref.rs
@@ -4,6 +4,7 @@ use salsa::Database;
 
 #[salsa::input]
 struct Input {
+    #[returns(copy)]
     number: usize,
 }
 

--- a/tests/tracked_method.rs
+++ b/tests/tracked_method.rs
@@ -10,11 +10,12 @@ use expect_test::expect;
 mod common;
 
 trait TrackedTrait {
-    fn tracked_trait_fn(self, db: &dyn salsa::Database) -> u32;
+    fn tracked_trait_fn(self, db: &dyn salsa::Database) -> &u32;
 }
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
@@ -29,6 +30,9 @@ impl MyInput {
     fn tracked_fn_ref(self, db: &dyn salsa::Database) -> u32 {
         self.field(db) * 3
     }
+
+    #[salsa::tracked]
+    fn tracked_unit(self, _db: &dyn salsa::Database) {}
 }
 
 #[salsa::tracked]
@@ -43,9 +47,10 @@ impl TrackedTrait for MyInput {
 fn execute() {
     let mut db = salsa::DatabaseImpl::new();
     let object = MyInput::new(&mut db, 22);
-    // assert_eq!(object.tracked_fn(&db), 44);
-    // assert_eq!(*object.tracked_fn_ref(&db), 66);
-    assert_eq!(object.tracked_trait_fn(&db), 88);
+    assert_eq!(*object.tracked_fn(&db), 44);
+    assert_eq!(*object.tracked_fn_ref(&db), 66);
+    assert_eq!(*object.tracked_trait_fn(&db), 88);
+    let _: &() = object.tracked_unit(&db);
 }
 
 #[test]
@@ -53,7 +58,7 @@ fn debug_name() {
     let mut db = common::ExecuteValidateLoggerDatabase::default();
     let object = MyInput::new(&mut db, 22);
 
-    assert_eq!(object.tracked_trait_fn(&db), 88);
+    assert_eq!(*object.tracked_trait_fn(&db), 88);
     db.assert_logs(expect![[r#"
         [
             "salsa_event(WillExecute { database_key: MyInput::tracked_trait_fn_(Id(0)) })",

--- a/tests/tracked_method_inherent_return_deref.rs
+++ b/tests/tracked_method_inherent_return_deref.rs
@@ -4,6 +4,7 @@ use salsa::Database;
 
 #[salsa::input]
 struct Input {
+    #[returns(copy)]
     number: usize,
 }
 

--- a/tests/tracked_method_inherent_return_ref.rs
+++ b/tests/tracked_method_inherent_return_ref.rs
@@ -4,6 +4,7 @@ use salsa::Database;
 
 #[salsa::input]
 struct Input {
+    #[returns(copy)]
     number: usize,
 }
 

--- a/tests/tracked_method_on_tracked_struct.rs
+++ b/tests/tracked_method_on_tracked_struct.rs
@@ -12,7 +12,7 @@ pub struct Input {
 
 #[salsa::tracked]
 impl Input {
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     pub fn source_tree(self, db: &dyn Database) -> SourceTree<'_> {
         SourceTree::new(db, self.name(db).clone())
     }
@@ -27,7 +27,7 @@ pub struct SourceTree<'db> {
 impl<'db1> SourceTree<'db1> {
     #[salsa::tracked(returns(ref))]
     pub fn inherent_item_name(self, db: &'db1 dyn Database) -> String {
-        self.name(db)
+        self.name(db).clone()
     }
 }
 
@@ -39,7 +39,7 @@ trait ItemName<'db1> {
 impl<'db1> ItemName<'db1> for SourceTree<'db1> {
     #[salsa::tracked(returns(ref))]
     fn trait_item_name(self, db: &'db1 dyn Database) -> String {
-        self.name(db)
+        self.name(db).clone()
     }
 }
 

--- a/tests/tracked_method_trait_return_ref.rs
+++ b/tests/tracked_method_trait_return_ref.rs
@@ -4,6 +4,7 @@ use salsa::Database;
 
 #[salsa::input]
 struct Input {
+    #[returns(copy)]
     number: usize,
 }
 

--- a/tests/tracked_method_with_self_ty.rs
+++ b/tests/tracked_method_with_self_ty.rs
@@ -14,12 +14,13 @@ trait TrackedTrait {
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
 #[salsa::tracked]
 impl MyInput {
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn tracked_fn(self, db: &dyn salsa::Database, other: Self) -> u32 {
         self.field(db) + other.field(db)
     }
@@ -29,7 +30,7 @@ impl MyInput {
 impl TrackedTrait for MyInput {
     type Type = u32;
 
-    #[salsa::tracked]
+    #[salsa::tracked(returns(copy))]
     fn tracked_trait_fn(self, db: &dyn salsa::Database, ty: Self::Type) -> Self::Type {
         Self::untracked_trait_fn();
         Self::tracked_fn(self, db, self) + ty

--- a/tests/tracked_struct.rs
+++ b/tests/tracked_struct.rs
@@ -6,23 +6,27 @@ use salsa::{Database, Setter};
 
 #[salsa::tracked]
 struct Tracked<'db> {
+    #[returns(copy)]
     untracked_1: usize,
 
+    #[returns(copy)]
     untracked_2: usize,
 }
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field1: usize,
+    #[returns(copy)]
     field2: usize,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn intermediate(db: &dyn salsa::Database, input: MyInput) -> Tracked<'_> {
     Tracked::new(db, input.field1(db), input.field2(db))
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn accumulate(db: &dyn salsa::Database, input: MyInput) -> (usize, usize) {
     let tracked = intermediate(db, input);
     let one = read_tracked_1(db, tracked);
@@ -31,12 +35,12 @@ fn accumulate(db: &dyn salsa::Database, input: MyInput) -> (usize, usize) {
     (one, two)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn read_tracked_1<'db>(db: &'db dyn Database, tracked: Tracked<'db>) -> usize {
     tracked.untracked_1(db)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn read_tracked_2<'db>(db: &'db dyn Database, tracked: Tracked<'db>) -> usize {
     tracked.untracked_2(db)
 }

--- a/tests/tracked_struct_db1_lt.rs
+++ b/tests/tracked_struct_db1_lt.rs
@@ -9,16 +9,19 @@ use test_log::test;
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
 #[salsa::tracked]
 struct MyTracked1<'db1> {
+    #[returns(copy)]
     field: MyTracked2<'db1>,
 }
 
 #[salsa::tracked]
 struct MyTracked2<'db2> {
+    #[returns(copy)]
     field: u32,
 }
 

--- a/tests/tracked_struct_disambiguates.rs
+++ b/tests/tracked_struct_disambiguates.rs
@@ -11,11 +11,13 @@ use salsa::Setter;
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
 #[salsa::input]
 struct MyInputs {
+    #[returns(clone)]
     field: Vec<MyInput>,
 }
 
@@ -70,7 +72,7 @@ fn alternate(
     }
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(clone))]
 fn batch(
     db: &dyn salsa::Database,
     inputs: MyInputs,

--- a/tests/tracked_struct_durability.rs
+++ b/tests/tracked_struct_durability.rs
@@ -29,45 +29,50 @@ trait Db: salsa::Database {
 
 #[salsa::input]
 struct File {
+    #[returns(copy)]
     field: usize,
 }
 
 #[salsa::tracked]
 struct Definition<'db> {
     #[tracked]
+    #[returns(copy)]
     file: File,
 }
 
 #[salsa::tracked]
 struct Index<'db> {
     #[tracked]
+    #[returns(copy)]
     definitions: Definitions<'db>,
 }
 
 #[salsa::tracked]
 struct Definitions<'db> {
     #[tracked]
+    #[returns(copy)]
     definition: Definition<'db>,
 }
 
 #[salsa::tracked]
 struct Inference<'db> {
     #[tracked]
+    #[returns(copy)]
     definition: Definition<'db>,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn index(db: &dyn Db, file: File) -> Index<'_> {
     let _ = file.field(db);
     Index::new(db, Definitions::new(db, Definition::new(db, file)))
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn definitions(db: &dyn Db, file: File) -> Definitions<'_> {
     index(db, file).definitions(db)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn infer<'db>(db: &'db dyn Db, definition: Definition<'db>) -> Inference<'db> {
     let file = definition.file(db);
     if file.field(db) < 1 {
@@ -80,7 +85,7 @@ fn infer<'db>(db: &'db dyn Db, definition: Definition<'db>) -> Inference<'db> {
     }
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn check(db: &dyn Db, file: File) -> Inference<'_> {
     let defs = definitions(db, file);
     infer(db, defs.definition(db))

--- a/tests/tracked_struct_manual_update.rs
+++ b/tests/tracked_struct_manual_update.rs
@@ -17,8 +17,10 @@ struct Tracked<'db> {
         MARK1.store(true, Ordering::Release);
         true
     })]
+    #[returns(copy)]
     tracked: usize,
     #[maybe_update(untracked_update)]
+    #[returns(copy)]
     untracked: usize,
 }
 
@@ -30,16 +32,18 @@ unsafe fn untracked_update(dst: *mut usize, src: usize) -> bool {
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field1: usize,
+    #[returns(copy)]
     field2: usize,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn intermediate(db: &dyn salsa::Database, input: MyInput) -> Tracked<'_> {
     Tracked::new(db, input.field1(db), input.field2(db))
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn accumulate(db: &dyn salsa::Database, input: MyInput) -> (usize, usize) {
     let tracked = intermediate(db, input);
     let one = read_tracked(db, tracked);
@@ -48,12 +52,12 @@ fn accumulate(db: &dyn salsa::Database, input: MyInput) -> (usize, usize) {
     (one, two)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn read_tracked<'db>(db: &'db dyn Database, tracked: Tracked<'db>) -> usize {
     tracked.tracked(db)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn read_untracked<'db>(db: &'db dyn Database, tracked: Tracked<'db>) -> usize {
     tracked.untracked(db)
 }

--- a/tests/tracked_struct_mixed_tracked_fields.rs
+++ b/tests/tracked_struct_mixed_tracked_fields.rs
@@ -8,33 +8,41 @@ use salsa::{Database, Setter};
 // the correct field indices are used when tracking dependencies.
 #[salsa::tracked]
 struct Tracked<'db> {
+    #[returns(copy)]
     untracked_1: usize,
 
     #[tracked]
+    #[returns(copy)]
     tracked_1: usize,
 
+    #[returns(copy)]
     untracked_2: usize,
 
+    #[returns(copy)]
     untracked_3: usize,
 
     #[tracked]
+    #[returns(copy)]
     tracked_2: usize,
 
+    #[returns(copy)]
     untracked_4: usize,
 }
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field1: usize,
+    #[returns(copy)]
     field2: usize,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn intermediate(db: &dyn salsa::Database, input: MyInput) -> Tracked<'_> {
     Tracked::new(db, 0, input.field1(db), 0, 0, input.field2(db), 0)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn accumulate(db: &dyn salsa::Database, input: MyInput) -> (usize, usize) {
     let tracked = intermediate(db, input);
     let one = read_tracked_1(db, tracked);
@@ -43,12 +51,12 @@ fn accumulate(db: &dyn salsa::Database, input: MyInput) -> (usize, usize) {
     (one, two)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn read_tracked_1<'db>(db: &'db dyn Database, tracked: Tracked<'db>) -> usize {
     tracked.tracked_1(db)
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn read_tracked_2<'db>(db: &'db dyn Database, tracked: Tracked<'db>) -> usize {
     tracked.tracked_2(db)
 }

--- a/tests/tracked_struct_recreate_new_revision.rs
+++ b/tests/tracked_struct_recreate_new_revision.rs
@@ -8,15 +8,17 @@ use salsa::Setter;
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     field: u32,
 }
 
 #[salsa::tracked(debug)]
 struct TrackedStruct<'db> {
+    #[returns(copy)]
     field: u32,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn tracked_fn(db: &dyn salsa::Database, input: MyInput) -> Option<TrackedStruct<'_>> {
     if input.field(db) == 1 {
         Some(TrackedStruct::new(db, 1))

--- a/tests/tracked_struct_with_interned_query.rs
+++ b/tests/tracked_struct_with_interned_query.rs
@@ -6,6 +6,7 @@ use salsa::Setter;
 
 #[salsa::input]
 struct MyInput {
+    #[returns(copy)]
     value: usize,
 }
 
@@ -14,12 +15,12 @@ struct Tracked<'db> {
     value: String,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn query_tracked(db: &dyn salsa::Database, input: MyInput) -> Tracked<'_> {
     Tracked::new(db, format!("{value}", value = input.value(db)))
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(clone))]
 fn join<'db>(db: &'db dyn salsa::Database, tracked: Tracked<'db>, with: String) -> String {
     format!("{}{}", tracked.value(db), with)
 }

--- a/tests/tracked_with_intern.rs
+++ b/tests/tracked_with_intern.rs
@@ -13,6 +13,7 @@ struct MyInput {
 #[salsa::tracked]
 struct MyTracked<'db> {
     #[tracked]
+    #[returns(copy)]
     field: MyInterned<'db>,
 }
 

--- a/tests/tracked_with_struct_db.rs
+++ b/tests/tracked_with_struct_db.rs
@@ -14,6 +14,7 @@ struct MyInput {
 #[salsa::tracked(debug)]
 struct MyTracked<'db> {
     #[tracked]
+    #[returns(copy)]
     data: MyInput,
     #[tracked]
     next: MyList<'db>,
@@ -25,7 +26,7 @@ enum MyList<'db> {
     Next(MyTracked<'db>),
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn create_tracked_list(db: &dyn Database, input: MyInput) -> MyTracked<'_> {
     let t0 = MyTracked::new(db, input, MyList::None);
     MyTracked::new(db, input, MyList::Next(t0))

--- a/tests/tracked_with_struct_ord.rs
+++ b/tests/tracked_with_struct_ord.rs
@@ -8,16 +8,18 @@ use test_log::test;
 #[salsa::input]
 #[derive(PartialOrd, Ord)]
 struct Input {
+    #[returns(copy)]
     value: usize,
 }
 
 #[salsa::tracked(debug)]
 #[derive(Ord, PartialOrd)]
 struct MyTracked<'db> {
+    #[returns(copy)]
     value: usize,
 }
 
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 fn create_tracked(db: &dyn Database, input: Input) -> MyTracked<'_> {
     MyTracked::new(db, input.value(db))
 }


### PR DESCRIPTION
Changes tracked functions and Salsa struct field getters to return references by default, 

I don't know what the appetite for this is, but this closes https://github.com/salsa-rs/salsa/issues/719


IMO, we should either make the change and accept that it's breaking or decide that we stick with `clone`. At least for ty, this defaulting to `ref` has been a repeating issue, and I occasionally go through all queries to find cases where we forgot the returns annotation. I also had Codex migrate ty, and it did so without much effort. So I don't expect this to be as painful as it used to be.


One caveat. There's one remaining place where Salsa always clones (and which may be surprising). And that's for many argument queries. The arguments are cloned out of the interned value. This does not change my perspective that `returns(ref)` is the better default.