### PR TITLE
feat: Add conditional SalsaValue derive proofs

### DIFF
--- a/book/src/plumbing/db_lifetime.md
+++ b/book/src/plumbing/db_lifetime.md
@@ -218,14 +218,27 @@ Salsa handles do implement it because access to their data goes back through the
 state.
 
 The derive supports types with at most one lifetime parameter, as well as type and const
-parameters. Generated implementations require generic field types to implement `SalsaValue`;
-types that need different bounds can provide a manual implementation instead.
+parameters. Generated implementations require generic field types to implement `SalsaValue`.
+When an unmodifiable field type cannot implement `SalsaValue`, a conditional proof can replace the
+field check with narrower predicates:
 
-If a field is known to satisfy the guarantee but its type cannot implement `SalsaValue`,
-`#[salsa_value(unsafe(prove_safe_to_retain_manually))]` skips the structural check for that field.
-The `unsafe` wrapper makes the proof obligation explicit: the author must ensure the field remains
-valid when Salsa retains it across revisions and rebinds its database lifetime. This manual
-assertion is supported by `derive(SalsaValue)` and directly on tracked and interned struct fields.
+```rust,ignore
+#[derive(salsa::SalsaValue)]
+struct QueryValue<T> {
+    #[salsa_value(unsafe(prove(T: salsa::SalsaValue)))]
+    value: ForeignContainer<T>,
+}
+```
+
+The predicates are added to the generated implementation, so `QueryValue<T>` only implements
+`SalsaValue` when `T` does. The compiler verifies that premise; the author asserts that the premise
+implies `ForeignContainer<T>` remains valid when Salsa retains it across revisions and rebinds its
+database lifetime.
+
+An unconditional `#[salsa_value(unsafe(prove_safe_to_retain_manually))]` proof skips the structural
+check without adding predicates. It is supported by `derive(SalsaValue)` and directly on tracked and
+interned struct fields. The author must ensure the field is safe for every generic instantiation
+accepted by the enclosing type.
 
 ## Updating tracked struct fields across revisions
 

--- a/book/src/plumbing/db_lifetime.md
+++ b/book/src/plumbing/db_lifetime.md
@@ -219,19 +219,15 @@ state.
 
 The derive supports types with at most one lifetime parameter, as well as type and const
 parameters. Generated implementations require generic field types to implement `SalsaValue`.
-The available field proofs depend on how the enclosing type is declared:
+Retention proofs are supported by `derive(SalsaValue)` and on tracked and interned struct fields;
+input fields do not support them.
 
-| Enclosing declaration | `unsafe(prove(...))` | `unsafe(prove_safe_to_retain_manually)` |
-| --- | --- | --- |
-| `derive(SalsaValue)` | Supported | Supported |
-| `#[salsa::tracked]` struct | Not supported | Supported |
-| `#[salsa::interned]` struct | Not supported | Supported |
-| `#[salsa::input]` struct | Not supported | Not supported |
-
-Conditional proofs add predicates to a generated `SalsaValue` implementation. Only
-`derive(SalsaValue)` generates an implementation whose generic bounds can be narrowed this way.
-When an unmodifiable field type cannot implement `SalsaValue`, a conditional proof can replace the
-field check with narrower predicates:
+On a type using `derive(SalsaValue)`, conditional proofs add predicates to the generated
+`SalsaValue` implementation, narrowing the generic instantiations that implement the trait. Tracked
+and interned structs do not support type or const parameters, so their predicates are instead
+verified for every database lifetime by the generated field assertions. When an unmodifiable field
+type cannot implement `SalsaValue`, a conditional proof can replace the field check with narrower
+predicates:
 
 ```rust,ignore
 #[derive(salsa::SalsaValue)]
@@ -247,9 +243,8 @@ implies `ForeignContainer<T>` remains valid when Salsa retains it across revisio
 database lifetime.
 
 An unconditional `#[salsa_value(unsafe(prove_safe_to_retain_manually))]` proof skips the structural
-check without adding predicates. It is supported by `derive(SalsaValue)` and directly on tracked and
-interned struct fields. The author must ensure the field is safe for every generic instantiation
-accepted by the enclosing type.
+check without adding predicates. The author must ensure the field is safe for every generic
+instantiation accepted by the enclosing type.
 
 ## Updating tracked struct fields across revisions
 

--- a/book/src/plumbing/db_lifetime.md
+++ b/book/src/plumbing/db_lifetime.md
@@ -219,6 +219,17 @@ state.
 
 The derive supports types with at most one lifetime parameter, as well as type and const
 parameters. Generated implementations require generic field types to implement `SalsaValue`.
+The available field proofs depend on how the enclosing type is declared:
+
+| Enclosing declaration | `unsafe(prove(...))` | `unsafe(prove_safe_to_retain_manually)` |
+| --- | --- | --- |
+| `derive(SalsaValue)` | Supported | Supported |
+| `#[salsa::tracked]` struct | Not supported | Supported |
+| `#[salsa::interned]` struct | Not supported | Supported |
+| `#[salsa::input]` struct | Not supported | Not supported |
+
+Conditional proofs add predicates to a generated `SalsaValue` implementation. Only
+`derive(SalsaValue)` generates an implementation whose generic bounds can be narrowed this way.
 When an unmodifiable field type cannot implement `SalsaValue`, a conditional proof can replace the
 field check with narrower predicates:
 

