### PR TITLE
chore: update CodSpeed action to v4.18.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,7 +191,7 @@ jobs:
         run: find target/codspeed -type f -exec chmod +x {} +
 
       - name: "Run benchmarks"
-        uses: CodSpeedHQ/action@a4a36bb07c0638b0b4ca52bf1f3dad1b4289e52f # v4.18.1
+        uses: CodSpeedHQ/action@eea136791682a28c919fed3838920681d1959d14 # v4.18.3
         with:
           mode: "simulation,memory,walltime"
           run: cargo codspeed run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,7 +191,7 @@ jobs:
         run: find target/codspeed -type f -exec chmod +x {} +
 
       - name: "Run benchmarks"
-        uses: CodSpeedHQ/action@eea136791682a28c919fed3838920681d1959d14 # v4.18.3
+        uses: CodSpeedHQ/action@9f3a37ece7abc84992501a7fcd54d1704f3458fa # v4.18.4
         with:
           mode: "simulation,memory,walltime"
           run: cargo codspeed run


### PR DESCRIPTION
Updates the CodSpeed benchmark action to v4.18.4, which fixes the v4.18.3 installer hash mismatch in the benchmark job.

Testing: Verified the pinned commit against the v4.18.4 release tag; GitHub Actions will rerun on the updated branch.