### PR TITLE
chore: update CodSpeed action to v4.18.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,7 +160,7 @@ jobs:
           cargo codspeed build -m walltime --bench eviction_walltime
 
       - name: "Run benchmarks"
-        uses: CodSpeedHQ/action@9f3a37ece7abc84992501a7fcd54d1704f3458fa # v4.18.4
+        uses: CodSpeedHQ/action@f99becdce5e5d51fd556489ebef684f4ecfd6286 # v4.18.5
         with:
           mode: "simulation,memory,walltime"
           run: cargo codspeed run


### PR DESCRIPTION
Updates the pinned CodSpeed GitHub Action from v4.18.4 to v4.18.5.