### PR TITLE
refactor: generalize eviction policy interface

### DIFF
--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -484,14 +484,14 @@ macro_rules! setup_tracked_fn {
                     }
                 }
 
-                /// Sets the lru capacity
+                /// Sets the eviction policy's tuning value.
                 ///
                 /// **WARNING:** Just like an ordinary write, this method triggers
                 /// cancellation. If you invoke it while a snapshot exists, it
                 /// will block until that snapshot is dropped -- if that snapshot
                 /// is owned by the current thread, this could trigger deadlock.
                 fn set_lru_capacity(db: &mut dyn $Db, value: usize) where for<'trivial_bounds> $Eviction: $zalsa::function::HasCapacity {
-                    $Configuration::fn_ingredient_mut(db).set_capacity(value);
+                    $Configuration::fn_ingredient_mut(db).set_tuning(value);
                 }
 
                 $zalsa::macro_if! { $needs_interner =>

--- a/src/function.rs
+++ b/src/function.rs
@@ -37,7 +37,7 @@ mod memo;
 mod specify;
 mod sync;
 
-pub use eviction::{EvictionPolicy, HasCapacity, Lru, NoopEviction};
+pub use eviction::{EvictionContext, EvictionPolicy, HasCapacity, Lru, NoopEviction};
 
 pub type Memo<C> = memo::Memo<'static, C>;
 
@@ -239,12 +239,14 @@ where
         DatabaseKeyIndex::new(self.index, key)
     }
 
-    /// Set eviction capacity. Only available when eviction policy supports it.
-    pub fn set_capacity(&mut self, capacity: usize)
+    /// Sets the eviction policy's tuning value.
+    ///
+    /// Only available when the eviction policy supports runtime tuning.
+    pub fn set_tuning(&mut self, tuning: usize)
     where
         C::Eviction: HasCapacity,
     {
-        self.eviction.set_capacity(capacity);
+        self.eviction.set_tuning(tuning);
     }
 
     /// Returns a reference to the memo value that lives as long as self.
@@ -276,17 +278,27 @@ where
         // We convert to a `NonNull` here as soon as possible because we are going to alias
         // into the `Box`, which is a `noalias` type.
         // FIXME: Use `Box::into_non_null` once stable
+        let has_value = memo.value.is_some();
         let memo = NonNull::from(Box::leak(Box::new(memo)));
 
-        if let Some(old_value) =
-            self.insert_memo_into_table_for(zalsa, id, memo, memo_ingredient_index)
-        {
+        let old_value = self.insert_memo_into_table_for(zalsa, id, memo, memo_ingredient_index);
+        let became_resident = has_value
+            && old_value.is_none_or(|old_value| {
+                // SAFETY: The old memo remains allocated in `deleted_entries` until the next
+                // revision, so it is valid to inspect here.
+                unsafe { old_value.as_ref().value.is_none() }
+            });
+
+        if let Some(old_value) = old_value {
             // In case there is a reference to the old memo out there, we have to store it
             // in the deleted entries. This will get cleared when a new revision starts.
             //
             // SAFETY: Once the revision starts, there will be no outstanding borrows to the
             // memo contents, and so it will be safe to free.
             unsafe { self.deleted_entries.push(old_value) };
+        }
+        if became_resident {
+            self.eviction.record_insert(id);
         }
         // SAFETY: memo has been inserted into the table
         unsafe { self.extend_memo_lifetime(memo.as_ref()) }
@@ -465,13 +477,11 @@ where
     }
 
     fn reset_for_new_revision(&mut self, table: &mut Table) {
-        self.eviction.for_each_evicted(|evict| {
-            let ingredient_index = table.ingredient_index(evict);
-            Self::evict_value_from_memo_for(
-                table.memos_mut(evict),
-                self.memo_ingredient_indices.get(ingredient_index),
-            )
-        });
+        let mut context = FunctionEvictionContext::<C> {
+            table,
+            memo_ingredient_indices: &self.memo_ingredient_indices,
+        };
+        self.eviction.start_new_revision(&mut context);
 
         self.deleted_entries.clear();
     }
