### PR TITLE
chore: merge CodSpeed benchmark jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,11 +126,12 @@ jobs:
       - name: Test with Shuttle
         run: cargo nextest run --features shuttle --test parallel
 
-  benchmarks-build:
+  benchmarks:
     # https://github.com/CodSpeedHQ/action/issues/126
-    if: github.repository == 'salsa-rs/salsa' &&github.event_name != 'merge_group'
-    name: Benchmarks (build)
-    runs-on: ubuntu-22.04-arm
+    if: github.repository == 'salsa-rs/salsa' && github.event_name != 'merge_group'
+    name: Benchmarks
+    runs-on: codspeed-macro
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -157,38 +158,6 @@ jobs:
             --bench dataflow \
             --bench eviction
           cargo codspeed build -m walltime --bench eviction_walltime
-
-      - name: "Upload benchmark binaries"
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: benchmark-binaries
-          compression-level: 1
-          path: target/codspeed
-          if-no-files-found: "error"
-          retention-days: 1
-
-  benchmarks:
-    name: Benchmarks
-    runs-on: codspeed-macro
-    timeout-minutes: 10
-    needs: benchmarks-build
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: "Setup codspeed"
-        uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # v2.82.5
-        with:
-          tool: cargo-codspeed
-
-      - name: "Download benchmark binaries"
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: benchmark-binaries
-          path: target/codspeed
-
-      - name: "Restore binary permissions"
-        run: find target/codspeed -type f -exec chmod +x {} +
 
       - name: "Run benchmarks"
         uses: CodSpeedHQ/action@a4a36bb07c0638b0b4ca52bf1f3dad1b4289e52f # v4.18.1


### PR DESCRIPTION
Build and run CodSpeed benchmarks in one walltime-runner job. This should ensure that all runs build with the same glibc version. 

The original motivation for running build as a separate job was that walltime runners are billed by minute. However, building the salsa benchmarks with a warm cache from master only takes ~30s. Uploading and downloading the build artifacts takes about 20s. We should also move to the pro tier soon, with sponsored runner minutes. So that it's less critical that we stay within the 500 free minutes.