### PR TITLE
fix: propagate poisoned cycle heads

### DIFF
--- a/src/cycle.rs
+++ b/src/cycle.rs
@@ -506,6 +506,11 @@ pub enum ProvisionalStatus<'db> {
         verified_at: Revision,
         cycle_heads: &'db CycleHeads,
     },
+    /// A provisional memo whose value was cleared while unwinding from a panic.
+    Poisoned {
+        iteration: IterationStamp,
+        verified_at: Revision,
+    },
     Final {
         iteration: IterationStamp,
         verified_at: Revision,
@@ -516,7 +521,9 @@ impl<'db> ProvisionalStatus<'db> {
     pub(crate) fn cycle_heads(&self) -> &'db CycleHeads {
         match self {
             ProvisionalStatus::Provisional { cycle_heads, .. } => cycle_heads,
-            ProvisionalStatus::Final { .. } => empty_cycle_heads(),
+            ProvisionalStatus::Poisoned { .. } | ProvisionalStatus::Final { .. } => {
+                empty_cycle_heads()
+            }
         }
     }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -358,8 +358,9 @@ where
 
     /// Returns `final` if the memo has the `verified_final` flag set.
     ///
-    /// Otherwise, the value is still provisional. For both final and provisional, it also
-    /// returns the iteration in which this memo was created (always 0 except for cycle heads).
+    /// Otherwise, the value is still provisional or the provisional memo has been poisoned. It
+    /// also returns the iteration in which this memo was created (always 0 except for cycle
+    /// heads).
     fn provisional_status<'db>(
         &self,
         zalsa: &'db Zalsa,
@@ -367,6 +368,13 @@ where
     ) -> Option<ProvisionalStatus<'db>> {
         let memo =
             self.get_memo_from_table_for(zalsa, input, self.memo_ingredient_index(zalsa, input))?;
+
+        if memo.value.is_none() && memo.header.may_be_provisional() {
+            return Some(ProvisionalStatus::Poisoned {
+                iteration: memo.header.revisions.iteration(),
+                verified_at: memo.header.verified_at.load(),
+            });
+        }
 
         Some(memo.header.provisional_status())
     }

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -1,7 +1,7 @@
 use smallvec::SmallVec;
 
 use crate::active_query::CompletedQuery;
-use crate::cycle::{CycleHeads, CycleRecoveryStrategy, IterationStamp};
+use crate::cycle::{CycleHeads, CycleRecoveryStrategy, IterationStamp, ProvisionalStatus};
 use crate::function::memo::{Memo, MemoHeader};
 use crate::function::sync::ReleaseMode;
 use crate::function::{ClaimGuard, Configuration, IngredientImpl};
