### PR TITLE
fix: restart fixpoint iteration after cancellation

### DIFF
--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -135,21 +135,31 @@ where
         let mut last_provisional_memo_opt: Option<&Memo<'db, C>> = None;
 
         let mut last_stale_tracked_ids: Vec<(Identity, Id)> = Vec::new();
+        let current_revision = zalsa.current_revision();
         let cancellation_count = zalsa.runtime().cancellation_count();
+        let mut opt_old_memo = opt_old_memo;
         let mut iteration = IterationStamp::initial(cancellation_count);
 
+        // An ordinary query doesn't memoize a cancelled execution. Match that behavior for
+        // fixpoint queries: a memo from an abandoned cancellation epoch in this revision doesn't
+        // seed the retry, while a memo from an older revision remains useful for backdating and
+        // output bookkeeping. Cancellation counts are only comparable within a revision.
         if let Some(old_memo) = opt_old_memo {
-            if let Some(previous_iteration) = old_memo.header.previous_iteration(
-                zalsa,
-                database_key_index,
-                cancellation_count,
-                old_memo.value.is_some(),
-            ) {
-                if previous_iteration.reuse_as_provisional {
-                    last_provisional_memo_opt = Some(old_memo);
-                }
+            if old_memo.header.verified_at.load() == current_revision {
+                match old_memo.header.previous_iteration(
+                    database_key_index,
+                    cancellation_count,
+                    old_memo.value.is_some(),
+                ) {
+                    Some(previous_iteration) => {
+                        if previous_iteration.reuse_as_provisional {
+                            last_provisional_memo_opt = Some(old_memo);
+                        }
 
-                iteration = previous_iteration.iteration;
+                        iteration = previous_iteration.iteration;
+                    }
+                    None => opt_old_memo = None,
+                }
             }
         }
 
@@ -291,11 +301,7 @@ where
             let new_memo = self.insert_memo(
                 zalsa,
                 id,
-                Memo::new(
-                    Some(new_value),
-                    zalsa.current_revision(),
-                    completed_query.revisions,
-                ),
+                Memo::new(Some(new_value), current_revision, completed_query.revisions),
                 memo_ingredient_index,
             );
 
@@ -359,14 +365,11 @@ enum QueryExecutionOutcome<'db> {
 impl MemoHeader {
     fn previous_iteration(
         &self,
-        zalsa: &Zalsa,
         database_key_index: DatabaseKeyIndex,
         cancellation_count: u8,
         has_value: bool,
     ) -> Option<PreviousIteration> {
-        if self.verified_at.load() != zalsa.current_revision()
-            || self.revisions.iteration().cancellation_count() != cancellation_count
-        {
+        if self.revisions.iteration().cancellation_count() != cancellation_count {
             return None;
         }
 

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -367,6 +367,12 @@ impl MemoHeader {
             return true;
         }
 
+        // A pending write can cancel a fixpoint iteration without advancing the revision.
+        // Provisional results from the abandoned execution must not be reused.
+        if self.revisions.iteration().cancellation_count() != zalsa.runtime().cancellation_count() {
+            return false;
+        }
+
         crate::tracing::trace!(
             "{database_key_index:?}: validate_may_be_provisional(memo = {memo:#?})",
             memo = self.tracing_debug(has_value)

--- a/tests/parallel/cancellation_in_fixpoint.rs
+++ b/tests/parallel/cancellation_in_fixpoint.rs
@@ -1,0 +1,86 @@
+// Shuttle doesn't like panics inside of its runtime.
+#![cfg(not(feature = "shuttle"))]
+
+//! A pending write must not leave reusable provisional memos behind.
+//!
+//! `cycle_a` and `cycle_b` establish a fixpoint cycle. The test interrupts that cycle
+//! with an explicit cancellation that does not advance the revision. The retry must start from a
+//! fresh cycle initial value.
+
+use salsa::{Cancelled, Database};
+
+use crate::setup::{Knobs, KnobsDatabase};
+use crate::sync::thread;
+
+#[salsa::input]
+struct Input {
+    #[returns(copy)]
+    value: u32,
+}
+
+#[salsa::tracked(returns(copy), cycle_fn = cycle_fn, cycle_initial = cycle_initial)]
+fn cycle_a(db: &dyn KnobsDatabase, input: Input) -> u32 {
+    let value = cycle_b(db, input);
+
+    db.signal(1);
+    db.wait_for(2);
+    cancellation_point(db, input);
+
+    value
+}
+
+#[salsa::tracked(returns(copy), cycle_fn = cycle_fn, cycle_initial = cycle_initial)]
+fn cycle_b(db: &dyn KnobsDatabase, input: Input) -> u32 {
+    let value = cycle_a(db, input);
+    value.saturating_add(1).min(input.value(db))
+}
+
+#[salsa::tracked]
+fn cancellation_point(db: &dyn KnobsDatabase, input: Input) {
+    input.value(db);
+}
+
+fn cycle_initial(_db: &dyn KnobsDatabase, _id: salsa::Id, _input: Input) -> u32 {
+    0
+}
+
+fn cycle_fn(
+    _db: &dyn KnobsDatabase,
+    _cycle: &salsa::Cycle,
+    _last_provisional_value: &u32,
+    value: u32,
+    _input: Input,
+) -> u32 {
+    value
+}
+
+#[test]
+fn same_revision_cancellation_leaves_fixpoint_cycle_reusable() {
+    let db = Knobs::default();
+    let db_writer = db.clone();
+    let db_t1 = db.clone();
+    let db_waiter = db.clone();
+    let input = Input::new(&db, 3);
+
+    db.signal_on_did_cancel(2);
+    drop(db);
+
+    let t1 = thread::spawn(move || Cancelled::catch(|| cycle_a(&db_t1, input)));
+
+    db_waiter.wait_for(1);
+    drop(db_waiter);
+
+    let t2 = thread::spawn({
+        let mut db_writer = db_writer;
+        move || {
+            db_writer.trigger_cancellation();
+            db_writer
+        }
+    });
+
+    assert!(matches!(t1.join().unwrap(), Err(Cancelled::PendingWrite)));
+
+    let db_after = t2.join().unwrap();
+
+    assert_eq!(cycle_a(&db_after, input), 3);
+}

--- a/tests/parallel/main.rs
+++ b/tests/parallel/main.rs
@@ -3,6 +3,7 @@
 mod setup;
 mod signal;
 
+mod cancellation_in_fixpoint;
 mod cancellation_token_cycle_nested;
 mod cancellation_token_multi_blocked;
 mod cancellation_token_recomputes;


### PR DESCRIPTION
It turns out, I missed a few places where we have to check for cancellations in https://github.com/salsa-rs/salsa/pull/1100. 

If we have:

* `query_a` -> `query_b` -> `query_a` (initial)
* `query_b` completes, 
* trigger cancellation, `query_a` unwinds before completing 
* Call `query_a` again. It sees a different cancellation count and re-executes
* `fetch_cold` now verifies `query_b`. `validate_provisional` returns true because `query_b` and the provisional memo of `query_a` have the same iteration (and cancellation count). `query_b` returns without re-executing, bypassing the insertion of a new initial value for `query_a`! 
* `query_a` sees that it's a cycle head and tries to read the provisional value. But the value of that memo is `None` -> panic.

This PR adds a check to never return `true` from `validate_provisional` if the memo is from a cancelled execution. 

This PR also adds a check that prevents a call to `seed_iteration` if the memo is from a different cancellation. This can result in leaking tracked structs, but this is an issue that applies equally to normal queries, see https://github.com/salsa-rs/salsa/issues/1237

Fixes [astral-sh/ty#3924](https://github.com/astral-sh/ty/issues/3924)

