### PR TITLE
docs: remove work-in-progress warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@
 
 <img alt="Salsa Logo" src="https://raw.githubusercontent.com/salsa-rs/logo/main/FerrisSalsa4-01.svg" width="200" />
 
-## Obligatory warning
-
-Very much a WORK IN PROGRESS at this point.
-
 ## Credits
 
 This system is heavily inspired by [adapton](http://adapton.org/), [glimmer](https://github.com/glimmerjs/glimmer-vm), and rustc's query


### PR DESCRIPTION
## Summary

While there are still occasional breaking changes, most of Salsa's APIs have been stable. ty and rust-analyzer use it now for years, without the need for a major refactor/rework. 

At this point, I think the `0.x` version is enough to signify that the API might still undergo breaking changes. 

I'm also happy to replace the prose with something less scary. But I just think what we have now is a drastic overstatement.