### PR TITLE
perf: shard tracked query synchronization by key

### DIFF
--- a/src/function/sync.rs
+++ b/src/function/sync.rs
@@ -9,7 +9,7 @@ use crate::runtime::{
     BlockOnTransferredOwner, BlockResult, BlockTransferredResult, Running, WaitResult,
 };
 use crate::sync::thread::{self};
-use crate::sync::{Mutex, shard_count};
+use crate::sync::{Mutex, max_parallelism};
 use crate::tracing;
 use crate::zalsa::Zalsa;
 use crate::{Id, IngredientIndex};
@@ -62,8 +62,10 @@ pub(crate) struct SyncState {
 
 impl SyncTable {
     pub(crate) fn new(ingredient: IngredientIndex) -> Self {
+        let shard_count = max_parallelism().next_power_of_two().max(2);
+
         Self {
-            syncs: (0..shard_count()).map(|_| CachePadded::default()).collect(),
+            syncs: (0..shard_count).map(|_| CachePadded::default()).collect(),
             ingredient,
         }
     }

--- a/src/function/sync.rs
+++ b/src/function/sync.rs
@@ -1,5 +1,7 @@
-use rustc_hash::FxHashMap;
+use crossbeam_utils::CachePadded;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 use std::collections::hash_map::OccupiedEntry;
+use std::hash::BuildHasher;
 
 use crate::key::DatabaseKeyIndex;
 use crate::plumbing::ZalsaLocal;
@@ -13,11 +15,14 @@ use crate::zalsa::Zalsa;
 use crate::{Id, IngredientIndex};
 
 pub(crate) type SyncGuard<'me> = crate::sync::MutexGuard<'me, FxHashMap<Id, SyncState>>;
+type SyncShard = CachePadded<Mutex<FxHashMap<Id, SyncState>>>;
+
+const SHARD_COUNT: usize = 32;
 
 /// Tracks the keys that are currently being processed; used to coordinate between
 /// worker threads.
 pub(crate) struct SyncTable {
-    syncs: Mutex<FxHashMap<Id, SyncState>>,
+    syncs: Box<[SyncShard]>,
     ingredient: IngredientIndex,
 }
 
@@ -60,9 +65,21 @@ pub(crate) struct SyncState {
 impl SyncTable {
     pub(crate) fn new(ingredient: IngredientIndex) -> Self {
         Self {
-            syncs: Default::default(),
+            syncs: (0..SHARD_COUNT).map(|_| CachePadded::default()).collect(),
             ingredient,
         }
+    }
+
+    #[inline]
+    fn shard_index(&self, key_index: Id) -> usize {
+        let hash = FxBuildHasher.hash_one(key_index) as usize;
+        let shift = usize::BITS - self.syncs.len().trailing_zeros();
+        (hash << 7) >> shift
+    }
+
+    #[inline]
+    fn syncs_for(&self, key_index: Id) -> &Mutex<FxHashMap<Id, SyncState>> {
+        &self.syncs[self.shard_index(key_index)]
     }
 
     /// Claims the given key index, or blocks if it is running on another thread.
@@ -73,7 +90,7 @@ impl SyncTable {
         key_index: Id,
         reentrant: Reentrancy,
     ) -> ClaimResult<'me> {
-        let mut write = self.syncs.lock();
+        let mut write = self.syncs_for(key_index).lock();
         match write.entry(key_index) {
             std::collections::hash_map::Entry::Occupied(occupied_entry) => {
                 let id = match occupied_entry.get().id {
@@ -137,7 +154,7 @@ impl SyncTable {
         key_index: Id,
         reentrant: Reentrancy,
     ) -> ClaimResult<'me, ()> {
-        let mut write = self.syncs.lock();
+        let mut write = self.syncs_for(key_index).lock();
         match write.entry(key_index) {
             std::collections::hash_map::Entry::Occupied(occupied_entry) => {
                 let id = match occupied_entry.get().id {
@@ -267,7 +284,7 @@ impl SyncTable {
     /// Note: The result of this method will immediately become stale unless the thread owning `key_index`
     /// is currently blocked on this thread (claiming `key_index` from this thread results in a cycle).
     pub(super) fn mark_as_transfer_target(&self, key_index: Id) -> Option<SyncOwner> {
-        let mut syncs = self.syncs.lock();
+        let mut syncs = self.syncs_for(key_index).lock();
         syncs.get_mut(&key_index).map(|state| {
             // We set `anyone_waiting` to true because it is used in `ClaimGuard::release`
             // to exit early if the query doesn't need to release any locks.
@@ -329,7 +346,7 @@ impl<'me> ClaimGuard<'me> {
     #[cold]
     #[inline(never)]
     fn release_panicking(&self) {
-        let mut syncs = self.sync_table.syncs.lock();
+        let mut syncs = self.sync_table.syncs_for(self.key_index).lock();
         let state = syncs.remove(&self.key_index).expect("key claimed twice?");
         let result = if self.zalsa_local.should_trigger_local_cancellation() {
             WaitResult::Cancelled
@@ -374,7 +391,7 @@ impl<'me> ClaimGuard<'me> {
     #[cold]
     #[inline(never)]
     fn release_self(&self) {
-        let mut syncs = self.sync_table.syncs.lock();
+        let mut syncs = self.sync_table.syncs_for(self.key_index).lock();
         let std::collections::hash_map::Entry::Occupied(mut state) = syncs.entry(self.key_index)
         else {
             panic!("key should only be claimed/released once");
@@ -404,7 +421,7 @@ impl<'me> ClaimGuard<'me> {
         else {
             self.release(
                 self.sync_table
-                    .syncs
+                    .syncs_for(self.key_index)
                     .lock()
                     .remove(&self.key_index)
                     .expect("key should only be claimed/released once"),
@@ -414,7 +431,7 @@ impl<'me> ClaimGuard<'me> {
             panic!("new owner to be a locked query")
         };
 
-        let mut syncs = self.sync_table.syncs.lock();
+        let mut syncs = self.sync_table.syncs_for(self.key_index).lock();
 
         let self_key = self.database_key_index();
         tracing::debug!(
@@ -450,7 +467,7 @@ impl<'me> ClaimGuard<'me> {
     fn drop_impl(&mut self) -> bool {
         match self.mode {
             ReleaseMode::Default => {
-                let mut syncs = self.sync_table.syncs.lock();
+                let mut syncs = self.sync_table.syncs_for(self.key_index).lock();
                 let state = syncs
                     .remove(&self.key_index)
                     .expect("key should only be claimed/released once");
@@ -538,5 +555,24 @@ pub(crate) enum Reentrancy {
 impl Reentrancy {
     const fn is_allow(self) -> bool {
         matches!(self, Reentrancy::Allow)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SHARD_COUNT, SyncTable};
+    use crate::{Id, IngredientIndex};
+
+    #[test]
+    fn keys_with_matching_page_slots_use_different_shards() {
+        let sync_table = SyncTable::new(IngredientIndex::new(0));
+        let mut used_shards = [false; SHARD_COUNT];
+
+        for page in 0..(SHARD_COUNT * 4) {
+            let key = Id::from_bits(((page as u64) << 7) | 1);
+            used_shards[sync_table.shard_index(key)] = true;
+        }
+
+        assert!(used_shards.into_iter().filter(|used| *used).count() >= SHARD_COUNT / 2);
     }
 }

--- a/src/function/sync.rs
+++ b/src/function/sync.rs
@@ -1,6 +1,7 @@
 use crossbeam_utils::CachePadded;
-use rustc_hash::{FxBuildHasher, FxHashMap};
-use std::collections::hash_map::OccupiedEntry;
+use hashbrown::HashTable;
+use hashbrown::hash_table::{Entry, OccupiedEntry};
+use rustc_hash::FxBuildHasher;
 use std::hash::BuildHasher;
 
 use crate::key::DatabaseKeyIndex;
@@ -14,8 +15,8 @@ use crate::tracing;
 use crate::zalsa::Zalsa;
 use crate::{Id, IngredientIndex};
 
-pub(crate) type SyncGuard<'me> = crate::sync::MutexGuard<'me, FxHashMap<Id, SyncState>>;
-type SyncShard = CachePadded<Mutex<FxHashMap<Id, SyncState>>>;
+pub(crate) type SyncGuard<'me> = crate::sync::MutexGuard<'me, HashTable<SyncState>>;
+type SyncShard = CachePadded<Mutex<HashTable<SyncState>>>;
 
 /// Tracks the keys that are currently being processed; used to coordinate between
 /// worker threads.
@@ -38,7 +39,10 @@ pub(crate) enum ClaimResult<'a, Guard = ClaimGuard<'a>> {
     },
 }
 
+#[derive(Debug)]
 pub(crate) struct SyncState {
+    key: Id,
+
     /// The thread id that currently owns this query (actively executing it or iterating it as part of a larger cycle).
     id: SyncOwner,
 
@@ -71,15 +75,15 @@ impl SyncTable {
     }
 
     #[inline]
-    fn shard_index(&self, key_index: Id) -> usize {
-        let hash = FxBuildHasher.hash_one(key_index) as usize;
+    fn shard_index(&self, hash: u64) -> usize {
+        let hash = hash as usize;
         let shift = usize::BITS - self.syncs.len().trailing_zeros();
         (hash << 7) >> shift
     }
 
     #[inline]
-    fn syncs_for(&self, key_index: Id) -> &Mutex<FxHashMap<Id, SyncState>> {
-        &self.syncs[self.shard_index(key_index)]
+    fn syncs_for(&self, hash: u64) -> &Mutex<HashTable<SyncState>> {
+        &self.syncs[self.shard_index(hash)]
     }
 
     /// Claims the given key index, or blocks if it is running on another thread.
@@ -90,9 +94,15 @@ impl SyncTable {
         key_index: Id,
         reentrant: Reentrancy,
     ) -> ClaimResult<'me> {
-        let mut write = self.syncs_for(key_index).lock();
-        match write.entry(key_index) {
-            std::collections::hash_map::Entry::Occupied(occupied_entry) => {
+        let hash = FxBuildHasher.hash_one(key_index);
+        let syncs = self.syncs_for(hash);
+        let mut write = syncs.lock();
+        match write.entry(
+            hash,
+            |state| state.key == key_index,
+            |state| FxBuildHasher.hash_one(state.key),
+        ) {
+            Entry::Occupied(occupied_entry) => {
                 let id = match occupied_entry.get().id {
                     SyncOwner::Thread(id) => id,
                     SyncOwner::Transferred => {
@@ -100,6 +110,8 @@ impl SyncTable {
                             zalsa,
                             zalsa_local,
                             occupied_entry,
+                            syncs,
+                            hash,
                             reentrant,
                         ) {
                             Ok(claimed) => claimed,
@@ -129,8 +141,9 @@ impl SyncTable {
                     BlockResult::Cycle => ClaimResult::Cycle { inner: false },
                 }
             }
-            std::collections::hash_map::Entry::Vacant(vacant_entry) => {
+            Entry::Vacant(vacant_entry) => {
                 vacant_entry.insert(SyncState {
+                    key: key_index,
                     id: SyncOwner::Thread(thread::current().id()),
                     anyone_waiting: false,
                     is_transfer_target: false,
@@ -138,9 +151,11 @@ impl SyncTable {
                 });
                 ClaimResult::Claimed(ClaimGuard {
                     key_index,
+                    ingredient: self.ingredient,
+                    hash,
                     zalsa,
                     zalsa_local,
-                    sync_table: self,
+                    syncs,
                     mode: ReleaseMode::Default,
                 })
             }
@@ -154,9 +169,10 @@ impl SyncTable {
         key_index: Id,
         reentrant: Reentrancy,
     ) -> ClaimResult<'me, ()> {
-        let mut write = self.syncs_for(key_index).lock();
-        match write.entry(key_index) {
-            std::collections::hash_map::Entry::Occupied(occupied_entry) => {
+        let hash = FxBuildHasher.hash_one(key_index);
+        let mut write = self.syncs_for(hash).lock();
+        match write.find_entry(hash, |state| state.key == key_index) {
+            Ok(occupied_entry) => {
                 let id = match occupied_entry.get().id {
                     SyncOwner::Thread(id) => id,
                     SyncOwner::Transferred => {
@@ -188,7 +204,7 @@ impl SyncTable {
                     BlockResult::Cycle => ClaimResult::Cycle { inner: false },
                 }
             }
-            std::collections::hash_map::Entry::Vacant(_) => ClaimResult::Claimed(()),
+            Err(_) => ClaimResult::Claimed(()),
         }
     }
 
@@ -198,10 +214,12 @@ impl SyncTable {
         &'me self,
         zalsa: &'me Zalsa,
         zalsa_local: &'me ZalsaLocal,
-        mut entry: OccupiedEntry<Id, SyncState>,
+        mut entry: OccupiedEntry<SyncState>,
+        syncs: &'me Mutex<HashTable<SyncState>>,
+        hash: u64,
         reentrant: Reentrancy,
     ) -> Result<ClaimResult<'me>, Box<BlockOnTransferredOwner<'me>>> {
-        let key_index = *entry.key();
+        let key_index = entry.get().key;
         let database_key_index = DatabaseKeyIndex::new(self.ingredient, key_index);
         let thread_id = thread::current().id();
 
@@ -220,9 +238,11 @@ impl SyncTable {
 
                 Ok(ClaimResult::Claimed(ClaimGuard {
                     key_index,
+                    ingredient: self.ingredient,
+                    hash,
                     zalsa,
                     zalsa_local,
-                    sync_table: self,
+                    syncs,
                     mode: ReleaseMode::SelfOnly,
                 }))
             }
@@ -232,17 +252,20 @@ impl SyncTable {
                 Err(other_thread)
             }
             BlockTransferredResult::Released => {
-                entry.insert(SyncState {
+                *entry.get_mut() = SyncState {
+                    key: key_index,
                     id: SyncOwner::Thread(thread_id),
                     anyone_waiting: false,
                     is_transfer_target: false,
                     claimed_twice: false,
-                });
+                };
                 Ok(ClaimResult::Claimed(ClaimGuard {
                     key_index,
+                    ingredient: self.ingredient,
+                    hash,
                     zalsa,
                     zalsa_local,
-                    sync_table: self,
+                    syncs,
                     mode: ReleaseMode::Default,
                 }))
             }
@@ -254,10 +277,10 @@ impl SyncTable {
     fn peek_claim_transferred<'me>(
         &'me self,
         zalsa: &'me Zalsa,
-        mut entry: OccupiedEntry<Id, SyncState>,
+        mut entry: OccupiedEntry<SyncState>,
         reentrant: Reentrancy,
     ) -> Result<ClaimResult<'me, ()>, Box<BlockOnTransferredOwner<'me>>> {
-        let key_index = *entry.key();
+        let key_index = entry.get().key;
         let database_key_index = DatabaseKeyIndex::new(self.ingredient, key_index);
         let thread_id = thread::current().id();
 
@@ -284,17 +307,20 @@ impl SyncTable {
     /// Note: The result of this method will immediately become stale unless the thread owning `key_index`
     /// is currently blocked on this thread (claiming `key_index` from this thread results in a cycle).
     pub(super) fn mark_as_transfer_target(&self, key_index: Id) -> Option<SyncOwner> {
-        let mut syncs = self.syncs_for(key_index).lock();
-        syncs.get_mut(&key_index).map(|state| {
-            // We set `anyone_waiting` to true because it is used in `ClaimGuard::release`
-            // to exit early if the query doesn't need to release any locks.
-            // However, there are now dependent queries that need to be released, that's why we set `anyone_waiting` to true,
-            // so that `ClaimGuard::release` no longer exits early.
-            state.anyone_waiting = true;
-            state.is_transfer_target = true;
+        let hash = FxBuildHasher.hash_one(key_index);
+        let mut syncs = self.syncs_for(hash).lock();
+        syncs
+            .find_mut(hash, |state| state.key == key_index)
+            .map(|state| {
+                // We set `anyone_waiting` to true because it is used in `ClaimGuard::release`
+                // to exit early if the query doesn't need to release any locks.
+                // However, there are now dependent queries that need to be released, that's why we set `anyone_waiting` to true,
+                // so that `ClaimGuard::release` no longer exits early.
+                state.anyone_waiting = true;
+                state.is_transfer_target = true;
 
-            state.id
-        })
+                state.id
+            })
     }
 }
 
@@ -320,8 +346,10 @@ pub enum SyncOwner {
 #[must_use]
 pub(crate) struct ClaimGuard<'me> {
     key_index: Id,
+    ingredient: IngredientIndex,
+    hash: u64,
     zalsa: &'me Zalsa,
-    sync_table: &'me SyncTable,
+    syncs: &'me Mutex<HashTable<SyncState>>,
     mode: ReleaseMode,
     zalsa_local: &'me ZalsaLocal,
 }
@@ -336,7 +364,7 @@ impl<'me> ClaimGuard<'me> {
     }
 
     pub(crate) const fn database_key_index(&self) -> DatabaseKeyIndex {
-        DatabaseKeyIndex::new(self.sync_table.ingredient, self.key_index)
+        DatabaseKeyIndex::new(self.ingredient, self.key_index)
     }
 
     pub(crate) fn set_release_mode(&mut self, mode: ReleaseMode) {
@@ -346,8 +374,12 @@ impl<'me> ClaimGuard<'me> {
     #[cold]
     #[inline(never)]
     fn release_panicking(&self) {
-        let mut syncs = self.sync_table.syncs_for(self.key_index).lock();
-        let state = syncs.remove(&self.key_index).expect("key claimed twice?");
+        let mut syncs = self.syncs.lock();
+        let state = syncs
+            .find_entry(self.hash, |state| state.key == self.key_index)
+            .expect("key claimed twice?")
+            .remove()
+            .0;
         let result = if self.zalsa_local.should_trigger_local_cancellation() {
             WaitResult::Cancelled
         } else {
@@ -391,9 +423,8 @@ impl<'me> ClaimGuard<'me> {
     #[cold]
     #[inline(never)]
     fn release_self(&self) {
-        let mut syncs = self.sync_table.syncs_for(self.key_index).lock();
-        let std::collections::hash_map::Entry::Occupied(mut state) = syncs.entry(self.key_index)
-        else {
+        let mut syncs = self.syncs.lock();
+        let Ok(mut state) = syncs.find_entry(self.hash, |state| state.key == self.key_index) else {
             panic!("key should only be claimed/released once");
         };
 
@@ -401,7 +432,7 @@ impl<'me> ClaimGuard<'me> {
             state.get_mut().claimed_twice = false;
             state.get_mut().id = SyncOwner::Transferred;
         } else {
-            self.release(state.remove(), WaitResult::Completed);
+            self.release(state.remove().0, WaitResult::Completed);
         }
     }
 
@@ -420,18 +451,19 @@ impl<'me> ClaimGuard<'me> {
             .mark_as_transfer_target(new_owner.key_index())
         else {
             self.release(
-                self.sync_table
-                    .syncs_for(self.key_index)
+                self.syncs
                     .lock()
-                    .remove(&self.key_index)
-                    .expect("key should only be claimed/released once"),
+                    .find_entry(self.hash, |state| state.key == self.key_index)
+                    .expect("key should only be claimed/released once")
+                    .remove()
+                    .0,
                 WaitResult::Panicked,
             );
 
             panic!("new owner to be a locked query")
         };
 
-        let mut syncs = self.sync_table.syncs_for(self.key_index).lock();
+        let mut syncs = self.syncs.lock();
 
         let self_key = self.database_key_index();
         tracing::debug!(
@@ -441,7 +473,7 @@ impl<'me> ClaimGuard<'me> {
         let SyncState {
             id, claimed_twice, ..
         } = syncs
-            .get_mut(&self.key_index)
+            .find_mut(self.hash, |state| state.key == self.key_index)
             .expect("key should only be claimed/released once");
 
         *id = SyncOwner::Transferred;
@@ -467,10 +499,12 @@ impl<'me> ClaimGuard<'me> {
     fn drop_impl(&mut self) -> bool {
         match self.mode {
             ReleaseMode::Default => {
-                let mut syncs = self.sync_table.syncs_for(self.key_index).lock();
+                let mut syncs = self.syncs.lock();
                 let state = syncs
-                    .remove(&self.key_index)
-                    .expect("key should only be claimed/released once");
+                    .find_entry(self.hash, |state| state.key == self.key_index)
+                    .expect("key should only be claimed/released once")
+                    .remove()
+                    .0;
 
                 self.release(state, WaitResult::Completed);
                 false

--- a/src/function/sync.rs
+++ b/src/function/sync.rs
@@ -16,12 +16,18 @@ use crate::zalsa::Zalsa;
 use crate::{Id, IngredientIndex};
 
 pub(crate) type SyncGuard<'me> = crate::sync::MutexGuard<'me, HashTable<SyncState>>;
-type SyncShard = CachePadded<Mutex<HashTable<SyncState>>>;
 
 /// Tracks the keys that are currently being processed; used to coordinate between
 /// worker threads.
 pub(crate) struct SyncTable {
-    syncs: Box<[SyncShard]>,
+    shards: Box<[CachePadded<SyncShard>]>,
+    ingredient: IngredientIndex,
+}
+
+struct SyncShard {
+    syncs: Mutex<HashTable<SyncState>>,
+
+    /// Fits into the shard's cache-line padding and keeps it out of `ClaimGuard`.
     ingredient: IngredientIndex,
 }
 
@@ -69,7 +75,14 @@ impl SyncTable {
         let shard_count = max_parallelism().next_power_of_two().max(2);
 
         Self {
-            syncs: (0..shard_count).map(|_| CachePadded::default()).collect(),
+            shards: (0..shard_count)
+                .map(|_| {
+                    CachePadded::new(SyncShard {
+                        syncs: Mutex::default(),
+                        ingredient,
+                    })
+                })
+                .collect(),
             ingredient,
         }
     }
@@ -77,13 +90,13 @@ impl SyncTable {
     #[inline]
     fn shard_index(&self, hash: u64) -> usize {
         let hash = hash as usize;
-        let shift = usize::BITS - self.syncs.len().trailing_zeros();
+        let shift = usize::BITS - self.shards.len().trailing_zeros();
         (hash << 7) >> shift
     }
 
     #[inline]
-    fn syncs_for(&self, hash: u64) -> &Mutex<HashTable<SyncState>> {
-        &self.syncs[self.shard_index(hash)]
+    fn shard_for(&self, hash: u64) -> &SyncShard {
+        &self.shards[self.shard_index(hash)]
     }
 
     /// Claims the given key index, or blocks if it is running on another thread.
@@ -95,8 +108,8 @@ impl SyncTable {
         reentrant: Reentrancy,
     ) -> ClaimResult<'me> {
         let hash = FxBuildHasher.hash_one(key_index);
-        let syncs = self.syncs_for(hash);
-        let mut write = syncs.lock();
+        let shard = self.shard_for(hash);
+        let mut write = shard.syncs.lock();
         match write.entry(
             hash,
             |state| state.key == key_index,
@@ -110,8 +123,7 @@ impl SyncTable {
                             zalsa,
                             zalsa_local,
                             occupied_entry,
-                            syncs,
-                            hash,
+                            shard,
                             reentrant,
                         ) {
                             Ok(claimed) => claimed,
@@ -151,11 +163,9 @@ impl SyncTable {
                 });
                 ClaimResult::Claimed(ClaimGuard {
                     key_index,
-                    ingredient: self.ingredient,
-                    hash,
                     zalsa,
                     zalsa_local,
-                    syncs,
+                    shard,
                     mode: ReleaseMode::Default,
                 })
             }
@@ -170,7 +180,7 @@ impl SyncTable {
         reentrant: Reentrancy,
     ) -> ClaimResult<'me, ()> {
         let hash = FxBuildHasher.hash_one(key_index);
-        let mut write = self.syncs_for(hash).lock();
+        let mut write = self.shard_for(hash).syncs.lock();
         match write.find_entry(hash, |state| state.key == key_index) {
             Ok(occupied_entry) => {
                 let id = match occupied_entry.get().id {
@@ -215,8 +225,7 @@ impl SyncTable {
         zalsa: &'me Zalsa,
         zalsa_local: &'me ZalsaLocal,
         mut entry: OccupiedEntry<SyncState>,
-        syncs: &'me Mutex<HashTable<SyncState>>,
-        hash: u64,
+        shard: &'me SyncShard,
         reentrant: Reentrancy,
     ) -> Result<ClaimResult<'me>, Box<BlockOnTransferredOwner<'me>>> {
         let key_index = entry.get().key;
@@ -238,11 +247,9 @@ impl SyncTable {
 
                 Ok(ClaimResult::Claimed(ClaimGuard {
                     key_index,
-                    ingredient: self.ingredient,
-                    hash,
                     zalsa,
                     zalsa_local,
-                    syncs,
+                    shard,
                     mode: ReleaseMode::SelfOnly,
                 }))
             }
@@ -261,11 +268,9 @@ impl SyncTable {
                 };
                 Ok(ClaimResult::Claimed(ClaimGuard {
                     key_index,
-                    ingredient: self.ingredient,
-                    hash,
                     zalsa,
                     zalsa_local,
-                    syncs,
+                    shard,
                     mode: ReleaseMode::Default,
                 }))
             }
@@ -308,7 +313,7 @@ impl SyncTable {
     /// is currently blocked on this thread (claiming `key_index` from this thread results in a cycle).
     pub(super) fn mark_as_transfer_target(&self, key_index: Id) -> Option<SyncOwner> {
         let hash = FxBuildHasher.hash_one(key_index);
-        let mut syncs = self.syncs_for(hash).lock();
+        let mut syncs = self.shard_for(hash).syncs.lock();
         syncs
             .find_mut(hash, |state| state.key == key_index)
             .map(|state| {
@@ -346,10 +351,8 @@ pub enum SyncOwner {
 #[must_use]
 pub(crate) struct ClaimGuard<'me> {
     key_index: Id,
-    ingredient: IngredientIndex,
-    hash: u64,
     zalsa: &'me Zalsa,
-    syncs: &'me Mutex<HashTable<SyncState>>,
+    shard: &'me SyncShard,
     mode: ReleaseMode,
     zalsa_local: &'me ZalsaLocal,
 }
@@ -364,19 +367,25 @@ impl<'me> ClaimGuard<'me> {
     }
 
     pub(crate) const fn database_key_index(&self) -> DatabaseKeyIndex {
-        DatabaseKeyIndex::new(self.ingredient, self.key_index)
+        DatabaseKeyIndex::new(self.shard.ingredient, self.key_index)
     }
 
     pub(crate) fn set_release_mode(&mut self, mode: ReleaseMode) {
         self.mode = mode;
     }
 
+    #[inline]
+    fn hash(&self) -> u64 {
+        FxBuildHasher.hash_one(self.key_index)
+    }
+
     #[cold]
     #[inline(never)]
     fn release_panicking(&self) {
-        let mut syncs = self.syncs.lock();
+        let hash = self.hash();
+        let mut syncs = self.shard.syncs.lock();
         let state = syncs
-            .find_entry(self.hash, |state| state.key == self.key_index)
+            .find_entry(hash, |state| state.key == self.key_index)
             .expect("key claimed twice?")
             .remove()
             .0;
@@ -423,8 +432,9 @@ impl<'me> ClaimGuard<'me> {
     #[cold]
     #[inline(never)]
     fn release_self(&self) {
-        let mut syncs = self.syncs.lock();
-        let Ok(mut state) = syncs.find_entry(self.hash, |state| state.key == self.key_index) else {
+        let hash = self.hash();
+        let mut syncs = self.shard.syncs.lock();
+        let Ok(mut state) = syncs.find_entry(hash, |state| state.key == self.key_index) else {
             panic!("key should only be claimed/released once");
         };
 
@@ -439,6 +449,8 @@ impl<'me> ClaimGuard<'me> {
     #[cold]
     #[inline(never)]
     pub(crate) fn transfer(&self, new_owner: DatabaseKeyIndex) -> bool {
+        let hash = self.hash();
+
         // Get the owning thread of `new_owner`.
         // The thread id is guaranteed to not be stale because `new_owner` must be blocked on `self_key`
         // or `transfer_lock` will panic (at least in debug builds).
@@ -451,9 +463,10 @@ impl<'me> ClaimGuard<'me> {
             .mark_as_transfer_target(new_owner.key_index())
         else {
             self.release(
-                self.syncs
+                self.shard
+                    .syncs
                     .lock()
-                    .find_entry(self.hash, |state| state.key == self.key_index)
+                    .find_entry(hash, |state| state.key == self.key_index)
                     .expect("key should only be claimed/released once")
                     .remove()
                     .0,
@@ -463,7 +476,7 @@ impl<'me> ClaimGuard<'me> {
             panic!("new owner to be a locked query")
         };
 
-        let mut syncs = self.syncs.lock();
+        let mut syncs = self.shard.syncs.lock();
 
         let self_key = self.database_key_index();
         tracing::debug!(
@@ -473,7 +486,7 @@ impl<'me> ClaimGuard<'me> {
         let SyncState {
             id, claimed_twice, ..
         } = syncs
-            .find_mut(self.hash, |state| state.key == self.key_index)
+            .find_mut(hash, |state| state.key == self.key_index)
             .expect("key should only be claimed/released once");
 
         *id = SyncOwner::Transferred;
@@ -499,9 +512,10 @@ impl<'me> ClaimGuard<'me> {
     fn drop_impl(&mut self) -> bool {
         match self.mode {
             ReleaseMode::Default => {
-                let mut syncs = self.syncs.lock();
+                let hash = self.hash();
+                let mut syncs = self.shard.syncs.lock();
                 let state = syncs
-                    .find_entry(self.hash, |state| state.key == self.key_index)
+                    .find_entry(hash, |state| state.key == self.key_index)
                     .expect("key should only be claimed/released once")
                     .remove()
                     .0;
@@ -570,6 +584,13 @@ impl std::fmt::Debug for ClaimGuard<'_> {
             .finish_non_exhaustive()
     }
 }
+
+#[cfg(all(not(feature = "shuttle"), target_pointer_width = "64"))]
+const _: [(); std::mem::size_of::<ClaimGuard<'static>>()] = [(); std::mem::size_of::<[usize; 6]>()];
+
+#[cfg(all(not(feature = "shuttle"), target_pointer_width = "64"))]
+const _: [(); std::mem::size_of::<CachePadded<SyncShard>>()] =
+    [(); std::mem::size_of::<CachePadded<Mutex<HashTable<SyncState>>>>()];
 
 /// Controls whether this thread can claim a query that transferred its ownership to a query
 /// this thread currently holds the lock for.

--- a/src/function/sync.rs
+++ b/src/function/sync.rs
@@ -8,16 +8,14 @@ use crate::plumbing::ZalsaLocal;
 use crate::runtime::{
     BlockOnTransferredOwner, BlockResult, BlockTransferredResult, Running, WaitResult,
 };
-use crate::sync::Mutex;
 use crate::sync::thread::{self};
+use crate::sync::{Mutex, shard_count};
 use crate::tracing;
 use crate::zalsa::Zalsa;
 use crate::{Id, IngredientIndex};
 
 pub(crate) type SyncGuard<'me> = crate::sync::MutexGuard<'me, FxHashMap<Id, SyncState>>;
 type SyncShard = CachePadded<Mutex<FxHashMap<Id, SyncState>>>;
-
-const SHARD_COUNT: usize = 32;
 
 /// Tracks the keys that are currently being processed; used to coordinate between
 /// worker threads.
@@ -65,7 +63,7 @@ pub(crate) struct SyncState {
 impl SyncTable {
     pub(crate) fn new(ingredient: IngredientIndex) -> Self {
         Self {
-            syncs: (0..SHARD_COUNT).map(|_| CachePadded::default()).collect(),
+            syncs: (0..shard_count()).map(|_| CachePadded::default()).collect(),
             ingredient,
         }
     }
@@ -555,24 +553,5 @@ pub(crate) enum Reentrancy {
 impl Reentrancy {
     const fn is_allow(self) -> bool {
         matches!(self, Reentrancy::Allow)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{SHARD_COUNT, SyncTable};
-    use crate::{Id, IngredientIndex};
-
-    #[test]
-    fn keys_with_matching_page_slots_use_different_shards() {
-        let sync_table = SyncTable::new(IngredientIndex::new(0));
-        let mut used_shards = [false; SHARD_COUNT];
-
-        for page in 0..(SHARD_COUNT * 4) {
-            let key = Id::from_bits(((page as u64) << 7) | 1);
-            used_shards[sync_table.shard_index(key)] = true;
-        }
-
-        assert!(used_shards.into_iter().filter(|used| *used).count() >= SHARD_COUNT / 2);
     }
 }

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -20,7 +20,7 @@ use crate::id::{AsId, FromId};
 use crate::ingredient::Ingredient;
 use crate::plumbing::{self, Jar, ZalsaLocal};
 use crate::revision::AtomicRevision;
-use crate::sync::{Arc, Mutex, OnceLock};
+use crate::sync::{Arc, Mutex, shard_count};
 use crate::table::Slot;
 use crate::table::memo::{MemoTable, MemoTableTypes, MemoTableWithTypesMut};
 use crate::zalsa::{IngredientIndex, JarKind, Zalsa};
@@ -1054,19 +1054,10 @@ where
 
 /// Creates the sharded storage outside of the generic [`IngredientImpl::new`] context.
 ///
-/// Keeping this helper non-generic avoids monomorphizing the `OnceLock` and iterator machinery for
-/// every interned struct configuration.
+/// Keeping this helper non-generic avoids monomorphizing the iterator machinery for every interned
+/// struct configuration.
 fn new_shards() -> Box<[CachePadded<Mutex<IngredientShard>>]> {
-    static SHARDS: OnceLock<usize> = OnceLock::new();
-    let shards = *SHARDS.get_or_init(|| {
-        let num_cpus = std::thread::available_parallelism()
-            .map(usize::from)
-            .unwrap_or(1);
-
-        (num_cpus * 4).next_power_of_two()
-    });
-
-    (0..shards).map(|_| Default::default()).collect()
+    (0..shard_count()).map(|_| Default::default()).collect()
 }
 
 /// A stable pointer to an interned value allocated in the database table.

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -20,7 +20,7 @@ use crate::id::{AsId, FromId};
 use crate::ingredient::Ingredient;
 use crate::plumbing::{self, Jar, ZalsaLocal};
 use crate::revision::AtomicRevision;
-use crate::sync::{Arc, Mutex, shard_count};
+use crate::sync::{Arc, Mutex, max_parallelism};
 use crate::table::Slot;
 use crate::table::memo::{MemoTable, MemoTableTypes, MemoTableWithTypesMut};
 use crate::zalsa::{IngredientIndex, JarKind, Zalsa};
@@ -1057,7 +1057,8 @@ where
 /// Keeping this helper non-generic avoids monomorphizing the iterator machinery for every interned
 /// struct configuration.
 fn new_shards() -> Box<[CachePadded<Mutex<IngredientShard>>]> {
-    (0..shard_count()).map(|_| Default::default()).collect()
+    let shard_count = (max_parallelism() * 4).next_power_of_two();
+    (0..shard_count).map(|_| Default::default()).collect()
 }
 
 /// A stable pointer to an interned value allocated in the database table.

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,5 +1,17 @@
 pub use shim::*;
 
+pub(crate) fn shard_count() -> usize {
+    static SHARDS: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+
+    *SHARDS.get_or_init(|| {
+        let num_cpus = std::thread::available_parallelism()
+            .map(usize::from)
+            .unwrap_or(1);
+
+        (num_cpus * 4).next_power_of_two()
+    })
+}
+
 #[cfg(feature = "shuttle")]
 pub mod shim {
     pub use shuttle::sync::*;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,14 +1,12 @@
 pub use shim::*;
 
-pub(crate) fn shard_count() -> usize {
-    static SHARDS: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+pub(crate) fn max_parallelism() -> usize {
+    static MAX_PARALLELISM: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
 
-    *SHARDS.get_or_init(|| {
-        let num_cpus = std::thread::available_parallelism()
+    *MAX_PARALLELISM.get_or_init(|| {
+        std::thread::available_parallelism()
             .map(usize::from)
-            .unwrap_or(1);
-
-        (num_cpus * 4).next_power_of_two()
+            .unwrap_or(1)
     })
 }
 


### PR DESCRIPTION
Shard tracked-query synchronization by hashed key so unrelated queries can be claimed and released in parallel. Reuse each query hash for shard selection, synchronization-table lookup, and release. 

We only use one shard per CPU because there's a memory and performance trade-off (applications using less than `available_parallelism` pay the overhead of more hash maps) and using twice or four times as many shards (as we do for interning), didn't show a meaningful improvement. I suspect that this is largely due to our locks being very short held. 

We don't use a `DashMap` because we don't need a `Read/Write` lock, the vast majority of operations require an exclusive lock, making a `Mutex` the right choice.  

Pydantic wall time, mean of eight randomized, interleaved runs:

| Threads | Before | After |
| ---: | ---: | ---: |
| 1 | 2,191 ms | 2,216 ms |
| 2 | 1,356 ms | 1,372 ms |
| 4 | 823 ms | 793 ms |
| 8 | 564 ms | 544 ms |
| 16 | 486 ms | 475 ms |
| 32 | 490 ms | 462 ms |
| 64 | 536 ms | 473 ms |


This was measured on a host with 32 physical and 64 logical core (which is why 64 is slightly slower). There are also some outlier files, which is why the runtime plateaus with more threads. 

At 64 threads, system CPU time falls from 564 ms to 210 ms and voluntary context switches fall from approximately 33,000 to 7,500.