@@ -554,6 +564,29 @@ where
         };
 
         serde::de::DeserializeSeed::deserialize(deserialize, deserializer)
+    }
+}
+
+struct FunctionEvictionContext<'a, C: Configuration> {
+    table: &'a mut Table,
+    memo_ingredient_indices: &'a <C::SalsaStruct<'static> as SalsaStructInDb>::MemoIngredientMap,
+}
+
+impl<C: Configuration> EvictionContext for FunctionEvictionContext<'_, C> {
+    fn last_verified_at(&mut self, id: Id) -> Option<Revision> {
+        let ingredient_index = self.table.ingredient_index(id);
+        IngredientImpl::<C>::last_verified_at_for(
+            self.table.memos_mut(id),
+            self.memo_ingredient_indices.get(ingredient_index),
+        )
+    }
+
+    fn evict_value(&mut self, id: Id) {
+        let ingredient_index = self.table.ingredient_index(id);
+        IngredientImpl::<C>::evict_value_from_memo_for(
+            self.table.memos_mut(id),
+            self.memo_ingredient_indices.get(ingredient_index),
+        )
     }
 }
 

--- a/src/function/eviction.rs
+++ b/src/function/eviction.rs
@@ -9,32 +9,52 @@ mod noop;
 pub use lru::Lru;
 pub use noop::NoopEviction;
 
-use crate::Id;
+use crate::{Id, Revision};
 
 /// Trait for cache eviction strategies.
 ///
 /// Implementations control when memoized values are evicted from the cache.
 /// The eviction policy is selected at compile time via the `Configuration` trait.
 pub trait EvictionPolicy: Send + Sync {
-    /// Create a new eviction policy with the given capacity.
-    fn new(capacity: usize) -> Self;
-
-    /// Record that an item was accessed.
-    fn record_use(&self, id: Id);
-
-    /// Set the maximum capacity.
-    fn set_capacity(&mut self, capacity: usize);
-
-    /// Iterate over items that should be evicted.
+    /// Creates a policy from its configured tuning value.
     ///
-    /// Called once per revision during `reset_for_new_revision`.
-    /// The callback `cb` should be invoked for each item to evict.
-    fn for_each_evicted(&mut self, cb: impl FnMut(Id));
+    /// A value of zero disables eviction.
+    fn new(tuning: usize) -> Self;
+
+    /// Records that `id` transitioned from having no cached value to having one.
+    fn record_insert(&self, _id: Id) {}
+
+    /// Records that a resident value was used.
+    ///
+    /// Implementations may treat this as a best-effort hint.
+    fn record_use(&self, _id: Id) {}
+
+    /// Changes the policy's tuning value.
+    ///
+    /// A value of zero disables eviction.
+    fn set_tuning(&mut self, tuning: usize);
+
+    /// Processes the start of a new revision.
+    ///
+    /// The policy may update its state, inspect memo metadata, and evict
+    /// resident values through `context`.
+    fn start_new_revision(&mut self, context: &mut impl EvictionContext);
 }
 
-/// Marker trait for eviction policies that have a configurable capacity.
+/// Memo operations available when starting a new revision.
+pub trait EvictionContext {
+    /// Returns the revision in which `id`'s resident value was last verified.
+    ///
+    /// Returns `None` if the memo no longer contains a resident value.
+    fn last_verified_at(&mut self, id: Id) -> Option<Revision>;
+
+    /// Evicts `id`'s cached value while retaining its memo metadata.
+    fn evict_value(&mut self, id: Id);
+}
+
+/// Marker trait for eviction policies whose tuning can be changed at runtime.
 ///
 /// This trait is used to conditionally generate the `set_lru_capacity` method
 /// on tracked functions. Only policies that implement this trait will expose
-/// runtime capacity configuration.
+/// runtime tuning.
 pub trait HasCapacity: EvictionPolicy {}

--- a/src/function/eviction/lru.rs
+++ b/src/function/eviction/lru.rs
@@ -9,7 +9,7 @@ use crate::Id;
 use crate::hash::FxLinkedHashSet;
 use crate::sync::Mutex;
 
