### PR TITLE
chore: fix cascading reparses in the lazy-input example

### DIFF
--- a/examples/lazy-input/main.rs
+++ b/examples/lazy-input/main.rs
@@ -161,8 +161,10 @@ impl Diagnostic {
 
 #[salsa::tracked]
 struct ParsedFile<'db> {
+    #[tracked]
     #[returns(copy)]
     value: u32,
+    #[tracked]
     #[returns(deref)]
     links: Vec<ParsedFile<'db>>,
 }


### PR DESCRIPTION
Mark `ParsedFile::value` and `ParsedFile::links` as `#[tracked]` so changing a leaf input no longer changes parent identities and triggers cascading reparses.

This completes the lazy-input example's migration to coarse-grained tracked structs introduced in [#657](https://github.com/salsa-rs/salsa/pull/657).
