### PR TITLE
fix: make immortal interned values cheaper

### DIFF
--- a/benches/creation.rs
+++ b/benches/creation.rs
@@ -42,6 +42,22 @@ fn intern_distinct_many(bencher: divan::Bencher) {
         });
 }
 
+/// Interns many distinct values with garbage collection disabled.
+#[divan::bench]
+fn intern_immortal_distinct_many(bencher: divan::Bencher) {
+    bencher
+        .with_inputs(|| {
+            let db = salsa::DatabaseImpl::default();
+            warm_db(&db);
+            let input = InternInput::new(black_box(&db), black_box(MANY), black_box(1));
+            (db, input)
+        })
+        .bench_local_refs(|(db, input)| {
+            let sum = intern_immortal_distinct_values(black_box(db), black_box(*input));
+            assert_eq!(black_box(sum), MANY);
+        });
+}
+
 /// Interns the same value many times inside a query.
 #[divan::bench]
 fn intern_same_many(bencher: divan::Bencher) {
@@ -59,6 +75,26 @@ fn intern_same_many(bencher: divan::Bencher) {
         })
         .bench_local_refs(|(db, input)| {
             let sum = intern_same_value(black_box(db), black_box(*input));
+            assert_eq!(black_box(sum), MANY);
+        });
+}
+
+/// Interns the same value many times with garbage collection disabled.
+#[divan::bench]
+fn intern_immortal_same_many(bencher: divan::Bencher) {
+    bencher
+        .with_inputs(|| {
+            let db = salsa::DatabaseImpl::default();
+            warm_db(&db);
+            let warm_input = InternInput::new(black_box(&db), black_box(MANY), black_box(1));
+            let sum = intern_immortal_same_value(black_box(&db), black_box(warm_input));
+
+            assert_eq!(black_box(sum), MANY);
+            let input = InternInput::new(black_box(&db), black_box(MANY), black_box(1));
+            (db, input)
+        })
+        .bench_local_refs(|(db, input)| {
+            let sum = intern_immortal_same_value(black_box(db), black_box(*input));
             assert_eq!(black_box(sum), MANY);
         });
 }
@@ -157,6 +193,12 @@ struct InternedValue<'db> {
     value: usize,
 }
 