--- a/components/salsa-macros/src/interned.rs
+++ b/components/salsa-macros/src/interned.rs
@@ -146,22 +146,24 @@ impl Macro {
         let CACHE = self.hygiene.ident("CACHE");
         let Db = self.hygiene.ident("Db");
 
-        let assert_fields_are_salsa_values = if self.args.non_salsa_values.is_some() {
-            quote! {}
+        let self_type = if has_lifetime {
+            syn::parse_quote!(#struct_ident<#db_lt>)
         } else {
-            field_tys
-                .iter()
-                .zip(field_manual_retention_proofs)
-                .map(|(field_ty, has_manual_retention_proof)| {
-                    crate::salsa_value::assert_salsa_value_field(
-                        &db_lt,
-                        &zalsa,
-                        field_ty,
-                        has_manual_retention_proof,
-                    )
-                })
-                .collect()
+            syn::parse_quote!(#struct_ident)
         };
+        let assert_fields_are_salsa_values: TokenStream = field_tys
+            .iter()
+            .zip(field_manual_retention_proofs)
+            .map(|(field_ty, proof)| {
+                if self.args.non_salsa_values.is_some() && proof.is_none() {
+                    quote! {}
+                } else {
+                    crate::salsa_value::assert_salsa_value_field_with_proof(
+                        &db_lt, &zalsa, field_ty, proof, &self_type,
+                    )
+                }
+            })
+            .collect();
 
         Ok(crate::debug::dump_tokens(
             struct_ident,

--- a/components/salsa-macros/src/lib.rs
+++ b/components/salsa-macros/src/lib.rs
@@ -521,9 +521,13 @@ pub fn tracked(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// A field accepts at most one `#[salsa_value(...)]` attribute:
 ///
+/// - **Unsafe: `#[salsa_value(unsafe(prove(Predicate, ...)))]`** suppresses the generated retention
+///   check for this field and adds the predicates to the generated `SalsaValue` implementation. The
+///   compiler verifies the predicates, but the author must ensure they imply that Salsa can replace
+///   the field's database lifetime with `'static` for storage and safely restore it later.
 /// - **Unsafe: `#[salsa_value(unsafe(prove_safe_to_retain_manually))]`** suppresses the generated
-///   retention check for this field. The author must ensure Salsa can replace its database lifetime
-///   with `'static` for storage and safely restore it later.
+///   retention check without adding predicates. The author must ensure the field is safe for every
+///   generic instantiation accepted by the enclosing type.
 ///
 /// # Safety
 ///
@@ -533,12 +537,23 @@ pub fn tracked(args: TokenStream, input: TokenStream) -> TokenStream {
 /// valid when Salsa retains the value across revisions and rebinds its database
 /// lifetime.
 ///
-/// # Example
+/// # Examples
 ///
 /// ```ignore
 /// #[derive(salsa::SalsaValue)]
 /// struct QueryValue<'db> {
 ///     item: MyInterned<'db>,
+/// }
+/// ```
+///
+/// A conditional proof narrows the generated implementation when an unmodifiable field type does
+/// not implement `SalsaValue`:
+///
+/// ```ignore
+/// #[derive(salsa::SalsaValue)]
+/// struct QueryValue<T> {
+///     #[salsa_value(unsafe(prove(T: salsa::SalsaValue)))]
+///     value: ForeignContainer<T>,
 /// }
 /// ```
 ///
@@ -558,5 +573,6 @@ pub(crate) fn token_stream_with_error(mut tokens: TokenStream, error: syn::Error
 }
 
 mod kw {
+    syn::custom_keyword!(prove);
     syn::custom_keyword!(prove_safe_to_retain_manually);
 }

--- a/components/salsa-macros/src/lib.rs
+++ b/components/salsa-macros/src/lib.rs
@@ -192,10 +192,13 @@ pub fn db(args: TokenStream, input: TokenStream) -> TokenStream {
 ///   [`salsa::SalsaAsDeref`] to return borrowed forms such as `Option<&T>` and
 ///   `Option<&T::Target>`. Every borrowed result is tied to the database borrow.
 /// - `#[get(IDENT)]` renames the generated getter.
+/// - **Unsafe: `#[salsa_value(unsafe(prove(Predicate, ...)))]`** replaces the retention check with
+///   predicates that must hold for every database lifetime. The compiler verifies the predicates,
+///   but the caller must ensure they imply that Salsa can retain the field and expose it with a later
+///   database lifetime.
 /// - **Unsafe: `#[salsa_value(unsafe(prove_safe_to_retain_manually))]`** suppresses the retention
-///   check for this field. The caller must ensure Salsa can retain the field and expose it with a
-///   later database lifetime. Conditional `unsafe(prove(...))` proofs are not supported on interned
-///   struct fields; they are only supported by `derive(SalsaValue)`.
+///   check for this field without adding predicates. The caller must ensure Salsa can retain the
+///   field and expose it with a later database lifetime.
 ///
 /// Other attributes, including documentation and lint attributes, are copied to the generated
 /// getter.
@@ -393,10 +396,13 @@ pub fn input(args: TokenStream, input: TokenStream) -> TokenStream {
 ///   recreated, avoiding the [`PartialEq`] requirement. It is most useful together with
 ///   `#[tracked]`: because the field does not contribute to identity, the struct can retain its
 ///   identity when recreated, while readers of the field are always invalidated.
+/// - **Unsafe: `#[salsa_value(unsafe(prove(Predicate, ...)))]`** replaces the retention check with
+///   predicates that must hold for every database lifetime. The compiler verifies the predicates,
+///   but the caller must ensure they imply that Salsa can retain the field and expose it with a later
+///   database lifetime.
 /// - **Unsafe: `#[salsa_value(unsafe(prove_safe_to_retain_manually))]`** suppresses the retention
-///   check for this field. The caller must ensure Salsa can retain the field and expose it with a
-///   later database lifetime. Conditional `unsafe(prove(...))` proofs are not supported on tracked
-///   struct fields; they are only supported by `derive(SalsaValue)`.
+///   check for this field without adding predicates. The caller must ensure Salsa can retain the
+///   field and expose it with a later database lifetime.
 ///
 /// Other attributes, including documentation and lint attributes, are copied to the generated
 /// getter.
@@ -524,9 +530,10 @@ pub fn tracked(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// # Field attributes
 ///
-/// These field attributes are supported only by `derive(SalsaValue)`. Salsa's `tracked` and
-/// `interned` struct macros support the unconditional proof below, but not conditional
-/// `unsafe(prove(...))` predicates. The `input` macro supports neither form.
+/// These field attributes are supported by `derive(SalsaValue)` and by Salsa's `tracked` and
+/// `interned` struct macros. On a derived type, conditional predicates become bounds on the
+/// generated `SalsaValue` implementation. On tracked and interned structs, they must hold for every
+/// database lifetime. The `input` macro supports neither form.
 ///
 /// A field accepts at most one `#[salsa_value(...)]` attribute:
 ///

--- a/components/salsa-macros/src/lib.rs
+++ b/components/salsa-macros/src/lib.rs
@@ -194,7 +194,8 @@ pub fn db(args: TokenStream, input: TokenStream) -> TokenStream {
 /// - `#[get(IDENT)]` renames the generated getter.
 /// - **Unsafe: `#[salsa_value(unsafe(prove_safe_to_retain_manually))]`** suppresses the retention
 ///   check for this field. The caller must ensure Salsa can retain the field and expose it with a
-///   later database lifetime.
+///   later database lifetime. Conditional `unsafe(prove(...))` proofs are not supported on interned
+///   struct fields; they are only supported by `derive(SalsaValue)`.
 ///
 /// Other attributes, including documentation and lint attributes, are copied to the generated
 /// getter.
@@ -324,6 +325,9 @@ pub fn supertype(input: TokenStream) -> TokenStream {
 /// - `#[default]` initializes the field with [`Default::default`], omits it from the constructor's
 ///   arguments, and adds a builder method for overriding the default.
 ///
+/// Input fields do not support `#[salsa_value(...)]`. Input field types are stored without database
+/// lifetime rebinding, so neither conditional nor unconditional retention proofs apply.
+///
 /// Other attributes, including documentation and lint attributes, are copied to the generated
 /// getter.
 ///
@@ -391,7 +395,8 @@ pub fn input(args: TokenStream, input: TokenStream) -> TokenStream {
 ///   identity when recreated, while readers of the field are always invalidated.
 /// - **Unsafe: `#[salsa_value(unsafe(prove_safe_to_retain_manually))]`** suppresses the retention
 ///   check for this field. The caller must ensure Salsa can retain the field and expose it with a
-///   later database lifetime.
+///   later database lifetime. Conditional `unsafe(prove(...))` proofs are not supported on tracked
+///   struct fields; they are only supported by `derive(SalsaValue)`.
 ///
 /// Other attributes, including documentation and lint attributes, are copied to the generated
 /// getter.
@@ -518,6 +523,10 @@ pub fn tracked(args: TokenStream, input: TokenStream) -> TokenStream {
 /// unions are not. Named fields, tuple fields, unit structs, and enum variants are supported.
 ///
 /// # Field attributes
+///
+/// These field attributes are supported only by `derive(SalsaValue)`. Salsa's `tracked` and
+/// `interned` struct macros support the unconditional proof below, but not conditional
+/// `unsafe(prove(...))` predicates. The `input` macro supports neither form.
 ///
 /// A field accepts at most one `#[salsa_value(...)]` attribute:
 ///

--- a/components/salsa-macros/src/salsa_struct.rs
+++ b/components/salsa-macros/src/salsa_struct.rs
@@ -101,8 +101,16 @@ pub(crate) const FIELD_OPTION_ATTRIBUTES: &[(
                 "multiple `#[salsa_value]` attributes on field",
             ));
         }
-        crate::salsa_value::parse_manual_retention_proof(attr)
-            .map_err(|error| syn::Error::new_spanned(ef.field, error.to_string()))?;
+        let proof = crate::salsa_value::parse_manual_retention_proof(attr)?;
+        if matches!(
+            proof,
+            crate::salsa_value::ManualRetentionProof::Conditional(_)
+        ) {
+            return Err(syn::Error::new_spanned(
+                ef.field,
+                "conditional retention proofs are only supported by `derive(SalsaValue)`",
+            ));
+        }
         ef.has_manual_retention_proof = true;
         Ok(())
     }),

--- a/components/salsa-macros/src/salsa_struct.rs
+++ b/components/salsa-macros/src/salsa_struct.rs
@@ -53,7 +53,7 @@ pub(crate) trait SalsaStructAllowedOptions: AllowedOptions {
     /// Are `#[default]` fields allowed?
     const ALLOW_DEFAULT: bool;
 
-    /// Is `#[salsa_value(unsafe(prove_safe_to_retain_manually))]` allowed on fields?
+    /// Are manual `#[salsa_value(...)]` retention proofs allowed on fields?
     const ALLOW_MANUAL_RETENTION_PROOF: bool;
 }
 
@@ -64,7 +64,7 @@ pub(crate) struct SalsaField<'s> {
     pub(crate) has_default_attr: bool,
     pub(crate) returns: syn::Ident,
     pub(crate) has_no_eq_attr: bool,
-    pub(crate) has_manual_retention_proof: bool,
+    pub(crate) manual_retention_proof: Option<crate::salsa_value::ManualRetentionProof>,
     get_name: syn::Ident,
     set_name: syn::Ident,
     unknown_attrs: Vec<&'s syn::Attribute>,
@@ -95,23 +95,13 @@ pub(crate) const FIELD_OPTION_ATTRIBUTES: &[(
         Ok(())
     }),
     ("salsa_value", |attr, ef| {
-        if ef.has_manual_retention_proof {
+        if ef.manual_retention_proof.is_some() {
             return Err(syn::Error::new_spanned(
                 ef.field,
                 "multiple `#[salsa_value]` attributes on field",
             ));
         }
-        let proof = crate::salsa_value::parse_manual_retention_proof(attr)?;
-        if matches!(
-            proof,
-            crate::salsa_value::ManualRetentionProof::Conditional(_)
-        ) {
-            return Err(syn::Error::new_spanned(
-                ef.field,
-                "conditional retention proofs are only supported by `derive(SalsaValue)`",
-            ));
-        }
-        ef.has_manual_retention_proof = true;
+        ef.manual_retention_proof = Some(crate::salsa_value::parse_manual_retention_proof(attr)?);
         Ok(())
     }),
     ("get", |attr, ef| {
@@ -234,11 +224,11 @@ where
         }
 
         for field in &self.fields {
-            if field.has_manual_retention_proof {
+            if field.manual_retention_proof.is_some() {
                 return Err(syn::Error::new_spanned(
                     field.field,
                     format!(
-                        "`#[salsa_value(unsafe(prove_safe_to_retain_manually))]` cannot be used with `#[salsa::{}]`",
+                        "`#[salsa_value(...)]` cannot be used with `#[salsa::{}]`",
                         A::KIND
                     ),
                 ));
@@ -362,10 +352,12 @@ where
         self.fields.iter().map(|f| &f.field.ty).collect()
     }
 
-    pub(crate) fn field_manual_retention_proofs(&self) -> Vec<bool> {
+    pub(crate) fn field_manual_retention_proofs(
+        &self,
+    ) -> Vec<Option<&crate::salsa_value::ManualRetentionProof>> {
         self.fields
             .iter()
-            .map(|field| field.has_manual_retention_proof)
+            .map(|field| field.manual_retention_proof.as_ref())
             .collect()
     }
 
@@ -494,7 +486,7 @@ impl<'s> SalsaField<'s> {
             returns,
             has_default_attr: false,
             has_no_eq_attr: false,
-            has_manual_retention_proof: false,
+            manual_retention_proof: None,
             get_name,
             set_name,
             unknown_attrs: Default::default(),

--- a/components/salsa-macros/src/salsa_value.rs
+++ b/components/salsa-macros/src/salsa_value.rs
@@ -1,10 +1,20 @@
 use std::collections::HashSet;
 
 use proc_macro2::TokenStream;
-use syn::{Attribute, spanned::Spanned, visit::Visit};
+use syn::{Attribute, parse::Parse, spanned::Spanned, visit::Visit};
 
 use crate::kw;
 use crate::xform::{ChangeLt, ChangeSelfPath};
+
+pub(crate) enum ManualRetentionProof {
+    Conditional(Vec<syn::WherePredicate>),
+    Unconditional,
+}
+
+struct CheckedField<'a> {
+    ty: &'a syn::Type,
+    proof: Option<ManualRetentionProof>,
+}
 
 pub(crate) fn salsa_value_derive(input: syn::DeriveInput) -> syn::Result<TokenStream> {
     if let syn::Data::Union(union) = &input.data {
@@ -26,16 +36,16 @@ pub(crate) fn salsa_value_derive(input: syn::DeriveInput) -> syn::Result<TokenSt
             "`derive(SalsaValue)` supports at most one lifetime parameter",
         ));
     }
-    let mut checked_field_types = Vec::new();
+    let mut checked_fields = Vec::new();
 
     match &input.data {
         syn::Data::Struct(data) => {
-            collect_checked_field_types(&data.fields, &mut checked_field_types)?;
+            collect_checked_field_types(&data.fields, &mut checked_fields)?;
         }
         syn::Data::Enum(data) => {
             for variant in &data.variants {
                 reject_salsa_value_attributes(&variant.attrs, "variant")?;
-                collect_checked_field_types(&variant.fields, &mut checked_field_types)?;
+                collect_checked_field_types(&variant.fields, &mut checked_fields)?;
             }
         }
         syn::Data::Union(_) => unreachable!(),
@@ -46,7 +56,7 @@ pub(crate) fn salsa_value_derive(input: syn::DeriveInput) -> syn::Result<TokenSt
     let derived_type = syn::parse_quote!(#ident #type_generics);
     let zalsa = quote::format_ident!("__salsa_plumbing");
 
-    let generics = add_field_bounds(input.generics.clone(), &checked_field_types);
+    let generics = add_field_bounds(input.generics.clone(), &checked_fields, &derived_type);
     let (impl_generics, _, where_clause) = generics.split_for_impl();
 
     let implementation = quote! {
@@ -60,19 +70,11 @@ pub(crate) fn salsa_value_derive(input: syn::DeriveInput) -> syn::Result<TokenSt
         return Ok(crate::debug::dump_tokens(&input.ident, implementation));
     };
 
-    let field_assertions =
-        checked_field_types
-            .iter()
-            .map(|(field_type, has_manual_retention_proof)| {
-                let field_type = replace_self_type(field_type, &derived_type);
+    let field_assertions = checked_fields.iter().map(|CheckedField { ty, proof }| {
+        let ty = replace_self_type(ty, &derived_type);
 
-                assert_salsa_value_field(
-                    &assertion_lifetime,
-                    &zalsa,
-                    &field_type,
-                    *has_manual_retention_proof,
-                )
-            });
+        assert_salsa_value_field(&assertion_lifetime, &zalsa, &ty, proof.is_some())
+    });
 
     let tokens = quote! {
         #implementation
@@ -93,26 +95,32 @@ pub(crate) fn salsa_value_derive(input: syn::DeriveInput) -> syn::Result<TokenSt
 
 fn add_field_bounds(
     mut generics: syn::Generics,
-    checked_field_types: &[(&syn::Type, bool)],
+    checked_fields: &[CheckedField<'_>],
+    derived_type: &syn::Type,
 ) -> syn::Generics {
     let type_params = generics
         .type_params()
         .map(|parameter| parameter.ident.clone())
         .collect::<HashSet<_>>();
 
-    for (field_type, has_manual_retention_proof) in checked_field_types {
-        if *has_manual_retention_proof {
-            continue;
+    for CheckedField { ty, proof } in checked_fields {
+        match proof {
+            Some(ManualRetentionProof::Conditional(predicates)) => {
+                generics.make_where_clause().predicates.extend(
+                    predicates
+                        .iter()
+                        .map(|predicate| replace_self_in_predicate(predicate, derived_type)),
+                );
+            }
+            Some(ManualRetentionProof::Unconditional) => {}
+            None if type_uses_type_param(ty, &type_params) => {
+                generics
+                    .make_where_clause()
+                    .predicates
+                    .push(syn::parse_quote!(#ty: ::salsa::SalsaValue));
+            }
+            None => {}
         }
-
-        if !type_uses_type_param(field_type, &type_params) {
-            continue;
-        }
-
-        generics
-            .make_where_clause()
-            .predicates
-            .push(syn::parse_quote!(#field_type: ::salsa::SalsaValue));
     }
 
     generics
@@ -148,22 +156,25 @@ fn type_uses_type_param(ty: &syn::Type, type_params: &HashSet<syn::Ident>) -> bo
 
 fn collect_checked_field_types<'a>(
     fields: &'a syn::Fields,
-    checked_field_types: &mut Vec<(&'a syn::Type, bool)>,
+    checked_fields: &mut Vec<CheckedField<'a>>,
 ) -> syn::Result<()> {
     for field in fields {
-        checked_field_types.push((&field.ty, field_has_manual_retention_proof(field)?));
+        checked_fields.push(CheckedField {
+            ty: &field.ty,
+            proof: field_manual_retention_proof(field)?,
+        });
     }
 
     Ok(())
 }
 
-fn field_has_manual_retention_proof(field: &syn::Field) -> syn::Result<bool> {
+fn field_manual_retention_proof(field: &syn::Field) -> syn::Result<Option<ManualRetentionProof>> {
     let mut attrs = field
         .attrs
         .iter()
         .filter(|attr| attr.path().is_ident("salsa_value"));
     let Some(attr) = attrs.next() else {
-        return Ok(false);
+        return Ok(None);
     };
 
     if attrs.next().is_some() {
@@ -173,20 +184,40 @@ fn field_has_manual_retention_proof(field: &syn::Field) -> syn::Result<bool> {
         ));
     }
 
-    parse_manual_retention_proof(attr)
-        .map_err(|error| syn::Error::new_spanned(field, error.to_string()))?;
-    Ok(true)
+    parse_manual_retention_proof(attr).map(Some)
 }
 
-pub(crate) fn parse_manual_retention_proof(attr: &Attribute) -> syn::Result<()> {
+pub(crate) fn parse_manual_retention_proof(attr: &Attribute) -> syn::Result<ManualRetentionProof> {
     attr.parse_args_with(|input: syn::parse::ParseStream<'_>| {
+        if input.peek(kw::prove) {
+            return Err(input.error("`prove(...)` must be wrapped in `unsafe(...)`"));
+        }
+
         let _: syn::Token![unsafe] = input.parse()?;
         let content;
         syn::parenthesized!(content in input);
-        content.parse::<kw::prove_safe_to_retain_manually>()?;
+
+        let proof = if content.peek(kw::prove) {
+            content.parse::<kw::prove>()?;
+            let predicates;
+            syn::parenthesized!(predicates in content);
+            if predicates.is_empty() {
+                return Err(predicates.error("`prove(...)` requires at least one predicate"));
+            }
+
+            ManualRetentionProof::Conditional(
+                predicates
+                    .parse_terminated(syn::WherePredicate::parse, syn::Token![,])?
+                    .into_iter()
+                    .collect(),
+            )
+        } else {
+            content.parse::<kw::prove_safe_to_retain_manually>()?;
+            ManualRetentionProof::Unconditional
+        };
 
         if content.is_empty() {
-            Ok(())
+            Ok(proof)
         } else {
             Err(content.error("unexpected token"))
         }
@@ -211,6 +242,18 @@ fn reject_salsa_value_attributes(attrs: &[Attribute], target: &str) -> syn::Resu
         Some(error) => Err(error),
         None => Ok(()),
     }
+}
+
+fn replace_self_in_predicate(
+    predicate: &syn::WherePredicate,
+    self_type: &syn::Type,
+) -> syn::WherePredicate {
+    let mut predicate = predicate.clone();
+    syn::visit_mut::VisitMut::visit_where_predicate_mut(
+        &mut ChangeSelfPath::new(self_type, None),
+        &mut predicate,
+    );
+    predicate
 }
 
 fn replace_self_type(ty: &syn::Type, self_type: &syn::Type) -> syn::Type {

--- a/components/salsa-macros/src/salsa_value.rs
+++ b/components/salsa-macros/src/salsa_value.rs
@@ -296,6 +296,34 @@ pub(crate) fn assert_salsa_value_field(
     }
 }
 
+pub(crate) fn assert_salsa_value_field_with_proof(
+    db_lt: &syn::Lifetime,
+    zalsa: &syn::Ident,
+    ty: &syn::Type,
+    proof: Option<&ManualRetentionProof>,
+    self_type: &syn::Type,
+) -> TokenStream {
+    match proof {
+        None => assert_salsa_value_or_static_expr(db_lt, zalsa, ty),
+        Some(ManualRetentionProof::Unconditional) => quote! {},
+        Some(ManualRetentionProof::Conditional(predicates)) => {
+            let predicates = predicates
+                .iter()
+                .map(|predicate| replace_self_in_predicate(predicate, self_type));
+            quote! {
+                {
+                    #[allow(unused_lifetimes)]
+                    fn _assert_manual_retention_proof<#db_lt>()
+                    where
+                        #(#predicates,)*
+                    {}
+                    _assert_manual_retention_proof::<#db_lt>();
+                }
+            }
+        }
+    }
+}
+
 fn assert_tracked_output_is_salsa_value(
     db_lt: &syn::Lifetime,
     zalsa: &syn::Ident,

--- a/components/salsa-macros/src/tracked_struct.rs
+++ b/components/salsa-macros/src/tracked_struct.rs
@@ -121,15 +121,13 @@ impl Macro {
 
         let field_tys = salsa_struct.field_tys();
         let field_manual_retention_proofs = salsa_struct.field_manual_retention_proofs();
+        let self_type = syn::parse_quote!(#struct_ident<#db_lt>);
         let assert_fields_are_salsa_values = field_tys
             .iter()
             .zip(field_manual_retention_proofs)
-            .map(|(ty, has_manual_retention_proof)| {
-                crate::salsa_value::assert_salsa_value_field(
-                    &db_lt,
-                    &zalsa,
-                    ty,
-                    has_manual_retention_proof,
+            .map(|(ty, proof)| {
+                crate::salsa_value::assert_salsa_value_field_with_proof(
+                    &db_lt, &zalsa, ty, proof, &self_type,
                 )
             })
             .collect::<TokenStream>();

--- a/src/input.rs
+++ b/src/input.rs
@@ -272,6 +272,7 @@ pub struct StructEntry<'db, C>
 where
     C: Configuration,
 {
+    #[cfg_attr(not(feature = "salsa_unstable"), allow(dead_code))]
     value: &'db Value<C>,
     key: DatabaseKeyIndex,
 }

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -119,6 +119,7 @@ impl LazyMemoEntries {
         self.as_mut_slice()?.get_mut(index)
     }
 
+    #[cfg(feature = "salsa_unstable")]
     fn iter(&self) -> std::slice::Iter<'_, MemoEntry> {
         self.as_slice().unwrap_or_default().iter()
     }

--- a/src/tracked_struct.rs
+++ b/src/tracked_struct.rs
@@ -946,6 +946,7 @@ pub struct StructEntry<'db, C>
 where
     C: Configuration,
 {
+    #[cfg_attr(not(feature = "salsa_unstable"), allow(dead_code))]
     value: &'db Value<C>,
     key: DatabaseKeyIndex,
 }

--- a/tests/compile-fail/derive_salsa_value_conditional_proof.rs
+++ b/tests/compile-fail/derive_salsa_value_conditional_proof.rs
@@ -1,0 +1,29 @@
+use std::marker::PhantomData;
+
+struct Foreign<T>(T);
+
+#[derive(salsa::SalsaValue)]
+struct ConditionallySafe<T> {
+    #[salsa_value(unsafe(prove(T: salsa::SalsaValue)))]
+    value: Foreign<T>,
+}
+
+#[derive(salsa::SalsaValue)]
+struct ConditionallyStatic<T> {
+    #[salsa_value(unsafe(prove(T: 'static)))]
+    value: Foreign<T>,
+}
+
+struct NotSalsaValue<'db>(PhantomData<&'db ()>);
+
+fn assert_salsa_value<T: salsa::SalsaValue>() {}
+
+fn rejects_unsatisfied_salsa_value_proof<'db>() {
+    assert_salsa_value::<ConditionallySafe<NotSalsaValue<'db>>>();
+}
+
+fn rejects_unsatisfied_static_proof<'db>() {
+    assert_salsa_value::<ConditionallyStatic<&'db ()>>();
+}
+
+fn main() {}

--- a/tests/compile-fail/derive_salsa_value_conditional_proof.stderr
+++ b/tests/compile-fail/derive_salsa_value_conditional_proof.stderr
@@ -1,0 +1,43 @@
+error[E0277]: `NotSalsaValue<'db>` doesn't implement `SalsaValue`
+  --> tests/compile-fail/derive_salsa_value_conditional_proof.rs:22:26
+   |
+22 |     assert_salsa_value::<ConditionallySafe<NotSalsaValue<'db>>>();
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `SalsaValue` is not implemented for `NotSalsaValue<'db>`
+  --> tests/compile-fail/derive_salsa_value_conditional_proof.rs:17:1
+   |
+17 | struct NotSalsaValue<'db>(PhantomData<&'db ()>);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: add `#[derive(salsa::SalsaValue)]` to `NotSalsaValue<'db>`
+   = help: the following other types implement trait `SalsaValue`:
+             &'static T
+             ()
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+           and $N others
+note: required for `ConditionallySafe<NotSalsaValue<'db>>` to implement `SalsaValue`
+  --> tests/compile-fail/derive_salsa_value_conditional_proof.rs:6:8
+   |
+ 6 | struct ConditionallySafe<T> {
+   |        ^^^^^^^^^^^^^^^^^^^^
+ 7 |     #[salsa_value(unsafe(prove(T: salsa::SalsaValue)))]
+   |                                   ----------------- unsatisfied trait bound
+   = help: consider manually implementing `SalsaValue` to avoid undesired bounds
+note: required by a bound in `assert_salsa_value`
+  --> tests/compile-fail/derive_salsa_value_conditional_proof.rs:19:26
+   |
+19 | fn assert_salsa_value<T: salsa::SalsaValue>() {}
+   |                          ^^^^^^^^^^^^^^^^^ required by this bound in `assert_salsa_value`
+
+error: lifetime may not live long enough
+  --> tests/compile-fail/derive_salsa_value_conditional_proof.rs:26:5
+   |
+25 | fn rejects_unsatisfied_static_proof<'db>() {
+   |                                     --- lifetime `'db` defined here
+26 |     assert_salsa_value::<ConditionallyStatic<&'db ()>>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'db` must outlive `'static`

--- a/tests/compile-fail/salsa_struct_conditional_proof.rs
+++ b/tests/compile-fail/salsa_struct_conditional_proof.rs
@@ -1,0 +1,27 @@
+use std::marker::PhantomData;
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct Foreign<T>(T);
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct NotSalsaValue<'db>(PhantomData<&'db ()>);
+
+#[salsa::interned]
+struct ConditionalInterned<'db> {
+    #[salsa_value(unsafe(prove(NotSalsaValue<'db>: salsa::SalsaValue)))]
+    value: Foreign<NotSalsaValue<'db>>,
+}
+
+#[salsa::interned(unsafe(non_salsa_values))]
+struct ConditionalInternedWithItemEscape<'db> {
+    #[salsa_value(unsafe(prove(NotSalsaValue<'db>: salsa::SalsaValue)))]
+    value: Foreign<NotSalsaValue<'db>>,
+}
+
+#[salsa::tracked]
+struct ConditionalTracked<'db> {
+    #[salsa_value(unsafe(prove(NotSalsaValue<'db>: salsa::SalsaValue)))]
+    value: Foreign<NotSalsaValue<'db>>,
+}
+
+fn main() {}

--- a/tests/compile-fail/salsa_struct_conditional_proof.stderr
+++ b/tests/compile-fail/salsa_struct_conditional_proof.stderr
@@ -1,0 +1,95 @@
+error[E0277]: `NotSalsaValue<'db>` doesn't implement `SalsaValue`
+  --> tests/compile-fail/salsa_struct_conditional_proof.rs:9:1
+   |
+ 9 | #[salsa::interned]
+   | ^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `SalsaValue` is not implemented for `NotSalsaValue<'db>`
+  --> tests/compile-fail/salsa_struct_conditional_proof.rs:7:1
+   |
+ 7 | struct NotSalsaValue<'db>(PhantomData<&'db ()>);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: add `#[derive(salsa::SalsaValue)]` to `NotSalsaValue<'db>`
+   = help: the following other types implement trait `SalsaValue`:
+             &'static T
+             ()
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+           and $N others
+note: required by a bound in `_::_assert_fields_are_salsa_values::_assert_manual_retention_proof`
+  --> tests/compile-fail/salsa_struct_conditional_proof.rs:11:52
+   |
+ 9 | #[salsa::interned]
+   | ------------------ required by a bound in this function
+10 | struct ConditionalInterned<'db> {
+11 |     #[salsa_value(unsafe(prove(NotSalsaValue<'db>: salsa::SalsaValue)))]
+   |                                                    ^^^^^^^^^^^^^^^^^ required by this bound in `_assert_manual_retention_proof`
+   = note: this error originates in the attribute macro `salsa::interned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `NotSalsaValue<'db>` doesn't implement `SalsaValue`
+  --> tests/compile-fail/salsa_struct_conditional_proof.rs:15:1
+   |
+15 | #[salsa::interned(unsafe(non_salsa_values))]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `SalsaValue` is not implemented for `NotSalsaValue<'db>`
+  --> tests/compile-fail/salsa_struct_conditional_proof.rs:7:1
+   |
+ 7 | struct NotSalsaValue<'db>(PhantomData<&'db ()>);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: add `#[derive(salsa::SalsaValue)]` to `NotSalsaValue<'db>`
+   = help: the following other types implement trait `SalsaValue`:
+             &'static T
+             ()
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+           and $N others
+note: required by a bound in `_::_assert_fields_are_salsa_values::_assert_manual_retention_proof`
+  --> tests/compile-fail/salsa_struct_conditional_proof.rs:17:52
+   |
+15 | #[salsa::interned(unsafe(non_salsa_values))]
+   | -------------------------------------------- required by a bound in this function
+16 | struct ConditionalInternedWithItemEscape<'db> {
+17 |     #[salsa_value(unsafe(prove(NotSalsaValue<'db>: salsa::SalsaValue)))]
+   |                                                    ^^^^^^^^^^^^^^^^^ required by this bound in `_assert_manual_retention_proof`
+   = note: this error originates in the attribute macro `salsa::interned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `NotSalsaValue<'db>` doesn't implement `SalsaValue`
+  --> tests/compile-fail/salsa_struct_conditional_proof.rs:21:1
+   |
+21 | #[salsa::tracked]
+   | ^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `SalsaValue` is not implemented for `NotSalsaValue<'db>`
+  --> tests/compile-fail/salsa_struct_conditional_proof.rs:7:1
+   |
+ 7 | struct NotSalsaValue<'db>(PhantomData<&'db ()>);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: add `#[derive(salsa::SalsaValue)]` to `NotSalsaValue<'db>`
+   = help: the following other types implement trait `SalsaValue`:
+             &'static T
+             ()
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+           and $N others
+note: required by a bound in `_::_assert_fields_are_salsa_values::_assert_manual_retention_proof`
+  --> tests/compile-fail/salsa_struct_conditional_proof.rs:23:52
+   |
+21 | #[salsa::tracked]
+   | ----------------- required by a bound in this function
+22 | struct ConditionalTracked<'db> {
+23 |     #[salsa_value(unsafe(prove(NotSalsaValue<'db>: salsa::SalsaValue)))]
+   |                                                    ^^^^^^^^^^^^^^^^^ required by this bound in `_assert_manual_retention_proof`
+   = note: this error originates in the attribute macro `salsa::tracked` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-fail/salsa_value_invalid_field_attributes.rs
+++ b/tests/compile-fail/salsa_value_invalid_field_attributes.rs
@@ -11,10 +11,48 @@ struct Malformed {
     field: String,
 }
 
+#[derive(salsa::SalsaValue)]
+struct MissingUnsafe<T> {
+    #[salsa_value(prove(T: salsa::SalsaValue))]
+    field: T,
+}
+
+#[derive(salsa::SalsaValue)]
+struct EmptyProof<T> {
+    #[salsa_value(unsafe(prove()))]
+    field: T,
+}
+
+#[derive(salsa::SalsaValue)]
+struct MalformedPredicate<T> {
+    #[salsa_value(unsafe(prove(T salsa::SalsaValue)))]
+    field: T,
+}
+
 #[salsa::input]
 struct Disallowed {
     #[salsa_value(unsafe(prove_safe_to_retain_manually))]
     field: String,
+}
+
+#[salsa::input]
+struct ConditionalDisallowed {
+    #[salsa_value(unsafe(prove(String: salsa::SalsaValue)))]
+    field: String,
+}
+
+#[salsa::interned(unsafe(no_lifetime), revisions = usize::MAX)]
+struct ConditionalInterned {
+    #[salsa_value(unsafe(prove(String: salsa::SalsaValue)))]
+    field: String,
+}
+
+#[salsa::tracked]
+struct ConditionalTracked<'db> {
+    #[salsa_value(unsafe(prove(
+        std::marker::PhantomData<&'db ()>: salsa::SalsaValue
+    )))]
+    field: std::marker::PhantomData<&'db ()>,
 }
 
 fn main() {}

--- a/tests/compile-fail/salsa_value_invalid_field_attributes.rs
+++ b/tests/compile-fail/salsa_value_invalid_field_attributes.rs
@@ -41,18 +41,4 @@ struct ConditionalDisallowed {
     field: String,
 }
 
-#[salsa::interned(unsafe(no_lifetime), revisions = usize::MAX)]
-struct ConditionalInterned {
-    #[salsa_value(unsafe(prove(String: salsa::SalsaValue)))]
-    field: String,
-}
-
-#[salsa::tracked]
-struct ConditionalTracked<'db> {
-    #[salsa_value(unsafe(prove(
-        std::marker::PhantomData<&'db ()>: salsa::SalsaValue
-    )))]
-    field: std::marker::PhantomData<&'db ()>,
-}
-
 fn main() {}

--- a/tests/compile-fail/salsa_value_invalid_field_attributes.stderr
+++ b/tests/compile-fail/salsa_value_invalid_field_attributes.stderr
@@ -7,23 +7,87 @@ error: multiple `#[salsa_value]` attributes on field
   | |_________________^
 
 error: expected `unsafe`
-  --> tests/compile-fail/salsa_value_invalid_field_attributes.rs:10:5
+  --> tests/compile-fail/salsa_value_invalid_field_attributes.rs:10:19
    |
-10 | /     #[salsa_value(prove_safe_to_retain_manually)]
-11 | |     field: String,
-   | |_________________^
+10 |     #[salsa_value(prove_safe_to_retain_manually)]
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `prove(...)` must be wrapped in `unsafe(...)`
+  --> tests/compile-fail/salsa_value_invalid_field_attributes.rs:16:19
+   |
+16 |     #[salsa_value(prove(T: salsa::SalsaValue))]
+   |                   ^^^^^
+
+error: unexpected end of input, `prove(...)` requires at least one predicate
+  --> tests/compile-fail/salsa_value_invalid_field_attributes.rs:22:32
+   |
+22 |     #[salsa_value(unsafe(prove()))]
+   |                                ^
+
+error: expected `:`
+  --> tests/compile-fail/salsa_value_invalid_field_attributes.rs:28:34
+   |
+28 |     #[salsa_value(unsafe(prove(T salsa::SalsaValue)))]
+   |                                  ^^^^^
 
 error: `#[salsa_value(unsafe(prove_safe_to_retain_manually))]` cannot be used with `#[salsa::input]`
-  --> tests/compile-fail/salsa_value_invalid_field_attributes.rs:16:5
+  --> tests/compile-fail/salsa_value_invalid_field_attributes.rs:34:5
    |
-16 | /     #[salsa_value(unsafe(prove_safe_to_retain_manually))]
-17 | |     field: String,
+34 | /     #[salsa_value(unsafe(prove_safe_to_retain_manually))]
+35 | |     field: String,
    | |_________________^
 
-error: cannot find attribute `salsa_value` in this scope
-  --> tests/compile-fail/salsa_value_invalid_field_attributes.rs:16:7
+error: conditional retention proofs are only supported by `derive(SalsaValue)`
+  --> tests/compile-fail/salsa_value_invalid_field_attributes.rs:40:5
    |
-16 |     #[salsa_value(unsafe(prove_safe_to_retain_manually))]
+40 | /     #[salsa_value(unsafe(prove(String: salsa::SalsaValue)))]
+41 | |     field: String,
+   | |_________________^
+
+error: conditional retention proofs are only supported by `derive(SalsaValue)`
+  --> tests/compile-fail/salsa_value_invalid_field_attributes.rs:46:5
+   |
+46 | /     #[salsa_value(unsafe(prove(String: salsa::SalsaValue)))]
+47 | |     field: String,
+   | |_________________^
+
+error: conditional retention proofs are only supported by `derive(SalsaValue)`
+  --> tests/compile-fail/salsa_value_invalid_field_attributes.rs:52:5
+   |
+52 | /     #[salsa_value(unsafe(prove(
+53 | |         std::marker::PhantomData<&'db ()>: salsa::SalsaValue
+54 | |     )))]
+55 | |     field: std::marker::PhantomData<&'db ()>,
+   | |____________________________________________^
+
+error: cannot find attribute `salsa_value` in this scope
+  --> tests/compile-fail/salsa_value_invalid_field_attributes.rs:52:7
+   |
+52 |     #[salsa_value(unsafe(prove(
+   |       ^^^^^^^^^^^
+   |
+   = note: `salsa_value` is an attribute that can be used by the derive macro `SalsaValue`, you might be missing a `derive` attribute
+
+error: cannot find attribute `salsa_value` in this scope
+  --> tests/compile-fail/salsa_value_invalid_field_attributes.rs:46:7
+   |
+46 |     #[salsa_value(unsafe(prove(String: salsa::SalsaValue)))]
+   |       ^^^^^^^^^^^
+   |
+   = note: `salsa_value` is an attribute that can be used by the derive macro `SalsaValue`, you might be missing a `derive` attribute
+
+error: cannot find attribute `salsa_value` in this scope
+  --> tests/compile-fail/salsa_value_invalid_field_attributes.rs:40:7
+   |
+40 |     #[salsa_value(unsafe(prove(String: salsa::SalsaValue)))]
+   |       ^^^^^^^^^^^
+   |
+   = note: `salsa_value` is an attribute that can be used by the derive macro `SalsaValue`, you might be missing a `derive` attribute
+
+error: cannot find attribute `salsa_value` in this scope
+  --> tests/compile-fail/salsa_value_invalid_field_attributes.rs:34:7
+   |
+34 |     #[salsa_value(unsafe(prove_safe_to_retain_manually))]
    |       ^^^^^^^^^^^
    |
    = note: `salsa_value` is an attribute that can be used by the derive macro `SalsaValue`, you might be missing a `derive` attribute

--- a/tests/compile-fail/salsa_value_invalid_field_attributes.stderr
+++ b/tests/compile-fail/salsa_value_invalid_field_attributes.stderr
@@ -30,51 +30,19 @@ error: expected `:`
 28 |     #[salsa_value(unsafe(prove(T salsa::SalsaValue)))]
    |                                  ^^^^^
 
-error: `#[salsa_value(unsafe(prove_safe_to_retain_manually))]` cannot be used with `#[salsa::input]`
+error: `#[salsa_value(...)]` cannot be used with `#[salsa::input]`
   --> tests/compile-fail/salsa_value_invalid_field_attributes.rs:34:5
    |
 34 | /     #[salsa_value(unsafe(prove_safe_to_retain_manually))]
 35 | |     field: String,
    | |_________________^
 
-error: conditional retention proofs are only supported by `derive(SalsaValue)`
+error: `#[salsa_value(...)]` cannot be used with `#[salsa::input]`
   --> tests/compile-fail/salsa_value_invalid_field_attributes.rs:40:5
    |
 40 | /     #[salsa_value(unsafe(prove(String: salsa::SalsaValue)))]
 41 | |     field: String,
    | |_________________^
-
-error: conditional retention proofs are only supported by `derive(SalsaValue)`
-  --> tests/compile-fail/salsa_value_invalid_field_attributes.rs:46:5
-   |
-46 | /     #[salsa_value(unsafe(prove(String: salsa::SalsaValue)))]
-47 | |     field: String,
-   | |_________________^
-
-error: conditional retention proofs are only supported by `derive(SalsaValue)`
-  --> tests/compile-fail/salsa_value_invalid_field_attributes.rs:52:5
-   |
-52 | /     #[salsa_value(unsafe(prove(
-53 | |         std::marker::PhantomData<&'db ()>: salsa::SalsaValue
-54 | |     )))]
-55 | |     field: std::marker::PhantomData<&'db ()>,
-   | |____________________________________________^
-
-error: cannot find attribute `salsa_value` in this scope
-  --> tests/compile-fail/salsa_value_invalid_field_attributes.rs:52:7
-   |
-52 |     #[salsa_value(unsafe(prove(
-   |       ^^^^^^^^^^^
-   |
-   = note: `salsa_value` is an attribute that can be used by the derive macro `SalsaValue`, you might be missing a `derive` attribute
-
-error: cannot find attribute `salsa_value` in this scope
-  --> tests/compile-fail/salsa_value_invalid_field_attributes.rs:46:7
-   |
-46 |     #[salsa_value(unsafe(prove(String: salsa::SalsaValue)))]
-   |       ^^^^^^^^^^^
-   |
-   = note: `salsa_value` is an attribute that can be used by the derive macro `SalsaValue`, you might be missing a `derive` attribute
 
 error: cannot find attribute `salsa_value` in this scope
   --> tests/compile-fail/salsa_value_invalid_field_attributes.rs:40:7

--- a/tests/compile-pass/derive-salsa-value-conditional-proofs.rs
+++ b/tests/compile-pass/derive-salsa-value-conditional-proofs.rs
@@ -1,0 +1,71 @@
+#![allow(dead_code)]
+
+use std::marker::PhantomData;
+
+struct Foreign<T>(T);
+struct ForeignMarker<T>(PhantomData<fn() -> T>);
+
+#[derive(salsa::SalsaValue)]
+struct UnconditionallySafe<T> {
+    #[salsa_value(unsafe(prove_safe_to_retain_manually))]
+    value: ForeignMarker<T>,
+}
+
+#[derive(salsa::SalsaValue)]
+enum ConditionalEnum<T> {
+    Empty,
+    Value(#[salsa_value(unsafe(prove(T: salsa::SalsaValue)))] Foreign<T>),
+}
+
+#[derive(salsa::SalsaValue)]
+struct ExistingWhereClause<T>
+where
+    T: Send,
+{
+    #[salsa_value(unsafe(prove(T: salsa::SalsaValue)))]
+    value: Foreign<T>,
+}
+
+#[derive(salsa::SalsaValue)]
+struct ContainsPhantomRef<'db>(PhantomData<&'db ()>);
+
+#[derive(salsa::SalsaValue)]
+struct LifetimePredicate<'db> {
+    #[salsa_value(unsafe(prove(
+        ContainsPhantomRef<'db>: salsa::SalsaValue,
+        Self: Sized,
+    )))]
+    value: Foreign<ContainsPhantomRef<'db>>,
+}
+
+trait Family {
+    type Value;
+}
+
+struct StringFamily;
+
+impl Family for StringFamily {
+    type Value = String;
+}
+
+#[derive(salsa::SalsaValue)]
+struct AssociatedTypePredicate<F: Family> {
+    #[salsa_value(unsafe(prove(F::Value: salsa::SalsaValue, Self: Sized)))]
+    value: Foreign<F::Value>,
+}
+
+fn assert_salsa_value<T: salsa::SalsaValue>() {}
+
+fn assert_non_static_proofs<'db>()
+where
+    UnconditionallySafe<&'db ()>: salsa::SalsaValue,
+    ConditionalEnum<ContainsPhantomRef<'db>>: salsa::SalsaValue,
+    LifetimePredicate<'db>: salsa::SalsaValue,
+{
+}
+
+fn main() {
+    assert_non_static_proofs();
+    assert_salsa_value::<ExistingWhereClause<String>>();
+    assert_salsa_value::<AssociatedTypePredicate<StringFamily>>();
+}

