### PR TITLE
refactor: replace generic database access with trait upcasting

### DIFF
--- a/benches/creation.rs
+++ b/benches/creation.rs
@@ -20,7 +20,8 @@ fn input_create_many(bencher: divan::Bencher, inputs: usize) {
         })
         .bench_local_refs(|db| {
             for value in 0..inputs {
-                let input = InputValue::new(black_box(&*db), black_box(value));
+                let db: &salsa::DatabaseImpl = black_box(&*db);
+                let input = InputValue::new(db, black_box(value));
                 black_box(input);
             }
         });

--- a/components/salsa-macro-rules/src/setup_accumulator_impl.rs
+++ b/components/salsa-macro-rules/src/setup_accumulator_impl.rs
@@ -42,10 +42,7 @@ macro_rules! setup_accumulator_impl {
             impl $zalsa::Accumulator for $Struct {
                 const DEBUG_NAME: &'static str = stringify!($Struct);
 
-                fn accumulate<Db>(self, db: &Db)
-                where
-                    Db: ?Sized + $zalsa::Database,
-                {
+                fn accumulate(self, db: &dyn $zalsa::Database) {
                     let (zalsa, zalsa_local) = db.zalsas();
                     $ingredient(zalsa).push(zalsa_local, self);
                 }

--- a/components/salsa-macro-rules/src/setup_input_struct.rs
+++ b/components/salsa-macro-rules/src/setup_input_struct.rs
@@ -251,11 +251,7 @@ macro_rules! setup_input_struct {
             }
             impl $Struct {
                 #[inline]
-                pub fn $new_fn<$Db>(db: &$Db, $($required_field_id: $required_field_ty),*) -> Self
-                where
-                    // FIXME(rust-lang/rust#65991): The `db` argument *should* have the type `dyn Database`
-                    $Db: ?Sized + salsa::Database,
-                {
+                pub fn $new_fn(db: &dyn $zalsa::Database, $($required_field_id: $required_field_ty),*) -> Self {
                     Self::builder($($required_field_id,)*).new(db)
                 }
 
@@ -266,11 +262,7 @@ macro_rules! setup_input_struct {
 
                 $(
                     $(#[$field_attr])*
-                    $field_getter_vis fn $field_getter_id<'db, $Db>(self, db: &'db $Db) -> $zalsa::return_mode_ty!($field_option, 'db, $field_ty)
-                    where
-                        // FIXME(rust-lang/rust#65991): The `db` argument *should* have the type `dyn Database`
-                        $Db: ?Sized + $zalsa::Database,
-                    {
+                    $field_getter_vis fn $field_getter_id<'db>(self, db: &'db dyn $zalsa::Database) -> $zalsa::return_mode_ty!($field_option, 'db, $field_ty) {
                         let (zalsa, zalsa_local) = db.zalsas();
                         let fields = $Configuration::ingredient_(zalsa).field(
                             zalsa,
@@ -288,11 +280,7 @@ macro_rules! setup_input_struct {
 
                 $(
                     #[must_use]
-                    $field_setter_vis fn $field_setter_id<'db, $Db>(self, db: &'db mut $Db) -> impl salsa::Setter<FieldTy = $field_ty>
-                    where
-                        // FIXME(rust-lang/rust#65991): The `db` argument *should* have the type `dyn Database`
-                        $Db: ?Sized + $zalsa::Database,
-                    {
+                    $field_setter_vis fn $field_setter_id<'db>(self, db: &'db mut dyn $zalsa::Database) -> impl salsa::Setter<FieldTy = $field_ty> {
                         let zalsa = db.zalsa_mut();
                         let (ingredient, revision) = $Configuration::ingredient_mut(zalsa);
                         $zalsa::input::SetterImpl::new(
@@ -306,21 +294,13 @@ macro_rules! setup_input_struct {
                 )*
 
                 $zalsa::macro_if! { $is_singleton =>
-                    pub fn try_get<$Db>(db: &$Db) -> Option<Self>
-                    where
-                        // FIXME(rust-lang/rust#65991): The `db` argument *should* have the type `dyn Database`
-                        $Db: ?Sized + salsa::Database,
-                    {
+                    pub fn try_get(db: &dyn $zalsa::Database) -> Option<Self> {
                         let zalsa = db.zalsa();
                         $Configuration::ingredient_(zalsa).get_singleton_input(zalsa)
                     }
 
                     #[track_caller]
-                    pub fn get<$Db>(db: &$Db) -> Self
-                    where
-                        // FIXME(rust-lang/rust#65991): The `db` argument *should* have the type `dyn Database`
-                        $Db: ?Sized + salsa::Database,
-                    {
+                    pub fn get(db: &dyn $zalsa::Database) -> Self {
                         Self::try_get(db).unwrap()
                     }
                 }
@@ -358,11 +338,7 @@ macro_rules! setup_input_struct {
             impl builder::$Builder {
                 /// Creates the new input with the set values.
                 #[must_use]
-                pub fn new<$Db>(self, db: &$Db) -> $Struct
-                where
-                    // FIXME(rust-lang/rust#65991): The `db` argument *should* have the type `dyn Database`
-                    $Db: ?Sized + ::salsa::Database
-                {
+                pub fn new(self, db: &dyn $zalsa::Database) -> $Struct {
                     let (zalsa, zalsa_local) = db.zalsas();
                     let current_revision = zalsa.current_revision();
                     let ingredient = $Configuration::ingredient_(zalsa);

--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -303,10 +303,8 @@ macro_rules! setup_interned_struct {
             unsafe impl< $($db_lt_arg)? > $zalsa::SalsaValue for $Struct< $($db_lt_arg)? > {}
 
             impl<$db_lt> $Struct< $($db_lt_arg)? >  {
-                pub fn $new_fn<$Db, $($indexed_ty: $zalsa::Lookup<$field_ty> + ::std::hash::Hash,)*>(db: &$db_lt $Db,  $($field_id: $indexed_ty),*) -> Self
+                pub fn $new_fn<$($indexed_ty: $zalsa::Lookup<$field_ty> + ::std::hash::Hash,)*>(db: &$db_lt dyn $zalsa::Database,  $($field_id: $indexed_ty),*) -> Self
                 where
-                    // FIXME(rust-lang/rust#65991): The `db` argument *should* have the type `dyn Database`
-                    $Db: ?Sized + ::salsa::Database,
                     $(
                         $field_ty: $zalsa::HashEqLike<$indexed_ty>,
                     )*
@@ -318,11 +316,7 @@ macro_rules! setup_interned_struct {
 
                 $(
                     $(#[$field_attr])*
-                    $field_getter_vis fn $field_getter_id<$Db>(self, db: &'db $Db) -> $zalsa::return_mode_ty!($field_option, 'db, $field_ty)
-                    where
-                        // FIXME(rust-lang/rust#65991): The `db` argument *should* have the type `dyn Database`
-                        $Db: ?Sized + $zalsa::Database,
-                    {
+                    $field_getter_vis fn $field_getter_id(self, db: &'db dyn $zalsa::Database) -> $zalsa::return_mode_ty!($field_option, 'db, $field_ty) {
                         let zalsa = db.zalsa();
                         let fields = $Configuration::ingredient(zalsa).fields(zalsa, self);
                         $zalsa::return_mode_expression!(

--- a/components/salsa-macro-rules/src/setup_tracked_struct.rs
+++ b/components/salsa-macro-rules/src/setup_tracked_struct.rs
@@ -341,11 +341,7 @@ macro_rules! setup_tracked_struct {
             unsafe impl $zalsa::SalsaValue for $Struct<'_> {}
 
             impl<$db_lt> $Struct<$db_lt> {
-                pub fn $new_fn<$Db>(db: &$db_lt $Db, $($field_id: $field_ty),*) -> Self
-                where
-                    // FIXME(rust-lang/rust#65991): The `db` argument *should* have the type `dyn Database`
-                    $Db: ?Sized + $zalsa::Database,
-                {
+                pub fn $new_fn(db: &$db_lt dyn $zalsa::Database, $($field_id: $field_ty),*) -> Self {
                     let (zalsa, zalsa_local) = db.zalsas();
                     $Configuration::ingredient_(zalsa).new_struct(
                         zalsa,zalsa_local,
@@ -355,11 +351,7 @@ macro_rules! setup_tracked_struct {
 
                 $(
                     $(#[$tracked_field_attr])*
-                    $tracked_getter_vis fn $tracked_getter_id<$Db>(self, db: &$db_lt $Db) -> $crate::return_mode_ty!($tracked_option, $db_lt, $tracked_ty)
-                    where
-                        // FIXME(rust-lang/rust#65991): The `db` argument *should* have the type `dyn Database`
-                        $Db: ?Sized + $zalsa::Database,
-                    {
+                    $tracked_getter_vis fn $tracked_getter_id(self, db: &$db_lt dyn $zalsa::Database) -> $crate::return_mode_ty!($tracked_option, $db_lt, $tracked_ty) {
                         let (zalsa, zalsa_local) = db.zalsas();
                         let fields = $Configuration::ingredient_(zalsa).tracked_field(zalsa, zalsa_local, self, $relative_tracked_index);
                         $crate::return_mode_expression!(
@@ -372,11 +364,7 @@ macro_rules! setup_tracked_struct {
 
                 $(
                     $(#[$untracked_field_attr])*
-                    $untracked_getter_vis fn $untracked_getter_id<$Db>(self, db: &$db_lt $Db) -> $crate::return_mode_ty!($untracked_option, $db_lt, $untracked_ty)
-                    where
-                        // FIXME(rust-lang/rust#65991): The `db` argument *should* have the type `dyn Database`
-                        $Db: ?Sized + $zalsa::Database,
-                    {
+                    $untracked_getter_vis fn $untracked_getter_id(self, db: &$db_lt dyn $zalsa::Database) -> $crate::return_mode_ty!($untracked_option, $db_lt, $untracked_ty) {
                         let zalsa = db.zalsa();
                         let fields = $Configuration::ingredient_(zalsa).untracked_field(zalsa, self);
                         $crate::return_mode_expression!(

--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use std::marker::PhantomData;
 use std::panic::UnwindSafe;
 
-use accumulated::{Accumulated, AnyAccumulated};
+use accumulated::Accumulated;
 
 use crate::function::VerifyResult;
 use crate::hash::{FxHashSet, FxIndexSet};
@@ -26,9 +26,7 @@ pub trait Accumulator: Send + Sync + Any + Sized + UnwindSafe {
     const DEBUG_NAME: &'static str;
 
     /// Accumulate an instance of this in the database for later retrieval.
-    fn accumulate<Db>(self, db: &Db)
-    where
-        Db: ?Sized + Database;
+    fn accumulate(self, db: &dyn Database);
 }
 
 pub struct JarImpl<A: Accumulator> {

--- a/src/accumulator/accumulated.rs
+++ b/src/accumulator/accumulated.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::fmt::Debug;
 
 use crate::accumulator::Accumulator;
@@ -6,11 +5,6 @@ use crate::accumulator::Accumulator;
 #[derive(Clone, Debug)]
 pub(crate) struct Accumulated<A: Accumulator> {
     values: Vec<A>,
-}
-
-pub(crate) trait AnyAccumulated: Any + Send + Sync {
-    fn as_dyn_any(&self) -> &dyn Any;
-    fn as_dyn_any_mut(&mut self) -> &mut dyn Any;
 }
 
 impl<A: Accumulator> Accumulated<A> {
@@ -28,27 +22,5 @@ impl<A: Accumulator> Default for Accumulated<A> {
         Self {
             values: Default::default(),
         }
-    }
-}
-
-impl<A> AnyAccumulated for Accumulated<A>
-where
-    A: Accumulator,
-{
-    fn as_dyn_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_dyn_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-}
-
-impl dyn AnyAccumulated {
-    pub fn accumulate<A: Accumulator>(&mut self, value: A) {
-        self.as_dyn_any_mut()
-            .downcast_mut::<Accumulated<A>>()
-            .unwrap()
-            .push(value);
     }
 }

--- a/src/accumulator/accumulated_map.rs
+++ b/src/accumulator/accumulated_map.rs
@@ -1,15 +1,16 @@
+use std::any::Any;
 use std::ops;
 
 use rustc_hash::FxBuildHasher;
 
 use crate::IngredientIndex;
+use crate::accumulator::Accumulator;
 use crate::accumulator::accumulated::Accumulated;
-use crate::accumulator::{Accumulator, AnyAccumulated};
 use crate::sync::atomic::{AtomicBool, Ordering};
 
 #[derive(Default)]
 pub struct AccumulatedMap {
-    map: hashbrown::HashMap<IngredientIndex, Box<dyn AnyAccumulated>, FxBuildHasher>,
+    map: hashbrown::HashMap<IngredientIndex, Box<dyn Any + Send + Sync>, FxBuildHasher>,
 }
 
 impl std::fmt::Debug for AccumulatedMap {
@@ -25,7 +26,9 @@ impl AccumulatedMap {
         self.map
             .entry(index)
             .or_insert_with(|| <Box<Accumulated<A>>>::default())
-            .accumulate(value);
+            .downcast_mut::<Accumulated<A>>()
+            .unwrap()
+            .push(value);
     }
 
     pub fn extend_with_accumulated<'slf, A: Accumulator>(
@@ -37,8 +40,7 @@ impl AccumulatedMap {
             return;
         };
 
-        a.as_dyn_any()
-            .downcast_ref::<Accumulated<A>>()
+        a.downcast_ref::<Accumulated<A>>()
             .unwrap()
             .extend_with_accumulated(output);
     }

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -35,10 +35,7 @@ impl Attached {
     }
 
     #[inline]
-    fn attach<Db, R>(&self, db: &Db, op: impl FnOnce() -> R) -> R
-    where
-        Db: ?Sized + Database,
-    {
+    fn attach<R>(&self, db: &dyn Database, op: impl FnOnce() -> R) -> R {
         struct DbGuard<'s> {
             /// The database that *we* attached on scope entry.
             ///
@@ -84,15 +81,12 @@ impl Attached {
             }
         }
 
-        let _guard = DbGuard::new(self, db.as_dyn_database());
+        let _guard = DbGuard::new(self, db);
         op()
     }
 
     #[inline]
-    fn attach_allow_change<Db, R>(&self, db: &Db, op: impl FnOnce() -> R) -> R
-    where
-        Db: ?Sized + Database,
-    {
+    fn attach_allow_change<R>(&self, db: &dyn Database, op: impl FnOnce() -> R) -> R {
         struct DbGuard<'s> {
             /// The database that *we* attached on scope entry.
             ///
@@ -150,7 +144,7 @@ impl Attached {
             }
         }
 
-        let _guard = DbGuard::new(self, db.as_dyn_database());
+        let _guard = DbGuard::new(self, db);
         op()
     }
 
@@ -169,10 +163,7 @@ impl Attached {
 /// Attach the database to the current thread and execute `op`.
 /// Panics if a different database has already been attached.
 #[inline]
-pub fn attach<R, Db>(db: &Db, op: impl FnOnce() -> R) -> R
-where
-    Db: ?Sized + Database,
-{
+pub fn attach<R>(db: &dyn Database, op: impl FnOnce() -> R) -> R {
     ATTACHED.with(
         #[inline]
         |a| a.attach(db, op),
@@ -186,10 +177,7 @@ where
 /// **Note:** Switching databases can cause bugs. If you do not intend to switch
 /// databases, prefer [`attach`] which will panic if you accidentally do.
 #[inline]
-pub fn attach_allow_change<R, Db>(db: &Db, op: impl FnOnce() -> R) -> R
-where
-    Db: ?Sized + Database,
-{
+pub fn attach_allow_change<R>(db: &dyn Database, op: impl FnOnce() -> R) -> R {
     ATTACHED.with(
         #[inline]
         |a| a.attach_allow_change(db, op),

--- a/src/database.rs
+++ b/src/database.rs
@@ -35,7 +35,7 @@ impl<'db, Db: Database + ?Sized> From<&'db mut Db> for RawDatabase<'db> {
 
 /// The trait implemented by all Salsa databases.
 /// You can create your own subtraits of this trait using the `#[salsa::db]`(`crate::db`) procedural macro.
-pub trait Database: Send + ZalsaDatabase + AsDynDatabase {
+pub trait Database: Send + ZalsaDatabase {
     /// Enforces current LRU limits, evicting entries if necessary.
     ///
     /// **WARNING:** Just like an ordinary write, this method triggers
@@ -145,21 +145,7 @@ pub trait Database: Send + ZalsaDatabase + AsDynDatabase {
     }
 }
 
-/// Upcast to a `dyn Database`.
-///
-/// Only required because upcasting does not work for unsized generic parameters.
-pub trait AsDynDatabase {
-    fn as_dyn_database(&self) -> &dyn Database;
-}
-
-impl<T: Database> AsDynDatabase for T {
-    #[inline(always)]
-    fn as_dyn_database(&self) -> &dyn Database {
-        self
-    }
-}
-
-pub fn current_revision<Db: ?Sized + Database>(db: &Db) -> Revision {
+pub fn current_revision(db: &dyn Database) -> Revision {
     db.zalsa().current_revision()
 }
 

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -7,7 +7,7 @@ use crate::hash::{FxHashSet, FxIndexSet};
 use crate::sync::Arc;
 use crate::table::Table;
 use crate::table::memo::MemoTableTypes;
-use crate::zalsa::{IngredientIndex, JarKind, Zalsa, transmute_data_mut_ptr, transmute_data_ptr};
+use crate::zalsa::{IngredientIndex, JarKind, Zalsa};
 use crate::zalsa_local::QueryEdge;
 use crate::{DatabaseKeyIndex, Id, Revision};
 
@@ -218,25 +218,17 @@ pub trait Ingredient: Any + fmt::Debug + Send + Sync {
 }
 
 impl dyn Ingredient {
-    /// Equivalent to the `downcast` method on `Any`.
-    ///
-    /// Because we do not have dyn-downcasting support, we need this workaround.
+    /// Downcasts this ingredient to `T`, panicking if it has a different type.
     pub fn assert_type<T: Any>(&self) -> &T {
-        assert_eq!(
-            self.type_id(),
-            TypeId::of::<T>(),
-            "ingredient `{self:?}` is not of type `{}`",
-            std::any::type_name::<T>()
-        );
-
-        // SAFETY: We know that the underlying data pointer
-        // refers to a value of type T because of the `TypeId` check above.
-        unsafe { transmute_data_ptr(self) }
+        (self as &dyn Any).downcast_ref::<T>().unwrap_or_else(|| {
+            panic!(
+                "ingredient `{self:?}` is not of type `{}`",
+                std::any::type_name::<T>()
+            )
+        })
     }
 
-    /// Equivalent to the `downcast` methods on `Any`.
-    ///
-    /// Because we do not have dyn-downcasting support, we need this workaround.
+    /// Downcasts this ingredient to `T` without checking its type in release builds.
     ///
     /// # Safety
     ///
@@ -249,24 +241,15 @@ impl dyn Ingredient {
             std::any::type_name::<T>()
         );
 
-        // SAFETY: Guaranteed by caller.
-        unsafe { transmute_data_ptr(self) }
+        // SAFETY: The caller guarantees that this ingredient has type `T`.
+        unsafe { &*std::ptr::from_ref(self).cast::<T>() }
     }
 
-    /// Equivalent to the `downcast` method on `Any`.
-    ///
-    /// Because we do not have dyn-downcasting support, we need this workaround.
+    /// Downcasts this ingredient to `T`, panicking if it has a different type.
     pub fn assert_type_mut<T: Any>(&mut self) -> &mut T {
-        assert_eq!(
-            Any::type_id(self),
-            TypeId::of::<T>(),
-            "ingredient `{self:?}` is not of type `{}`",
-            std::any::type_name::<T>()
-        );
-
-        // SAFETY: We know that the underlying data pointer
-        // refers to a value of type T because of the `TypeId` check above.
-        unsafe { transmute_data_mut_ptr(self) }
+        (self as &mut dyn Any)
+            .downcast_mut::<T>()
+            .unwrap_or_else(|| panic!("ingredient is not of type `{}`", std::any::type_name::<T>()))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,8 +371,7 @@ pub mod plumbing {
     pub use crate::tracked_struct::{TrackedStructInDb, update_field};
     pub use crate::views::DatabaseDownCaster;
     pub use crate::zalsa::{
-        ErasedJar, HasJar, IngredientIndex, JarKind, Zalsa, ZalsaDatabase, register_jar,
-        transmute_data_ptr, views,
+        ErasedJar, HasJar, IngredientIndex, JarKind, Zalsa, ZalsaDatabase, register_jar, views,
     };
     pub use crate::zalsa_local::ZalsaLocal;
 

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -51,7 +51,7 @@ pub unsafe trait ZalsaDatabase: Any {
     fn zalsa_local(&self) -> &ZalsaLocal;
 }
 
-pub fn views<Db: ?Sized + Database>(db: &Db) -> &Views {
+pub fn views(db: &dyn Database) -> &Views {
     db.zalsa().views()
 }
 /// Nonce type representing the underlying database storage.
@@ -567,27 +567,3 @@ macro_rules! register_jar {
 
 #[cfg(not(feature = "inventory"))]
 pub use crate::register_jar;
-
-/// Given a wide pointer `T`, extracts the data pointer (typed as `U`).
-///
-/// # Safety
-///
-/// `U` must be correct type for the data pointer.
-pub unsafe fn transmute_data_ptr<T: ?Sized, U>(t: &T) -> &U {
-    let t: *const T = t;
-    let u: *const U = t as *const U;
-    // SAFETY: the caller must guarantee that `T` is a wide pointer for `U`
-    unsafe { &*u }
-}
-
-/// Given a wide pointer `T`, extracts the data pointer (typed as `U`).
-///
-/// # Safety
-///
-/// `U` must be correct type for the data pointer.
-pub(crate) unsafe fn transmute_data_mut_ptr<T: ?Sized, U>(t: &mut T) -> &mut U {
-    let t: *mut T = t;
-    let u: *mut U = t as *mut U;
-    // SAFETY: the caller must guarantee that `T` is a wide pointer for `U`
-    unsafe { &mut *u }
-}

--- a/tests/compile-fail/interned_struct_unknown_attribute.stderr
+++ b/tests/compile-fail/interned_struct_unknown_attribute.stderr
@@ -1,10 +1,10 @@
-error: only a single lifetime parameter is accepted
+error: #[salsa::tracked] must also be applied to the impl block for tracked methods
  --> tests/compile-fail/interned_struct_unknown_attribute.rs:1:1
   |
 1 | #[salsa::interned]
   | ^^^^^^^^^^^^^^^^^^
   |
-  = note: this error originates in the attribute macro `salsa::interned` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `salsa::plumbing::setup_interned_struct` which comes from the expansion of the attribute macro `salsa::interned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot find attribute `unknown_attr` in this scope
  --> tests/compile-fail/interned_struct_unknown_attribute.rs:5:7

--- a/tests/compile-fail/span-input-setter.stderr
+++ b/tests/compile-fail/span-input-setter.stderr
@@ -2,11 +2,11 @@ error[E0308]: mismatched types
   --> tests/compile-fail/span-input-setter.rs:10:21
    |
 10 |     input.set_field(22);
-   |           --------- ^^ expected `&mut _`, found integer
+   |           --------- ^^ expected `&mut dyn Database`, found integer
    |           |
    |           arguments to this method are incorrect
    |
-   = note: expected mutable reference `&mut _`
+   = note: expected mutable reference `&mut (dyn Database + 'static)`
                            found type `{integer}`
 note: method defined here
   --> tests/compile-fail/span-input-setter.rs:3:5
@@ -16,7 +16,3 @@ note: method defined here
  2 | pub struct MyInput {
  3 |     field: u32,
    |     ^^^^^
-help: consider mutably borrowing here
-   |
-10 |     input.set_field(&mut 22);
-   |                     ++++

--- a/tests/compile-fail/span-tracked-getter.stderr
+++ b/tests/compile-fail/span-tracked-getter.stderr
@@ -2,11 +2,11 @@ error[E0308]: mismatched types
  --> tests/compile-fail/span-tracked-getter.rs:9:13
   |
 9 |     x.field(22);
-  |       ----- ^^ expected `&_`, found integer
+  |       ----- ^^ expected `&dyn Database`, found integer
   |       |
   |       arguments to this method are incorrect
   |
-  = note: expected reference `&_`
+  = note: expected reference `&(dyn Database + 'static)`
                   found type `{integer}`
 note: method defined here
  --> tests/compile-fail/span-tracked-getter.rs:3:5
@@ -16,10 +16,6 @@ note: method defined here
 2 | pub struct MyTracked<'db> {
 3 |     field: u32,
   |     ^^^^^
-help: consider borrowing here
-  |
-9 |     x.field(&22);
-  |             +
 
 warning: variable does not need to be mutable
   --> tests/compile-fail/span-tracked-getter.rs:13:9

--- a/tests/compile-fail/tracked_struct_unknown_attribute.stderr
+++ b/tests/compile-fail/tracked_struct_unknown_attribute.stderr
@@ -1,10 +1,10 @@
-error: only a single lifetime parameter is accepted
+error: #[salsa::tracked] must also be applied to the impl block for tracked methods
  --> tests/compile-fail/tracked_struct_unknown_attribute.rs:1:1
   |
 1 | #[salsa::tracked]
   | ^^^^^^^^^^^^^^^^^
   |
-  = note: this error originates in the attribute macro `salsa::tracked` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `salsa::plumbing::setup_tracked_struct` which comes from the expansion of the attribute macro `salsa::tracked` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot find attribute `unknown_attr` in this scope
  --> tests/compile-fail/tracked_struct_unknown_attribute.rs:5:7


### PR DESCRIPTION
Use stabilized trait upcasting to simplify database APIs and remove obsolete casting shims.

I upgraded ty to see if this requires any downstream changes, and it does. The `cycle` functions may now need type annotations for `db`. I think that's acceptable. 

But I'm happy to go either way (remove the FIXME, use trait upcasting)

