### PR TITLE
fix: make query-stack reentrancy memory-safe

### DIFF
--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -525,20 +525,19 @@ pub struct Backtrace(Box<[CapturedQuery]>);
 impl Backtrace {
     pub fn capture() -> Option<Self> {
         crate::with_attached_database(|db| {
-            db.zalsa_local().try_with_query_stack(|stack| {
-                Backtrace(
-                    stack
-                        .iter()
-                        .rev()
-                        .map(|query| CapturedQuery {
-                            database_key_index: query.database_key_index,
-                            durability: query.durability,
-                            changed_at: query.changed_at,
-                            cycle_heads: query.cycle_heads.clone(),
-                        })
-                        .collect(),
-                )
-            })
+            let stack = db.zalsa_local().try_query_stack()?;
+            Some(Backtrace(
+                stack
+                    .iter()
+                    .rev()
+                    .map(|query| CapturedQuery {
+                        database_key_index: query.database_key_index,
+                        durability: query.durability,
+                        changed_at: query.changed_at,
+                        cycle_heads: query.cycle_heads.clone(),
+                    })
+                    .collect(),
+            ))
         })?
     }
 }

--- a/src/active_query.rs
+++ b/src/active_query.rs
@@ -170,6 +170,11 @@ impl ActiveQuery {
         self.accumulated.accumulate(index, value);
     }
 
