### PR TITLE
chore: clarify ingredient cache safety invariants

### DIFF
--- a/components/salsa-macro-rules/src/setup_accumulator_impl.rs
+++ b/components/salsa-macro-rules/src/setup_accumulator_impl.rs
@@ -34,8 +34,8 @@ macro_rules! setup_accumulator_impl {
                 static $CACHE: $zalsa::IngredientCache<$zalsa_struct::IngredientImpl<$Struct>> =
                     $zalsa::IngredientCache::new();
 
-                // SAFETY: `lookup_jar_by_type` returns a valid ingredient index, and the only
-                // ingredient created by our jar is the struct ingredient.
+                // SAFETY: The ingredient at offset 0 in `JarImpl<$Struct>` has type
+                // `IngredientImpl<$Struct>`.
                 unsafe { $CACHE.get_or_create::<$zalsa_struct::JarImpl<$Struct>, 0>(zalsa) }
             }
 

--- a/components/salsa-macro-rules/src/setup_input_struct.rs
+++ b/components/salsa-macro-rules/src/setup_input_struct.rs
@@ -156,8 +156,8 @@ macro_rules! setup_input_struct {
                     static CACHE: $zalsa::IngredientCache<$zalsa_struct::IngredientImpl<$Configuration>> =
                         $zalsa::IngredientCache::new();
 
-                    // SAFETY: `lookup_jar_by_type` returns a valid ingredient index, and the only
-                    // ingredient created by our jar is the struct ingredient.
+                    // SAFETY: The ingredient at offset 0 in `JarImpl<$Configuration>` has type
+                    // `IngredientImpl<$Configuration>`.
                     unsafe {
                         CACHE.get_or_create::<$zalsa_struct::JarImpl<$Configuration>, 0>(zalsa)
                     }

--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -211,8 +211,8 @@ macro_rules! setup_interned_struct {
                     static CACHE: $zalsa::IngredientCache<$zalsa_struct::IngredientImpl<$Configuration>> =
                         $zalsa::IngredientCache::new();
 
-                    // SAFETY: `lookup_jar_by_type` returns a valid ingredient index, and the only
-                    // ingredient created by our jar is the struct ingredient.
+                    // SAFETY: The ingredient at offset 0 in `JarImpl<$Configuration>` has type
+                    // `IngredientImpl<$Configuration>`.
                     unsafe {
                         CACHE.get_or_create::<$zalsa_struct::JarImpl<$Configuration>, 0>(zalsa)
                     }

--- a/components/salsa-macro-rules/src/setup_tracked_fn.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_fn.rs
@@ -273,8 +273,8 @@ macro_rules! setup_tracked_fn {
 
                 #[inline]
                 fn fn_ingredient_<'z>(db: &dyn $Db, zalsa: &'z $zalsa::Zalsa) -> &'z $zalsa::function::IngredientImpl<$Configuration> {
-                    // SAFETY: `lookup_jar_by_type` returns a valid ingredient index, and the first
-                    // ingredient created by our jar is the function ingredient.
+                    // SAFETY: The ingredient at offset 0 in `$fn_name` has type
+                    // `function::IngredientImpl<$Configuration>`.
                     unsafe {
                         $FN_CACHE.get_or_create::<$fn_name, 0>(zalsa)
                     }
@@ -302,8 +302,8 @@ macro_rules! setup_tracked_fn {
                     fn intern_ingredient_<'z>(
                         zalsa: &'z $zalsa::Zalsa
                     ) -> &'z $zalsa::interned::IngredientImpl<$Configuration> {
-                        // SAFETY: `lookup_jar_by_type` returns a valid ingredient index, and the second
-                        // ingredient created by our jar is the interned ingredient (given `needs_interner`).
+                        // SAFETY: When an interner is needed, the ingredient at offset 1 in
+                        // `$fn_name` has type `interned::IngredientImpl<$Configuration>`.
                         unsafe {
                             $INTERN_CACHE.get_or_create::<$fn_name, 1>(zalsa)
                         }

--- a/components/salsa-macro-rules/src/setup_tracked_struct.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_struct.rs
@@ -241,8 +241,8 @@ macro_rules! setup_tracked_struct {
                     static CACHE: $zalsa::IngredientCache<$zalsa_struct::IngredientImpl<$Configuration>> =
                         $zalsa::IngredientCache::new();
 
-                    // SAFETY: `lookup_jar_by_type` returns a valid ingredient index, and the only
-                    // ingredient created by our jar is the struct ingredient.
+                    // SAFETY: The ingredient at offset 0 in `JarImpl<$Configuration>` has type
+                    // `IngredientImpl<$Configuration>`.
                     unsafe {
                         CACHE.get_or_create::<$zalsa_struct::JarImpl<$Configuration>, 0>(zalsa)
                     }

--- a/tests/interned-structs_self_ref.rs
+++ b/tests/interned-structs_self_ref.rs
@@ -112,8 +112,8 @@ const _: () = {
             static CACHE: zalsa_::IngredientCache<zalsa_struct_::IngredientImpl<Configuration_>> =
                 zalsa_::IngredientCache::new();
 
-            // SAFETY: `lookup_jar_by_type` returns a valid ingredient index, and the only
-            // ingredient created by our jar is the struct ingredient.
+            // SAFETY: The ingredient at offset 0 in `JarImpl<Configuration_>` has type
+            // `IngredientImpl<Configuration_>`.
             unsafe { CACHE.get_or_create::<zalsa_struct_::JarImpl<Configuration_>, 0>(zalsa) }
         }
     }


### PR DESCRIPTION
Follow up to https://dl.acm.org/doi/pdf/10.1145/3627535.3638491. Updating the safety comments.