--- a/tests/compile-pass/salsa-value-conditional-proofs.rs
+++ b/tests/compile-pass/salsa-value-conditional-proofs.rs
@@ -2,6 +2,7 @@
 
 use std::marker::PhantomData;
 
+#[derive(Clone, PartialEq, Eq, Hash)]
 struct Foreign<T>(T);
 struct ForeignMarker<T>(PhantomData<fn() -> T>);
 
@@ -52,6 +53,29 @@ impl Family for StringFamily {
 struct AssociatedTypePredicate<F: Family> {
     #[salsa_value(unsafe(prove(F::Value: salsa::SalsaValue, Self: Sized)))]
     value: Foreign<F::Value>,
+}
+
+#[salsa::interned]
+struct InternedValue<'db> {
+    text: String,
+}
+
+#[salsa::interned]
+struct ConditionalInterned<'db> {
+    #[salsa_value(unsafe(prove(
+        InternedValue<'db>: salsa::SalsaValue,
+        Self: Sized,
+    )))]
+    value: Foreign<InternedValue<'db>>,
+}
+
+#[salsa::tracked]
+struct ConditionalTracked<'db> {
+    #[salsa_value(unsafe(prove(
+        InternedValue<'db>: salsa::SalsaValue,
+        Self: Sized,
+    )))]
+    value: Foreign<InternedValue<'db>>,
 }
 
 fn assert_salsa_value<T: salsa::SalsaValue>() {}

