### PR TITLE
chore: Update compact_str to v0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ inventory = { version = "0.3.24", optional = true }
 rayon = { version = "1.10.0", optional = true }
 
 # Stuff we want SalsaValue impls for by default
-compact_str = { version = "0.9", optional = true }
+compact_str = { version = "0.10", optional = true }
 triomphe = { version = "0.1", optional = true }
 
 shuttle = { version = "0.9.1", optional = true }


### PR DESCRIPTION
Updates the optional `compact_str` dependency from v0.9 to v0.10.

v0.10 includes some unsoundness hardening and performance improvements.