+    #[cfg(feature = "accumulator")]
+    pub(super) fn take_accumulated(&mut self) -> AccumulatedMap {
+        mem::take(&mut self.accumulated)
+    }
+
     /// Adds a key to our list of outputs, returning whether it was newly inserted.
     pub(super) fn add_output(&mut self, key: DatabaseKeyIndex) -> bool {
         self.input_outputs.insert(QueryEdge::output(key))

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -573,18 +573,15 @@ fn outer_cycle(
     // First, look for the outer most cycle head on the same thread.
     // Using the outer most over the inner most should reduce the need
     // for transitive transfers.
-    // SAFETY: We don't call into with_query_stack recursively
-    if let Some(same_thread) = unsafe {
-        zalsa_local.with_query_stack_unchecked(|stack| {
-            stack
-                .iter()
-                .find(|active_query| {
-                    active_query.database_key_index != current_key
-                        && cycle_heads.contains(&active_query.database_key_index)
-                })
-                .map(|active_query| active_query.database_key_index)
-        })
-    } {
+    if let Some(same_thread) = zalsa_local.with_query_stack(|stack| {
+        stack
+            .iter()
+            .find(|active_query| {
+                active_query.database_key_index != current_key
+                    && cycle_heads.contains(&active_query.database_key_index)
+            })
+            .map(|active_query| active_query.database_key_index)
+    }) {
         return Some(same_thread);
     }
 

--- a/src/function/execute.rs
+++ b/src/function/execute.rs
@@ -573,15 +573,15 @@ fn outer_cycle(
     // First, look for the outer most cycle head on the same thread.
     // Using the outer most over the inner most should reduce the need
     // for transitive transfers.
-    if let Some(same_thread) = zalsa_local.with_query_stack(|stack| {
-        stack
-            .iter()
-            .find(|active_query| {
-                active_query.database_key_index != current_key
-                    && cycle_heads.contains(&active_query.database_key_index)
-            })
-            .map(|active_query| active_query.database_key_index)
-    }) {
+    let same_thread = zalsa_local
+        .query_stack()
+        .iter()
+        .find(|active_query| {
+            active_query.database_key_index != current_key
+                && cycle_heads.contains(&active_query.database_key_index)
+        })
+        .map(|active_query| active_query.database_key_index);
+    if let Some(same_thread) = same_thread {
         return Some(same_thread);
     }
 

--- a/src/function/fetch.rs
+++ b/src/function/fetch.rs
@@ -169,16 +169,14 @@ where
     ) -> &'db Memo<C> {
         // no provisional value; create/insert/return initial provisional value
         match C::CYCLE_STRATEGY {
-            // SAFETY: We do not access the query stack reentrantly.
-            CycleRecoveryStrategy::Panic => unsafe {
-                zalsa_local.with_query_stack_unchecked(|stack| {
-                    panic!(
-                        "dependency graph cycle when querying {database_key_index:#?}, \
-                    set cycle_fn/cycle_initial to fixpoint iterate.\n\
-                    Query stack:\n{stack:#?}",
-                    );
-                })
-            },
+            CycleRecoveryStrategy::Panic => {
+                let stack = zalsa_local.query_stack_keys();
+                panic!(
+                    "dependency graph cycle when querying {database_key_index:#?}, \
+                set cycle_fn/cycle_initial to fixpoint iterate.\n\
+                Query stack:\n{stack:#?}",
+                );
+            }
             CycleRecoveryStrategy::Fixpoint | CycleRecoveryStrategy::FallbackImmediate => {
                 let cancellation_count = zalsa.runtime().cancellation_count();
                 // check if there's a provisional value for this query

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -726,14 +726,11 @@ fn validate_same_iteration(
         .next()
         .is_none()
     {
-        let on_stack = zalsa_local.with_query_stack(|stack| {
-            stack
-                .iter()
-                .rev()
-                .any(|query| query.database_key_index == memo_database_key_index)
-        });
-
-        return on_stack;
+        return zalsa_local
+            .query_stack()
+            .iter()
+            .rev()
+            .any(|query| query.database_key_index == memo_database_key_index);
     }
 
     let cycle_heads_iter = TryClaimCycleHeadsIter::new(zalsa, cycle_heads);

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -552,16 +552,14 @@ fn maybe_changed_after_cold_cycle(
     cycle_recovery_strategy: CycleRecoveryStrategy,
 ) -> VerifyResult {
     match cycle_recovery_strategy {
-        // SAFETY: We do not access the query stack reentrantly.
-        CycleRecoveryStrategy::Panic => unsafe {
-            zalsa_local.with_query_stack_unchecked(|stack| {
-                panic!(
-                    "dependency graph cycle when validating {database_key_index:#?}, \
-                    set cycle_fn/cycle_initial to fixpoint iterate.\n\
-                    Query stack:\n{stack:#?}",
-                );
-            })
-        },
+        CycleRecoveryStrategy::Panic => {
+            let stack = zalsa_local.query_stack_keys();
+            panic!(
+                "dependency graph cycle when validating {database_key_index:#?}, \
+                set cycle_fn/cycle_initial to fixpoint iterate.\n\
+                Query stack:\n{stack:#?}",
+            );
+        }
         // We flatten the dependencies of queries with cycle handling that participate in a query.
         // Verifying those queries should never result in a cycle because all function dependencies were removed.
         // That means, if we hit this path, then some query introduced a new cycle that didn't exist
@@ -728,15 +726,12 @@ fn validate_same_iteration(
         .next()
         .is_none()
     {
-        // SAFETY: We do not access the query stack reentrantly.
-        let on_stack = unsafe {
-            zalsa_local.with_query_stack_unchecked(|stack| {
-                stack
-                    .iter()
-                    .rev()
-                    .any(|query| query.database_key_index == memo_database_key_index)
-            })
-        };
+        let on_stack = zalsa_local.with_query_stack(|stack| {
+            stack
+                .iter()
+                .rev()
+                .any(|query| query.database_key_index == memo_database_key_index)
+        });
 
         return on_stack;
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -160,8 +160,8 @@ impl<Db: Database> Storage<Db> {
     fn cancel_others(&mut self) -> &mut Zalsa {
         debug_assert!(
             self.zalsa_local
-                .try_with_query_stack(|stack| stack.is_empty())
-                == Some(true),
+                .try_query_stack()
+                .is_some_and(|stack| stack.is_empty()),
             "attempted to cancel within query computation, this is a deadlock"
         );
         {

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -180,51 +180,40 @@ impl ZalsaLocal {
 
     #[inline]
     pub(crate) fn push_query(&self, database_key_index: DatabaseKeyIndex) -> ActiveQueryGuard<'_> {
-        // SAFETY: We do not access the query stack reentrantly.
-        unsafe {
-            self.with_query_stack_unchecked_mut(|stack| {
-                stack.push_new_query(database_key_index);
+        self.with_query_stack_mut(|stack| {
+            stack.push_new_query(database_key_index);
 
-                ActiveQueryGuard {
-                    local_state: self,
-                    database_key_index,
-                    #[cfg(debug_assertions)]
-                    push_len: stack.len(),
-                }
-            })
-        }
+            ActiveQueryGuard {
+                local_state: self,
+                database_key_index,
+                #[cfg(debug_assertions)]
+                push_len: stack.len(),
+            }
+        })
     }
 
-    /// Executes a closure within the context of the current active query stacks (mutable).
+    /// Mutably borrows the active query stack for the closure.
     ///
-    /// # Safety
+    /// # Panics
     ///
-    /// The closure cannot access the query stack reentrantly, whether mutable or immutable.
+    /// Panics if the stack is already borrowed. Callers should release the borrow before
+    /// invoking user code, including destructors and panic hooks.
     #[inline(always)]
-    pub(crate) unsafe fn with_query_stack_unchecked_mut<R>(
+    pub(crate) fn with_query_stack_mut<R>(
         &self,
         f: impl UnwindSafe + FnOnce(&mut QueryStack) -> R,
     ) -> R {
-        // SAFETY: The caller guarantees that the query stack will not be accessed reentrantly.
-        // Additionally, `ZalsaLocal` is `!Sync`, and we never expose a reference to the query
-        // stack except through this method, so we have exclusive access.
-        unsafe { f(&mut self.query_stack.try_borrow_mut().unwrap_unchecked()) }
+        f(&mut self.query_stack.borrow_mut())
     }
 
-    /// Executes a closure within the context of the current active query stacks.
+    /// Borrows the active query stack for the closure.
     ///
-    /// # Safety
+    /// # Panics
     ///
-    /// No mutable references to the query stack can exist while the closure is executed.
+    /// Panics if the stack is already mutably borrowed.
     #[inline(always)]
-    pub(crate) unsafe fn with_query_stack_unchecked<R>(
-        &self,
-        f: impl UnwindSafe + FnOnce(&QueryStack) -> R,
-    ) -> R {
-        // SAFETY: The caller guarantees that the query stack will not being accessed mutably.
-        // Additionally, `ZalsaLocal` is `!Sync`, and we never expose a reference to the query
-        // stack except through this method, so we have exclusive access.
-        unsafe { f(&self.query_stack.try_borrow().unwrap_unchecked()) }
+    pub(crate) fn with_query_stack<R>(&self, f: impl UnwindSafe + FnOnce(&QueryStack) -> R) -> R {
+        f(&self.query_stack.borrow())
     }
 
     #[inline(always)]
@@ -239,17 +228,20 @@ impl ZalsaLocal {
             .map(|stack| f(stack))
     }
 
+    /// Captures query keys so diagnostic formatting and panic hooks can run without borrowing
+    /// the query stack.
+    pub(crate) fn query_stack_keys(&self) -> Vec<DatabaseKeyIndex> {
+        self.with_query_stack(|stack| stack.iter().map(|query| query.database_key_index).collect())
+    }
+
     /// Returns the index of the active query along with its *current* durability/changed-at
     /// information. As the query continues to execute, naturally, that information may change.
     pub(crate) fn active_query(&self) -> Option<(DatabaseKeyIndex, Stamp)> {
-        // SAFETY: We do not access the query stack reentrantly.
-        unsafe {
-            self.with_query_stack_unchecked(|stack| {
-                stack
-                    .last()
-                    .map(|active_query| (active_query.database_key_index, active_query.stamp()))
-            })
-        }
+        self.with_query_stack(|stack| {
+            stack
+                .last()
+                .map(|active_query| (active_query.database_key_index, active_query.stamp()))
+        })
     }
 
     /// Returns the active query, its current dependencies, and any provisional cycle results it
@@ -257,18 +249,15 @@ impl ZalsaLocal {
     pub(crate) fn active_query_with_cycle_heads(
         &self,
     ) -> Option<(DatabaseKeyIndex, Stamp, CycleHeads)> {
-        // SAFETY: We do not access the query stack reentrantly.
-        unsafe {
-            self.with_query_stack_unchecked(|stack| {
-                stack.last().map(|active_query| {
-                    (
-                        active_query.database_key_index,
-                        active_query.stamp(),
-                        active_query.cycle_heads().clone(),
-                    )
-                })
+        self.with_query_stack(|stack| {
+            stack.last().map(|active_query| {
+                (
+                    active_query.database_key_index,
+                    active_query.stamp(),
+                    active_query.cycle_heads().clone(),
+                )
             })
-        }
+        })
     }
 
     /// Add an output to the current query's list of dependencies
@@ -280,41 +269,34 @@ impl ZalsaLocal {
         index: IngredientIndex,
         value: A,
     ) -> Result<(), ()> {
-        // SAFETY: We do not access the query stack reentrantly.
-        unsafe {
-            self.with_query_stack_unchecked_mut(|stack| {
-                if let Some(top_query) = stack.last_mut() {
-                    top_query.accumulate(index, value);
-                    Ok(())
-                } else {
-                    Err(())
-                }
-            })
-        }
+        let result = self.with_query_stack_mut(|stack| {
+            if let Some(top_query) = stack.last_mut() {
+                top_query.accumulate(index, value);
+                Ok(())
+            } else {
+                Err(value)
+            }
+        });
+        // A rejected value's destructor may reenter the database.
+        result.map_err(drop)
     }
 
     /// Add an output to the current query's list of dependencies, returning whether it was new.
     pub(crate) fn add_output(&self, entity: DatabaseKeyIndex) -> bool {
-        // SAFETY: We do not access the query stack reentrantly.
-        unsafe {
-            self.with_query_stack_unchecked_mut(|stack| {
-                stack
-                    .last_mut()
-                    .is_some_and(|top_query| top_query.add_output(entity))
-            })
-        }
+        self.with_query_stack_mut(|stack| {
+            stack
+                .last_mut()
+                .is_some_and(|top_query| top_query.add_output(entity))
+        })
     }
 
     /// Check whether `entity` is a tracked struct that was created by the currently active query (if any)
     pub(crate) fn is_tracked_struct_of_active_query(&self, entity: DatabaseKeyIndex) -> bool {
-        // SAFETY: We do not access the query stack reentrantly.
-        unsafe {
-            self.with_query_stack_unchecked_mut(|stack| {
-                stack
-                    .last_mut()
-                    .is_some_and(|top_query| top_query.tracked_struct_ids().is_active(entity))
-            })
-        }
+        self.with_query_stack_mut(|stack| {
+            stack
+                .last_mut()
+                .is_some_and(|top_query| top_query.tracked_struct_ids().is_active(entity))
+        })
     }
 
     /// Register that currently active query reads the given input
@@ -335,23 +317,20 @@ impl ZalsaLocal {
             changed_at
         );
 
-        // SAFETY: We do not access the query stack reentrantly.
-        unsafe {
-            self.with_query_stack_unchecked_mut(|stack| {
-                if let Some(top_query) = stack.last_mut() {
-                    top_query.add_read(
-                        input,
-                        durability,
-                        changed_at,
-                        cycle_heads,
-                        #[cfg(feature = "accumulator")]
-                        has_accumulated,
-                        #[cfg(feature = "accumulator")]
-                        accumulated_inputs,
-                    );
-                }
-            })
-        }
+        self.with_query_stack_mut(|stack| {
+            if let Some(top_query) = stack.last_mut() {
+                top_query.add_read(
+                    input,
+                    durability,
+                    changed_at,
+                    cycle_heads,
+                    #[cfg(feature = "accumulator")]
+                    has_accumulated,
+                    #[cfg(feature = "accumulator")]
+                    accumulated_inputs,
+                );
+            }
+        })
     }
 
     /// Register that currently active query reads the given input
@@ -369,27 +348,21 @@ impl ZalsaLocal {
             changed_at
         );
 
-        // SAFETY: We do not access the query stack reentrantly.
-        unsafe {
-            self.with_query_stack_unchecked_mut(|stack| {
-                if let Some(top_query) = stack.last_mut() {
-                    top_query.add_read_simple(input, durability, changed_at);
-                }
-            })
-        }
+        self.with_query_stack_mut(|stack| {
+            if let Some(top_query) = stack.last_mut() {
+                top_query.add_read_simple(input, durability, changed_at);
+            }
+        })
     }
 
     /// Update the active query's changed revision without recording a dependency edge.
     #[inline(always)]
     pub(crate) fn report_tracked_read_revision(&self, changed_at: Revision) {
-        // SAFETY: We do not access the query stack reentrantly.
-        unsafe {
-            self.with_query_stack_unchecked_mut(|stack| {
-                if let Some(top_query) = stack.last_mut() {
-                    top_query.add_changed_at(changed_at);
-                }
-            })
-        }
+        self.with_query_stack_mut(|stack| {
+            if let Some(top_query) = stack.last_mut() {
+                top_query.add_changed_at(changed_at);
+            }
+        })
     }
 
     /// Register that the current query read an untracked value
@@ -399,14 +372,11 @@ impl ZalsaLocal {
     /// * `current_revision`, the current revision
     #[inline(always)]
     pub(crate) fn report_untracked_read(&self, current_revision: Revision) {
-        // SAFETY: We do not access the query stack reentrantly.
-        unsafe {
-            self.with_query_stack_unchecked_mut(|stack| {
-                if let Some(top_query) = stack.last_mut() {
-                    top_query.add_untracked_read(current_revision);
-                }
-            })
-        }
+        self.with_query_stack_mut(|stack| {
+            if let Some(top_query) = stack.last_mut() {
+                top_query.add_untracked_read(current_revision);
+            }
+        })
     }
 
     /// Called when the active queries creates an index from the
@@ -421,42 +391,33 @@ impl ZalsaLocal {
     ///   * the disambiguator index
     #[track_caller]
     pub(crate) fn disambiguate(&self, key: IdentityHash) -> (Stamp, Disambiguator) {
-        // SAFETY: We do not access the query stack reentrantly.
-        unsafe {
-            self.with_query_stack_unchecked_mut(|stack| {
-                let top_query = stack.last_mut().expect(
-                    "cannot create a tracked struct disambiguator outside of a tracked function",
-                );
-                let disambiguator = top_query.disambiguate(key);
-                (top_query.stamp(), disambiguator)
-            })
-        }
+        self.with_query_stack_mut(|stack| {
+            let top_query = stack.last_mut().expect(
+                "cannot create a tracked struct disambiguator outside of a tracked function",
+            );
+            let disambiguator = top_query.disambiguate(key);
+            (top_query.stamp(), disambiguator)
+        })
     }
 
     #[track_caller]
     pub(crate) fn tracked_struct_id(&self, identity: &Identity) -> Option<Id> {
-        // SAFETY: We do not access the query stack reentrantly.
-        unsafe {
-            self.with_query_stack_unchecked_mut(|stack| {
-                let top_query = stack
-                    .last_mut()
-                    .expect("cannot create a tracked struct ID outside of a tracked function");
-                top_query.tracked_struct_ids_mut().reuse(identity)
-            })
-        }
+        self.with_query_stack_mut(|stack| {
+            let top_query = stack
+                .last_mut()
+                .expect("cannot create a tracked struct ID outside of a tracked function");
+            top_query.tracked_struct_ids_mut().reuse(identity)
+        })
     }
 
     #[track_caller]
     pub(crate) fn store_tracked_struct_id(&self, identity: Identity, id: Id) {
-        // SAFETY: We do not access the query stack reentrantly.
-        unsafe {
-            self.with_query_stack_unchecked_mut(|stack| {
-                let top_query = stack
-                    .last_mut()
-                    .expect("cannot store a tracked struct ID outside of a tracked function");
-                top_query.tracked_struct_ids_mut().insert(identity, id);
-            })
-        }
+        self.with_query_stack_mut(|stack| {
+            let top_query = stack
+                .last_mut()
+                .expect("cannot store a tracked struct ID outside of a tracked function");
+            top_query.tracked_struct_ids_mut().insert(identity, id);
+        })
     }
 
     #[inline]
@@ -1920,15 +1881,12 @@ pub(crate) struct ActiveQueryGuard<'me> {
 impl<'me> ActiveQueryGuard<'me> {
     /// Initialize the tracked struct ids with the values from the prior execution.
     pub(crate) fn seed_tracked_struct_ids(&self, tracked_struct_ids: &[(Identity, Id)]) {
-        // SAFETY: We do not access the query stack reentrantly.
-        unsafe {
-            self.local_state.with_query_stack_unchecked_mut(|stack| {
-                #[cfg(debug_assertions)]
-                assert_eq!(stack.len(), self.push_len, "mismatched push and pop");
-                let frame = stack.last_mut().unwrap();
-                frame.tracked_struct_ids_mut().seed(tracked_struct_ids);
-            })
-        }
+        self.local_state.with_query_stack_mut(|stack| {
+            #[cfg(debug_assertions)]
+            assert_eq!(stack.len(), self.push_len, "mismatched push and pop");
+            let frame = stack.last_mut().unwrap();
+            frame.tracked_struct_ids_mut().seed(tracked_struct_ids);
+        })
     }
 
     /// Append the given `outputs` to the query's output list.
@@ -1940,38 +1898,29 @@ impl<'me> ActiveQueryGuard<'me> {
 
         let tracked_ids = previous.tracked_struct_ids();
 
-        // SAFETY: We do not access the query stack reentrantly.
-        unsafe {
-            self.local_state.with_query_stack_unchecked_mut(|stack| {
-                #[cfg(debug_assertions)]
-                assert_eq!(stack.len(), self.push_len, "mismatched push and pop");
-                let frame = stack.last_mut().unwrap();
-                frame.seed_iteration(durability, changed_at, edges, untracked_read, tracked_ids);
-            })
-        }
+        self.local_state.with_query_stack_mut(|stack| {
+            #[cfg(debug_assertions)]
+            assert_eq!(stack.len(), self.push_len, "mismatched push and pop");
+            let frame = stack.last_mut().unwrap();
+            frame.seed_iteration(durability, changed_at, edges, untracked_read, tracked_ids);
+        })
     }
 
     pub(crate) fn take_cycle_heads(&mut self) -> CycleHeads {
-        // SAFETY: We do not access the query stack reentrantly.
-        unsafe {
-            self.local_state.with_query_stack_unchecked_mut(|stack| {
-                #[cfg(debug_assertions)]
-                assert_eq!(stack.len(), self.push_len);
-                let frame = stack.last_mut().unwrap();
-                frame.take_cycle_heads()
-            })
-        }
+        self.local_state.with_query_stack_mut(|stack| {
+            #[cfg(debug_assertions)]
+            assert_eq!(stack.len(), self.push_len);
+            let frame = stack.last_mut().unwrap();
+            frame.take_cycle_heads()
+        })
     }
 
     pub(crate) fn detach(self) -> DetachedQuery<'me> {
-        // SAFETY: We do not access the query stack reentrantly.
-        let input_outputs = unsafe {
-            self.local_state.with_query_stack_unchecked_mut(|stack| {
-                #[cfg(debug_assertions)]
-                assert_eq!(stack.len(), self.push_len);
-                stack.last_mut().unwrap().detach_input_outputs()
-            })
-        };
+        let input_outputs = self.local_state.with_query_stack_mut(|stack| {
+            #[cfg(debug_assertions)]
+            assert_eq!(stack.len(), self.push_len);
+            stack.last_mut().unwrap().detach_input_outputs()
+        });
         DetachedQuery {
             guard: self,
             input_outputs,
@@ -1980,17 +1929,14 @@ impl<'me> ActiveQueryGuard<'me> {
 
     /// Invoked when the query has successfully completed execution.
     fn complete(self, iteration: IterationStamp) -> CompletedQuery {
-        // SAFETY: We do not access the query stack reentrantly.
-        let query = unsafe {
-            self.local_state.with_query_stack_unchecked_mut(|stack| {
-                stack.pop_into_revisions(
-                    self.database_key_index,
-                    iteration,
-                    #[cfg(debug_assertions)]
-                    self.push_len,
-                )
-            })
-        };
+        let query = self.local_state.with_query_stack_mut(|stack| {
+            stack.pop_into_revisions(
+                self.database_key_index,
+                iteration,
+                #[cfg(debug_assertions)]
+                self.push_len,
+            )
+        });
         std::mem::forget(self);
         query
     }
@@ -2009,20 +1955,16 @@ impl<'me> ActiveQueryGuard<'me> {
         detached_input_outputs: DetachedInputOutputs,
         force_extra: bool,
     ) -> QueryCompletion {
-        // SAFETY: We do not access the query stack reentrantly.
-        let completion = unsafe {
-            self.local_state
-                .with_query_stack_unchecked_mut(move |stack| {
-                    stack.pop_detached_completion(
-                        self.database_key_index,
-                        iteration,
-                        detached_input_outputs,
-                        force_extra,
-                        #[cfg(debug_assertions)]
-                        self.push_len,
-                    )
-                })
-        };
+        let completion = self.local_state.with_query_stack_mut(move |stack| {
+            stack.pop_detached_completion(
+                self.database_key_index,
+                iteration,
+                detached_input_outputs,
+                force_extra,
+                #[cfg(debug_assertions)]
+                self.push_len,
+            )
+        });
         std::mem::forget(self);
         completion
     }
@@ -2053,16 +1995,22 @@ impl DetachedQuery<'_> {
 
 impl Drop for ActiveQueryGuard<'_> {
     fn drop(&mut self) {
-        // SAFETY: We do not access the query stack reentrantly.
-        unsafe {
-            self.local_state.with_query_stack_unchecked_mut(|stack| {
-                stack.pop(
-                    self.database_key_index,
-                    #[cfg(debug_assertions)]
-                    self.push_len,
-                );
-            })
-        };
+        // Keep user values alive until the frame is popped and the stack borrow is released.
+        #[cfg(feature = "accumulator")]
+        let accumulated = self
+            .local_state
+            .with_query_stack_mut(|stack| stack.last_mut().unwrap().take_accumulated());
+
+        self.local_state.with_query_stack_mut(|stack| {
+            stack.pop(
+                self.database_key_index,
+                #[cfg(debug_assertions)]
+                self.push_len,
+            );
+        });
+
+        #[cfg(feature = "accumulator")]
+        drop(accumulated);
     }
 }
 
@@ -2273,6 +2221,25 @@ mod tests {
     };
     use super::{OriginAndExtra, PackedQueryEdge, QueryEdge, QueryOriginRef};
     use crate::{DatabaseKeyIndex, Id, IngredientIndex};
+
+    #[test]
+    fn reentrant_query_stack_borrows_panic() {
+        let local = super::ZalsaLocal::new();
+
+        assert!(
+            std::panic::catch_unwind(|| {
+                local.with_query_stack_mut(|_| local.with_query_stack(|_| ()));
+            })
+            .is_err()
+        );
+        assert!(
+            std::panic::catch_unwind(|| {
+                local.with_query_stack(|_| local.with_query_stack_mut(|_| ()));
+            })
+            .is_err()
+        );
+        local.with_query_stack_mut(|stack| assert!(stack.is_empty()));
+    }
 
     #[test]
     fn query_origin_packs_edges_that_fit() {

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -1997,15 +1997,24 @@ impl Drop for ActiveQueryGuard<'_> {
     fn drop(&mut self) {
         // Keep user values alive until the frame is popped and the stack borrow is released.
         #[cfg(feature = "accumulator")]
-        let accumulated = self
-            .local_state
-            .with_query_stack_mut(|stack| stack.last_mut().unwrap().take_accumulated());
+        let mut accumulated = None;
+        // Only ownership is transferred through this reference. If popping panics, the outer
+        // local is still dropped after the query-stack borrow has unwound.
+        #[cfg(feature = "accumulator")]
+        let mut accumulated_out = std::panic::AssertUnwindSafe(&mut accumulated);
+        let database_key_index = self.database_key_index;
+        #[cfg(debug_assertions)]
+        let push_len = self.push_len;
 
-        self.local_state.with_query_stack_mut(|stack| {
+        self.local_state.with_query_stack_mut(move |stack| {
+            #[cfg(feature = "accumulator")]
+            {
+                **accumulated_out = Some(stack.last_mut().unwrap().take_accumulated());
+            }
             stack.pop(
-                self.database_key_index,
+                database_key_index,
                 #[cfg(debug_assertions)]
-                self.push_len,
+                push_len,
             );
         });
 

--- a/src/zalsa_local.rs
+++ b/src/zalsa_local.rs
@@ -1,10 +1,9 @@
 use std::alloc::{Layout, alloc, dealloc, handle_alloc_error};
-use std::cell::{RefCell, UnsafeCell};
+use std::cell::{Ref, RefCell, UnsafeCell};
 use std::fmt;
 use std::fmt::Formatter;
 use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
-use std::panic::UnwindSafe;
 use std::ptr::{self, NonNull};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
@@ -180,68 +179,50 @@ impl ZalsaLocal {
 
     #[inline]
     pub(crate) fn push_query(&self, database_key_index: DatabaseKeyIndex) -> ActiveQueryGuard<'_> {
-        self.with_query_stack_mut(|stack| {
-            stack.push_new_query(database_key_index);
+        let mut stack = self.query_stack.borrow_mut();
+        stack.push_new_query(database_key_index);
 
-            ActiveQueryGuard {
-                local_state: self,
-                database_key_index,
-                #[cfg(debug_assertions)]
-                push_len: stack.len(),
-            }
-        })
+        ActiveQueryGuard {
+            local_state: self,
+            database_key_index,
+            #[cfg(debug_assertions)]
+            push_len: stack.len(),
+        }
     }
 
-    /// Mutably borrows the active query stack for the closure.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the stack is already borrowed. Callers should release the borrow before
-    /// invoking user code, including destructors and panic hooks.
-    #[inline(always)]
-    pub(crate) fn with_query_stack_mut<R>(
-        &self,
-        f: impl UnwindSafe + FnOnce(&mut QueryStack) -> R,
-    ) -> R {
-        f(&mut self.query_stack.borrow_mut())
-    }
-
-    /// Borrows the active query stack for the closure.
+    /// Borrows the active query stack. Release the guard before invoking user code, including
+    /// diagnostic formatting and panic hooks.
     ///
     /// # Panics
     ///
     /// Panics if the stack is already mutably borrowed.
     #[inline(always)]
-    pub(crate) fn with_query_stack<R>(&self, f: impl UnwindSafe + FnOnce(&QueryStack) -> R) -> R {
-        f(&self.query_stack.borrow())
+    pub(crate) fn query_stack(&self) -> Ref<'_, QueryStack> {
+        self.query_stack.borrow()
     }
 
     #[inline(always)]
-    pub(crate) fn try_with_query_stack<R>(
-        &self,
-        f: impl UnwindSafe + FnOnce(&QueryStack) -> R,
-    ) -> Option<R> {
-        self.query_stack
-            .try_borrow()
-            .ok()
-            .as_ref()
-            .map(|stack| f(stack))
+    pub(crate) fn try_query_stack(&self) -> Option<Ref<'_, QueryStack>> {
+        self.query_stack.try_borrow().ok()
     }
 
     /// Captures query keys so diagnostic formatting and panic hooks can run without borrowing
     /// the query stack.
     pub(crate) fn query_stack_keys(&self) -> Vec<DatabaseKeyIndex> {
-        self.with_query_stack(|stack| stack.iter().map(|query| query.database_key_index).collect())
+        self.query_stack
+            .borrow()
+            .iter()
+            .map(|query| query.database_key_index)
+            .collect()
     }
 
     /// Returns the index of the active query along with its *current* durability/changed-at
     /// information. As the query continues to execute, naturally, that information may change.
     pub(crate) fn active_query(&self) -> Option<(DatabaseKeyIndex, Stamp)> {
-        self.with_query_stack(|stack| {
-            stack
-                .last()
-                .map(|active_query| (active_query.database_key_index, active_query.stamp()))
-        })
+        self.query_stack
+            .borrow()
+            .last()
+            .map(|active_query| (active_query.database_key_index, active_query.stamp()))
     }
 
     /// Returns the active query, its current dependencies, and any provisional cycle results it
@@ -249,14 +230,12 @@ impl ZalsaLocal {
     pub(crate) fn active_query_with_cycle_heads(
         &self,
     ) -> Option<(DatabaseKeyIndex, Stamp, CycleHeads)> {
-        self.with_query_stack(|stack| {
-            stack.last().map(|active_query| {
-                (
-                    active_query.database_key_index,
-                    active_query.stamp(),
-                    active_query.cycle_heads().clone(),
-                )
-            })
+        self.query_stack.borrow().last().map(|active_query| {
+            (
+                active_query.database_key_index,
+                active_query.stamp(),
+                active_query.cycle_heads().clone(),
+            )
         })
     }
 
@@ -269,34 +248,33 @@ impl ZalsaLocal {
         index: IngredientIndex,
         value: A,
     ) -> Result<(), ()> {
-        let result = self.with_query_stack_mut(|stack| {
+        let result = {
+            let mut stack = self.query_stack.borrow_mut();
             if let Some(top_query) = stack.last_mut() {
                 top_query.accumulate(index, value);
                 Ok(())
             } else {
                 Err(value)
             }
-        });
+        };
         // A rejected value's destructor may reenter the database.
         result.map_err(drop)
     }
 
     /// Add an output to the current query's list of dependencies, returning whether it was new.
     pub(crate) fn add_output(&self, entity: DatabaseKeyIndex) -> bool {
-        self.with_query_stack_mut(|stack| {
-            stack
-                .last_mut()
-                .is_some_and(|top_query| top_query.add_output(entity))
-        })
+        self.query_stack
+            .borrow_mut()
+            .last_mut()
+            .is_some_and(|top_query| top_query.add_output(entity))
     }
 
     /// Check whether `entity` is a tracked struct that was created by the currently active query (if any)
     pub(crate) fn is_tracked_struct_of_active_query(&self, entity: DatabaseKeyIndex) -> bool {
-        self.with_query_stack_mut(|stack| {
-            stack
-                .last_mut()
-                .is_some_and(|top_query| top_query.tracked_struct_ids().is_active(entity))
-        })
+        self.query_stack
+            .borrow_mut()
+            .last_mut()
+            .is_some_and(|top_query| top_query.tracked_struct_ids().is_active(entity))
     }
 
     /// Register that currently active query reads the given input
@@ -317,20 +295,18 @@ impl ZalsaLocal {
             changed_at
         );
 
-        self.with_query_stack_mut(|stack| {
-            if let Some(top_query) = stack.last_mut() {
-                top_query.add_read(
-                    input,
-                    durability,
-                    changed_at,
-                    cycle_heads,
-                    #[cfg(feature = "accumulator")]
-                    has_accumulated,
-                    #[cfg(feature = "accumulator")]
-                    accumulated_inputs,
-                );
-            }
-        })
+        if let Some(top_query) = self.query_stack.borrow_mut().last_mut() {
+            top_query.add_read(
+                input,
+                durability,
+                changed_at,
+                cycle_heads,
+                #[cfg(feature = "accumulator")]
+                has_accumulated,
+                #[cfg(feature = "accumulator")]
+                accumulated_inputs,
+            );
+        }
     }
 
     /// Register that currently active query reads the given input
@@ -348,21 +324,17 @@ impl ZalsaLocal {
             changed_at
         );
 
-        self.with_query_stack_mut(|stack| {
-            if let Some(top_query) = stack.last_mut() {
-                top_query.add_read_simple(input, durability, changed_at);
-            }
-        })
+        if let Some(top_query) = self.query_stack.borrow_mut().last_mut() {
+            top_query.add_read_simple(input, durability, changed_at);
+        }
     }
 
     /// Update the active query's changed revision without recording a dependency edge.
     #[inline(always)]
     pub(crate) fn report_tracked_read_revision(&self, changed_at: Revision) {
-        self.with_query_stack_mut(|stack| {
-            if let Some(top_query) = stack.last_mut() {
-                top_query.add_changed_at(changed_at);
-            }
-        })
+        if let Some(top_query) = self.query_stack.borrow_mut().last_mut() {
+            top_query.add_changed_at(changed_at);
+        }
     }
 
     /// Register that the current query read an untracked value
@@ -372,11 +344,9 @@ impl ZalsaLocal {
     /// * `current_revision`, the current revision
     #[inline(always)]
     pub(crate) fn report_untracked_read(&self, current_revision: Revision) {
-        self.with_query_stack_mut(|stack| {
-            if let Some(top_query) = stack.last_mut() {
-                top_query.add_untracked_read(current_revision);
-            }
-        })
+        if let Some(top_query) = self.query_stack.borrow_mut().last_mut() {
+            top_query.add_untracked_read(current_revision);
+        }
     }
 
     /// Called when the active queries creates an index from the
@@ -391,33 +361,30 @@ impl ZalsaLocal {
     ///   * the disambiguator index
     #[track_caller]
     pub(crate) fn disambiguate(&self, key: IdentityHash) -> (Stamp, Disambiguator) {
-        self.with_query_stack_mut(|stack| {
-            let top_query = stack.last_mut().expect(
-                "cannot create a tracked struct disambiguator outside of a tracked function",
-            );
-            let disambiguator = top_query.disambiguate(key);
-            (top_query.stamp(), disambiguator)
-        })
+        let mut stack = self.query_stack.borrow_mut();
+        let top_query = stack
+            .last_mut()
+            .expect("cannot create a tracked struct disambiguator outside of a tracked function");
+        let disambiguator = top_query.disambiguate(key);
+        (top_query.stamp(), disambiguator)
     }
 
     #[track_caller]
     pub(crate) fn tracked_struct_id(&self, identity: &Identity) -> Option<Id> {
-        self.with_query_stack_mut(|stack| {
-            let top_query = stack
-                .last_mut()
-                .expect("cannot create a tracked struct ID outside of a tracked function");
-            top_query.tracked_struct_ids_mut().reuse(identity)
-        })
+        let mut stack = self.query_stack.borrow_mut();
+        let top_query = stack
+            .last_mut()
+            .expect("cannot create a tracked struct ID outside of a tracked function");
+        top_query.tracked_struct_ids_mut().reuse(identity)
     }
 
     #[track_caller]
     pub(crate) fn store_tracked_struct_id(&self, identity: Identity, id: Id) {
-        self.with_query_stack_mut(|stack| {
-            let top_query = stack
-                .last_mut()
-                .expect("cannot store a tracked struct ID outside of a tracked function");
-            top_query.tracked_struct_ids_mut().insert(identity, id);
-        })
+        let mut stack = self.query_stack.borrow_mut();
+        let top_query = stack
+            .last_mut()
+            .expect("cannot store a tracked struct ID outside of a tracked function");
+        top_query.tracked_struct_ids_mut().insert(identity, id);
     }
 
     #[inline]
@@ -451,10 +418,11 @@ impl ZalsaLocal {
     }
 }
 
-// Okay to implement as `ZalsaLocal`` is !Sync
+// Okay to implement as `ZalsaLocal` is !Sync:
 // - `most_recent_pages` can't observe broken states as we cannot panic such that we enter an
 //   inconsistent state
-// - neither can `query_stack` as we require the closures accessing it to be `UnwindSafe`
+// - query-stack borrows are checked and released during unwinding; `ActiveQueryGuard` removes
+//   abandoned frames before dropping their accumulated user values.
 impl std::panic::RefUnwindSafe for ZalsaLocal {}
 
 /// Summarizes "all the inputs that a query used" and "all the outputs it has written to".
@@ -1881,12 +1849,11 @@ pub(crate) struct ActiveQueryGuard<'me> {
 impl<'me> ActiveQueryGuard<'me> {
     /// Initialize the tracked struct ids with the values from the prior execution.
     pub(crate) fn seed_tracked_struct_ids(&self, tracked_struct_ids: &[(Identity, Id)]) {
-        self.local_state.with_query_stack_mut(|stack| {
-            #[cfg(debug_assertions)]
-            assert_eq!(stack.len(), self.push_len, "mismatched push and pop");
-            let frame = stack.last_mut().unwrap();
-            frame.tracked_struct_ids_mut().seed(tracked_struct_ids);
-        })
+        let mut stack = self.local_state.query_stack.borrow_mut();
+        #[cfg(debug_assertions)]
+        assert_eq!(stack.len(), self.push_len, "mismatched push and pop");
+        let frame = stack.last_mut().unwrap();
+        frame.tracked_struct_ids_mut().seed(tracked_struct_ids);
     }
 
     /// Append the given `outputs` to the query's output list.
@@ -1898,29 +1865,28 @@ impl<'me> ActiveQueryGuard<'me> {
 
         let tracked_ids = previous.tracked_struct_ids();
 
-        self.local_state.with_query_stack_mut(|stack| {
-            #[cfg(debug_assertions)]
-            assert_eq!(stack.len(), self.push_len, "mismatched push and pop");
-            let frame = stack.last_mut().unwrap();
-            frame.seed_iteration(durability, changed_at, edges, untracked_read, tracked_ids);
-        })
+        let mut stack = self.local_state.query_stack.borrow_mut();
+        #[cfg(debug_assertions)]
+        assert_eq!(stack.len(), self.push_len, "mismatched push and pop");
+        let frame = stack.last_mut().unwrap();
+        frame.seed_iteration(durability, changed_at, edges, untracked_read, tracked_ids);
     }
 
     pub(crate) fn take_cycle_heads(&mut self) -> CycleHeads {
-        self.local_state.with_query_stack_mut(|stack| {
-            #[cfg(debug_assertions)]
-            assert_eq!(stack.len(), self.push_len);
-            let frame = stack.last_mut().unwrap();
-            frame.take_cycle_heads()
-        })
+        let mut stack = self.local_state.query_stack.borrow_mut();
+        #[cfg(debug_assertions)]
+        assert_eq!(stack.len(), self.push_len);
+        let frame = stack.last_mut().unwrap();
+        frame.take_cycle_heads()
     }
 
     pub(crate) fn detach(self) -> DetachedQuery<'me> {
-        let input_outputs = self.local_state.with_query_stack_mut(|stack| {
+        let input_outputs = {
+            let mut stack = self.local_state.query_stack.borrow_mut();
             #[cfg(debug_assertions)]
             assert_eq!(stack.len(), self.push_len);
             stack.last_mut().unwrap().detach_input_outputs()
-        });
+        };
         DetachedQuery {
             guard: self,
             input_outputs,
@@ -1929,14 +1895,16 @@ impl<'me> ActiveQueryGuard<'me> {
 
     /// Invoked when the query has successfully completed execution.
     fn complete(self, iteration: IterationStamp) -> CompletedQuery {
-        let query = self.local_state.with_query_stack_mut(|stack| {
-            stack.pop_into_revisions(
+        let query = self
+            .local_state
+            .query_stack
+            .borrow_mut()
+            .pop_into_revisions(
                 self.database_key_index,
                 iteration,
                 #[cfg(debug_assertions)]
                 self.push_len,
-            )
-        });
+            );
         std::mem::forget(self);
         query
     }
@@ -1955,16 +1923,18 @@ impl<'me> ActiveQueryGuard<'me> {
         detached_input_outputs: DetachedInputOutputs,
         force_extra: bool,
     ) -> QueryCompletion {
-        let completion = self.local_state.with_query_stack_mut(move |stack| {
-            stack.pop_detached_completion(
+        let completion = self
+            .local_state
+            .query_stack
+            .borrow_mut()
+            .pop_detached_completion(
                 self.database_key_index,
                 iteration,
                 detached_input_outputs,
                 force_extra,
                 #[cfg(debug_assertions)]
                 self.push_len,
-            )
-        });
+            );
         std::mem::forget(self);
         completion
     }
@@ -1997,26 +1967,20 @@ impl Drop for ActiveQueryGuard<'_> {
     fn drop(&mut self) {
         // Keep user values alive until the frame is popped and the stack borrow is released.
         #[cfg(feature = "accumulator")]
-        let mut accumulated = None;
-        // Only ownership is transferred through this reference. If popping panics, the outer
-        // local is still dropped after the query-stack borrow has unwound.
-        #[cfg(feature = "accumulator")]
-        let mut accumulated_out = std::panic::AssertUnwindSafe(&mut accumulated);
-        let database_key_index = self.database_key_index;
-        #[cfg(debug_assertions)]
-        let push_len = self.push_len;
+        let accumulated;
 
-        self.local_state.with_query_stack_mut(move |stack| {
+        {
+            let mut stack = self.local_state.query_stack.borrow_mut();
             #[cfg(feature = "accumulator")]
             {
-                **accumulated_out = Some(stack.last_mut().unwrap().take_accumulated());
+                accumulated = stack.last_mut().unwrap().take_accumulated();
             }
             stack.pop(
-                database_key_index,
+                self.database_key_index,
                 #[cfg(debug_assertions)]
-                push_len,
+                self.push_len,
             );
-        });
+        }
 
         #[cfg(feature = "accumulator")]
         drop(accumulated);
@@ -2230,25 +2194,6 @@ mod tests {
     };
     use super::{OriginAndExtra, PackedQueryEdge, QueryEdge, QueryOriginRef};
     use crate::{DatabaseKeyIndex, Id, IngredientIndex};
-
-    #[test]
-    fn reentrant_query_stack_borrows_panic() {
-        let local = super::ZalsaLocal::new();
-
-        assert!(
-            std::panic::catch_unwind(|| {
-                local.with_query_stack_mut(|_| local.with_query_stack(|_| ()));
-            })
-            .is_err()
-        );
-        assert!(
-            std::panic::catch_unwind(|| {
-                local.with_query_stack(|_| local.with_query_stack_mut(|_| ()));
-            })
-            .is_err()
-        );
-        local.with_query_stack_mut(|stack| assert!(stack.is_empty()));
-    }
 
     #[test]
     fn query_origin_packs_edges_that_fit() {

--- a/tests/query-stack-reentrancy.rs
+++ b/tests/query-stack-reentrancy.rs
@@ -1,0 +1,120 @@
+#![cfg(feature = "inventory")]
+#![forbid(unsafe_code)]
+
+use std::cell::Cell;
+use std::panic::{self, catch_unwind};
+use std::sync::Arc;
+
+#[cfg(feature = "accumulator")]
+use salsa::Accumulator;
+use salsa::Database;
+
+thread_local! {
+    static DB: salsa::DatabaseImpl = salsa::DatabaseImpl::default();
+    static REENTER_FROM_HOOK: Cell<bool> = const { Cell::new(false) };
+    static HOOK_CALLS: Cell<usize> = const { Cell::new(0) };
+    #[cfg(feature = "accumulator")]
+    static DROPS: Cell<usize> = const { Cell::new(0) };
+}
+
+#[cfg(feature = "accumulator")]
+#[test]
+fn rejected_accumulator_can_reenter() {
+    DB.with(|db| {
+        DROPS.set(0);
+        let result = catch_unwind(|| Reenter.accumulate(db));
+        assert_eq!(
+            result.unwrap_err().downcast_ref::<&str>(),
+            Some(&"cannot accumulate values outside of an active tracked function")
+        );
+        assert_eq!(DROPS.get(), 1);
+        assert_eq!(read(db), 42);
+    });
+}
+
+#[cfg(feature = "accumulator")]
+#[test]
+fn discarded_accumulator_can_reenter() {
+    DB.with(|db| {
+        DROPS.set(0);
+        let result = catch_unwind(|| accumulate_then_panic(db));
+        assert_eq!(
+            result.unwrap_err().downcast_ref::<&str>(),
+            Some(&"query panic")
+        );
+        assert_eq!(DROPS.get(), 1);
+        assert_eq!(read(db), 42);
+    });
+}
+
+#[test]
+fn cycle_panic_hook_can_reenter() {
+    // Hooks are process-wide. Only reenter on this test's thread, and preserve the existing hook
+    // for panics in other tests.
+    let previous_hook = Arc::new(panic::take_hook());
+    let fallback = previous_hook.clone();
+    panic::set_hook(Box::new(move |info| {
+        if REENTER_FROM_HOOK.replace(false) {
+            DB.with(|db| {
+                db.report_untracked_read();
+                assert_eq!(read(db), 42);
+            });
+            HOOK_CALLS.set(HOOK_CALLS.get() + 1);
+        } else {
+            fallback(info);
+        }
+    }));
+
+    HOOK_CALLS.set(0);
+    REENTER_FROM_HOOK.set(true);
+    let result = catch_unwind(|| DB.with(|db| recursive(db)));
+    REENTER_FROM_HOOK.set(false);
+
+    // Restore the hook before making assertions that could panic.
+    drop(panic::take_hook());
+    panic::set_hook(Arc::try_unwrap(previous_hook).unwrap_or_else(|_| unreachable!()));
+
+    let panic = result.unwrap_err();
+    assert!(
+        panic
+            .downcast_ref::<String>()
+            .unwrap()
+            .contains("dependency graph cycle when querying")
+    );
+    assert_eq!(HOOK_CALLS.get(), 1);
+    DB.with(|db| assert_eq!(read(db), 42));
+}
+
+#[salsa::tracked(returns(copy))]
+fn read(_db: &dyn Database) -> u32 {
+    42
+}
+
+#[salsa::tracked(returns(copy))]
+fn recursive(db: &dyn Database) {
+    recursive(db);
+}
+
+#[cfg(feature = "accumulator")]
+#[salsa::accumulator]
+#[derive(Debug)]
+struct Reenter;
+
+#[cfg(feature = "accumulator")]
+impl Drop for Reenter {
+    fn drop(&mut self) {
+        DB.with(|db| {
+            db.report_untracked_read();
+            // This query can reuse the frame that is currently being discarded.
+            assert_eq!(read(db), 42);
+        });
+        DROPS.set(DROPS.get() + 1);
+    }
+}
+
+#[cfg(feature = "accumulator")]
+#[salsa::tracked(returns(copy))]
+fn accumulate_then_panic(db: &dyn Database) {
+    Reenter.accumulate(db);
+    panic!("query panic");
+}


### PR DESCRIPTION
Use checked query-stack borrows and release them before dropping discarded accumulators or reporting cycles.
This lets destructors and panic hooks reenter a consistent stack without causing undefined behavior.
A small wall-time benchmark regression remains to be investigated.
Testing: Added regression coverage; workspace tests, Clippy, and targeted Miri checks pass.
