### PR TITLE
perf: discard oversized query bookkeeping tables

### DIFF
--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -6,7 +6,7 @@ use crate::accumulator::{
     Accumulator,
     accumulated_map::{AccumulatedMap, AtomicInputAccumulatedValues, InputAccumulatedValues},
 };
-use crate::hash::FxIndexSet;
+use crate::hash::{FxIndexSet, should_discard_retained_capacity};
 use crate::key::DatabaseKeyIndex;
 use crate::runtime::Stamp;
 use crate::sync::atomic::AtomicBool;
@@ -276,7 +276,7 @@ impl ActiveQuery {
             #[cfg(feature = "accumulator")]
                 accumulated_inputs: _,
         } = self;
-        input_outputs.clear();
+        clear_input_outputs(input_outputs);
         disambiguator_map.clear();
         tracked_struct_ids.clear();
         *cycle_heads = Default::default();
@@ -402,7 +402,9 @@ impl QueryStack {
             push_len,
         );
         let completion = active_query.prepare_completion(iteration, false);
-        completion.finish(active_query.input_outputs.drain(..))
+        let completed_query = completion.finish(active_query.input_outputs.iter().copied());
+        clear_input_outputs(&mut active_query.input_outputs);
+        completed_query
     }
 
     pub(crate) fn pop_detached_completion(
@@ -420,7 +422,7 @@ impl QueryStack {
         );
         let completion = active_query.prepare_completion(iteration, force_extra);
         let DetachedInputOutputs(mut reusable_frame_input_outputs) = detached_input_outputs;
-        reusable_frame_input_outputs.clear();
+        clear_input_outputs(&mut reusable_frame_input_outputs);
         active_query.input_outputs = reusable_frame_input_outputs;
         completion
     }
@@ -446,6 +448,14 @@ impl QueryStack {
         let active_query = &mut self.stack[self.len];
         debug_assert_eq!(active_query.database_key_index, key, "unbalanced push/pop");
         active_query
+    }
+}
+
+fn clear_input_outputs(input_outputs: &mut FxIndexSet<QueryEdge>) {
+    if should_discard_retained_capacity(input_outputs.len(), input_outputs.capacity()) {
+        *input_outputs = Default::default();
+    } else {
+        input_outputs.clear();
     }
 }
 

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -5,7 +5,7 @@ use crate::cycle::{CycleHeads, CycleRecoveryStrategy, IterationStamp, Provisiona
 use crate::function::memo::{Memo, MemoHeader};
 use crate::function::sync::ReleaseMode;
 use crate::function::{ClaimGuard, ClaimResult, Configuration, IngredientImpl, Reentrancy};
-use crate::hash::{FxHashSet, FxIndexSet};
+use crate::hash::{FxHashSet, FxIndexSet, should_discard_retained_capacity};
 use crate::plumbing::ZalsaLocal;
 use crate::sync::thread;
 use crate::tracked_struct::Identity;
@@ -945,9 +945,18 @@ fn complete_cycle_query(
         &mut seen,
     );
 
-    seen.clear();
+    if should_discard_retained_capacity(seen.len(), seen.capacity()) {
+        seen = Default::default();
+    } else {
+        seen.clear();
+    }
     let completion = detached_query.pop_completion(iteration, true);
-    let completed_query = completion.finish(flattened.drain(..));
+    let completed_query = completion.finish(flattened.iter().copied());
+    if should_discard_retained_capacity(flattened.len(), flattened.capacity()) {
+        flattened = Default::default();
+    } else {
+        flattened.clear();
+    }
     #[cfg(feature = "accumulator")]
     assert!(
         completed_query

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,9 +1,20 @@
 use std::hash::{BuildHasher, Hash, Hasher};
 
+// Clearing a retained hash table scans its entire control-byte array, making cleanup O(capacity)
+// even when few entries remain. Below 16K, that scan is cheaper than allocator churn. Above it,
+// retain up to 2x slack because geometric growth can naturally leave a new table about half full.
+const MIN_INDEX_CAPACITY_TO_DISCARD: usize = 1 << 14;
+const RETAINED_INDEX_CAPACITY_FACTOR: usize = 2;
+
 pub(crate) type FxHasher = std::hash::BuildHasherDefault<rustc_hash::FxHasher>;
 pub(crate) type FxIndexSet<K> = indexmap::IndexSet<K, FxHasher>;
 pub(crate) type FxLinkedHashSet<K> = hashlink::LinkedHashSet<K, FxHasher>;
 pub(crate) type FxHashSet<K> = std::collections::HashSet<K, FxHasher>;
+
+pub(crate) fn should_discard_retained_capacity(len: usize, capacity: usize) -> bool {
+    capacity >= MIN_INDEX_CAPACITY_TO_DISCARD
+        && capacity > len.saturating_mul(RETAINED_INDEX_CAPACITY_FACTOR)
+}
 
 pub(crate) fn hash<T: Hash>(t: &T) -> u64 {
     FxHasher::default().hash_one(t)


### PR DESCRIPTION
`IndexMap` clears retained hash control bytes in `O(capacity)`, making sparse query (like 2 edges) frames expensive after a large query. 

Ideally, this would be something that `HashTable` handles better. For now, we'll drop the allocation if we've seen one overly large `IndexMap` that is only very sparsely populated. Specifically, we preserve up to 2x slack above a 16K floor.

Testing: ty shows a 0.77% static-frame improvement.