@@ -649,6 +649,17 @@ fn collect_all_cycle_heads(
         let provisional_status = ingredient
             .provisional_status(zalsa, current_head.key_index())
             .expect("cycle head memo must have been created during the execution");
+
+        if let ProvisionalStatus::Poisoned {
+            iteration,
+            verified_at,
+        } = provisional_status
+        {
+            tracing::warn!(
+                "Propagating panic for poisoned cycle head {current_head:?} from {verified_at:?} at {iteration:?}"
+            );
+            Cancelled::PropagatedPanic.throw();
+        }
 
         // A query should only ever depend on other heads that are provisional.
         // If this invariant is violated, it means that this query participates in a cycle,

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -5,7 +5,7 @@ use crate::function::sync::ClaimResult;
 use crate::function::{Configuration, IngredientImpl, Reentrancy};
 use crate::zalsa::{MemoIngredientIndex, Zalsa};
 use crate::zalsa_local::{QueryRevisions, ZalsaLocal};
-use crate::{DatabaseKeyIndex, Id};
+use crate::{Cancelled, DatabaseKeyIndex, Id};
 
 impl<C> IngredientImpl<C>
 where
@@ -188,6 +188,15 @@ where
                 let memo_guard = self.get_memo_from_table_for(zalsa, id, memo_ingredient_index);
                 if let Some(memo) = &memo_guard {
                     let revisions = &memo.header.revisions;
+                    // Don't replace a poisoned memo from this execution with a new initial value.
+                    if memo.value.is_none()
+                        && memo.header.may_be_provisional()
+                        && memo.header.verified_at.load() == zalsa.current_revision()
+                        && revisions.iteration().cancellation_count() == cancellation_count
+                    {
+                        Cancelled::PropagatedPanic.throw();
+                    }
+
                     // Ideally, we'd use the last provisional memo even if it wasn't a cycle head in the last iteration
                     // but that would require inserting itself as a cycle head, which either requires clone
                     // on the value OR a concurrent `Vec` for cycle heads.

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -674,7 +674,9 @@ fn validate_provisional(
         };
 
         match provisional_status {
-            ProvisionalStatus::Provisional { .. } => return false,
+            ProvisionalStatus::Provisional { .. } | ProvisionalStatus::Poisoned { .. } => {
+                return false;
+            }
             ProvisionalStatus::Final {
                 iteration,
                 verified_at,

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -14,7 +14,7 @@ use crate::sync::atomic::Ordering;
 use crate::table::memo::{DummyMemo, MemoTableWithTypesMut, ToDynMemo};
 use crate::zalsa::{MemoIngredientIndex, Zalsa};
 use crate::zalsa_local::{QueryOriginRef, QueryRevisions};
-use crate::{Event, EventKind, Id, Revision};
+use crate::{Cancelled, Event, EventKind, Id, Revision};
 
 impl<C: Configuration> IngredientImpl<C> {
     /// Inserts the memo for the given key; (atomically) overwrites and returns any previously existing memo
@@ -538,6 +538,19 @@ impl Iterator for TryClaimCycleHeadsIter<'_> {
                         iteration,
                         verified_at,
                     } => (iteration, verified_at),
+                    ProvisionalStatus::Poisoned {
+                        iteration,
+                        verified_at,
+                    } => {
+                        if verified_at == self.zalsa.current_revision()
+                            && iteration.cancellation_count()
+                                == self.zalsa.runtime().cancellation_count()
+                        {
+                            Cancelled::PropagatedPanic.throw();
+                        }
+
+                        return Some(TryClaimHeadsResult::Available);
+                    }
                 };
 
                 Some(TryClaimHeadsResult::Cycle {

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -70,7 +70,8 @@ pub trait Ingredient: Any + fmt::Debug + Send + Sync {
 
     /// Returns information about the current provisional status of `input`.
     ///
-    /// Is it a provisional value or has it been finalized and in which iteration.
+    /// Is it a provisional value, a poisoned provisional memo, or has it been finalized and in
+    /// which iteration.
     ///
     /// Returns `None` if `input` doesn't exist.
     fn provisional_status<'db>(

--- a/tests/parallel/cycle_merge_after_panic.rs
+++ b/tests/parallel/cycle_merge_after_panic.rs
@@ -1,0 +1,122 @@
+//! A poisoned cycle head must not be merged with an earlier provisional iteration.
+//!
+//! This models the overlapping attribute/range cycles from astral-sh/ty#4077. Each scope contains
+//! sixteen expressions in chunks of four, giving the following dependency shape:
+//!
+//! ```text
+//! attribute(scope, index, false)
+//! ├─ attribute(scope, small_index, true)
+//! └─ once the provisional value reaches 3:
+//!    attribute(other_scope, late_index, true)
+//!    └─ range(other_scope, preceding_chunk)
+//!       └─ attribute(other_scope, chunk_expressions, true)
+//! ```
+//!
+//! Four threads enter different attribute queries together. An overlapping range cycle eventually
+//! becomes a head and its recovery panics. Unwinding poisons provisional memos with `None` at
+//! iteration 0 while another thread can still hold an attribute head from iteration 2. That thread
+//! must propagate the panic, not merge the two iterations. All dependencies are determined by
+//! tracked arguments and provisional results; there is no thread-local query state.
+
+#![cfg(not(feature = "shuttle"))]
+
+use salsa::Database;
+use std::marker::PhantomData;
+use std::panic::{self, AssertUnwindSafe};
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+const NUM_SCOPES: u32 = 3;
+const NUM_EXPRESSIONS: u32 = 16;
+const CHUNK_SIZE: u32 = 4;
+const FIXPOINT_LIMIT: u32 = 3;
+const NUM_WORKERS: usize = 4;
+
+struct StaticClassLiteral<'db>(PhantomData<&'db ()>);
+
+#[salsa::tracked]
+impl<'db> StaticClassLiteral<'db> {
+    #[salsa::tracked(
+        returns(copy),
+        cycle_fn = |_, _, previous: &u32, _, _, _, _| (previous + 1).min(FIXPOINT_LIMIT),
+        cycle_initial = |_, _, _, _, _| 0
+    )]
+    fn implicit_attribute_inner(db: &'db dyn Database, scope: u32, index: u32, infer: bool) -> u32 {
+        if infer {
+            for chunk in 0..index / CHUNK_SIZE {
+                analyze_non_terminal_call_range(db, scope, chunk);
+            }
+            let target_scope = (scope + 1 + (index + 1) % (NUM_SCOPES - 1)) % NUM_SCOPES;
+            Self::implicit_attribute_inner(db, target_scope, index % 7, false)
+        } else {
+            let first = Self::implicit_attribute_inner(db, scope, (index + 2) % 3, true);
+            if first >= FIXPOINT_LIMIT {
+                let expression = NUM_EXPRESSIONS - 1 - (3 * index) % (NUM_EXPRESSIONS / 2);
+                let other_scope = (scope + 1 + index % NUM_SCOPES) % NUM_SCOPES;
+                Self::implicit_attribute_inner(db, other_scope, expression, true);
+            }
+
+            (first + 1).min(FIXPOINT_LIMIT)
+        }
+    }
+}
+
+#[salsa::tracked(
+    returns(copy),
+    cycle_fn = |_, _, _, _, _, _| panic!("range cycle"),
+    cycle_initial = |_, _, _, _| ()
+)]
+fn analyze_non_terminal_call_range(db: &dyn Database, scope: u32, chunk: u32) {
+    for expression in chunk * CHUNK_SIZE..(chunk + 1) * CHUNK_SIZE {
+        StaticClassLiteral::implicit_attribute_inner(db, scope, expression, true);
+    }
+}
+
+fn attempt() {
+    let db = salsa::DatabaseImpl::default();
+    let barrier = Arc::new(Barrier::new(NUM_WORKERS));
+    let mut threads = Vec::with_capacity(NUM_WORKERS);
+
+    for worker in 0..NUM_WORKERS {
+        let db = db.clone();
+        let barrier = barrier.clone();
+        threads.push(thread::spawn(move || {
+            barrier.wait();
+
+            let scope = worker as u32 % NUM_SCOPES;
+            panic::catch_unwind(AssertUnwindSafe(|| {
+                StaticClassLiteral::implicit_attribute_inner(&db, scope, worker as u32, false)
+            }))
+        }));
+    }
+
+    let results: Vec<_> = threads
+        .into_iter()
+        .map(|thread| thread.join().unwrap())
+        .collect();
+    let mut range_panics = 0;
+    for result in results {
+        match result {
+            Ok(_) => {}
+            Err(error) if error.is::<salsa::Cancelled>() => {}
+            Err(error)
+                if error
+                    .downcast_ref::<&str>()
+                    .is_some_and(|message| *message == "range cycle") =>
+            {
+                range_panics += 1;
+            }
+            Err(error) => panic::resume_unwind(error),
+        }
+    }
+
+    assert!(range_panics > 0, "the range recovery was never invoked");
+}
+
+#[test]
+fn cycle_heads_from_different_iterations() {
+    let count = if cfg!(miri) { 1 } else { 100 };
+    for _ in 0..count {
+        attempt();
+    }
+}

--- a/tests/parallel/main.rs
+++ b/tests/parallel/main.rs
@@ -11,6 +11,7 @@ mod cycle_a_t1_b_t2;
 mod cycle_a_t1_b_t2_fallback;
 mod cycle_ab_peeping_c;
 mod cycle_iteration_mismatch;
+mod cycle_merge_after_panic;
 mod cycle_nested_deep;
 mod cycle_nested_deep_conditional;
 mod cycle_nested_deep_conditional_changed;


### PR DESCRIPTION
The root cause is a race between:

1. one thread unwinding from a panic and replacing a provisional cycle memo with a poisoned, iteration-0 memo; and
2. another thread still completing an overlapping cycle using that same cycle head at iteration 2.

The second thread then tries to merge the two views of the cycle head:

```text
active cycle:   head @ iteration 2
poisoned memo:  head @ iteration 0
```

Salsa assumes a cycle head has one consistent iteration, so the merge asserts.

The fix detects that the memo was poisoned and propagates the panic instead of treating its reset state as a valid provisional cycle result. This is a logical scheduling race, not a Rust data race.