--- a/tests/derive_salsa_value.rs
+++ b/tests/derive_salsa_value.rs
@@ -16,6 +16,29 @@ struct GenericPhantom<T>(std::marker::PhantomData<T>);
 #[derive(salsa::SalsaValue)]
 struct ConstGeneric<const N: usize>([u8; N]);
 
+struct Foreign<T>(T);
+struct ForeignPair<T, U>(T, U);
+
+#[derive(salsa::SalsaValue)]
+struct ConditionallySafe<T> {
+    #[salsa_value(unsafe(prove(T: salsa::SalsaValue)))]
+    value: Foreign<T>,
+}
+
+#[derive(salsa::SalsaValue)]
+struct ConditionallyStatic<T> {
+    #[salsa_value(unsafe(prove(T: 'static)))]
+    value: Foreign<T>,
+}
+
+#[derive(salsa::SalsaValue)]
+struct ConditionallyMixed<T, U> {
+    #[salsa_value(unsafe(prove(T: salsa::SalsaValue, U: 'static,)))]
+    value: ForeignPair<T, U>,
+}
+
+struct StaticNotSalsaValue;
+
 #[derive(salsa::SalsaValue)]
 struct ContainsPhantomRef<'db> {
     marker: std::marker::PhantomData<&'db ()>,
