### PR TITLE
bump MSRV to 1.88

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,17 +13,21 @@ concurrency:
 
 jobs:
   test:
-    name: Test
+    name: ${{ matrix.name }}
     strategy:
       matrix:
-        rust:
-          - 1.88.0
-          - stable
-          - beta
-        experimental:
-          - false
         include:
-          - rust: nightly
+          - name: MSRV
+            rust: msrv
+            experimental: false
+          - name: Stable
+            rust: stable
+            experimental: false
+          - name: Beta
+            rust: beta
+            experimental: false
+          - name: Nightly
+            rust: nightly
             experimental: true
     continue-on-error: ${{ matrix.experimental }}
     runs-on: ubuntu-latest
@@ -33,15 +37,21 @@ jobs:
       - name: Setup Rust toolchain
         shell: bash
         run: |
-          if [[ "${{ matrix.rust }}" == "stable" ]]; then
+          rust="${{ matrix.rust }}"
+          if [[ "$rust" == "msrv" ]]; then
+            rust="$(sed -n 's/^rust-version = "\(.*\)"$/\1/p' Cargo.toml)"
+            test -n "$rust"
+          fi
+
+          if [[ "$rust" == "stable" ]]; then
             rustup component add rustfmt clippy
           else
             args=(--component rustfmt --component clippy)
-            if [[ "${{ matrix.rust }}" == "nightly" ]]; then
+            if [[ "$rust" == "nightly" ]]; then
               args+=(--allow-downgrade)
             fi
-            rustup toolchain install "${{ matrix.rust }}" "${args[@]}"
-            rustup override set "${{ matrix.rust }}"
+            rustup toolchain install "$rust" "${args[@]}"
+            rustup override set "$rust"
           fi
           rustup show active-toolchain
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.85.0
+          - 1.88.0
           - stable
           - beta
         experimental:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,21 +13,17 @@ concurrency:
 
 jobs:
   test:
-    name: ${{ matrix.name }}
+    name: Test
     strategy:
       matrix:
+        rust:
+          - 1.88.0
+          - stable
+          - beta
+        experimental:
+          - false
         include:
-          - name: MSRV
-            rust: msrv
-            experimental: false
-          - name: Stable
-            rust: stable
-            experimental: false
-          - name: Beta
-            rust: beta
-            experimental: false
-          - name: Nightly
-            rust: nightly
+          - rust: nightly
             experimental: true
     continue-on-error: ${{ matrix.experimental }}
     runs-on: ubuntu-latest
@@ -37,21 +33,15 @@ jobs:
       - name: Setup Rust toolchain
         shell: bash
         run: |
-          rust="${{ matrix.rust }}"
-          if [[ "$rust" == "msrv" ]]; then
-            rust="$(sed -n 's/^rust-version = "\(.*\)"$/\1/p' Cargo.toml)"
-            test -n "$rust"
-          fi
-
-          if [[ "$rust" == "stable" ]]; then
+          if [[ "${{ matrix.rust }}" == "stable" ]]; then
             rustup component add rustfmt clippy
           else
             args=(--component rustfmt --component clippy)
-            if [[ "$rust" == "nightly" ]]; then
+            if [[ "${{ matrix.rust }}" == "nightly" ]]; then
               args+=(--allow-downgrade)
             fi
-            rustup toolchain install "$rust" "${args[@]}"
-            rustup override set "$rust"
+            rustup toolchain install "${{ matrix.rust }}" "${args[@]}"
+            rustup override set "${{ matrix.rust }}"
           fi
           rustup show active-toolchain
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,4 +146,4 @@ authors = ["Salsa developers"]
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/salsa-rs/salsa"
-rust-version = "1.85"
+rust-version = "1.88"

