### PR TITLE
Inline input field access helper

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -227,6 +227,7 @@ impl<C: Configuration> IngredientImpl<C> {
     /// Access field of an input.
     /// Note that this function returns the entire tuple of value fields.
     /// The caller is responsible for selecting the appropriate element.
+    #[inline]
     pub fn field<'db>(
         &'db self,
         zalsa: &'db Zalsa,


### PR DESCRIPTION
## Summary
- Add an inline hint to the input field access helper

## Notes
Local instruction-count inspection showed that inlining `input::IngredientImpl::field` removes the hot call from the input field read query body. Marking `data` / `data_raw` alone does not help, because the query body still calls `field`; interned field reads were already inlined in the benchmark body without additional hints.

## Verification
- cargo check