+#[salsa::interned(revisions = usize::MAX)]
+struct ImmortalInternedValue<'db> {
+    #[returns(copy)]
+    value: usize,
+}
+
 #[salsa::input]
 struct TrackedInput {
     #[returns(copy)]
@@ -215,6 +257,38 @@ fn intern_same_value(db: &dyn salsa::Database, input: InternInput) -> usize {
 
     for _ in 0..count {
         let interned = InternedValue::new(db, value);
+        black_box(interned);
+        sum += value;
+    }
+
+    sum
+}
+
+#[salsa::tracked(returns(copy))]
+#[inline(never)]
+fn intern_immortal_distinct_values(db: &dyn salsa::Database, input: InternInput) -> usize {
+    let count = input.count(db);
+    let value = input.value(db);
+    let mut sum = 0;
+
+    for offset in 0..count {
+        let interned = ImmortalInternedValue::new(db, value + offset);
+        black_box(interned);
+        sum += value;
+    }
+
+    sum
+}
+
+#[salsa::tracked(returns(copy))]
+#[inline(never)]
+fn intern_immortal_same_value(db: &dyn salsa::Database, input: InternInput) -> usize {
+    let count = input.count(db);
+    let value = input.value(db);
+    let mut sum = 0;
+
+    for _ in 0..count {
+        let interned = ImmortalInternedValue::new(db, value);
         black_box(interned);
         sum += value;
     }

--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -31,6 +31,9 @@ macro_rules! setup_interned_struct {
         // The minimum number of revisions to keep the value interned.
         revisions: $($revisions:expr)?,
 
+        // The eviction policy selected from the revision configuration.
+        eviction: $Eviction:ty,
+
         // the lifetime used in the desugared interned struct.
         // if the `db_lt_arg`, is present, this is `db_lt_arg`, but otherwise,
         // it is `'static`.
@@ -173,6 +176,7 @@ macro_rules! setup_interned_struct {
 
                 type Fields<'a> = $StructDataIdent<'a>;
                 type Struct<'db> = $Struct< $($db_lt_arg)? >;
+                type Eviction = $Eviction;
 
                 $(
                     fn heap_size(value: &Self::Fields<'_>) -> Option<usize> {

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -223,6 +223,8 @@ macro_rules! setup_tracked_fn {
 
                         type Struct<$db_lt> = $InternedData<$db_lt>;
 
+                        type Eviction = $zalsa::interned::Lru;
+
                         fn serialize<S: $zalsa::serde::Serializer>(
                             fields: &Self::Fields<'_>,
                             serializer: S,

--- a/components/salsa-macros/src/interned.rs
+++ b/components/salsa-macros/src/interned.rs
@@ -116,7 +116,17 @@ impl Macro {
         let generate_debug_impl = salsa_struct.generate_debug_impl();
         let has_lifetime = salsa_struct.generate_lifetime();
         let id = salsa_struct.id();
-        let revisions = salsa_struct.revisions();
+        let revisions = salsa_struct.revisions().next();
+        let eviction = revisions.map_or_else(
+            || quote!(::salsa::plumbing::interned::Lru),
+            |revisions| {
+                quote!(
+                    <::salsa::plumbing::interned::EvictionSelector<
+                        { #revisions == ::core::usize::MAX }
+                    > as ::salsa::plumbing::interned::SelectEviction>::Eviction
+                )
+            },
+        );
 
         let (db_lt_arg, cfg, interior_lt) = if has_lifetime {
             (
@@ -177,7 +187,8 @@ impl Macro {
                     db_lt: #db_lt,
                     db_lt_arg: #db_lt_arg,
                     id: #id,
-                    revisions: #(#revisions)*,
+                    revisions: #revisions,
+                    eviction: #eviction,
                     interior_lt: #interior_lt,
                     new_fn: #new_fn,
                     field_options: [#(#field_options),*],

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -9,23 +9,23 @@ use std::path::{Path, PathBuf};
 use std::ptr::NonNull;
 
 use crossbeam_utils::CachePadded;
-use intrusive_collections::{LinkedList, LinkedListLink, UnsafeRef, intrusive_adapter};
 use rustc_hash::FxBuildHasher;
-use smallvec::SmallVec;
 
-use crate::durability::Durability;
 use crate::function::VerifyResult;
 use crate::hash::{FxHashSet, FxIndexSet};
 use crate::id::{AsId, FromId};
 use crate::ingredient::Ingredient;
 use crate::plumbing::{self, Jar, ZalsaLocal};
-use crate::revision::AtomicRevision;
 use crate::sync::{Arc, Mutex, OnceLock};
 use crate::table::Slot;
 use crate::table::memo::{MemoTable, MemoTableTypes, MemoTableWithTypesMut};
 use crate::zalsa::{IngredientIndex, JarKind, Zalsa};
 use crate::zalsa_local::QueryEdge;
 use crate::{DatabaseKeyIndex, Event, EventKind, Id, Revision};
+
+mod eviction;
+
+pub use eviction::{EvictionPolicy, EvictionSelector, Lru, NoopEviction, SelectEviction};
 
 #[cfg(not(test))]
 const DEFAULT_REVISIONS: usize = 3;
@@ -60,6 +60,9 @@ pub unsafe trait Configuration: Sized + 'static {
     /// The end user struct
     type Struct<'db>: Copy + FromId + AsId;
 
+    /// The eviction policy used by this interned ingredient.
+    type Eviction: EvictionPolicy;
+
     /// Returns the size of any heap allocations in the output value, in bytes.
     fn heap_size(_value: &Self::Fields<'_>) -> Option<usize> {
         None
@@ -90,7 +93,8 @@ pub struct JarImpl<C: Configuration> {
 /// The interned ingredient hashes values of type `C::Fields` to produce an `Id`.
 ///
 /// It used to store interned structs but also to store the ID fields of a tracked struct.
-/// Interned values are garbage collected and their memory reused based on an LRU heuristic.
+/// The selected eviction policy controls whether interned values are garbage collected and their
+/// memory reused.
 pub struct IngredientImpl<C: Configuration> {
     /// Index of this ingredient in the database (used to construct database-IDs, etc).
     ingredient_index: IngredientIndex,
@@ -102,49 +106,44 @@ pub struct IngredientImpl<C: Configuration> {
     shift: u32,
 
     /// Sharded data that can only be accessed through a lock.
-    shards: Box<[CachePadded<Mutex<IngredientShard>>]>,
+    shards: Shards<C::Eviction>,
 
-    /// A queue of recent revisions in which values were interned.
-    revision_queue: RevisionQueue,
+    /// The eviction policy and any ingredient-wide eviction state.
+    eviction: C::Eviction,
 
     memo_table_types: Arc<MemoTableTypes>,
 
     _marker: PhantomData<fn() -> C>,
 }
 
-struct IngredientShard {
+type Shards<E> = Box<[CachePadded<Mutex<IngredientShard<E>>>]>;
+
+struct IngredientShard<E: EvictionPolicy> {
     /// Maps from data to the existing interned value for that data.
     ///
     /// The pointer is stable for the lifetime of the database. Storing it directly avoids a table
     /// lookup when hashing or comparing an existing entry.
     key_map: hashbrown::HashTable<ValueKey>,
 
-    /// An intrusive linked list for LRU.
-    lru: LinkedList<LruEntryAdapter>,
+    /// Per-shard eviction state.
+    eviction: E::Shard,
 }
 
-impl Default for IngredientShard {
+impl<E: EvictionPolicy> Default for IngredientShard<E> {
     fn default() -> Self {
         Self {
-            lru: LinkedList::default(),
+            eviction: E::Shard::default(),
             key_map: hashbrown::HashTable::new(),
         }
     }
 }
 
-// SAFETY: `IngredientShard` is only accessed through its mutex. Its LRU contains pointers to live,
-// stable values from this ingredient, and those pointers and their links are accessed only while
-// holding that mutex.
-unsafe impl Send for IngredientShard {}
-
-// SAFETY: `shard` is immutable. `lru` and `durability` are accessed only while holding the owning
+// SAFETY: `shard` is immutable. Eviction state is accessed only while holding the owning
 // ingredient shard lock. `fields` is mutated only while holding that lock after stale-slot reuse
 // guarantees no references remain, and is read only while holding the lock or after validation in
 // the current revision. `memos` supports concurrent shared access, and is mutated only with
 // exclusive access or after stale-slot reuse guarantees no shared references remain.
 unsafe impl<C: Configuration> Sync for Value<C> {}
-
-intrusive_adapter!(LruEntryAdapter = UnsafeRef<LruEntry>: LruEntry { link => LinkedListLink });
 
 /// Struct storing the interned fields.
 pub struct Value<C>
@@ -156,8 +155,8 @@ where
     /// This is immutable after construction and may be read to locate the protecting shard lock.
     shard: u16,
 
-    /// Type-erased state used by the LRU scan.
-    lru: LruEntry,
+    /// Per-value eviction state.
+    eviction: <C::Eviction as EvictionPolicy>::Entry,
 
     /// The interned fields for this value.
     ///
@@ -178,119 +177,7 @@ where
     /// adding it to the already aligned entry would increase the entry's size.
     /// This may only be accessed while holding the value's shard lock, or with exclusive access
     /// to the database.
-    durability: UnsafeCell<Durability>,
-}
-
-/// Type-erased state stored in the intrusive LRU list.
-struct LruEntry {
-    /// Intrusive links, accessed only while holding the owning shard lock.
-    link: LinkedListLink,
-
-    /// Metadata used to decide whether and how this slot can be reused.
-    ///
-    /// This may only be accessed while holding the owning shard lock, or with exclusive access to
-    /// the database.
-    metadata: UnsafeCell<EntryMetadata>,
-}
-
-impl LruEntry {
-    /// Returns a pointer to `value.lru` with provenance derived from `value`.
-    #[inline]
-    fn ptr_from_value<C: Configuration>(value: &Value<C>) -> *const Self {
-        let value = std::ptr::from_ref(value).cast::<u8>();
-
-        // SAFETY: `lru` is a field within `value`, so adding its offset is in bounds. Starting from
-        // `value`, rather than `value.lru`, gives the result provenance that permits
-        // `value_from_ptr` to subtract the offset again.
-        unsafe { value.add(std::mem::offset_of!(Value<C>, lru)).cast() }
-    }
-
-    /// Recovers a value from its LRU entry.
-    ///
-    /// # Safety
-    ///
-    /// `entry` must have been produced by `Self::ptr_from_value` for the same configuration, and
-    /// its value must remain live for the returned lifetime.
-    #[inline]
-    unsafe fn value_from_ptr<'a, C: Configuration>(entry: *const Self) -> &'a Value<C> {
-        // SAFETY: `ptr_from_value` derives `entry` from the enclosing `Value<C>` pointer, so
-        // subtracting the same field offset recovers that pointer. The other requirements are
-        // guaranteed by the caller.
-        unsafe {
-            &*entry
-                .cast::<u8>()
-                .sub(std::mem::offset_of!(Value<C>, lru))
-                .cast::<Value<C>>()
-        }
-    }
-}
-
-/// Metadata read by the type-erased LRU scan.
-///
-/// Durability is deliberately not stored here: it determines whether an entry is added to the
-/// list, but is not needed once the scan begins. Keeping it on `Value` also lets Rust place the
-/// byte in outer padding instead of growing the aligned `LruEntry`.
-#[derive(Clone, Copy)]
-struct EntryMetadata {
-    /// The interned ID for this value.
-    ///
-    /// Storing this on the value itself is necessary to identify slots
-    /// from the LRU list, as well as keep track of the generation.
-    ///
-    /// Values that are reused increment the ID generation, as if they had
-    /// allocated a new slot. This eliminates the need for dependency edges
-    /// on queries that *read* from an interned value, as any memos dependent
-    /// on the previous value will not match the new ID.
-    ///
-    /// However, reusing a slot invalidates the previous ID, so queries that
-    /// *create* a reusable interned value record dependency edges to ensure the
-    /// value is re-interned with a new ID.
-    id: Id,
-
-    /// The revision the value was most-recently interned in.
-    last_interned_at: Revision,
-}
-
-/// Returns `true` if a value slot with the given durability can be reused when interning.
-///
-/// This intentionally remains generic so the compiler specializes the immortal and reusable
-/// configurations instead of branching on `REVISIONS` at runtime.
-fn is_reusable<C: Configuration>(durability: Durability) -> bool {
-    // Garbage collection is disabled.
-    if C::REVISIONS == IMMORTAL {
-        return false;
-    }
-
-    // Collecting higher durability values requires invalidating the revision for their
-    // durability (see `Database::synthetic_write`, which requires a mutable reference to
-    // the database) to avoid short-circuiting calls to `maybe_changed_after`. This is
-    // necessary because `maybe_changed_after` for interned values is not "pure"; it updates
-    // the `last_interned_at` field before validating a given value to ensure that it is not
-    // reused after read in the current revision.
-    durability == Durability::LOW
-}
-
-/// Record a dependency on this value if its slot can be reused.
-fn report_tracked_read_if_reusable<C: Configuration>(
-    zalsa_local: &ZalsaLocal,
-    index: DatabaseKeyIndex,
-    current_revision: Revision,
-    durability: Durability,
-) {
-    if is_reusable::<C>(durability) {
-        zalsa_local.report_tracked_read_simple(index, durability, current_revision);
-    } else {
-        // The value cannot be reused, so the dependency edge is unnecessary. Its durability
-        // is derived from the active query, but its revision must still contribute to the
-        // query's stamp because the interned ID may have changed due to reuse.
-        zalsa_local.report_tracked_read_revision(current_revision);
-    }
-}
-
-struct ReusableSlot {
-    entry: *const LruEntry,
-    old_id: Id,
-    new_id: Id,
+    durability: <C::Eviction as EvictionPolicy>::Durability,
 }
 
 impl<C> Value<C>
@@ -360,14 +247,14 @@ where
     C: Configuration,
 {
     pub fn new(ingredient_index: IngredientIndex) -> Self {
-        let shards = new_shards();
+        let shards = new_shards::<C::Eviction>();
         let shift = usize::BITS - shards.len().trailing_zeros();
 
         Self {
             ingredient_index,
             hasher: FxBuildHasher,
             memo_table_types: Arc::new(MemoTableTypes::default()),
-            revision_queue: RevisionQueue::new(C::REVISIONS),
+            eviction: C::Eviction::new(C::REVISIONS),
             shift,
             shards,
             _marker: PhantomData,
@@ -446,11 +333,8 @@ where
         // so instead we go with this and transmute the lifetime in the `eq` closure
         C::Fields<'db>: HashEqLike<Key>,
     {
-        // Record the current revision as active.
         let current_revision = zalsa.current_revision();
-        if C::REVISIONS != IMMORTAL {
-            self.revision_queue.record(current_revision);
-        }
+        self.eviction.record_revision(current_revision);
 
         // Hash the value before acquiring the lock.
         let hash = self.hasher.hash_one(&key);
@@ -466,401 +350,63 @@ where
         if let Some(value) = shard.key_map.find(hash, eq) {
             // SAFETY: Values remain allocated for the lifetime of the database.
             let value = unsafe { value.value::<C>() };
+            // SAFETY: We hold the lock for the shard containing the value.
+            let id = unsafe { C::Eviction::id(&value.eviction) };
 
-            // SAFETY: We hold the lock for the shard containing the value, giving us exclusive
-            // access to its entry metadata and durability.
-            let (metadata, durability) =
-                unsafe { (&mut *value.lru.metadata.get(), &mut *value.durability.get()) };
-            let index = self.database_key_index(metadata.id);
-
-            // Validate the value in this revision to avoid reuse.
-            if metadata.last_interned_at < current_revision {
-                metadata.last_interned_at = current_revision;
-
-                zalsa.event(&|| {
-                    Event::new(EventKind::DidValidateInternedValue {
-                        key: index,
-                        revision: current_revision,
-                    })
-                });
-
-                if is_reusable::<C>(*durability) {
-                    // Move the value to the front of the LRU list.
-                    //
-                    // SAFETY: We hold the lock for the shard containing the value, and `value` is
-                    // a reusable value that was previously interned, so is in the list.
-                    unsafe { shard.lru.cursor_mut_from_ptr(&value.lru).remove() };
-
-                    // SAFETY: The value pointer is valid for the lifetime of the database
-                    // and never accessed mutably directly.
-                    unsafe {
-                        shard
-                            .lru
-                            .push_front(UnsafeRef::from_raw(LruEntry::ptr_from_value(value)))
-                    };
-                }
-            }
-
-            if let Some((_, stamp)) = zalsa_local.active_query() {
-                let was_reusable = is_reusable::<C>(*durability);
-
-                // Record the maximum durability across all queries that intern this value.
-                *durability = std::cmp::max(*durability, stamp.durability);
-
-                // If the value is no longer reusable, i.e. the durability increased, remove it
-                // from the LRU.
-                if was_reusable && !is_reusable::<C>(*durability) {
-                    // SAFETY: We hold the lock for the shard containing the value, and `value`
-                    // was previously reusable, so is in the list.
-                    unsafe { shard.lru.cursor_mut_from_ptr(&value.lru).remove() };
-                }
-            }
-
-            // Record a dependency on the value if its slot can be reused.
-            //
-            // See `intern_id_cold` for why we need to use `current_revision` here. Note that just
-            // because this value was previously interned does not mean it was previously interned
-            // by *our query*, so the same considerations apply.
-            report_tracked_read_if_reusable::<C>(zalsa_local, index, current_revision, *durability);
-
-            return metadata.id;
-        }
-
-        // Fill up the table for the first few revisions without attempting garbage collection.
-        if !self.revision_queue.is_primed() {
-            return self.intern_id_cold(
-                key,
-                zalsa,
-                zalsa_local,
-                assemble,
-                shard,
-                shard_index,
-                hash,
-            );
-        }
-
-        // Otherwise, try to reuse a stale slot.
-        // SAFETY: We hold the lock for this ingredient's shard, and `current_revision` is the
-        // database's current revision.
-        let Some((slot, value)) = (unsafe { self.find_reusable_slot(current_revision, shard) })
-        else {
-            // If we could not find a stale slot, we are forced to allocate a new one.
-            return self.intern_id_cold(
-                key,
-                zalsa,
-                zalsa_local,
-                assemble,
-                shard,
-                shard_index,
-                hash,
-            );
-        };
-
-        // Record the durability of the current query on the interned value.
-        let (durability, last_interned_at) = zalsa_local
-            .active_query()
-            .map(|(_, stamp)| (stamp.durability, current_revision))
-            // If there is no active query this durability does not actually matter.
-            // `last_interned_at` needs to be `Revision::MAX`, see the `intern_access_in_different_revision` test.
-            .unwrap_or((Durability::MAX, Revision::max()));
-
-        // Assemble and hash the replacement before mutating the existing slot. Both operations
-        // can invoke user code and panic.
-        // SAFETY: We call `from_internal_data` to restore the correct lifetime before access.
-        let new_fields = unsafe { self.to_internal_data(assemble(slot.new_id, key)) };
-
-        // SAFETY: We hold the lock for the shard containing the value.
-        let old_hash = self.hasher.hash_one(unsafe { &*value.fields.get() });
-
-        let index = self.database_key_index(slot.new_id);
-
-        // Record a dependency on the new value if its slot can be reused.
-        //
-        // See `intern_id_cold` for why we need to use `current_revision` here.
-        report_tracked_read_if_reusable::<C>(zalsa_local, index, current_revision, durability);
-
-        // Reserve space while the old slot is still intact. Resizing can invoke user hashing, so
-        // doing it before mutating the slot leaves the old value reachable if that panics. Once
-        // capacity is available, replacing the pointer entry cannot invoke user code.
-        // SAFETY: We hold the lock for the shard containing every value passed to `hasher`.
-        let hasher = |value: &ValueKey| unsafe { self.value_hash(value.value::<C>()) };
-        shard.key_map.reserve(1, hasher);
-
-        // Remove the value from the LRU list.
-        // SAFETY: We hold the shard lock and `value` is currently in the LRU.
-        unsafe { shard.lru.cursor_mut_from_ptr(&value.lru).remove() };
-
-        // Remove the previous value from the key map.
-        //
-        // The pointer stays the same when a slot is reused, but the fields and thus the hash can
-        // change, so we need to re-insert it. The old and new hashes map to the same shard, because
-        // we selected the LRU list based on the new fields.
-        let value_key = ValueKey::new(value);
-        shard
-            .key_map
-            .find_entry(old_hash, |found_value| found_value.0 == value_key.0)
-            .unwrap_or_else(|_| panic!("interned value in LRU so must be in key_map"))
-            .remove();
-
-        // Replace the fields without dropping the previous value until the slot is consistent.
-        //
-        // SAFETY: `find_reusable_slot` guarantees that the value is reusable and stale, so no
-        // references to its fields remain. We still hold the shard lock.
-        let old_fields = unsafe { std::mem::replace(&mut *value.fields.get(), new_fields) };
-
-        // Mark the slot as reused.
-        // SAFETY: We still hold the lock for the shard containing the value, giving us exclusive
-        // access to its entry metadata and durability.
-        unsafe {
-            *value.lru.metadata.get() = EntryMetadata {
-                id: slot.new_id,
-                last_interned_at,
-            };
-            *value.durability.get() = durability;
-        }
-
-        shard.key_map.insert_unique(hash, value_key, hasher);
-
-        if is_reusable::<C>(durability) {
-            // Move the value to the front of the LRU list.
-            //
-            // SAFETY: The value pointer is valid for the lifetime of the database
-            // and is never accessed mutably directly.
-            unsafe {
-                shard
-                    .lru
-                    .push_front(UnsafeRef::from_raw(LruEntry::ptr_from_value(value)))
+            // SAFETY: We hold the lock for the shard containing the value.
+            return unsafe {
+                self.eviction.intern_existing(eviction::InternExisting {
+                    zalsa,
+                    zalsa_local,
+                    index: self.database_key_index(id),
+                    current_revision,
+                    entry: eviction::entry_ptr(value),
+                    durability: &value.durability,
+                    shard: &mut shard.eviction,
+                })
             };
         }
 
-        // SAFETY: `find_reusable_slot` guarantees that the value is reusable and stale, so no
-        // references to its memos remain. We still hold the shard lock.
-        let memo_table = unsafe { &mut *value.memos.get() };
-
-        // Free the memos associated with the previous interned value.
-        //
-        // SAFETY: The memo table belongs to a value allocated with these memo-table types.
-        unsafe { self.clear_memos(zalsa, memo_table, slot.old_id) };
-
-        drop(old_fields);
-
-        zalsa.event(&|| {
-            Event::new(EventKind::DidReuseInternedValue {
-                key: index,
-                revision: current_revision,
-            })
-        });
-
-        slot.new_id
+        self.eviction.intern_missing(eviction::InternMissing {
+            ingredient: self,
+            zalsa,
+            zalsa_local,
+            key,
+            assemble,
+            key_map: &mut shard.key_map,
+            shard: &mut shard.eviction,
+            shard_index,
+            hash,
+            current_revision,
+        })
     }
 
-    /// The cold path for interning a value, allocating a new slot.
-    ///
-    /// Returns `true` if the current thread interned the value.
-    #[allow(clippy::too_many_arguments)]
-    fn intern_id_cold<'db, Key>(
-        &'db self,
-        key: Key,
-        zalsa: &Zalsa,
-        zalsa_local: &ZalsaLocal,
-        assemble: impl FnOnce(Id, Key) -> C::Fields<'db>,
-        shard: &mut IngredientShard,
-        shard_index: usize,
-        hash: u64,
-    ) -> crate::Id
-    where
-        Key: Hash,
-        C::Fields<'db>: HashEqLike<Key>,
-    {
-        let current_revision = zalsa.current_revision();
-
-        // Record the durability of the current query on the interned value.
-        let (durability, last_interned_at) = zalsa_local
-            .active_query()
-            .map(|(_, stamp)| (stamp.durability, current_revision))
-            // If there is no active query this durability does not actually matter.
-            // `last_interned_at` needs to be `Revision::MAX`, see the `intern_access_in_different_revision` test.
-            .unwrap_or((Durability::MAX, Revision::max()));
-
-        // Allocate the value slot.
-        let (id, value) = zalsa_local.allocate(zalsa, self.ingredient_index, |id| Value::<C> {
-            shard: shard_index as u16,
-            lru: LruEntry {
-                link: LinkedListLink::new(),
-                metadata: UnsafeCell::new(EntryMetadata {
-                    id,
-                    last_interned_at,
-                }),
-            },
-            // SAFETY: We call `from_internal_data` to restore the correct lifetime before access.
-            fields: UnsafeCell::new(unsafe { self.to_internal_data(assemble(id, key)) }),
-            // SAFETY: We only ever access the memos of a value that we allocated through
-            // our `MemoTableTypes`.
-            memos: UnsafeCell::new(unsafe { MemoTable::new(self.memo_table_types()) }),
-            durability: UnsafeCell::new(durability),
-        });
-
-        // Insert the newly allocated value.
-        // SAFETY: We hold this ingredient's shard lock, and `value` is the live, stable value that
-        // we just allocated in that shard.
-        unsafe { self.insert_value(shard, hash, value) };
-
-        let index = self.database_key_index(id);
-
-        // Record a dependency on the newly interned value if its slot can be reused.
-        //
-        // Note that the ID is unique to this use of the interned slot, so it seems logical to use
-        // `Revision::start()` here. However, it is possible that the ID we read is different from
-        // the previous execution of this query if the previous slot has been reused. In that case,
-        // the query has changed without a corresponding input changing. Using `current_revision`
-        // for dependencies on interned values encodes the fact that interned IDs are not stable
-        // across revisions.
-        report_tracked_read_if_reusable::<C>(zalsa_local, index, current_revision, durability);
-
-        zalsa.event(&|| {
-            Event::new(EventKind::DidInternValue {
-                key: index,
-                revision: current_revision,
-            })
-        });
-
-        id
-    }
-
-    /// Inserts a newly interned value into the LRU list and key map.
+    /// Inserts a newly interned value into the eviction state and key map.
     ///
     /// # Safety
     ///
     /// `shard` must be a locked shard from this ingredient, and `value` must be the live, stable
     /// `Value<C>` allocated in that shard.
-    unsafe fn insert_value(&self, shard: &mut IngredientShard, hash: u64, value: &Value<C>) {
-        /// Inserts a newly allocated value without depending on `C`.
-        ///
-        /// # Safety
-        ///
-        /// The caller must hold `shard`'s lock. `value_key` and `entry` must have been produced
-        /// from the same live value in this shard,
-        /// `reusable` must reflect whether that value is reusable, and `hasher` must hash values
-        /// while that lock is held.
-        unsafe fn inner(
-            shard: &mut IngredientShard,
-            hash: u64,
-            value_key: ValueKey,
-            entry: *const LruEntry,
-            reusable: bool,
-            hasher: &dyn Fn(&ValueKey) -> u64,
-        ) {
-            if reusable {
-                // SAFETY: The caller guarantees that `entry` points to a live `LruEntry` and was
-                // derived from its enclosing value.
-                unsafe { shard.lru.push_front(UnsafeRef::from_raw(entry)) };
-            }
+    unsafe fn insert_value(
+        &self,
+        key_map: &mut hashbrown::HashTable<ValueKey>,
+        shard: &mut <C::Eviction as EvictionPolicy>::Shard,
+        hash: u64,
+        value: &Value<C>,
+    ) {
+        // SAFETY: We hold the shard lock, and the value is live in this shard.
+        unsafe {
+            self.eviction
+                .insert_entry(shard, eviction::entry_ptr(value), &value.durability)
+        };
 
-            insert_unique_erased(shard, hash, value_key, hasher);
-
-            debug_assert_eq!(hash, hasher(&value_key));
-        }
-
-        // SAFETY: We hold the lock for the shard containing the value.
-        let durability = unsafe { *value.durability.get() };
-        let reusable = is_reusable::<C>(durability);
         let value_key = ValueKey::new(value);
 
         // SAFETY: We hold the lock for the shard containing every value passed to `hasher`.
         let hasher = |value: &ValueKey| unsafe { self.value_hash(value.value::<C>()) };
+        insert_unique_erased(key_map, hash, value_key, &hasher);
 
-        // SAFETY: We hold the lock for `shard`; `value_key` and `ptr_from_value` were derived from
-        // the same live value in that shard, and `reusable` was read from that value.
-        unsafe {
-            inner(
-                shard,
-                hash,
-                value_key,
-                LruEntry::ptr_from_value(value),
-                reusable,
-                &hasher,
-            )
-        };
-    }
-
-    /// Finds a reusable slot and reconstructs its typed value.
-    ///
-    /// # Safety
-    ///
-    /// `shard` must be a locked shard from this ingredient, and `current_revision` must be the
-    /// database's current revision. Every LRU entry pointer must have been derived from its live
-    /// enclosing `Value<C>` using `LruEntry::ptr_from_value`, so subtracting the field offset
-    /// recovers that value. Those values must remain stable for the ingredient's lifetime.
-    ///
-    /// The LRU contains only reusable values. Therefore, a slot returned as stale has no
-    /// outstanding references to its fields or memos and may be mutated while the lock is held.
-    unsafe fn find_reusable_slot(
-        &self,
-        current_revision: Revision,
-        shard: &mut IngredientShard,
-    ) -> Option<(ReusableSlot, &Value<C>)> {
-        /// Finds the least-recently-used stale slot whose generation can be incremented.
-        ///
-        /// # Safety
-        ///
-        /// The caller must hold `shard`'s lock, and every pointer in its LRU must refer to a live
-        /// `LruEntry` belonging to the shard.
-        unsafe fn inner(
-            revision_queue: &RevisionQueue,
-            current_revision: Revision,
-            shard: &mut IngredientShard,
-        ) -> Option<ReusableSlot> {
-            let mut cursor = shard.lru.back_mut();
-
-            while let Some(entry) = cursor.as_cursor().clone_pointer() {
-                let entry = UnsafeRef::into_raw(entry);
-
-                // SAFETY: The caller guarantees that `entry` points to a live value in this shard
-                // and that we hold the shard lock, which grants exclusive access to `metadata`.
-                let metadata = unsafe { &mut *(*entry).metadata.get() };
-
-                // The value must not have been read in the current revision to be collected
-                // soundly, but we also do not want to collect values that have been read recently.
-                //
-                // Note that the list is sorted by LRU, so if the tail of the list is not stale, we
-                // will not find any stale slots.
-                if !revision_queue.is_stale(metadata.last_interned_at) {
-                    return None;
-                }
-
-                // We should never reuse a value that was accessed in the current revision.
-                debug_assert!(metadata.last_interned_at < current_revision);
-
-                let old_id = metadata.id;
-
-                // Increment the generation of the ID, as if we allocated a new slot.
-                //
-                // If the ID is at its maximum generation, we are forced to leak the slot.
-                if let Some(new_id) = old_id.next_generation() {
-                    return Some(ReusableSlot {
-                        entry,
-                        old_id,
-                        new_id,
-                    });
-                }
-
-                // This slot can never be reused. Remove it and retry with the previous element.
-                cursor.remove().unwrap();
-                cursor = shard.lru.back_mut();
-            }
-
-            None
-        }
-
-        // SAFETY: Guaranteed by the caller.
-        let slot = unsafe { inner(&self.revision_queue, current_revision, shard) }?;
-
-        // SAFETY: The caller guarantees that this is a shard from `self`. Its LRU contains only
-        // entries produced by `LruEntry::ptr_from_value` for stable values allocated by this
-        // ingredient.
-        let value = unsafe { LruEntry::value_from_ptr::<C>(slot.entry) };
-
-        Some((slot, value))
+        debug_assert_eq!(hash, hasher(&value_key));
     }
 
     /// Clears the given memo table.
@@ -971,20 +517,13 @@ where
         let value = zalsa.table().get::<Value<C>>(id);
 
         debug_assert!(
-            {
+            !C::Eviction::CAN_REUSE || {
                 let _shard = self.shards[value.shard as usize].lock();
 
-                // SAFETY: We hold the lock for the shard containing the value, giving us shared
-                // access to its durability.
-                let durability = unsafe { *value.durability.get() };
-
-                !is_reusable::<C>(durability) || {
-                    // SAFETY: We hold the lock for the shard containing the value, giving us shared
-                    // access to its entry metadata.
-                    let last_interned_at = unsafe { (*value.lru.metadata.get()).last_interned_at };
-
-                    let last_changed_revision = zalsa.last_changed_revision(durability);
-                    last_interned_at >= last_changed_revision
+                // SAFETY: We hold the lock for the shard containing the value.
+                unsafe {
+                    self.eviction
+                        .is_valid(zalsa, &value.eviction, &value.durability)
                 }
             },
             "Data for reusable `{database_key:?}` was not interned in the latest revision for its durability.",
@@ -1038,10 +577,10 @@ where
                     unsafe { self.shards.get_unchecked(value.shard as usize) }.lock();
 
                 // SAFETY: We hold the lock for the shard containing the value.
-                unsafe { (*value.lru.metadata.get()).id }
+                unsafe { C::Eviction::id(&value.eviction) }
             } else {
                 // SAFETY: The caller guarantees we hold the lock for the shard containing the value.
-                unsafe { (*value.lru.metadata.get()).id }
+                unsafe { C::Eviction::id(&value.eviction) }
             };
 
             StructEntry {
@@ -1052,11 +591,9 @@ where
     }
 }
 
-/// Creates the sharded storage outside of the generic [`IngredientImpl::new`] context.
-///
-/// Keeping this helper non-generic avoids monomorphizing the `OnceLock` and iterator machinery for
-/// every interned struct configuration.
-fn new_shards() -> Box<[CachePadded<Mutex<IngredientShard>>]> {
+/// Creates the sharded storage once per eviction policy, rather than once per interned
+/// configuration.
+fn new_shards<E: EvictionPolicy>() -> Shards<E> {
     static SHARDS: OnceLock<usize> = OnceLock::new();
     let shards = *SHARDS.get_or_init(|| {
         let num_cpus = std::thread::available_parallelism()
@@ -1096,12 +633,12 @@ unsafe impl Sync for ValueKey {}
 
 /// Inserts a value pointer while keeping the hasher and rehashing logic independent of `C`.
 fn insert_unique_erased(
-    shard: &mut IngredientShard,
+    key_map: &mut hashbrown::HashTable<ValueKey>,
     hash: u64,
     value: ValueKey,
     hasher: &dyn Fn(&ValueKey) -> u64,
 ) {
-    shard.key_map.insert_unique(hash, value, hasher);
+    key_map.insert_unique(hash, value, hasher);
 }
 
 /// An interned struct entry.
@@ -1153,39 +690,27 @@ where
         input: Id,
         _revision: Revision,
     ) -> VerifyResult {
-        // Record the current revision as active.
-        let current_revision = zalsa.current_revision();
-        if C::REVISIONS != IMMORTAL {
-            self.revision_queue.record(current_revision);
+        if !C::Eviction::CAN_REUSE {
+            return VerifyResult::unchanged();
         }
 
-        let value = zalsa.table().get::<Value<C>>(input);
+        let current_revision = zalsa.current_revision();
+        self.eviction.record_revision(current_revision);
 
+        let value = zalsa.table().get::<Value<C>>(input);
         // SAFETY: `value.shard` is guaranteed to be in-bounds for `self.shards`.
         let _shard = unsafe { self.shards.get_unchecked(value.shard as usize) }.lock();
 
         // SAFETY: We hold the lock for the shard containing the value.
-        let metadata = unsafe { &mut *value.lru.metadata.get() };
-
-        // The slot was reused.
-        if metadata.id.generation() > input.generation() {
-            return VerifyResult::changed();
+        unsafe {
+            self.eviction.maybe_changed_after(
+                zalsa,
+                self.database_key_index(input),
+                input,
+                current_revision,
+                &value.eviction,
+            )
         }
-
-        // Validate the value for the current revision to avoid reuse.
-        metadata.last_interned_at = current_revision;
-
-        zalsa.event(&|| {
-            let index = self.database_key_index(input);
-
-            Event::new(EventKind::DidValidateInternedValue {
-                key: index,
-                revision: current_revision,
-            })
-        });
-
-        // Any change to an interned value results in a new ID generation.
-        VerifyResult::unchanged()
     }
 
     fn collect_minimum_serialized_edges(
@@ -1195,7 +720,7 @@ where
         serialized_edges: &mut FxIndexSet<QueryEdge>,
         _visited_edges: &mut FxHashSet<QueryEdge>,
     ) {
-        if C::PERSIST && C::REVISIONS != IMMORTAL {
+        if C::PERSIST && C::Eviction::CAN_REUSE {
             // If the interned struct is being persisted, it may be reachable through transitive queries.
             // Additionally, interned struct dependencies are impure in that garbage collection can
             // invalidate a dependency without a base input necessarily being updated. Thus, we must
@@ -1325,97 +850,6 @@ where
     #[inline(always)]
     fn memos_mut(&mut self) -> &mut crate::table::memo::MemoTable {
         self.memos.get_mut()
-    }
-}
-
-/// Keep track of revisions in which interned values were read, to determine staleness.
-///
-/// An interned value is considered stale if it has not been read in the past `REVS`
-/// revisions. However, we only consider revisions in which interned values were actually
-/// read, as revisions may be created in bursts.
-struct RevisionQueue {
-    lock: Mutex<()>,
-    /// Recent revisions, stored inline for the default configuration.
-    revisions: SmallVec<[AtomicRevision; DEFAULT_REVISIONS]>,
-}
-
-// `#[salsa::interned(revisions = usize::MAX)]` disables garbage collection.
-const IMMORTAL: NonZeroUsize = NonZeroUsize::MAX;
-
-impl RevisionQueue {
-    fn new(capacity: NonZeroUsize) -> Self {
-        let revisions = if capacity == IMMORTAL {
-            SmallVec::new()
-        } else {
-            (0..capacity.get())
-                .map(|_| AtomicRevision::start())
-                .collect()
-        };
-
-        Self {
-            lock: Mutex::new(()),
-            revisions,
-        }
-    }
-
-    /// Record the given revision as active.
-    #[inline]
-    fn record(&self, revision: Revision) {
-        debug_assert!(
-            !self.revisions.is_empty(),
-            "cannot record revisions when interned garbage collection is disabled"
-        );
-
-        // Fast-path: We already recorded this revision.
-        if self.revisions[0].load() >= revision {
-            return;
-        }
-
-        self.record_cold(revision);
-    }
-
-    #[cold]
-    fn record_cold(&self, revision: Revision) {
-        let _lock = self.lock.lock();
-
-        // Another thread may have recorded this revision while we waited for the lock.
-        if self.revisions[0].load() >= revision {
-            return;
-        }
-
-        // Otherwise, update the queue, maintaining sorted order.
-        //
-        // Note that this should only happen once per revision.
-        for i in (1..self.revisions.len()).rev() {
-            self.revisions[i].store(self.revisions[i - 1].load());
-        }
-
-        self.revisions[0].store(revision);
-    }
-
-    /// Returns `true` if the given revision is old enough to be considered stale.
-    #[inline]
-    fn is_stale(&self, revision: Revision) -> bool {
-        let Some(oldest) = self.revisions.last() else {
-            return false;
-        };
-        let oldest = oldest.load();
-
-        // If we have not recorded `REVS` revisions yet, nothing can be stale.
-        if oldest == Revision::start() {
-            return false;
-        }
-
-        revision < oldest
-    }
-
-    /// Returns `true` if the configured number of revisions have been recorded as active,
-    /// i.e. enough data has been recorded to start garbage collection.
-    #[inline]
-    fn is_primed(&self) -> bool {
-        self.revisions
-            .last()
-            .is_some_and(|oldest| oldest.load() > Revision::start())
     }
 }
 
@@ -1756,11 +1190,10 @@ mod persistence {
     use std::fmt;
     use std::hash::BuildHasher;
 
-    use intrusive_collections::LinkedListLink;
     use serde::ser::{SerializeMap, SerializeStruct};
     use serde::{Deserialize, de};
 
-    use super::{Configuration, EntryMetadata, IngredientImpl, LruEntry, Value};
+    use super::{Configuration, EvictionPolicy, IngredientImpl, Value};
     use crate::plumbing::Ingredient;
     use crate::table::memo::MemoTable;
     use crate::zalsa::Zalsa;
@@ -1795,7 +1228,7 @@ mod persistence {
             for (_, value) in zalsa.table().slots_of::<Value<C>>() {
                 // SAFETY: The safety invariant of `Ingredient::serialize` ensures we have exclusive access
                 // to the database.
-                let id = unsafe { (*value.lru.metadata.get()).id };
+                let id = unsafe { C::Eviction::id(&value.eviction) };
 
                 map.serialize_entry(&id.as_bits(), value)?;
             }
@@ -1816,12 +1249,11 @@ mod persistence {
 
             let Value {
                 fields,
-                lru,
+                eviction,
                 durability,
                 shard: _,
                 memos: _,
             } = self;
-            let LruEntry { link: _, metadata } = lru;
 
             // SAFETY: The safety invariant of `Ingredient::serialize` ensures we have exclusive access
             // to the database.
@@ -1829,14 +1261,8 @@ mod persistence {
 
             // SAFETY: The safety invariant of `Ingredient::serialize` ensures we have exclusive access
             // to the database.
-            let durability = unsafe { *durability.get() };
-
-            // SAFETY: The safety invariant of `Ingredient::serialize` ensures we have exclusive access
-            // to the database.
-            let EntryMetadata {
-                last_interned_at,
-                id: _,
-            } = unsafe { *metadata.get() };
+            let (durability, last_interned_at) =
+                unsafe { C::Eviction::serialized_metadata(eviction, durability) };
 
             value.serialize_field("durability", &durability)?;
             value.serialize_field("last_interned_at", &last_interned_at)?;
@@ -1911,20 +1337,14 @@ mod persistence {
 
                 let value = Value::<C> {
                     shard: shard_index as u16,
-                    lru: LruEntry {
-                        link: LinkedListLink::new(),
-                        metadata: UnsafeCell::new(EntryMetadata {
-                            id,
-                            last_interned_at: value.last_interned_at,
-                        }),
-                    },
+                    eviction: C::Eviction::new_entry(id, value.last_interned_at),
                     fields: UnsafeCell::new(value.fields.0),
                     // SAFETY: We only ever access the memos of a value that we allocated through
                     // our `MemoTableTypes`.
                     memos: UnsafeCell::new(unsafe {
                         MemoTable::new(ingredient.memo_table_types())
                     }),
-                    durability: UnsafeCell::new(value.durability),
+                    durability: C::Eviction::new_durability(value.durability),
                 };
 
                 // Force initialize the relevant page.
@@ -1955,7 +1375,9 @@ mod persistence {
                 //
                 // SAFETY: We hold this ingredient's shard lock, and `value` is the live, stable
                 // value that we just allocated in that shard.
-                unsafe { ingredient.insert_value(shard, hash, value) };
+                unsafe {
+                    ingredient.insert_value(&mut shard.key_map, &mut shard.eviction, hash, value)
+                };
             }
 
             Ok(())
@@ -1992,13 +1414,17 @@ mod persistence {
 mod _static_assertions {
     use std::mem;
 
-    use super::LruEntry;
-    use super::{Configuration, Value};
+    use super::eviction::{LruEntry, NoopEntry};
+    use super::{Configuration, EvictionPolicy, Lru, NoopEviction, Value};
     use crate::{Id, plumbing};
 
     const _: [(); mem::size_of::<LruEntry>()] = [(); mem::size_of::<[usize; 4]>()];
-
     const _: [(); mem::size_of::<Value<DummyConfiguration>>()] = [(); mem::size_of::<[usize; 7]>()];
+
+    const _: [(); mem::size_of::<NoopEviction>()] = [(); 0];
+    const _: [(); mem::size_of::<<NoopEviction as EvictionPolicy>::Shard>()] = [(); 0];
+    const _: [(); mem::size_of::<NoopEntry>()] = [(); mem::size_of::<Id>()];
+    const _: [(); mem::size_of::<Value<NoopConfiguration>>()] = [(); mem::size_of::<[usize; 4]>()];
 
     struct DummyConfiguration;
 
@@ -2011,6 +1437,7 @@ mod _static_assertions {
 
         type Fields<'db> = [u8; 1];
         type Struct<'db> = Id;
+        type Eviction = Lru;
 
         fn serialize<S>(_: &Self::Fields<'_>, _: S) -> Result<S::Ok, S::Error>
         where
@@ -2026,52 +1453,32 @@ mod _static_assertions {
             unimplemented!()
         }
     }
-}
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+    struct NoopConfiguration;
 
-    struct TestConfiguration;
-
-    // SAFETY: The fields are `()` for every database lifetime.
-    unsafe impl Configuration for TestConfiguration {
-        const LOCATION: crate::ingredient::Location = crate::ingredient::Location {
-            file: file!(),
-            line: line!(),
-        };
-        const DEBUG_NAME: &'static str = "TestConfiguration";
+    // SAFETY: The fields are `[u8; 1]` for every database lifetime.
+    unsafe impl Configuration for NoopConfiguration {
+        const LOCATION: crate::ingredient::Location =
+            crate::ingredient::Location { file: "", line: 0 };
+        const DEBUG_NAME: &'static str = "";
         const PERSIST: bool = false;
-        const REVISIONS: NonZeroUsize = NonZeroUsize::new(2).unwrap();
 
-        type Fields<'db> = ();
+        type Fields<'db> = [u8; 1];
         type Struct<'db> = Id;
+        type Eviction = NoopEviction;
 
-        fn serialize<S>(_value: &Self::Fields<'_>, _serializer: S) -> Result<S::Ok, S::Error>
+        fn serialize<S>(_: &Self::Fields<'_>, _: S) -> Result<S::Ok, S::Error>
         where
             S: plumbing::serde::Serializer,
         {
             unimplemented!()
         }
 
-        fn deserialize<'de, D>(_deserializer: D) -> Result<Self::Fields<'static>, D::Error>
+        fn deserialize<'de, D>(_: D) -> Result<Self::Fields<'static>, D::Error>
         where
             D: plumbing::serde::Deserializer<'de>,
         {
             unimplemented!()
         }
-    }
-
-    #[test]
-    fn revision_queue_records_each_revision_once() {
-        let queue = RevisionQueue::new(TestConfiguration::REVISIONS);
-        let revision = Revision::start().next();
-
-        // Simulate two threads that both passed the fast-path check before taking the lock.
-        queue.record_cold(revision);
-        queue.record_cold(revision);
-
-        assert_eq!(queue.revisions[0].load(), revision);
-        assert_eq!(queue.revisions[1].load(), Revision::start());
     }
 }

--- a/src/interned/eviction.rs
+++ b/src/interned/eviction.rs
@@ -1,0 +1,260 @@
+mod lru;
+mod noop;
+
+pub use lru::{Lru, LruEntry};
+pub use noop::{NoopEntry, NoopEviction};
+
+/// Selects the eviction policy from an interned revision configuration.
+#[doc(hidden)]
+pub struct EvictionSelector<const IMMORTAL: bool>;
+
+/// Maps an interned revision configuration to its eviction policy.
+#[doc(hidden)]
+pub trait SelectEviction {
+    type Eviction: EvictionPolicy;
+}
+
+impl SelectEviction for EvictionSelector<false> {
+    type Eviction = Lru;
+}
+
+impl SelectEviction for EvictionSelector<true> {
+    type Eviction = NoopEviction;
+}
+
+use std::cell::UnsafeCell;
+use std::hash::Hash;
+use std::num::NonZeroUsize;
+
+use crate::durability::Durability;
+use crate::function::VerifyResult;
+use crate::ingredient::Ingredient;
+use crate::plumbing::ZalsaLocal;
+use crate::table::memo::MemoTable;
+use crate::zalsa::Zalsa;
+use crate::{DatabaseKeyIndex, Event, EventKind, Id, Revision};
+
+use super::{Configuration, HashEqLike, IngredientImpl, Value, ValueKey};
+
+/// Compile-time eviction policy for an interned ingredient.
+pub trait EvictionPolicy: Send + Sync + 'static {
+    /// Whether this policy can invalidate an interned dependency through slot reuse.
+    const CAN_REUSE: bool;
+
+    /// Per-shard eviction state.
+    type Shard: Default + Send;
+
+    /// Per-value eviction state.
+    type Entry: Send;
+
+    /// Per-value durability state.
+    type Durability: Send;
+
+    /// Creates the ingredient-wide eviction state.
+    fn new(revisions: NonZeroUsize) -> Self;
+
+    /// Creates the per-value eviction state.
+    fn new_entry(id: Id, last_interned_at: Revision) -> Self::Entry;
+
+    /// Creates the per-value durability state.
+    fn new_durability(durability: Durability) -> Self::Durability;
+
+    /// Returns the initial durability and last-interned revision for a new value.
+    fn initial_metadata(
+        zalsa_local: &ZalsaLocal,
+        current_revision: Revision,
+    ) -> (Durability, Revision);
+
+    /// Returns the stable ID stored on an interned value.
+    ///
+    /// # Safety
+    ///
+    /// The caller must hold the value's shard lock or have exclusive database access.
+    unsafe fn id(entry: &Self::Entry) -> Id;
+
+    /// Returns the metadata serialized for an interned value.
+    ///
+    /// # Safety
+    ///
+    /// The caller must hold the value's shard lock or have exclusive database access.
+    unsafe fn serialized_metadata(
+        entry: &Self::Entry,
+        durability: &Self::Durability,
+    ) -> (Durability, Revision);
+
+    /// Records an active revision.
+    fn record_revision(&self, revision: Revision);
+
+    /// Records an access to an existing value.
+    ///
+    /// # Safety
+    ///
+    /// The caller must hold the value's shard lock. `entry` must have provenance derived from the
+    /// enclosing value so that the policy can retain it in intrusive storage.
+    unsafe fn intern_existing(&self, existing: InternExisting<'_, Self>) -> Id
+    where
+        Self: Sized;
+
+    /// Interns a missing value, reusing a stale slot if this policy supports it.
+    fn intern_missing<'db, C, Key, Assemble>(
+        &self,
+        missing: InternMissing<'_, 'db, C, Key, Assemble>,
+    ) -> Id
+    where
+        Self: Sized,
+        C: Configuration<Eviction = Self>,
+        Key: Hash,
+        C::Fields<'db>: HashEqLike<Key>,
+        Assemble: FnOnce(Id, Key) -> C::Fields<'db>;
+
+    /// Adds a newly allocated or restored value to the policy's per-shard state.
+    ///
+    /// # Safety
+    ///
+    /// The caller must hold the value's shard lock. `entry` must have provenance derived from the
+    /// enclosing value so that the policy can retain it in intrusive storage.
+    unsafe fn insert_entry(
+        &self,
+        shard: &mut Self::Shard,
+        entry: *const Self::Entry,
+        durability: &Self::Durability,
+    );
+
+    /// Reports any dependency or query-stamp update required by a newly interned value.
+    ///
+    /// # Safety
+    ///
+    /// The caller must hold the value's shard lock.
+    unsafe fn report_tracked_read(
+        &self,
+        zalsa_local: &ZalsaLocal,
+        index: DatabaseKeyIndex,
+        current_revision: Revision,
+        durability: &Self::Durability,
+    );
+
+    /// Returns whether the value is safe to expose in the current revision.
+    ///
+    /// # Safety
+    ///
+    /// The caller must hold the value's shard lock.
+    unsafe fn is_valid(
+        &self,
+        zalsa: &Zalsa,
+        entry: &Self::Entry,
+        durability: &Self::Durability,
+    ) -> bool;
+
+    /// Validates an interned dependency, returning whether its slot was reused.
+    ///
+    /// # Safety
+    ///
+    /// The caller must hold the value's shard lock.
+    unsafe fn maybe_changed_after(
+        &self,
+        zalsa: &Zalsa,
+        index: DatabaseKeyIndex,
+        input: Id,
+        current_revision: Revision,
+        entry: &Self::Entry,
+    ) -> VerifyResult;
+}
+
+/// Context for a lookup that found an existing interned value.
+pub struct InternExisting<'a, E: EvictionPolicy> {
+    pub(super) zalsa: &'a Zalsa,
+    pub(super) zalsa_local: &'a ZalsaLocal,
+    pub(super) index: DatabaseKeyIndex,
+    pub(super) current_revision: Revision,
+    pub(super) entry: *const E::Entry,
+    pub(super) durability: &'a E::Durability,
+    pub(super) shard: &'a mut E::Shard,
+}
+
+/// Context for a lookup that needs to allocate or reuse an interned value.
+pub struct InternMissing<'a, 'db, C: Configuration, Key, Assemble> {
+    pub(super) ingredient: &'db IngredientImpl<C>,
+    pub(super) zalsa: &'db Zalsa,
+    pub(super) zalsa_local: &'db ZalsaLocal,
+    pub(super) key: Key,
+    pub(super) assemble: Assemble,
+    pub(super) key_map: &'a mut hashbrown::HashTable<ValueKey>,
+    pub(super) shard: &'a mut <C::Eviction as EvictionPolicy>::Shard,
+    pub(super) shard_index: usize,
+    pub(super) hash: u64,
+    pub(super) current_revision: Revision,
+}
+
+impl<'db, C, Key, Assemble> InternMissing<'_, 'db, C, Key, Assemble>
+where
+    C: Configuration,
+    Key: Hash,
+    C::Fields<'db>: HashEqLike<Key>,
+    Assemble: FnOnce(Id, Key) -> C::Fields<'db>,
+{
+    /// Allocates a new interned value for this miss.
+    #[inline(always)]
+    pub(super) fn intern_new(self) -> Id {
+        let Self {
+            ingredient,
+            zalsa,
+            zalsa_local,
+            key,
+            assemble,
+            key_map,
+            shard,
+            shard_index,
+            hash,
+            current_revision,
+        } = self;
+
+        let (durability, last_interned_at) =
+            C::Eviction::initial_metadata(zalsa_local, current_revision);
+
+        let (id, value) =
+            zalsa_local.allocate(zalsa, ingredient.ingredient_index, |id| Value::<C> {
+                shard: shard_index as u16,
+                eviction: C::Eviction::new_entry(id, last_interned_at),
+                // SAFETY: `from_internal_data` restores the correct lifetime before access.
+                fields: UnsafeCell::new(unsafe { ingredient.to_internal_data(assemble(id, key)) }),
+                // SAFETY: We only access memos allocated through this ingredient's table types.
+                memos: UnsafeCell::new(unsafe { MemoTable::new(ingredient.memo_table_types()) }),
+                durability: C::Eviction::new_durability(durability),
+            });
+
+        // SAFETY: We hold the shard lock and `value` is the live value just allocated in it.
+        unsafe { ingredient.insert_value(key_map, shard, hash, value) };
+
+        let index = ingredient.database_key_index(id);
+        // SAFETY: We still hold the lock for the shard containing the newly allocated value.
+        unsafe {
+            ingredient.eviction.report_tracked_read(
+                zalsa_local,
+                index,
+                current_revision,
+                &value.durability,
+            )
+        };
+
+        zalsa.event(&|| {
+            Event::new(EventKind::DidInternValue {
+                key: index,
+                revision: current_revision,
+            })
+        });
+
+        id
+    }
+}
+
+/// Returns a pointer to `value.eviction` with provenance derived from `value`.
+#[inline]
+pub(super) fn entry_ptr<C: Configuration>(
+    value: &Value<C>,
+) -> *const <C::Eviction as EvictionPolicy>::Entry {
+    let value = std::ptr::from_ref(value).cast::<u8>();
+
+    // SAFETY: `eviction` is a field within `value`, so adding its offset is in bounds. Starting
+    // from `value` permits an intrusive policy to recover the enclosing allocation.
+    unsafe { value.add(std::mem::offset_of!(Value<C>, eviction)).cast() }
+}

--- a/src/interned/eviction/lru.rs
+++ b/src/interned/eviction/lru.rs
@@ -1,0 +1,550 @@
+use std::cell::UnsafeCell;
+use std::hash::{BuildHasher, Hash};
+use std::num::NonZeroUsize;
+
+use intrusive_collections::{LinkedList, LinkedListLink, UnsafeRef, intrusive_adapter};
+use smallvec::SmallVec;
+
+use crate::durability::Durability;
+use crate::function::VerifyResult;
+use crate::plumbing::ZalsaLocal;
+use crate::revision::AtomicRevision;
+use crate::sync::Mutex;
+use crate::zalsa::Zalsa;
+use crate::{DatabaseKeyIndex, Event, EventKind, Id, Revision};
+
+use super::{EvictionPolicy, InternExisting, InternMissing};
+use crate::interned::{Configuration, DEFAULT_REVISIONS, HashEqLike, Value, ValueKey};
+
+/// Type-erased state stored in the intrusive LRU list.
+pub struct LruEntry {
+    /// Intrusive links, accessed only while holding the owning shard lock.
+    link: LinkedListLink,
+
+    /// Metadata used to decide whether and how this slot can be reused.
+    ///
+    /// This may only be accessed while holding the owning shard lock, or with exclusive access to
+    /// the database.
+    metadata: UnsafeCell<EntryMetadata>,
+}
+
+/// Metadata read by the type-erased LRU scan.
+///
+/// Durability is deliberately not stored here: it determines whether an entry is added to the
+/// list, but is not needed once the scan begins. Keeping it on `Value` also lets Rust place the
+/// byte in outer padding instead of growing the aligned `LruEntry`.
+#[derive(Clone, Copy)]
+struct EntryMetadata {
+    /// The interned ID for this value.
+    ///
+    /// Storing this on the value itself is necessary to identify slots
+    /// from the LRU list, as well as keep track of the generation.
+    ///
+    /// Values that are reused increment the ID generation, as if they had
+    /// allocated a new slot. This eliminates the need for dependency edges
+    /// on queries that *read* from an interned value, as any memos dependent
+    /// on the previous value will not match the new ID.
+    ///
+    /// However, reusing a slot invalidates the previous ID, so queries that
+    /// *create* a reusable interned value record dependency edges to ensure the
+    /// value is re-interned with a new ID.
+    id: Id,
+
+    /// The revision the value was most-recently interned in.
+    last_interned_at: Revision,
+}
+
+struct ReusableSlot {
+    entry: *const LruEntry,
+    old_id: Id,
+    new_id: Id,
+}
+
+intrusive_adapter!(LruEntryAdapter = UnsafeRef<LruEntry>: LruEntry { link => LinkedListLink });
+
+/// LRU eviction for interned values.
+pub struct Lru {
+    revision_queue: RevisionQueue,
+}
+
+/// Per-shard LRU state.
+#[derive(Default)]
+pub struct LruShard {
+    lru: LinkedList<LruEntryAdapter>,
+}
+
+// SAFETY: `LruShard` is only accessed through its ingredient shard mutex. Its LRU contains
+// pointers to live, stable values, and those pointers and links are accessed only while holding
+// that mutex.
+unsafe impl Send for LruShard {}
+
+impl EvictionPolicy for Lru {
+    const CAN_REUSE: bool = true;
+
+    type Shard = LruShard;
+    type Entry = LruEntry;
+    type Durability = UnsafeCell<Durability>;
+
+    fn new(revisions: NonZeroUsize) -> Self {
+        debug_assert_ne!(revisions, IMMORTAL);
+        Self {
+            revision_queue: RevisionQueue::new(revisions),
+        }
+    }
+
+    fn new_entry(id: Id, last_interned_at: Revision) -> Self::Entry {
+        LruEntry {
+            link: LinkedListLink::new(),
+            metadata: UnsafeCell::new(EntryMetadata {
+                id,
+                last_interned_at,
+            }),
+        }
+    }
+
+    fn new_durability(durability: Durability) -> Self::Durability {
+        UnsafeCell::new(durability)
+    }
+
+    fn initial_metadata(
+        zalsa_local: &ZalsaLocal,
+        current_revision: Revision,
+    ) -> (Durability, Revision) {
+        zalsa_local
+            .active_query()
+            .map(|(_, stamp)| (stamp.durability, current_revision))
+            // If there is no active query this durability does not actually matter.
+            // `last_interned_at` needs to be `Revision::MAX`, see the
+            // `intern_access_in_different_revision` test.
+            .unwrap_or((Durability::MAX, Revision::max()))
+    }
+
+    unsafe fn id(entry: &Self::Entry) -> Id {
+        // SAFETY: Guaranteed by the caller.
+        unsafe { (*entry.metadata.get()).id }
+    }
+
+    unsafe fn serialized_metadata(
+        entry: &Self::Entry,
+        durability: &Self::Durability,
+    ) -> (Durability, Revision) {
+        // SAFETY: Guaranteed by the caller.
+        unsafe { (*durability.get(), (*entry.metadata.get()).last_interned_at) }
+    }
+
+    #[inline(always)]
+    fn record_revision(&self, revision: Revision) {
+        self.revision_queue.record(revision);
+    }
+
+    #[inline(always)]
+    unsafe fn intern_existing(&self, existing: InternExisting<'_, Self>) -> Id {
+        let InternExisting {
+            zalsa,
+            zalsa_local,
+            index,
+            current_revision,
+            entry,
+            durability,
+            shard,
+        } = existing;
+
+        // SAFETY: Guaranteed by the caller.
+        let (metadata, durability) =
+            unsafe { (&mut *(*entry).metadata.get(), &mut *durability.get()) };
+
+        if metadata.last_interned_at < current_revision {
+            metadata.last_interned_at = current_revision;
+
+            zalsa.event(&|| {
+                Event::new(EventKind::DidValidateInternedValue {
+                    key: index,
+                    revision: current_revision,
+                })
+            });
+
+            if self.is_reusable(*durability) {
+                // SAFETY: The caller holds the shard lock and this reusable entry is in the LRU.
+                unsafe { shard.lru.cursor_mut_from_ptr(&*entry).remove() };
+                // SAFETY: The caller guarantees that `entry` points to a live value in this shard.
+                unsafe { shard.lru.push_front(UnsafeRef::from_raw(entry)) };
+            }
+        }
+
+        if let Some((_, stamp)) = zalsa_local.active_query() {
+            let was_reusable = self.is_reusable(*durability);
+            *durability = std::cmp::max(*durability, stamp.durability);
+
+            if was_reusable && !self.is_reusable(*durability) {
+                // SAFETY: The caller holds the shard lock and this formerly reusable entry is in the LRU.
+                unsafe { shard.lru.cursor_mut_from_ptr(&*entry).remove() };
+            }
+        }
+
+        self.report_tracked_read_value(zalsa_local, index, current_revision, *durability);
+
+        metadata.id
+    }
+
+    #[inline(always)]
+    fn intern_missing<'db, C, Key, Assemble>(
+        &self,
+        missing: InternMissing<'_, 'db, C, Key, Assemble>,
+    ) -> Id
+    where
+        C: Configuration<Eviction = Self>,
+        Key: Hash,
+        C::Fields<'db>: HashEqLike<Key>,
+        Assemble: FnOnce(Id, Key) -> C::Fields<'db>,
+    {
+        if !self.revision_queue.is_primed() {
+            return missing.intern_new();
+        }
+
+        // SAFETY: The caller holds this ingredient's shard lock.
+        let Some(slot) =
+            (unsafe { self.find_reusable_slot(missing.current_revision, &mut *missing.shard) })
+        else {
+            return missing.intern_new();
+        };
+
+        let InternMissing {
+            ingredient,
+            zalsa,
+            zalsa_local,
+            key,
+            assemble,
+            key_map,
+            shard,
+            shard_index: _,
+            hash,
+            current_revision,
+        } = missing;
+
+        // SAFETY: The LRU only contains entries derived from live values in this shard.
+        let value = unsafe { value_from_entry_ptr::<C>(slot.entry) };
+
+        let (durability, last_interned_at) = Self::initial_metadata(zalsa_local, current_revision);
+
+        // Assemble and hash the replacement before mutating the existing slot. Both operations
+        // can invoke user code and panic.
+        // SAFETY: `from_internal_data` restores the correct lifetime before access.
+        let new_fields = unsafe { ingredient.to_internal_data(assemble(slot.new_id, key)) };
+        // SAFETY: We hold the lock for the shard containing the value.
+        let old_hash = ingredient.hasher.hash_one(unsafe { &*value.fields.get() });
+        let index = ingredient.database_key_index(slot.new_id);
+
+        self.report_tracked_read_value(zalsa_local, index, current_revision, durability);
+
+        // Reserve space while the old slot is intact: hashing may panic during rehashing.
+        // SAFETY: The caller holds the lock for every value passed to `hasher`.
+        let hasher = |value: &ValueKey| unsafe { ingredient.value_hash(value.value::<C>()) };
+        key_map.reserve(1, hasher);
+
+        // SAFETY: The stale, reusable entry is in this shard's LRU.
+        unsafe { shard.lru.cursor_mut_from_ptr(&value.eviction).remove() };
+
+        let value_key = ValueKey::new(value);
+        key_map
+            .find_entry(old_hash, |found_value| found_value.0 == value_key.0)
+            .unwrap_or_else(|_| panic!("interned value in LRU so must be in key_map"))
+            .remove();
+
+        // SAFETY: A stale reusable value has no outstanding references to its fields or memos.
+        let old_fields = unsafe { std::mem::replace(&mut *value.fields.get(), new_fields) };
+        // SAFETY: We still hold the shard lock.
+        unsafe {
+            *value.eviction.metadata.get() = EntryMetadata {
+                id: slot.new_id,
+                last_interned_at,
+            };
+            *value.durability.get() = durability;
+        }
+
+        key_map.insert_unique(hash, value_key, hasher);
+
+        if self.is_reusable(durability) {
+            // SAFETY: The value is live and the entry pointer retains its enclosing provenance.
+            unsafe { shard.lru.push_front(UnsafeRef::from_raw(slot.entry)) };
+        }
+
+        // SAFETY: A stale reusable value has no outstanding references to its memos.
+        let memo_table = unsafe { &mut *value.memos.get() };
+        // SAFETY: The memo table belongs to the value allocated by this ingredient.
+        unsafe { ingredient.clear_memos(zalsa, memo_table, slot.old_id) };
+
+        drop(old_fields);
+
+        zalsa.event(&|| {
+            Event::new(EventKind::DidReuseInternedValue {
+                key: index,
+                revision: current_revision,
+            })
+        });
+
+        slot.new_id
+    }
+
+    unsafe fn insert_entry(
+        &self,
+        shard: &mut Self::Shard,
+        entry: *const Self::Entry,
+        durability: &Self::Durability,
+    ) {
+        // SAFETY: Guaranteed by the caller.
+        let durability = unsafe { *durability.get() };
+        if self.is_reusable(durability) {
+            // SAFETY: The caller guarantees that `entry` points to a live value in this shard.
+            unsafe { shard.lru.push_front(UnsafeRef::from_raw(entry)) };
+        }
+    }
+
+    unsafe fn report_tracked_read(
+        &self,
+        zalsa_local: &ZalsaLocal,
+        index: DatabaseKeyIndex,
+        current_revision: Revision,
+        durability: &Self::Durability,
+    ) {
+        // SAFETY: Guaranteed by the caller.
+        let durability = unsafe { *durability.get() };
+        self.report_tracked_read_value(zalsa_local, index, current_revision, durability);
+    }
+
+    unsafe fn is_valid(
+        &self,
+        zalsa: &Zalsa,
+        entry: &Self::Entry,
+        durability: &Self::Durability,
+    ) -> bool {
+        // SAFETY: Guaranteed by the caller.
+        let durability = unsafe { *durability.get() };
+        if !self.is_reusable(durability) {
+            return true;
+        }
+
+        // SAFETY: Guaranteed by the caller.
+        let last_interned_at = unsafe { (*entry.metadata.get()).last_interned_at };
+        last_interned_at >= zalsa.last_changed_revision(durability)
+    }
+
+    unsafe fn maybe_changed_after(
+        &self,
+        zalsa: &Zalsa,
+        index: DatabaseKeyIndex,
+        input: Id,
+        current_revision: Revision,
+        entry: &Self::Entry,
+    ) -> VerifyResult {
+        // SAFETY: Guaranteed by the caller.
+        let metadata = unsafe { &mut *entry.metadata.get() };
+        if metadata.id.generation() > input.generation() {
+            return VerifyResult::changed();
+        }
+
+        metadata.last_interned_at = current_revision;
+        zalsa.event(&|| {
+            Event::new(EventKind::DidValidateInternedValue {
+                key: index,
+                revision: current_revision,
+            })
+        });
+
+        VerifyResult::unchanged()
+    }
+}
+
+impl Lru {
+    fn is_reusable(&self, durability: Durability) -> bool {
+        // Collecting higher durability values requires invalidating the revision for their
+        // durability to avoid short-circuiting `maybe_changed_after`.
+        durability == Durability::LOW
+    }
+
+    fn report_tracked_read_value(
+        &self,
+        zalsa_local: &ZalsaLocal,
+        index: DatabaseKeyIndex,
+        current_revision: Revision,
+        durability: Durability,
+    ) {
+        if self.is_reusable(durability) {
+            zalsa_local.report_tracked_read_simple(index, durability, current_revision);
+        } else {
+            // Reusing an interned ID can change a query without a corresponding input changing.
+            zalsa_local.report_tracked_read_revision(current_revision);
+        }
+    }
+
+    /// Finds the least-recently-used stale slot whose generation can be incremented.
+    ///
+    /// # Safety
+    ///
+    /// The caller must hold the shard lock, and all LRU entries must belong to live values in that
+    /// shard.
+    unsafe fn find_reusable_slot(
+        &self,
+        current_revision: Revision,
+        shard: &mut LruShard,
+    ) -> Option<ReusableSlot> {
+        let mut cursor = shard.lru.back_mut();
+
+        while let Some(entry) = cursor.as_cursor().clone_pointer() {
+            let entry = UnsafeRef::into_raw(entry);
+
+            // SAFETY: Guaranteed by the caller.
+            let metadata = unsafe { &mut *(*entry).metadata.get() };
+
+            if !self.revision_queue.is_stale(metadata.last_interned_at) {
+                return None;
+            }
+
+            debug_assert!(metadata.last_interned_at < current_revision);
+
+            let old_id = metadata.id;
+            if let Some(new_id) = old_id.next_generation() {
+                return Some(ReusableSlot {
+                    entry,
+                    old_id,
+                    new_id,
+                });
+            }
+
+            cursor.remove().unwrap();
+            cursor = shard.lru.back_mut();
+        }
+
+        None
+    }
+}
+
+/// Recovers a value from its intrusive LRU entry.
+///
+/// # Safety
+///
+/// `entry` must have been produced by `eviction::entry_ptr` for the same configuration, and its
+/// value must remain live for the returned lifetime.
+#[inline]
+unsafe fn value_from_entry_ptr<'a, C: Configuration<Eviction = Lru>>(
+    entry: *const LruEntry,
+) -> &'a Value<C> {
+    // SAFETY: `entry_ptr` derives `entry` from the enclosing value pointer.
+    unsafe {
+        &*entry
+            .cast::<u8>()
+            .sub(std::mem::offset_of!(Value<C>, eviction))
+            .cast::<Value<C>>()
+    }
+}
+
+/// Keep track of revisions in which interned values were read, to determine staleness.
+///
+/// An interned value is considered stale if it has not been read in the past `REVS`
+/// revisions. However, we only consider revisions in which interned values were actually
+/// read, as revisions may be created in bursts.
+struct RevisionQueue {
+    lock: Mutex<()>,
+    /// Recent revisions, stored inline for the default configuration.
+    revisions: SmallVec<[AtomicRevision; DEFAULT_REVISIONS]>,
+}
+
+// `#[salsa::interned(revisions = usize::MAX)]` disables garbage collection.
+const IMMORTAL: NonZeroUsize = NonZeroUsize::MAX;
+
+impl RevisionQueue {
+    fn new(capacity: NonZeroUsize) -> Self {
+        let revisions = if capacity == IMMORTAL {
+            SmallVec::new()
+        } else {
+            (0..capacity.get())
+                .map(|_| AtomicRevision::start())
+                .collect()
+        };
+
+        Self {
+            lock: Mutex::new(()),
+            revisions,
+        }
+    }
+
+    /// Record the given revision as active.
+    #[inline]
+    fn record(&self, revision: Revision) {
+        debug_assert!(
+            !self.revisions.is_empty(),
+            "cannot record revisions when interned garbage collection is disabled"
+        );
+
+        // Fast-path: We already recorded this revision.
+        if self.revisions[0].load() >= revision {
+            return;
+        }
+
+        self.record_cold(revision);
+    }
+
+    #[cold]
+    fn record_cold(&self, revision: Revision) {
+        let _lock = self.lock.lock();
+
+        // Another thread may have recorded this revision while we waited for the lock.
+        if self.revisions[0].load() >= revision {
+            return;
+        }
+
+        // Otherwise, update the queue, maintaining sorted order.
+        //
+        // Note that this should only happen once per revision.
+        for i in (1..self.revisions.len()).rev() {
+            self.revisions[i].store(self.revisions[i - 1].load());
+        }
+
+        self.revisions[0].store(revision);
+    }
+
+    /// Returns `true` if the given revision is old enough to be considered stale.
+    #[inline]
+    fn is_stale(&self, revision: Revision) -> bool {
+        let Some(oldest) = self.revisions.last() else {
+            return false;
+        };
+        let oldest = oldest.load();
+
+        // If we have not recorded `REVS` revisions yet, nothing can be stale.
+        if oldest == Revision::start() {
+            return false;
+        }
+
+        revision < oldest
+    }
+
+    /// Returns `true` if the configured number of revisions have been recorded as active,
+    /// i.e. enough data has been recorded to start garbage collection.
+    #[inline]
+    fn is_primed(&self) -> bool {
+        self.revisions
+            .last()
+            .is_some_and(|oldest| oldest.load() > Revision::start())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+
+    use super::RevisionQueue;
+    use crate::Revision;
+
+    #[test]
+    fn revision_queue_records_each_revision_once() {
+        let queue = RevisionQueue::new(NonZeroUsize::new(2).unwrap());
+        let revision = Revision::start().next();
+
+        // Simulate two threads that both passed the fast-path check before taking the lock.
+        queue.record_cold(revision);
+        queue.record_cold(revision);
+
+        assert_eq!(queue.revisions[0].load(), revision);
+        assert_eq!(queue.revisions[1].load(), Revision::start());
+    }
+}

--- a/src/interned/eviction/noop.rs
+++ b/src/interned/eviction/noop.rs
@@ -1,0 +1,120 @@
+use std::hash::Hash;
+use std::num::NonZeroUsize;
+
+use crate::durability::Durability;
+use crate::function::VerifyResult;
+use crate::plumbing::ZalsaLocal;
+use crate::zalsa::Zalsa;
+use crate::{DatabaseKeyIndex, Id, Revision};
+
+use super::{EvictionPolicy, InternExisting, InternMissing};
+use crate::interned::{Configuration, HashEqLike};
+
+/// Compile-time opt-out from interned eviction.
+pub struct NoopEviction;
+
+/// Stable per-value state for an interned ingredient without eviction.
+pub struct NoopEntry {
+    id: Id,
+}
+
+impl EvictionPolicy for NoopEviction {
+    const CAN_REUSE: bool = false;
+
+    type Shard = ();
+    type Entry = NoopEntry;
+    type Durability = ();
+
+    fn new(_revisions: NonZeroUsize) -> Self {
+        Self
+    }
+
+    fn new_entry(id: Id, _last_interned_at: Revision) -> Self::Entry {
+        NoopEntry { id }
+    }
+
+    fn new_durability(_durability: Durability) -> Self::Durability {}
+
+    #[inline(always)]
+    fn initial_metadata(
+        _zalsa_local: &ZalsaLocal,
+        _current_revision: Revision,
+    ) -> (Durability, Revision) {
+        (Durability::MAX, Revision::max())
+    }
+
+    unsafe fn id(entry: &Self::Entry) -> Id {
+        entry.id
+    }
+
+    unsafe fn serialized_metadata(
+        _entry: &Self::Entry,
+        _durability: &Self::Durability,
+    ) -> (Durability, Revision) {
+        (Durability::MAX, Revision::max())
+    }
+
+    #[inline(always)]
+    fn record_revision(&self, _revision: Revision) {}
+
+    #[inline(always)]
+    unsafe fn intern_existing(&self, existing: InternExisting<'_, Self>) -> Id {
+        // SAFETY: Guaranteed by the caller.
+        unsafe { (*existing.entry).id }
+    }
+
+    #[inline(always)]
+    fn intern_missing<'db, C, Key, Assemble>(
+        &self,
+        missing: InternMissing<'_, 'db, C, Key, Assemble>,
+    ) -> Id
+    where
+        C: Configuration<Eviction = Self>,
+        Key: Hash,
+        C::Fields<'db>: HashEqLike<Key>,
+        Assemble: FnOnce(Id, Key) -> C::Fields<'db>,
+    {
+        missing.intern_new()
+    }
+
+    #[inline(always)]
+    unsafe fn insert_entry(
+        &self,
+        _shard: &mut Self::Shard,
+        _entry: *const Self::Entry,
+        _durability: &Self::Durability,
+    ) {
+    }
+
+    #[inline(always)]
+    unsafe fn report_tracked_read(
+        &self,
+        _zalsa_local: &ZalsaLocal,
+        _index: DatabaseKeyIndex,
+        _current_revision: Revision,
+        _durability: &Self::Durability,
+    ) {
+    }
+
+    #[inline(always)]
+    unsafe fn is_valid(
+        &self,
+        _zalsa: &Zalsa,
+        _entry: &Self::Entry,
+        _durability: &Self::Durability,
+    ) -> bool {
+        true
+    }
+
+    #[inline(always)]
+    unsafe fn maybe_changed_after(
+        &self,
+        _zalsa: &Zalsa,
+        _index: DatabaseKeyIndex,
+        _input: Id,
+        _current_revision: Revision,
+        _entry: &Self::Entry,
+    ) -> VerifyResult {
+        VerifyResult::unchanged()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,7 +408,10 @@ pub mod plumbing {
     }
 
     pub mod interned {
-        pub use crate::interned::{Configuration, IngredientImpl, JarImpl, Value};
+        pub use crate::interned::{
+            Configuration, EvictionPolicy, EvictionSelector, IngredientImpl, JarImpl, Lru,
+            NoopEviction, SelectEviction, Value,
+        };
     }
 
     pub mod function {

--- a/tests/interned-immortal-persistence.rs
+++ b/tests/interned-immortal-persistence.rs
@@ -1,0 +1,66 @@
+#![cfg(all(feature = "persistence", feature = "inventory"))]
+
+use salsa::plumbing::AsId;
+
+#[salsa::interned(persist, revisions = usize::MAX)]
+struct Name<'db> {
+    text: String,
+}
+
+#[test]
+fn immortal_persistence_restores_generation_and_metadata() {
+    let mut db = salsa::DatabaseImpl::default();
+    let name = Name::new(&db, "name".to_owned());
+    let id = name.as_id();
+
+    let mut serialized =
+        serde_json::to_value(<dyn salsa::Database>::as_serialize(&mut db)).unwrap();
+    let ingredient = serialized["ingredients"]
+        .as_object_mut()
+        .unwrap()
+        .values_mut()
+        .find(|ingredient| {
+            ingredient.as_object().is_some_and(|values| {
+                values
+                    .values()
+                    .any(|value| value["fields"] == serde_json::json!(["name"]))
+            })
+        })
+        .unwrap()
+        .as_object_mut()
+        .unwrap();
+
+    let mut value = ingredient.remove(&id.as_bits().to_string()).unwrap();
+    assert_eq!(value["durability"], 3);
+    assert_eq!(value["last_interned_at"], u64::MAX);
+
+    // Metadata persisted before eviction was disabled is still accepted.
+    value["durability"] = serde_json::json!(0);
+    value["last_interned_at"] = serde_json::json!(1);
+
+    let restored_id = id.with_generation(7);
+    ingredient.insert(restored_id.as_bits().to_string(), value);
+
+    let serialized = serde_json::to_string(&serialized).unwrap();
+    let mut restored = salsa::DatabaseImpl::default();
+    <dyn salsa::Database>::deserialize(
+        &mut restored,
+        &mut serde_json::Deserializer::from_str(&serialized),
+    )
+    .unwrap();
+
+    let name = Name::new(&restored, "name".to_owned());
+    assert_eq!(name.as_id(), restored_id);
+    assert_eq!(name.text(&restored), "name");
+
+    let reserialized =
+        serde_json::to_value(<dyn salsa::Database>::as_serialize(&mut restored)).unwrap();
+    let value = reserialized["ingredients"]
+        .as_object()
+        .unwrap()
+        .values()
+        .find_map(|ingredient| ingredient.get(restored_id.as_bits().to_string()))
+        .unwrap();
+    assert_eq!(value["durability"], 3);
+    assert_eq!(value["last_interned_at"], u64::MAX);
+}

--- a/tests/interned-revisions.rs
+++ b/tests/interned-revisions.rs
@@ -287,7 +287,9 @@ fn test_non_reusable_value_still_updates_query_stamp() {
     assert!(outer(&db, input));
 }
 
-#[salsa::interned(revisions = usize::MAX)]
+const IMMORTAL_REVISIONS: usize = usize::MAX;
+
+#[salsa::interned(revisions = IMMORTAL_REVISIONS)]
 #[derive(Debug)]
 struct Immortal<'db> {
     field1: BadHash,
@@ -349,6 +351,32 @@ fn test_immortal() {
         assert_eq!(result.field1(&db).0, i);
         assert_eq!(salsa::plumbing::AsId::as_id(&result).generation(), 0);
     }
+}
+
+#[test]
+fn test_reintern_immortal() {
+    #[salsa::tracked(returns(copy))]
+    fn function(db: &dyn Database, input: Input) -> Immortal<'_> {
+        let _ = input.field1(db);
+        Immortal::new(db, BadHash(0))
+    }
+
+    let mut db = common::EventLoggerDatabase::default();
+    let input = Input::new(&db, 0);
+
+    let first = salsa::plumbing::AsId::as_id(&function(&db, input));
+    db.clear_logs();
+
+    input.set_field1(&mut db).to(1);
+    let second = salsa::plumbing::AsId::as_id(&function(&db, input));
+
+    assert_eq!(first, second);
+    db.assert_logs(expect![[r#"
+        [
+            "DidSetCancellationFlag",
+            "WillCheckCancellation",
+            "WillExecute { database_key: function(Id(0)) }",
+        ]"#]]);
 }
 
 #[test]

--- a/tests/interned-structs_self_ref.rs
+++ b/tests/interned-structs_self_ref.rs
@@ -90,6 +90,7 @@ const _: () = {
         const DEBUG_NAME: &'static str = "InternedString";
         type Fields<'a> = StructData<'a>;
         type Struct<'a> = InternedString<'a>;
+        type Eviction = zalsa_struct_::Lru;
 
         const PERSIST: bool = false;
 


### PR DESCRIPTION
Main benefit; It also reduces the size of each interned value because we avoid storing the unnecessary Lru overhead.

Maps `revisions = usize::MAX` to a compact compile-time no-eviction policy while keeping LRU as the default and preserving the existing macro API.
Removes unused LRU state and bookkeeping for immortal values; simulation improves hot interning by 32.6% and cold interning by 13.6%, with no LRU regression.
Testing: Added behavioral, persistence, layout, and performance coverage; full suites and lint checks pass.