### PR TITLE
perf: Allow toggling events off statically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ ordermap = { version = "1", optional = true }
 [features]
 default = ["salsa_unstable", "rayon", "macros", "inventory", "accumulator"]
 inventory = ["dep:inventory"]
+events-introspection = []
 
 # Enables Salsa's `DEBUG` and `TRACE` tracing events and spans. Disabled by default.
 detailed-trace = []
@@ -96,6 +97,9 @@ rustversion = "=1.0.23"
 test-log = { version = "=0.2.21", features = ["trace"] }
 trybuild = "=1.0.118"
 serde_json = "=1.0.151"
+
+# Enable the events-introspection feature for tests
+salsa = { path = ".", features = ["events-introspection"] }
 
 [[bench]]
 name = "creation"

--- a/src/zalsa.rs
+++ b/src/zalsa.rs
@@ -170,6 +170,7 @@ pub struct Zalsa {
     /// Each handle gets its own runtime, but the runtimes have shared state between them.
     runtime: Runtime,
 
+    #[cfg(feature = "events-introspection")]
     event_callback: Option<Box<dyn Fn(crate::Event) + Send + Sync>>,
 }
 
@@ -185,6 +186,10 @@ impl Zalsa {
         event_callback: Option<Box<dyn Fn(crate::Event) + Send + Sync + 'static>>,
         jars: Vec<ErasedJar>,
     ) -> Self {
+        if cfg!(not(feature = "events-introspection")) && event_callback.is_some() {
+            panic!("cannot provide an event callback if the `events-introspection` feature is off");
+        }
+
         let mut zalsa = Self {
             views_of: Views::new::<Db>(),
             jar_map: HashMap::default(),
@@ -193,6 +198,7 @@ impl Zalsa {
             ingredients_requiring_reset: Vec::new(),
             runtime: Runtime::default(),
             memo_ingredient_indices: Default::default(),
+            #[cfg(feature = "events-introspection")]
             event_callback,
             #[cfg(not(feature = "inventory"))]
             nonce: NONCE.nonce(),
@@ -481,6 +487,11 @@ impl Zalsa {
     }
 
     #[inline(always)]
+    #[cfg(not(feature = "events-introspection"))]
+    pub fn event(&self, _event: &impl Fn() -> crate::Event) {}
+
+    #[inline(always)]
+    #[cfg(feature = "events-introspection")]
     pub fn event(&self, event: &dyn Fn() -> crate::Event) {
         if self.event_callback.is_some() {
             self.event_cold(event);
@@ -490,6 +501,7 @@ impl Zalsa {
     // Avoid inlining, as events are typically only enabled for debugging purposes.
     #[cold]
     #[inline(never)]
+    #[cfg(feature = "events-introspection")]
     pub fn event_cold(&self, event: &dyn Fn() -> crate::Event) {
         let event_callback = self.event_callback.as_ref().unwrap();
         event_callback(event());


### PR DESCRIPTION
They are typically only used for tests, and removing them statically removes a load+branch and sometimes more (the callback can pessimize compiler optimizations).

This will fail tests as they need this. I'll fix this, but this will prevent seeing the benchmark impact, so I'm first opening the PR without.