--- a/benches/accumulator.rs
+++ b/benches/accumulator.rs
@@ -37,11 +37,11 @@ fn root(db: &dyn salsa::Database, input: Input) -> Vec<usize> {
 fn infer_expression<'db>(db: &'db dyn salsa::Database, expression: Expression<'db>) -> usize {
     let number = expression.number(db);
 
-    if number % 10 == 0 {
+    if number.is_multiple_of(10) {
         Diagnostic(format!("Number is {number}")).accumulate(db);
     }
 
-    if number != 0 && number % 2 == 0 {
+    if number != 0 && number.is_multiple_of(2) {
         let sub_expression = Expression::new(db, number / 2);
         let _ = infer_expression(db, sub_expression);
     }

--- a/benches/eviction_walltime.rs
+++ b/benches/eviction_walltime.rs
@@ -151,7 +151,9 @@ fn scan_resistance(bencher: divan::Bencher, policy: Policy) {
                 let mut accesses = Vec::with_capacity(HOT_ITEMS + ITEMS_PER_ROUND);
 
                 // Mix three reusable entries with every two one-shot entries.
-                for (hot_chunk, cold_chunk) in hot.chunks_exact(3).zip(cold.chunks_exact(2)) {
+                for (hot_chunk, cold_chunk) in
+                    hot.as_chunks::<3>().0.iter().zip(cold.as_chunks::<2>().0)
+                {
                     accesses.extend_from_slice(hot_chunk);
                     accesses.extend_from_slice(cold_chunk);
                 }

--- a/components/salsa-macros/src/fn_util.rs
+++ b/components/salsa-macros/src/fn_util.rs
@@ -9,10 +9,10 @@ pub fn input_ids(hygiene: &Hygiene, sig: &syn::Signature, skip: usize) -> Vec<sy
         .skip(skip)
         .zip(0..)
         .map(|(input, index)| {
-            if let syn::FnArg::Typed(typed) = input {
-                if let syn::Pat::Ident(ident) = &*typed.pat {
-                    return ident.ident.clone();
-                }
+            if let syn::FnArg::Typed(typed) = input
+                && let syn::Pat::Ident(ident) = &*typed.pat
+            {
+                return ident.ident.clone();
             }
 
             hygiene.ident(format!("input{index}"))

--- a/components/salsa-macros/src/salsa_value.rs
+++ b/components/salsa-macros/src/salsa_value.rs
@@ -135,10 +135,10 @@ fn type_uses_type_param(ty: &syn::Type, type_params: &HashSet<syn::Ident>) -> bo
 
     impl<'ast> Visit<'ast> for UsesTypeParam<'_> {
         fn visit_type_path(&mut self, path: &'ast syn::TypePath) {
-            if path.qself.is_none() {
-                if let Some(segment) = path.path.segments.first() {
-                    self.result |= self.type_params.contains(&segment.ident);
-                }
+            if path.qself.is_none()
+                && let Some(segment) = path.path.segments.first()
+            {
+                self.result |= self.type_params.contains(&segment.ident);
             }
 
             if !self.result {

--- a/components/salsa-macros/src/tracked_fn.rs
+++ b/components/salsa-macros/src/tracked_fn.rs
@@ -400,13 +400,13 @@ pub fn check_db_argument<'arg>(
                 return Err(syn::Error::new(typed.ty.span(), tykind_error_msg));
             };
 
-            if let Some(lt) = explicit_lt {
-                if ref_type.lifetime.is_none() {
-                    return Err(syn::Error::new_spanned(
-                        ref_type.and_token,
-                        format!("must have a `{}` lifetime", lt.lifetime.to_token_stream()),
-                    ));
-                }
+            if let Some(lt) = explicit_lt
+                && ref_type.lifetime.is_none()
+            {
+                return Err(syn::Error::new_spanned(
+                    ref_type.and_token,
+                    format!("must have a `{}` lifetime", lt.lifetime.to_token_stream()),
+                ));
             }
 
             let extract_db_path = || -> Result<&'arg syn::Path, Span> {

--- a/components/salsa-macros/src/xform.rs
+++ b/components/salsa-macros/src/xform.rs
@@ -126,12 +126,11 @@ impl syn::visit_mut::VisitMut for ChangeSelfPath<'_> {
         if let syn::Type::Path(syn::TypePath {
             qself: None, path, ..
         }) = i
+            && path.segments.len() == 1
+            && path.segments.first().is_some_and(|s| s.ident == "Self")
         {
-            if path.segments.len() == 1 && path.segments.first().is_some_and(|s| s.ident == "Self")
-            {
-                let span = path.segments.first().unwrap().span();
-                *i = respan(self.self_ty, span);
-            }
+            let span = path.segments.first().unwrap().span();
+            *i = respan(self.self_ty, span);
         }
         syn::visit_mut::visit_type_mut(self, i);
     }

--- a/components/salsa-macros/src/xform.rs
+++ b/components/salsa-macros/src/xform.rs
@@ -127,10 +127,10 @@ impl syn::visit_mut::VisitMut for ChangeSelfPath<'_> {
             qself: None, path, ..
         }) = i
             && path.segments.len() == 1
-            && path.segments.first().is_some_and(|s| s.ident == "Self")
+            && let Some(segment) = path.segments.first()
+            && segment.ident == "Self"
         {
-            let span = path.segments.first().unwrap().span();
-            *i = respan(self.self_ty, span);
+            *i = respan(self.self_ty, segment.span());
         }
         syn::visit_mut::visit_type_mut(self, i);
     }

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -75,11 +75,11 @@ impl Attached {
             #[inline]
             fn drop(&mut self) {
                 // Reset database to null if we did anything in `DbGuard::new`.
-                if let Some(attached) = self.state {
-                    if let Some(prev) = attached.database.replace(None) {
-                        // SAFETY: `prev` is a valid pointer to a database.
-                        unsafe { prev.as_ref().zalsa_local().uncancel() };
-                    }
+                if let Some(attached) = self.state
+                    && let Some(prev) = attached.database.replace(None)
+                {
+                    // SAFETY: `prev` is a valid pointer to a database.
+                    unsafe { prev.as_ref().zalsa_local().uncancel() };
                 }
             }
         }
@@ -141,11 +141,11 @@ impl Attached {
             #[inline]
             fn drop(&mut self) {
                 // Reset database to null if we did anything in `DbGuard::new`.
-                if let Some(attached) = self.state {
-                    if let Some(prev) = attached.database.replace(self.prev) {
-                        // SAFETY: `prev` is a valid pointer to a database.
-                        unsafe { prev.as_ref().zalsa_local().uncancel() };
-                    }
+                if let Some(attached) = self.state
+                    && let Some(prev) = attached.database.replace(self.prev)
+                {
+                    // SAFETY: `prev` is a valid pointer to a database.
+                    unsafe { prev.as_ref().zalsa_local().uncancel() };
                 }
             }
         }

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -143,22 +143,22 @@ where
         // fixpoint queries: a memo from an abandoned cancellation epoch in this revision doesn't
         // seed the retry, while a memo from an older revision remains useful for backdating and
         // output bookkeeping. Cancellation counts are only comparable within a revision.
-        if let Some(old_memo) = opt_old_memo {
-            if old_memo.header.verified_at.load() == current_revision {
-                match old_memo.header.previous_iteration(
-                    database_key_index,
-                    cancellation_count,
-                    old_memo.value.is_some(),
-                ) {
-                    Some(previous_iteration) => {
-                        if previous_iteration.reuse_as_provisional {
-                            last_provisional_memo_opt = Some(old_memo);
-                        }
-
-                        iteration = previous_iteration.iteration;
+        if let Some(old_memo) = opt_old_memo
+            && old_memo.header.verified_at.load() == current_revision
+        {
+            match old_memo.header.previous_iteration(
+                database_key_index,
+                cancellation_count,
+                old_memo.value.is_some(),
+            ) {
+                Some(previous_iteration) => {
+                    if previous_iteration.reuse_as_provisional {
+                        last_provisional_memo_opt = Some(old_memo);
                     }
-                    None => opt_old_memo = None,
+
+                    iteration = previous_iteration.iteration;
                 }
+                None => opt_old_memo = None,
             }
         }
 

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -138,20 +138,19 @@ where
         // Now that we've claimed the item, check again to see if there's a "hot" value.
         let opt_old_memo = self.get_memo_from_table_for(zalsa, id, memo_ingredient_index);
 
-        if let Some(old_memo) = opt_old_memo {
-            if old_memo.value.is_some()
-                && old_memo.header.verify_memo(
-                    db.into(),
-                    &claim_guard,
-                    C::CYCLE_STRATEGY,
-                    #[cfg(feature = "detailed-trace")]
-                    true,
-                )
-            {
-                // SAFETY: memo is present in memo_map and we have verified that it is
-                // still valid for the current revision.
-                return unsafe { Some(self.extend_memo_lifetime(old_memo)) };
-            }
+        if let Some(old_memo) = opt_old_memo
+            && old_memo.value.is_some()
+            && old_memo.header.verify_memo(
+                db.into(),
+                &claim_guard,
+                C::CYCLE_STRATEGY,
+                #[cfg(feature = "detailed-trace")]
+                true,
+            )
+        {
+            // SAFETY: memo is present in memo_map and we have verified that it is
+            // still valid for the current revision.
+            return unsafe { Some(self.extend_memo_lifetime(old_memo)) };
         }
 
         self.execute(db, claim_guard, opt_old_memo)

--- a/src/function/specify.rs
+++ b/src/function/specify.rs
@@ -86,23 +86,24 @@ where
         // specification can replace it while we decide whether to keep or overwrite it.
         let old_memo = self.get_memo_from_table_for(zalsa, key, memo_ingredient_index);
 
-        if let Some(old_memo) = old_memo {
-            if old_memo.header.verified_at.load() == revision && old_memo.value.is_some() {
-                // A value produced by another query wins this revision.
-                let QueryOriginRef::Assigned(owner) = old_memo.header.origin() else {
-                    return;
-                };
-                debug_assert_eq!(owner, active_query_key);
+        if let Some(old_memo) = old_memo
+            && old_memo.header.verified_at.load() == revision
+            && old_memo.value.is_some()
+        {
+            // A value produced by another query wins this revision.
+            let QueryOriginRef::Assigned(owner) = old_memo.header.origin() else {
+                return;
+            };
+            debug_assert_eq!(owner, active_query_key);
 
-                let first_assignment_in_execution = zalsa_local.add_output(database_key_index);
-                // Outputs from a prior provisional iteration are seeded into the active query,
-                // so they don't count as duplicate calls in this execution.
-                if cycle_heads.is_empty()
-                    && !old_memo.header.was_cycle_participant()
-                    && !first_assignment_in_execution
-                {
-                    panic!("cannot call `specify` twice for the same key in one query execution");
-                }
+            let first_assignment_in_execution = zalsa_local.add_output(database_key_index);
+            // Outputs from a prior provisional iteration are seeded into the active query,
+            // so they don't count as duplicate calls in this execution.
+            if cycle_heads.is_empty()
+                && !old_memo.header.was_cycle_participant()
+                && !first_assignment_in_execution
+            {
+                panic!("cannot call `specify` twice for the same key in one query execution");
             }
         }
 

--- a/src/runtime/dependency_graph.rs
+++ b/src/runtime/dependency_graph.rs
@@ -421,8 +421,7 @@ impl DependencyGraph {
                     edge.blocked_on_id = new_owner_thread;
                     debug_assert!(
                         !edges.depends_on(new_owner_thread, *dependent),
-                        "Circular reference between blocked edges: {:#?}",
-                        edges
+                        "Circular reference between blocked edges: {edges:#?}"
                     );
                 }
             };

--- a/src/table.rs
+++ b/src/table.rs
@@ -419,21 +419,21 @@ impl Iterator for ErasedSlots<'_> {
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            if let Some((page_index, page, slots)) = &mut self.current_page {
-                if let Some(slot_index) = slots.next() {
-                    let slot_index = SlotIndex::new(slot_index);
-                    let id = make_id(*page_index, slot_index);
+            if let Some((page_index, page, slots)) = &mut self.current_page
+                && let Some(slot_index) = slots.next()
+            {
+                let slot_index = SlotIndex::new(slot_index);
+                let id = make_id(*page_index, slot_index);
 
-                    // SAFETY: `slot_index` is below the initialized length captured when the page
-                    // became current, so the resulting pointer is within the page allocation.
-                    let slot = unsafe {
-                        page.data
-                            .as_ptr()
-                            .byte_add(slot_index.0 * page.slot_vtable.layout.size())
-                    };
+                // SAFETY: `slot_index` is below the initialized length captured when the page
+                // became current, so the resulting pointer is within the page allocation.
+                let slot = unsafe {
+                    page.data
+                        .as_ptr()
+                        .byte_add(slot_index.0 * page.slot_vtable.layout.size())
+                };
 
-                    return Some((id, slot));
-                }
+                return Some((id, slot));
             }
 
             self.current_page = self.pages.find_map(|(page_index, page)| {

--- a/tests/parallel/cancellation_token_multi_blocked.rs
+++ b/tests/parallel/cancellation_token_multi_blocked.rs
@@ -76,8 +76,7 @@ fn multiple_threads_blocked_on_cancelled() {
     let r1_cancelled = r1.unwrap_err().downcast::<salsa::Cancelled>().map(|c| *c);
     assert!(
         matches!(r1_cancelled, Ok(Cancelled::Local)),
-        "t1 should be locally cancelled, got: {:?}",
-        r1_cancelled
+        "t1 should be locally cancelled, got: {r1_cancelled:?}"
     );
 
     // t2 and t3 should both succeed with the correct value

--- a/tests/parallel/cycle_nested_deep_panic.rs
+++ b/tests/parallel/cycle_nested_deep_panic.rs
@@ -114,14 +114,12 @@ where
     if let Some(message) = err.downcast_ref::<&str>() {
         assert!(
             message.contains("set cycle_fn/cycle_initial to fixpoint iterate"),
-            "Expected error message to contain 'set cycle_fn/cycle_initial to fixpoint iterate', but got: {}",
-            message
+            "Expected error message to contain 'set cycle_fn/cycle_initial to fixpoint iterate', but got: {message}"
         );
     } else if let Some(message) = err.downcast_ref::<String>() {
         assert!(
             message.contains("set cycle_fn/cycle_initial to fixpoint iterate"),
-            "Expected error message to contain 'set cycle_fn/cycle_initial to fixpoint iterate', but got: {}",
-            message
+            "Expected error message to contain 'set cycle_fn/cycle_initial to fixpoint iterate', but got: {message}"
         );
     } else if err.downcast_ref::<salsa::Cancelled>().is_some() {
         // This is okay, because Salsa throws a Cancelled::PropagatedPanic when a panic occurs in a query

--- a/tests/parallel/lru_eviction_cancels_cycle.rs
+++ b/tests/parallel/lru_eviction_cancels_cycle.rs
@@ -86,8 +86,7 @@ fn lru_eviction_recomputes_cycle_query() {
     let err = r1.unwrap_err();
     assert!(
         err.downcast_ref::<Cancelled>().is_some(),
-        "Thread 1 should have been cancelled, got: {:?}",
-        err
+        "Thread 1 should have been cancelled, got: {err:?}"
     );
 
     // Thread 2 should complete successfully


### PR DESCRIPTION
Bump the workspace MSRV from Rust 1.85 to 1.88.

trybuild now requires 1.88; it also gives us dyn trait upcasting and let chains. Rust 1.88 was released in June 2025.

