### PR TITLE
chore: time out CodSpeed benchmarks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,6 +168,7 @@ jobs:
   benchmarks:
     name: Benchmarks
     runs-on: codspeed-macro
+    timeout-minutes: 10
     needs: benchmarks-build
     steps:
       - name: Checkout


### PR DESCRIPTION
Cancel CodSpeed benchmark runs after 10 minutes so a stuck run cannot occupy the dedicated runner indefinitely.

Testing: Validated the workflow diff with Git whitespace checks.
