### PR TITLE
Require immortal storage for lifetime-free interned values

### DIFF
--- a/components/salsa-macros/src/lib.rs
+++ b/components/salsa-macros/src/lib.rs
@@ -171,11 +171,10 @@ pub fn db(args: TokenStream, input: TokenStream) -> TokenStream {
 /// - `id = PATH` uses `PATH` as a legacy ID adapter instead of [`salsa::Id`]. The custom type must
 ///   implement [`Copy`] + [`Clone`] + [`PartialEq`] + [`Eq`] + [`Hash`] as well as
 ///   `salsa::plumbing::AsId` and `salsa::plumbing::FromId`.
-/// - **Unsafe: `no_lifetime` is strongly discouraged.** It adapts code that cannot carry the
-///   database lifetime by generating a struct without one. This bypasses the compile-time
-///   guarantee that an interned handle cannot outlive its database revision. The caller becomes
-///   responsible for ensuring every handle remains valid as revisions advance and interned slots
-///   may be reclaimed or reused.
+/// - **Unsafe: `unsafe(no_lifetime)` is strongly discouraged.** It adapts code that cannot carry
+///   the database lifetime by generating a struct without one. This bypasses the compile-time
+///   guarantee that an interned handle cannot outlive its database. It must be combined with
+///   `revisions = usize::MAX` so that interned slots are never reclaimed or reused.
 /// - **Unsafe: `unsafe(non_salsa_values)` is strongly discouraged.** It adapts field types that do
 ///   not implement [`salsa::SalsaValue`] by suppressing the generated checks. The caller becomes
 ///   responsible for ensuring retained values remain valid across revisions. Prefer adapting only

--- a/components/salsa-macros/src/options.rs
+++ b/components/salsa-macros/src/options.rs
@@ -251,38 +251,32 @@ impl<A: AllowedOptions> syn::parse::Parse for Options<A> {
                     ));
                 }
             } else if ident == "no_lifetime" {
-                if A::NO_LIFETIME {
+                return Err(syn::Error::new(
+                    ident.span(),
+                    "`no_lifetime` must be written as `unsafe(no_lifetime)`",
+                ));
+            } else if ident == "unsafe" {
+                let content;
+                parenthesized!(content in input);
+                let ident = syn::Ident::parse_any(&content)?;
+                if ident == "no_lifetime" && A::NO_LIFETIME {
                     if let Some(old) = options.no_lifetime.replace(ident) {
                         return Err(syn::Error::new(
                             old.span(),
                             "option `no_lifetime` provided twice",
                         ));
                     }
-                } else {
-                    return Err(syn::Error::new(
-                        ident.span(),
-                        "`no_lifetime` option not allowed here",
-                    ));
-                }
-            } else if ident == "unsafe" {
-                if A::NON_SALSA_VALUES {
-                    let content;
-                    parenthesized!(content in input);
-                    let ident = syn::Ident::parse_any(&content)?;
-                    if ident == "non_salsa_values" {
-                        if let Some(old) = options.non_salsa_values.replace(ident) {
-                            return Err(syn::Error::new(
-                                old.span(),
-                                "option `non_salsa_values` provided twice",
-                            ));
-                        }
-                    } else {
-                        return Err(syn::Error::new(ident.span(), "expected `non_salsa_values`"));
+                } else if ident == "non_salsa_values" && A::NON_SALSA_VALUES {
+                    if let Some(old) = options.non_salsa_values.replace(ident) {
+                        return Err(syn::Error::new(
+                            old.span(),
+                            "option `non_salsa_values` provided twice",
+                        ));
                     }
                 } else {
                     return Err(syn::Error::new(
                         ident.span(),
-                        "`unsafe` options not allowed here",
+                        "unsafe option not allowed here",
                     ));
                 }
             } else if ident == "persist" {
@@ -549,9 +543,43 @@ impl<A: AllowedOptions> syn::parse::Parse for Options<A> {
             let _comma = Comma::parse(input)?;
         }
 
+        if let Some(no_lifetime) = &options.no_lifetime {
+            let Some(revisions) = &options.revisions else {
+                return Err(syn::Error::new(
+                    no_lifetime.span(),
+                    "`unsafe(no_lifetime)` requires `revisions = usize::MAX`",
+                ));
+            };
+            let syn::Expr::Path(revisions_path) = revisions else {
+                return Err(syn::Error::new(
+                    revisions.span(),
+                    "`unsafe(no_lifetime)` requires `revisions = usize::MAX`",
+                ));
+            };
+            let path = &revisions_path.path;
+            let is_usize_max =
+                revisions_path.qself.is_none()
+                    && path.leading_colon.is_none()
+                    && path.segments.len() == 2
+                    && path.segments.first().is_some_and(|segment| {
+                        segment.ident == "usize" && segment.arguments.is_none()
+                    })
+                    && path.segments.last().is_some_and(|segment| {
+                        segment.ident == "MAX" && segment.arguments.is_none()
+                    });
+
+            if !is_usize_max {
+                return Err(syn::Error::new(
+                    revisions.span(),
+                    "`unsafe(no_lifetime)` requires `revisions = usize::MAX`",
+                ));
+            }
+        }
+
         Ok(options)
     }
 }
+
 impl<A: AllowedOptions> quote::ToTokens for Options<A> {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         let Self {
@@ -586,7 +614,7 @@ impl<A: AllowedOptions> quote::ToTokens for Options<A> {
             tokens.extend(quote::quote! { debug, });
         }
         if no_lifetime.is_some() {
-            tokens.extend(quote::quote! { no_lifetime, });
+            tokens.extend(quote::quote! { unsafe(no_lifetime), });
         }
         if singleton.is_some() {
             tokens.extend(quote::quote! { singleton, });

--- a/tests/compile-fail/interned_struct_incompatibles.rs
+++ b/tests/compile-fail/interned_struct_incompatibles.rs
@@ -39,4 +39,19 @@ struct InternedWithZeroRevisions {
     field: u32,
 }
 
+#[salsa::interned(no_lifetime, revisions = usize::MAX)]
+struct InternedWithUnwrappedNoLifetime {
+    field: u32,
+}
+
+#[salsa::interned(unsafe(no_lifetime))]
+struct InternedWithReclaimableDefault {
+    field: u32,
+}
+
+#[salsa::interned(unsafe(no_lifetime), revisions = 3)]
+struct InternedWithReclaimableExplicit {
+    field: u32,
+}
+
 fn main() {}

--- a/tests/compile-fail/interned_struct_incompatibles.stderr
+++ b/tests/compile-fail/interned_struct_incompatibles.stderr
@@ -41,6 +41,24 @@ error: `#[tracked]` cannot be used with `#[salsa::interned]`
 34 | |     field: u32,
    | |______________^
 
+error: `no_lifetime` must be written as `unsafe(no_lifetime)`
+  --> tests/compile-fail/interned_struct_incompatibles.rs:42:19
+   |
+42 | #[salsa::interned(no_lifetime, revisions = usize::MAX)]
+   |                   ^^^^^^^^^^^
+
+error: `unsafe(no_lifetime)` requires `revisions = usize::MAX`
+  --> tests/compile-fail/interned_struct_incompatibles.rs:47:26
+   |
+47 | #[salsa::interned(unsafe(no_lifetime))]
+   |                          ^^^^^^^^^^^
+
+error: `unsafe(no_lifetime)` requires `revisions = usize::MAX`
+  --> tests/compile-fail/interned_struct_incompatibles.rs:52:52
+   |
+52 | #[salsa::interned(unsafe(no_lifetime), revisions = 3)]
+   |                                                    ^
+
 error: cannot find attribute `tracked` in this scope
   --> tests/compile-fail/interned_struct_incompatibles.rs:33:7
    |

--- a/tests/debug_bounds.rs
+++ b/tests/debug_bounds.rs
@@ -31,13 +31,13 @@ struct NotDebugInterned {
     field: NotDebug,
 }
 
-#[salsa::interned(no_lifetime, debug)]
+#[salsa::interned(unsafe(no_lifetime), revisions = usize::MAX, debug)]
 struct DebugInternedNoLifetime {
     #[returns(copy)]
     field: Debug,
 }
 
-#[salsa::interned(no_lifetime)]
+#[salsa::interned(unsafe(no_lifetime), revisions = usize::MAX)]
 struct NotDebugInternedNoLifetime {
     #[returns(copy)]
     field: NotDebug,

--- a/tests/intern_access_in_different_revision.rs
+++ b/tests/intern_access_in_different_revision.rs
@@ -2,7 +2,7 @@
 
 use salsa::{Durability, Setter};
 
-#[salsa::interned(no_lifetime)]
+#[salsa::interned(unsafe(no_lifetime), revisions = usize::MAX)]
 struct Interned {
     #[returns(copy)]
     field: u32,

--- a/tests/interned-structs.rs
+++ b/tests/interned-structs.rs
@@ -47,7 +47,7 @@ struct InternedPathBuf<'db> {
     data1: PathBuf,
 }
 
-#[salsa::interned(no_lifetime, debug)]
+#[salsa::interned(unsafe(no_lifetime), revisions = usize::MAX, debug)]
 struct InternedStringNoLifetime {
     data: String,
 }
@@ -80,7 +80,12 @@ struct InternedStringWithCustomId<'db> {
     data: String,
 }
 
-#[salsa::interned(id = SalsaIdWrapper, no_lifetime, debug)]
+#[salsa::interned(
+    id = SalsaIdWrapper,
+    unsafe(no_lifetime),
+    revisions = usize::MAX,
+    debug
+)]
 struct InternedStringWithCustomIdAndNoLifetime<'db> {
     data: String,
 }

--- a/tests/supertype_overlap.rs
+++ b/tests/supertype_overlap.rs
@@ -3,12 +3,12 @@
 
 use salsa::plumbing::ZalsaDatabase;
 
-#[salsa::interned(no_lifetime, debug)]
+#[salsa::interned(unsafe(no_lifetime), revisions = usize::MAX, debug)]
 struct Name {
     text: String,
 }
 
-#[salsa::interned(no_lifetime, debug)]
+#[salsa::interned(unsafe(no_lifetime), revisions = usize::MAX, debug)]
 struct Age {
     #[returns(copy)]
     value: u32,

--- a/tests/tracked_fn_on_interned_enum.rs
+++ b/tests/tracked_fn_on_interned_enum.rs
@@ -3,7 +3,7 @@
 //! Test that a `tracked` fn on a `salsa::interned`
 //! compiles and executes successfully.
 
-#[salsa::interned(no_lifetime, debug)]
+#[salsa::interned(unsafe(no_lifetime), revisions = usize::MAX, debug)]
 struct Name {
     name: String,
 }
@@ -13,7 +13,7 @@ struct NameAndAge<'db> {
     name_and_age: String,
 }
 
-#[salsa::interned(no_lifetime, debug)]
+#[salsa::interned(unsafe(no_lifetime), revisions = usize::MAX, debug)]
 struct Age {
     #[returns(copy)]
     age: u32,


### PR DESCRIPTION
The escape hatch can easily cause UB, so mark it unsafe and also require to disable the LRU for it, as that leans on the lifetimes for correctness.

We should be able to remove our uses of this soon-ish at which point we can fully drop it