### PR TITLE
perf: cache table page metadata during memo eviction

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -474,13 +474,13 @@ where
     }
 
     fn reset_for_new_revision(&mut self, table: &mut Table) {
-        self.eviction.for_each_evicted(|evict| {
-            let ingredient_index = table.ingredient_index(evict);
-            Self::evict_value_from_memo_for(
-                table.memos_mut(evict),
-                self.memo_ingredient_indices.get(ingredient_index),
-            )
+        let memo_ingredient_indices = &self.memo_ingredient_indices;
+        let mut memos = table.memo_cursor_mut::<Memo<C>, _>(|ingredient_index| {
+            memo_ingredient_indices.get(ingredient_index)
         });
+
+        self.eviction
+            .for_each_evicted(|id| memos.map(id, Self::evict_value_from_memo));
 
         self.deleted_entries.clear();
     }

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -11,7 +11,7 @@ use crate::ingredient::WaitForResult;
 use crate::key::DatabaseKeyIndex;
 use crate::revision::AtomicRevision;
 use crate::sync::atomic::Ordering;
-use crate::table::memo::{DummyMemo, MemoTableWithTypesMut, ToDynMemo};
+use crate::table::memo::{DummyMemo, ToDynMemo};
 use crate::zalsa::{MemoIngredientIndex, Zalsa};
 use crate::zalsa_local::{QueryOriginRef, QueryRevisions};
 use crate::{Event, EventKind, Id, Revision};
@@ -46,21 +46,11 @@ impl<C: Configuration> IngredientImpl<C> {
         Some(unsafe { memo.as_ref() })
     }
 
-    /// Evicts the existing memo for the given key, replacing it
-    /// with an equivalent memo that has no value. If the memo is untracked
-    /// or has values assigned as output of another query, this has no effect.
-    pub(super) fn evict_value_from_memo_for(
-        table: MemoTableWithTypesMut<'_>,
-        memo_ingredient_index: MemoIngredientIndex,
-    ) {
-        let map = |memo: &mut Memo<C>| {
-            if memo.header.can_evict_value() {
-                // Set the memo value to `None`.
-                memo.value = None;
-            }
-        };
-
-        table.map_memo(memo_ingredient_index, map)
+    /// Evicts the memoized value unless it cannot be reconstructed.
+    pub(super) fn evict_value_from_memo(memo: &mut Memo<C>) {
+        if memo.header.can_evict_value() {
+            memo.value = None;
+        }
     }
 }
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -793,8 +793,8 @@ mod tests {
     ) -> NonNull<TestMemo> {
         let memo = NonNull::from(Box::leak(Box::new(TestMemo(value))));
         // SAFETY: Test slots ignore the revision, and `memo_index` matches the page's types.
-        let old =
-            unsafe { table.memos::<TestSlot>(id, Revision::start()) }.insert(memo_index, memo);
+        let memos = unsafe { table.memos::<TestSlot>(id, Revision::start()) };
+        let old = memos.insert(memo_index, memo);
         assert!(old.is_none());
         memo
     }

--- a/src/table.rs
+++ b/src/table.rs
@@ -25,23 +25,6 @@ const MAX_PAGES: usize = Id::MAX_USIZE / PAGE_LEN;
 /// A typed [`Page`] view.
 pub(crate) struct PageView<'p, T: Slot>(&'p Page, PhantomData<&'p T>);
 
-/// Typed mutable access to one memo ingredient across a stream of table IDs.
-pub(crate) struct MemoCursorMut<'t, M, F> {
-    table: &'t mut Table,
-    memo_index: F,
-    resolved_page: Option<ResolvedPage<M>>,
-}
-
-struct ResolvedPage<M> {
-    page_index: PageIndex,
-    data: NonNull<()>,
-    initialized: usize,
-    slot_size: usize,
-    memos_mut: SlotMemosMutFnErased,
-    memo_index: MemoIngredientIndex,
-    marker: PhantomData<M>,
-}
-
 pub struct Table {
     pages: boxcar::Vec<Page>,
     /// Map from ingredient to non-full pages that are up for grabs
@@ -425,6 +408,13 @@ impl Table {
     }
 }
 
+/// Typed mutable access to one memo ingredient across a stream of table IDs.
+pub(crate) struct MemoCursorMut<'t, M, F> {
+    table: &'t mut Table,
+    memo_index: F,
+    resolved_page: Option<ResolvedPage<M>>,
+}
+
 impl<M, F> MemoCursorMut<'_, M, F>
 where
     M: Memo,