@@ -69,6 +92,12 @@ where
 {
 }
 
+fn assert_conditional_non_static<'db>()
+where
+    ConditionallySafe<ContainsPhantomRef<'db>>: salsa::SalsaValue,
+{
+}
+
 fn assert_generic_phantom<'db>()
 where
     GenericPhantom<&'db ()>: salsa::SalsaValue,
@@ -85,6 +114,24 @@ where
 
 #[test]
 fn derives_salsa_value() {
+    let ConditionallySafe {
+        value: Foreign(value),
+    } = ConditionallySafe {
+        value: Foreign(String::new()),
+    };
+    let _ = value;
+    let ConditionallyStatic {
+        value: Foreign(value),
+    } = ConditionallyStatic {
+        value: Foreign(StaticNotSalsaValue),
+    };
+    let _ = value;
+    let ConditionallyMixed {
+        value: ForeignPair(value, static_value),
+    } = ConditionallyMixed {
+        value: ForeignPair(String::new(), StaticNotSalsaValue),
+    };
+    let _ = (value, static_value);
     let contains_phantom_ref = ContainsPhantomRef {
         marker: std::marker::PhantomData,
     };
@@ -94,6 +141,7 @@ fn derives_salsa_value() {
     let _ = contains_invariant.value.0;
     assert_contains_phantom_ref(contains_phantom_ref.marker);
     assert_invariant_container_output();
+    assert_conditional_non_static();
     let recursive = Recursive::Cons(Box::new(Recursive::Nil));
     let Recursive::Cons(recursive) = recursive else {
         unreachable!()
@@ -109,6 +157,9 @@ fn derives_salsa_value() {
     assert_non_static_standard_values();
     assert_salsa_value::<Generic<String>>();
     assert_salsa_value::<Generic<ContainsPhantomRef<'static>>>();
+    assert_salsa_value::<ConditionallySafe<String>>();
+    assert_salsa_value::<ConditionallyStatic<StaticNotSalsaValue>>();
+    assert_salsa_value::<ConditionallyMixed<String, StaticNotSalsaValue>>();
     assert_salsa_value::<GenericRecursive<String>>();
     assert_salsa_value::<ConstGeneric<4>>();
     assert_salsa_value::<ContainsPhantomRef<'static>>();


### PR DESCRIPTION
I am not a fan of using the new escape hatch, as usually the reason for having to use it is that the field contains a foreign type you cannot implement the trait for. This implements something I added for the previous `Update` derive that allows changing the required bounds of the emitted impl. That way one can still rely on parts of the typesystem and only escaping specific types in the fields.