-use super::{EvictionPolicy, HasCapacity};
+use super::{EvictionContext, EvictionPolicy, HasCapacity};
 
 /// Least Recently Used eviction policy.
 ///
@@ -43,21 +43,21 @@ impl EvictionPolicy for Lru {
         }
     }
 
-    fn set_capacity(&mut self, capacity: usize) {
+    fn set_tuning(&mut self, capacity: usize) {
         self.capacity = NonZeroUsize::new(capacity);
         if self.capacity.is_none() {
             self.set.get_mut().clear();
         }
     }
 
-    fn for_each_evicted(&mut self, mut cb: impl FnMut(Id)) {
+    fn start_new_revision(&mut self, context: &mut impl EvictionContext) {
         let Some(cap) = self.capacity else {
             return;
         };
         let set = self.set.get_mut();
         while set.len() > cap.get() {
             if let Some(id) = set.pop_front() {
-                cb(id);
+                context.evict_value(id);
             }
         }
     }

--- a/src/function/eviction/noop.rs
+++ b/src/function/eviction/noop.rs
@@ -2,7 +2,7 @@
 //!
 //! This is the default eviction policy when no LRU capacity is specified.
 
-use crate::{Id, function::EvictionPolicy};
+use crate::function::{EvictionContext, EvictionPolicy};
 
 /// No eviction - cache grows unbounded.
 pub struct NoopEviction;
@@ -13,11 +13,8 @@ impl EvictionPolicy for NoopEviction {
     }
 
     #[inline(always)]
-    fn record_use(&self, _id: Id) {}
+    fn set_tuning(&mut self, _capacity: usize) {}
 
     #[inline(always)]
-    fn set_capacity(&mut self, _capacity: usize) {}
-
-    #[inline(always)]
-    fn for_each_evicted(&mut self, _cb: impl FnMut(Id)) {}
+    fn start_new_revision(&mut self, _context: &mut impl EvictionContext) {}
 }

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -56,9 +56,9 @@ impl<C: Configuration> IngredientImpl<C> {
         Some(unsafe { transmute::<&Memo<'static, C>, &'db Memo<'db, C>>(static_memo.as_ref()) })
     }
 
-    /// Evicts the existing memo for the given key, replacing it
-    /// with an equivalent memo that has no value. If the memo is untracked
-    /// or has values assigned as output of another query, this has no effect.
+    /// Evicts the value from the existing memo for the given key.
+    /// If the memo is untracked or has values assigned as output of another query,
+    /// this has no effect.
     pub(super) fn evict_value_from_memo_for(
         table: MemoTableWithTypesMut<'_>,
         memo_ingredient_index: MemoIngredientIndex,
@@ -71,6 +71,20 @@ impl<C: Configuration> IngredientImpl<C> {
         };
 
         table.map_memo(memo_ingredient_index, map)
+    }
+
+    /// Returns when the resident value was last verified.
+    pub(super) fn last_verified_at_for(
+        table: MemoTableWithTypesMut<'_>,
+        memo_ingredient_index: MemoIngredientIndex,
+    ) -> Option<Revision> {
+        let mut last_verified_at = None;
+        table.map_memo(memo_ingredient_index, |memo: &mut Memo<'static, C>| {
+            if memo.value.is_some() {
+                last_verified_at = Some(memo.header.verified_at.load());
+            }
+        });
+        last_verified_at
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,7 +401,9 @@ pub mod plumbing {
         pub use crate::function::Configuration;
         pub use crate::function::IngredientImpl;
         pub use crate::function::Memo;
-        pub use crate::function::{EvictionPolicy, HasCapacity, Lru, NoopEviction};
+        pub use crate::function::{
+            EvictionContext, EvictionPolicy, HasCapacity, Lru, NoopEviction,
+        };
         pub use crate::table::memo::MemoEntryType;
     }
 


### PR DESCRIPTION
Generalize tracked-function eviction around insertion and usage events plus a revision context. This keeps the existing LRU behavior while allowing policies to inspect memo revisions and evict values without depending on table internals.

This should put most infrastructure (except some macro `eviction_policy(lru)`) in place, for generational and even within-revision garbage collection