@@ -442,7 +432,7 @@ where
             self.resolve_page(page_index);
         }
 
-        self.resolved_page.as_mut().unwrap().map(slot, f);
+        self.resolved_page.as_ref().unwrap().map(slot, f);
     }
 
     #[cold]
@@ -451,7 +441,7 @@ where
         let page = self
             .table
             .pages
-            .get_mut(index)
+            .get(index)
             .unwrap_or_else(|| panic!("index `{index}` is uninitialized"));
         let memo_index = (self.memo_index)(page.ingredient);
         page.memo_types.assert_type::<M>(memo_index);
@@ -468,9 +458,19 @@ where
     }
 }
 
+struct ResolvedPage<M> {
+    page_index: PageIndex,
+    data: NonNull<()>,
+    initialized: usize,
+    slot_size: usize,
+    memos_mut: SlotMemosMutFnErased,
+    memo_index: MemoIngredientIndex,
+    marker: PhantomData<M>,
+}
+
 impl<M: Memo> ResolvedPage<M> {
     #[inline]
-    fn map(&mut self, slot: SlotIndex, f: impl FnOnce(&mut M)) {
+    fn map(&self, slot: SlotIndex, f: impl FnOnce(&mut M)) {
         assert!(
             slot.0 < self.initialized,
             "out of bounds access `{slot:?}` (maximum slot `{}`)",
@@ -718,12 +718,13 @@ mod tests {
         let missing = allocate_slot(&table, page_a, &types_a);
         let b0 = allocate_slot(&table, page_b, &types_b);
         let b1 = allocate_slot(&table, page_b, &types_b);
-        let a0_memo = insert_memo(&table, a0, memo_a, 0);
-        let a1_memo = insert_memo(&table, a1, memo_a, 0);
-        let b0_memo = insert_memo(&table, b0, memo_b, 0);
-        let b1_memo = insert_memo(&table, b1, memo_b, 0);
+        insert_memo(&table, a0, memo_a, 0);
+        insert_memo(&table, a1, memo_a, 1);
+        insert_memo(&table, b0, memo_b, 2);
+        insert_memo(&table, b1, memo_b, 3);
 
         let mut resolutions = Vec::new();
+        let mut values = Vec::new();
         {
             let mut cursor = table.memo_cursor_mut::<TestMemo, _>(|ingredient| {
                 resolutions.push(ingredient);
@@ -735,18 +736,15 @@ mod tests {
             });
 
             for id in [a1, a0, b1, b0, a0, missing] {
-                cursor.map(id, |memo| memo.0 += 1);
+                cursor.map(id, |memo| {
+                    values.push(memo.0);
+                    memo.0 += 10;
+                });
             }
         }
 
         assert_eq!(resolutions, [ingredient_a, ingredient_b, ingredient_a]);
-        // SAFETY: The table owns these memos until it is dropped below.
-        unsafe {
-            assert_eq!(a0_memo.as_ref().0, 2);
-            assert_eq!(a1_memo.as_ref().0, 1);
-            assert_eq!(b0_memo.as_ref().0, 1);
-            assert_eq!(b1_memo.as_ref().0, 1);
-        }
+        assert_eq!(values, [1, 0, 3, 2, 10]);
     }
 
     #[test]
@@ -785,18 +783,12 @@ mod tests {
         id
     }
 
-    fn insert_memo(
-        table: &Table,
-        id: Id,
-        memo_index: MemoIngredientIndex,
-        value: usize,
-    ) -> NonNull<TestMemo> {
+    fn insert_memo(table: &Table, id: Id, memo_index: MemoIngredientIndex, value: usize) {
         let memo = NonNull::from(Box::leak(Box::new(TestMemo(value))));
         // SAFETY: Test slots ignore the revision, and `memo_index` matches the page's types.
         let memos = unsafe { table.memos::<TestSlot>(id, Revision::start()) };
         let old = memos.insert(memo_index, memo);
         assert!(old.is_none());
-        memo
     }
 
     struct TestSlot {

--- a/src/table.rs
+++ b/src/table.rs
@@ -11,7 +11,8 @@ use rustc_hash::FxHashMap;
 
 use crate::sync::atomic::{AtomicUsize, Ordering};
 use crate::sync::{Arc, Mutex};
-use crate::table::memo::{MemoTableTypes, MemoTableWithTypes, MemoTableWithTypesMut};
+use crate::table::memo::{Memo, MemoTableTypes, MemoTableWithTypes};
+use crate::zalsa::MemoIngredientIndex;
 use crate::{Id, IngredientIndex, Revision};
 
 pub(crate) mod memo;
@@ -23,6 +24,23 @@ const MAX_PAGES: usize = Id::MAX_USIZE / PAGE_LEN;
 
 /// A typed [`Page`] view.
 pub(crate) struct PageView<'p, T: Slot>(&'p Page, PhantomData<&'p T>);
+
+/// Typed mutable access to one memo ingredient across a stream of table IDs.
+pub(crate) struct MemoCursorMut<'t, M, F> {
+    table: &'t mut Table,
+    memo_index: F,
+    resolved_page: Option<ResolvedPage<M>>,
+}
+
+struct ResolvedPage<M> {
+    page_index: PageIndex,
+    data: NonNull<()>,
+    initialized: usize,
+    slot_size: usize,
+    memos_mut: SlotMemosMutFnErased,
+    memo_index: MemoIngredientIndex,
+    marker: PhantomData<M>,
+}
 
 pub struct Table {
     pages: boxcar::Vec<Page>,
@@ -351,18 +369,17 @@ impl Table {
         unsafe { page.memo_types.attach_memos(memos) }
     }
 
-    /// Get the memo table associated with `id`
-    pub(crate) fn memos_mut(&mut self, id: Id) -> MemoTableWithTypesMut<'_> {
-        let (page, slot) = split_id(id);
-        let page_index = page.0;
-        let page = self
-            .pages
-            .get_mut(page_index)
-            .unwrap_or_else(|| panic!("index `{page_index}` is uninitialized"));
-        // SAFETY: We supply a proper slot pointer and the caller is required to pass the `current_revision`.
-        let memos = unsafe { &mut *(page.slot_vtable.memos_mut)(page.get(slot)) };
-        // SAFETY: The `Page` keeps the correct memo types.
-        unsafe { page.memo_types.attach_memos_mut(memos) }
+    /// Returns a cursor that caches page metadata while mutating memos of type `M`.
+    pub(crate) fn memo_cursor_mut<M, F>(&mut self, memo_index: F) -> MemoCursorMut<'_, M, F>
+    where
+        M: Memo,
+        F: FnMut(IngredientIndex) -> MemoIngredientIndex,
+    {
+        MemoCursorMut {
+            table: self,
+            memo_index,
+            resolved_page: None,
+        }
     }
 
     pub(crate) fn slots_of<T: Slot>(&self) -> impl Iterator<Item = (Id, &T)> + '_ {
@@ -405,6 +422,70 @@ impl Table {
             .entry(ingredient)
             .or_default()
             .push(page);
+    }
+}
+
+impl<M, F> MemoCursorMut<'_, M, F>
+where
+    M: Memo,
+    F: FnMut(IngredientIndex) -> MemoIngredientIndex,
+{
+    /// Calls `f` on the memo for `id`, if present.
+    #[inline]
+    pub(crate) fn map(&mut self, id: Id, f: impl FnOnce(&mut M)) {
+        let (page_index, slot) = split_id(id);
+        if self
+            .resolved_page
+            .as_ref()
+            .is_none_or(|page| page.page_index != page_index)
+        {
+            self.resolve_page(page_index);
+        }
+
+        self.resolved_page.as_mut().unwrap().map(slot, f);
+    }
+
+    #[cold]
+    fn resolve_page(&mut self, page_index: PageIndex) {
+        let index = page_index.0;
+        let page = self
+            .table
+            .pages
+            .get_mut(index)
+            .unwrap_or_else(|| panic!("index `{index}` is uninitialized"));
+        let memo_index = (self.memo_index)(page.ingredient);
+        page.memo_types.assert_type::<M>(memo_index);
+
+        self.resolved_page = Some(ResolvedPage {
+            page_index,
+            data: page.data,
+            initialized: page.allocated.load(Ordering::Acquire),
+            slot_size: page.slot_vtable.layout.size(),
+            memos_mut: page.slot_vtable.memos_mut,
+            memo_index,
+            marker: PhantomData,
+        });
+    }
+}
+
+impl<M: Memo> ResolvedPage<M> {
+    #[inline]
+    fn map(&mut self, slot: SlotIndex, f: impl FnOnce(&mut M)) {
+        assert!(
+            slot.0 < self.initialized,
+            "out of bounds access `{slot:?}` (maximum slot `{}`)",
+            self.initialized
+        );
+
+        // SAFETY: The cursor holds exclusive access to the table, and `slot` was checked against
+        // the initialized length captured when this page was resolved.
+        let slot = unsafe { self.data.as_ptr().byte_add(slot.0 * self.slot_size) };
+        // SAFETY: `slot` belongs to the page whose slot vtable supplied `memos_mut`.
+        let memos = unsafe { &mut *(self.memos_mut)(slot) };
+        // SAFETY: The memo type was validated against this page's types during resolution.
+        if let Some(memo) = unsafe { memos.get_mut_unchecked(self.memo_index) } {
+            f(memo);
+        }
     }
 }
 
@@ -608,4 +689,158 @@ pub fn split_id(id: Id) -> (PageIndex, SlotIndex) {
     let slot = index & PAGE_LEN_MASK;
     let page = index >> PAGE_LEN_BITS;
     (PageIndex::new(page), SlotIndex::new(slot))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::DatabaseKeyIndex;
+    use crate::table::memo::{MemoEntryType, MemoTable};
+    use crate::zalsa::Zalsa;
+
+    #[test]
+    fn memo_cursor_caches_pages_with_ingredient_specific_memo_indices() {
+        let mut table = Table::default();
+        let ingredient_a = IngredientIndex::new(1);
+        let ingredient_b = IngredientIndex::new(2);
+        let memo_a = MemoIngredientIndex::from_usize(0);
+        let memo_b = MemoIngredientIndex::from_usize(1);
+        let types_a = memo_types([MemoEntryType::of::<TestMemo>()]);
+        let types_b = memo_types([
+            MemoEntryType::of::<OtherMemo>(),
+            MemoEntryType::of::<TestMemo>(),
+        ]);
+        let page_a = table.push_page::<TestSlot>(ingredient_a, types_a.clone());
+        let page_b = table.push_page::<TestSlot>(ingredient_b, types_b.clone());
+
+        let a0 = allocate_slot(&table, page_a, &types_a);
+        let a1 = allocate_slot(&table, page_a, &types_a);
+        let missing = allocate_slot(&table, page_a, &types_a);
+        let b0 = allocate_slot(&table, page_b, &types_b);
+        let b1 = allocate_slot(&table, page_b, &types_b);
+        let a0_memo = insert_memo(&table, a0, memo_a, 0);
+        let a1_memo = insert_memo(&table, a1, memo_a, 0);
+        let b0_memo = insert_memo(&table, b0, memo_b, 0);
+        let b1_memo = insert_memo(&table, b1, memo_b, 0);
+
+        let mut resolutions = Vec::new();
+        {
+            let mut cursor = table.memo_cursor_mut::<TestMemo, _>(|ingredient| {
+                resolutions.push(ingredient);
+                match ingredient {
+                    index if index == ingredient_a => memo_a,
+                    index if index == ingredient_b => memo_b,
+                    _ => unreachable!(),
+                }
+            });
+
+            for id in [a1, a0, b1, b0, a0, missing] {
+                cursor.map(id, |memo| memo.0 += 1);
+            }
+        }
+
+        assert_eq!(resolutions, [ingredient_a, ingredient_b, ingredient_a]);
+        // SAFETY: The table owns these memos until it is dropped below.
+        unsafe {
+            assert_eq!(a0_memo.as_ref().0, 2);
+            assert_eq!(a1_memo.as_ref().0, 1);
+            assert_eq!(b0_memo.as_ref().0, 1);
+            assert_eq!(b1_memo.as_ref().0, 1);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "inconsistent type-id")]
+    fn memo_cursor_validates_the_memo_type_when_resolving_a_page() {
+        let mut table = Table::default();
+        let ingredient = IngredientIndex::new(1);
+        let memo_index = MemoIngredientIndex::from_usize(0);
+        let types = memo_types([MemoEntryType::of::<TestMemo>()]);
+        let page = table.push_page::<TestSlot>(ingredient, types.clone());
+        let id = allocate_slot(&table, page, &types);
+        let mut cursor = table.memo_cursor_mut::<OtherMemo, _>(|_| memo_index);
+
+        cursor.map(id, |_| unreachable!());
+    }
+
+    fn memo_types<const N: usize>(entries: [MemoEntryType; N]) -> Arc<MemoTableTypes> {
+        let mut types = MemoTableTypes::default();
+        for (index, entry) in entries.into_iter().enumerate() {
+            types.set(MemoIngredientIndex::from_usize(index), entry);
+        }
+        Arc::new(types)
+    }
+
+    fn allocate_slot(table: &Table, page: PageIndex, types: &MemoTableTypes) -> Id {
+        // SAFETY: Tests allocate sequentially and are the only writers to the page.
+        let result = unsafe {
+            table.page::<TestSlot>(page).allocate(page, |_| TestSlot {
+                // SAFETY: The slot is only accessed with `types`.
+                memos: MemoTable::new(types),
+            })
+        };
+        let Ok((id, _)) = result else {
+            panic!("test page is full")
+        };
+        id
+    }
+
+    fn insert_memo(
+        table: &Table,
+        id: Id,
+        memo_index: MemoIngredientIndex,
+        value: usize,
+    ) -> NonNull<TestMemo> {
+        let memo = NonNull::from(Box::leak(Box::new(TestMemo(value))));
+        // SAFETY: Test slots ignore the revision, and `memo_index` matches the page's types.
+        let old =
+            unsafe { table.memos::<TestSlot>(id, Revision::start()) }.insert(memo_index, memo);
+        assert!(old.is_none());
+        memo
+    }
+
+    struct TestSlot {
+        memos: MemoTable,
+    }
+
+    // SAFETY: `TestSlot` is private to this test module and has one slot type per ingredient.
+    unsafe impl Slot for TestSlot {
+        unsafe fn memos(slot: *const Self, _: Revision) -> *const MemoTable {
+            // SAFETY: The caller provides a valid slot pointer.
+            unsafe { &raw const (*slot).memos }
+        }
+
+        fn memos_mut(&mut self) -> &mut MemoTable {
+            &mut self.memos
+        }
+    }
+
+    struct TestMemo(usize);
+    struct OtherMemo;
+
+    impl Memo for TestMemo {
+        fn has_value(&self) -> bool {
+            true
+        }
+
+        fn remove_outputs(&self, _: &Zalsa, _: DatabaseKeyIndex) {}
+
+        #[cfg(feature = "salsa_unstable")]
+        fn memory_usage(&self) -> crate::database::MemoInfo {
+            unimplemented!()
+        }
+    }
+
+    impl Memo for OtherMemo {
+        fn has_value(&self) -> bool {
+            true
+        }
+
+        fn remove_outputs(&self, _: &Zalsa, _: DatabaseKeyIndex) {}
+
+        #[cfg(feature = "salsa_unstable")]
+        fn memory_usage(&self) -> crate::database::MemoInfo {
+            unimplemented!()
+        }
+    }
 }

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -53,7 +53,7 @@ impl MemoTable {
     /// `M` must match the type registered for `memo_ingredient_index` in the
     /// [`MemoTableTypes`] associated with this table.
     #[inline]
-    pub(crate) unsafe fn get_mut_unchecked<M: Memo>(
+    pub(super) unsafe fn get_mut_unchecked<M: Memo>(
         &mut self,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> Option<&mut M> {
@@ -304,7 +304,7 @@ impl MemoTableTypes {
 
     /// Validates the memo type registered at `memo_ingredient_index`.
     #[inline]
-    pub(crate) fn assert_type<M: Memo>(&self, memo_ingredient_index: MemoIngredientIndex) {
+    pub(super) fn assert_type<M: Memo>(&self, memo_ingredient_index: MemoIngredientIndex) {
         let Some(type_) = self.types.get(memo_ingredient_index.as_usize()) else {
             type_assert_failed(memo_ingredient_index);
         };
@@ -487,42 +487,6 @@ pub(crate) struct MemoTableWithTypesMut<'a> {
 }
 
 impl MemoTableWithTypesMut<'_> {
-    /// Calls `f` on the memo at `memo_ingredient_index`.
-    ///
-    /// If the memo is not present, `f` is not called.
-    #[allow(dead_code)] // The cursor uses a private unchecked path after validating its page.
-    pub(crate) fn map_memo<M: Memo>(
-        self,
-        memo_ingredient_index: MemoIngredientIndex,
-        f: impl FnOnce(&mut M),
-    ) {
-        let Some(MemoEntry { atomic_memo }) =
-            self.memos.memos.get_mut(memo_ingredient_index.as_usize())
-        else {
-            return;
-        };
-
-        // SAFETY: Any indices that are in-bounds for the `MemoTable` are also in-bounds for its
-        // corresponding `MemoTableTypes`, by construction.
-        let type_ = unsafe {
-            self.types
-                .types
-                .get_unchecked(memo_ingredient_index.as_usize())
-        };
-
-        // Verify that the we are casting to the correct type.
-        if type_.type_id != TypeId::of::<M>() {
-            type_assert_failed(memo_ingredient_index);
-        }
-
-        let Some(memo) = NonNull::new(*atomic_memo.get_mut()) else {
-            return;
-        };
-
-        // SAFETY: We asserted that the type is correct above.
-        f(unsafe { MemoEntryType::from_dummy(memo).as_mut() });
-    }
-
     /// To drop an entry, we need its type, so we don't implement `Drop`, and instead have this method.
     ///
     /// Note that calling this multiple times is safe, dropping an uninitialized entry is a no-op.

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -45,6 +45,24 @@ impl MemoTable {
     pub fn reset(&mut self) {
         self.memos.clear();
     }
+
+    /// Returns the memo at `memo_ingredient_index` without validating its erased type.
+    ///
+    /// # Safety
+    ///
+    /// `M` must match the type registered for `memo_ingredient_index` in the
+    /// [`MemoTableTypes`] associated with this table.
+    #[inline]
+    pub(crate) unsafe fn get_mut_unchecked<M: Memo>(
+        &mut self,
+        memo_ingredient_index: MemoIngredientIndex,
+    ) -> Option<&mut M> {
+        let MemoEntry { atomic_memo } = self.memos.get_mut(memo_ingredient_index.as_usize())?;
+        let memo = NonNull::new(*atomic_memo.get_mut())?;
+
+        // SAFETY: The caller guarantees that `M` matches the entry's registered type.
+        Some(unsafe { MemoEntryType::from_dummy(memo).as_mut() })
+    }
 }
 
 pub trait Memo: Any + Send + Sync {
@@ -284,6 +302,18 @@ impl MemoTableTypes {
         self.types.len()
     }
 
+    /// Validates the memo type registered at `memo_ingredient_index`.
+    #[inline]
+    pub(crate) fn assert_type<M: Memo>(&self, memo_ingredient_index: MemoIngredientIndex) {
+        let Some(type_) = self.types.get(memo_ingredient_index.as_usize()) else {
+            type_assert_failed(memo_ingredient_index);
+        };
+
+        if type_.type_id != TypeId::of::<M>() {
+            type_assert_failed(memo_ingredient_index);
+        }
+    }
+
     /// # Safety
     ///
     /// The types table must be the correct one of `memos`.
@@ -460,6 +490,7 @@ impl MemoTableWithTypesMut<'_> {
     /// Calls `f` on the memo at `memo_ingredient_index`.
     ///
     /// If the memo is not present, `f` is not called.
+    #[allow(dead_code)] // The cursor uses a private unchecked path after validating its page.
     pub(crate) fn map_memo<M: Memo>(
         self,
         memo_ingredient_index: MemoIngredientIndex,


### PR DESCRIPTION
Cache the last resolved table page while evicting memo values, avoiding repeated page, vtable, memo-index, and type lookups for page-local victim streams. It slightly reduces the number of instructions on the eviction path for LRU, but it's a bigger impact for SIEVE where the eviction policy intentionally evicts items in their page order. 

This keeps eviction policies storage-agnostic while preserving arbitrary ID ordering; the isolated sweep prototype improved by roughly 15%.


## Benchmarks

Local benchmarks, because CodSpeed is bugged right now


Benchmark | #1234 on LRU | #1234 on SIEVE (#1226)
-- | -- | --
fast_path | −0.2% | +0.8%
fast_path_and_sweep | +0.6% | +0.4%
fill_and_evict | +0.4% | −0.1%
one_hit_wonders | −0.1% | −2.0%
phase_change | −0.1% | −0.9%
project_check_then_incremental | +1.1% | −0.1%
scan_resistance | −1.4% | −1.5%
Policy-specific instructions | −1.39% | −4.39%



