### PR TITLE
perf: Avoid checking the TypeId of memos

### DIFF
--- a/examples/lazy-input/main.rs
+++ b/examples/lazy-input/main.rs
@@ -197,14 +197,7 @@ fn parse(db: &dyn Db, input: File) -> ParsedFile<'_> {
         .filter_map(|path| {
             let relative_path = match path.parse::<PathBuf>() {
                 Ok(path) => path,
-                Err(err) => {
-                    Diagnostic::push_error(
-                        db,
-                        input,
-                        Report::new(err).wrap_err(format!("Failed to parse path: {path}")),
-                    );
-                    return None;
-                }
+                Err(err) => match err {},
             };
             let link_path = input.path(db).parent().unwrap().join(relative_path);
             match db.input(link_path) {

--- a/src/function.rs
+++ b/src/function.rs
@@ -924,11 +924,14 @@ mod persistence {
                 // SAFETY: We provide the current revision.
                 let memo_table = unsafe { zalsa.table().dyn_memos(id, zalsa.current_revision()) };
 
-                memo_table.insert(
-                    memo_ingredient_index,
-                    // FIXME: Use `Box::into_non_null` once stable.
-                    NonNull::from(Box::leak(Box::new(memo))),
-                );
+                // SAFETY: The memo_ingredient_index is ours.
+                unsafe {
+                    memo_table.insert(
+                        memo_ingredient_index,
+                        // FIXME: Use `Box::into_non_null` once stable.
+                        NonNull::from(Box::leak(Box::new(memo))),
+                    );
+                }
             }
 
             Ok(())

--- a/src/function/maybe_changed_after.rs
+++ b/src/function/maybe_changed_after.rs
@@ -242,7 +242,8 @@ where
                 claim_guard,
                 old_memo,
             } => {
-                let old_memo = old_memo.downcast::<C>();
+                // SAFETY: We pass the correct `IngredientIndex`, and the user cannot mess with them.
+                let old_memo = unsafe { old_memo.downcast::<C>() };
 
                 if old_memo.value.is_none() {
                     return Some(VerifyResult::changed());

--- a/src/function/memo.rs
+++ b/src/function/memo.rs
@@ -1,3 +1,4 @@
+#[cfg(debug_assertions)]
 use std::any::TypeId;
 use std::fmt::{Debug, Formatter};
 use std::marker::PhantomData;
@@ -24,9 +25,14 @@ impl<C: Configuration> IngredientImpl<C> {
         memo: NonNull<Memo<C>>,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> Option<NonNull<Memo<C>>> {
-        zalsa
-            .memo_table_for::<C::SalsaStruct<'_>>(id)
-            .insert(memo_ingredient_index, memo)
+        // SAFETY: We pass the correct `IngredientIndex`, and the user cannot mess with them.
+        // To create a chain of safety proofs we would need to mark this unsafe as well, but this essentially
+        // requires marking all Salsa code unsafe so I gave up.
+        unsafe {
+            zalsa
+                .memo_table_for::<C::SalsaStruct<'_>>(id)
+                .insert(memo_ingredient_index, memo)
+        }
     }
 
     /// Loads the current memo for `key_index`. This does not hold any sort of
@@ -38,9 +44,12 @@ impl<C: Configuration> IngredientImpl<C> {
         id: Id,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> Option<&'db Memo<C>> {
-        let memo = zalsa
-            .memo_table_for::<C::SalsaStruct<'_>>(id)
-            .get(memo_ingredient_index)?;
+        // SAFETY: We pass the correct `IngredientIndex`, and the user cannot mess with them.
+        let memo = unsafe {
+            zalsa
+                .memo_table_for::<C::SalsaStruct<'_>>(id)
+                .get(memo_ingredient_index)?
+        };
         // SAFETY: The memo table owns this allocation for at least `'db`.
         Some(unsafe { memo.as_ref() })
     }
@@ -75,7 +84,8 @@ impl<C: Configuration> IngredientImpl<C> {
             }
         };
 
-        table.map_memo(memo_ingredient_index, map)
+        // SAFETY: We pass the correct `IngredientIndex`, and the user cannot mess with them.
+        unsafe { table.map_memo(memo_ingredient_index, map) }
     }
 }
 
@@ -114,6 +124,7 @@ pub(crate) struct ErasedMemo<'db> {
     to_dyn_fn: ToDynMemo,
 
     /// The concrete memo type, used to assert that downcasts match the registered memo type.
+    #[cfg(debug_assertions)]
     type_id: TypeId,
 
     /// Binds shared access to the allocation lifetime.
@@ -133,12 +144,13 @@ impl<'memo> ErasedMemo<'memo> {
     pub(crate) unsafe fn from_raw_parts(
         data: NonNull<DummyMemo>,
         to_dyn_fn: ToDynMemo,
-        type_id: TypeId,
+        #[cfg(debug_assertions)] _type_id: TypeId,
     ) -> Self {
         Self {
             data,
             to_dyn_fn,
-            type_id,
+            #[cfg(debug_assertions)]
+            type_id: _type_id,
             _lifetime: PhantomData,
         }
     }
@@ -165,15 +177,20 @@ impl<'memo> ErasedMemo<'memo> {
     ///
     /// Panics if the memo was created for a different configuration, matching
     /// [`MemoTableWithTypes::get`](crate::table::memo::MemoTableWithTypes::get).
+    ///
+    /// # Safety
+    ///
+    /// The memo type must match, meaning the `MemoIngredientIndex` must be correct.
     #[inline]
-    pub(super) fn downcast<C: Configuration>(self) -> &'memo Memo<C> {
+    pub(super) unsafe fn downcast<C: Configuration>(self) -> &'memo Memo<C> {
+        #[cfg(debug_assertions)]
         assert_eq!(
             self.type_id,
             TypeId::of::<Memo<C>>(),
             "ErasedMemo downcast with the wrong configuration",
         );
 
-        // SAFETY: The type check proves that `data` points to `Memo<C>`; the handle guarantees
+        // SAFETY: Our precondition guarantees that `data` points to `Memo<C>`; the handle guarantees
         // that the allocation is valid for shared access for `'memo`.
         unsafe { self.data.cast::<Memo<C>>().as_ref() }
     }
@@ -614,8 +631,12 @@ mod _memory_usage {
         [(); std::mem::size_of::<[usize; 4]>()];
     const _: [(); std::mem::size_of::<super::Memo<DummyConfiguration>>()] =
         [(); std::mem::size_of::<[usize; 5]>()];
+    #[cfg(debug_assertions)]
     const _: [(); std::mem::size_of::<super::ErasedMemo<'static>>()] =
         [(); std::mem::size_of::<[usize; 4]>()];
+    #[cfg(not(debug_assertions))]
+    const _: [(); std::mem::size_of::<super::ErasedMemo<'static>>()] =
+        [(); std::mem::size_of::<[usize; 2]>()];
 
     struct DummyStruct;
 

--- a/src/table/memo.rs
+++ b/src/table/memo.rs
@@ -1,4 +1,6 @@
-use std::any::{Any, TypeId};
+use std::any::Any;
+#[cfg(debug_assertions)]
+use std::any::TypeId;
 use std::fmt::Debug;
 use std::mem;
 use std::ptr::{self, NonNull};
@@ -202,6 +204,7 @@ impl Drop for LazyMemoEntries {
 #[derive(Clone, Copy, Debug)]
 pub struct MemoEntryType {
     /// The `type_id` of the erased memo type `M`
+    #[cfg(debug_assertions)]
     type_id: TypeId,
 
     /// A type-coercion function for the erased memo type `M`.
@@ -212,6 +215,7 @@ impl MemoEntryType {
     #[inline]
     pub fn of<M: Memo>() -> Self {
         Self {
+            #[cfg(debug_assertions)]
             type_id: TypeId::of::<M>(),
             to_dyn_fn: Self::to_dyn_fn::<M>(),
         }
@@ -346,7 +350,10 @@ impl<'a> MemoSlot<'a> {
 }
 
 impl<'a> MemoTableWithTypes<'a> {
-    pub(crate) fn insert<M: Memo>(
+    /// # Safety
+    ///
+    /// The memo type must match, meaning the `MemoIngredientIndex` must be correct.
+    pub(crate) unsafe fn insert<M: Memo>(
         self,
         memo_ingredient_index: MemoIngredientIndex,
         memo: NonNull<M>,
@@ -356,48 +363,46 @@ impl<'a> MemoTableWithTypes<'a> {
             .memos
             .get_or_init(memo_ingredient_index.as_usize())?;
 
-        // SAFETY: Any indices that are in-bounds for the `MemoTable` are also in-bounds for its
-        // corresponding `MemoTableTypes`, by construction.
-        let type_ = unsafe {
-            self.types
-                .types
-                .get_unchecked(memo_ingredient_index.as_usize())
-        };
+        #[cfg(debug_assertions)]
+        {
+            let type_ = &self.types.types[memo_ingredient_index.as_usize()];
 
-        // Verify that the we are casting to the correct type.
-        if type_.type_id != TypeId::of::<M>() {
-            type_assert_failed(memo_ingredient_index);
+            // Verify that the we are casting to the correct type.
+            if type_.type_id != TypeId::of::<M>() {
+                type_assert_failed(memo_ingredient_index);
+            }
         }
 
         let old_memo = atomic_memo.swap(MemoEntryType::to_dummy(memo).as_ptr(), Ordering::AcqRel);
 
-        // SAFETY: We asserted that the type is correct above.
+        // SAFETY: Our precondition.
         NonNull::new(old_memo).map(|old_memo| unsafe { MemoEntryType::from_dummy(old_memo) })
     }
 
     /// Returns a pointer to the memo at the given index, if one has been inserted.
+    ///
+    /// # Safety
+    ///
+    /// The memo type must match, meaning the `MemoIngredientIndex` must be correct.
     #[inline]
-    pub(crate) fn get<M: Memo>(
+    pub(crate) unsafe fn get<M: Memo>(
         self,
         memo_ingredient_index: MemoIngredientIndex,
     ) -> Option<NonNull<M>> {
         let MemoEntry { atomic_memo } = self.memos.memos.get(memo_ingredient_index.as_usize())?;
 
-        // SAFETY: Any indices that are in-bounds for the `MemoTable` are also in-bounds for its
-        // corresponding `MemoTableTypes`, by construction.
-        let type_ = unsafe {
-            self.types
-                .types
-                .get_unchecked(memo_ingredient_index.as_usize())
-        };
+        #[cfg(debug_assertions)]
+        {
+            let type_ = &self.types.types[memo_ingredient_index.as_usize()];
 
-        // Verify that the we are casting to the correct type.
-        if type_.type_id != TypeId::of::<M>() {
-            type_assert_failed(memo_ingredient_index);
+            // Verify that the we are casting to the correct type.
+            if type_.type_id != TypeId::of::<M>() {
+                type_assert_failed(memo_ingredient_index);
+            }
         }
 
+        // SAFETY: Our precondition.
         NonNull::new(atomic_memo.load(Ordering::Acquire))
-            // SAFETY: We asserted that the type is correct above.
             .map(|memo| unsafe { MemoEntryType::from_dummy(memo) })
     }
 
@@ -428,7 +433,14 @@ impl<'a> MemoTableWithTypes<'a> {
         // base address, with spatial provenance covering the allocation, paired with `type_`; the
         // acquire load observes its initialization. The caller guarantees that the allocation
         // remains valid for `'a`.
-        Some(unsafe { ErasedMemo::from_raw_parts(memo, type_.to_dyn_fn, type_.type_id) })
+        Some(unsafe {
+            ErasedMemo::from_raw_parts(
+                memo,
+                type_.to_dyn_fn,
+                #[cfg(debug_assertions)]
+                type_.type_id,
+            )
+        })
     }
 
     #[cfg(feature = "salsa_unstable")]
@@ -461,7 +473,11 @@ impl MemoTableWithTypesMut<'_> {
     /// Calls `f` on the memo at `memo_ingredient_index`.
     ///
     /// If the memo is not present, `f` is not called.
-    pub(crate) fn map_memo<M: Memo>(
+    ///
+    /// # Safety
+    ///
+    /// The memo type must match, meaning the `MemoIngredientIndex` must be correct.
+    pub(crate) unsafe fn map_memo<M: Memo>(
         self,
         memo_ingredient_index: MemoIngredientIndex,
         f: impl FnOnce(&mut M),
@@ -472,17 +488,14 @@ impl MemoTableWithTypesMut<'_> {
             return;
         };
 
-        // SAFETY: Any indices that are in-bounds for the `MemoTable` are also in-bounds for its
-        // corresponding `MemoTableTypes`, by construction.
-        let type_ = unsafe {
-            self.types
-                .types
-                .get_unchecked(memo_ingredient_index.as_usize())
-        };
+        #[cfg(debug_assertions)]
+        {
+            let type_ = &self.types.types[memo_ingredient_index.as_usize()];
 
-        // Verify that the we are casting to the correct type.
-        if type_.type_id != TypeId::of::<M>() {
-            type_assert_failed(memo_ingredient_index);
+            // Verify that the we are casting to the correct type.
+            if type_.type_id != TypeId::of::<M>() {
+                type_assert_failed(memo_ingredient_index);
+            }
         }
 
         let Some(memo) = NonNull::new(*atomic_memo.get_mut()) else {
@@ -533,6 +546,7 @@ impl MemoTableWithTypesMut<'_> {
 }
 
 /// This function is explicitly outlined to avoid debug machinery in the hot-path.
+#[cfg(debug_assertions)]
 #[cold]
 #[inline(never)]
 fn type_assert_failed(memo_ingredient_index: MemoIngredientIndex) -> ! {


### PR DESCRIPTION
Generally user code cannot touch them; however I need to see the benchmarks to see if this is worth the extra unsafe.