### PR TITLE
Allow create self-referential interneds without replicating the macro's work

### DIFF
--- a/components/salsa-macro-rules/src/setup_interned_struct.rs
+++ b/components/salsa-macro-rules/src/setup_interned_struct.rs
@@ -54,6 +54,9 @@ macro_rules! setup_interned_struct {
         // Indices for each field from 0..N -- must be unsuffixed (e.g., `0`, `1`).
         field_indices: [$($field_index:tt),*],
 
+        // Indices for fields that participate in `Hash`/`Eq` impls.
+        hash_eq_field_indices: [$($hash_eq_field_index:tt),*],
+
         // Indexed types for each field (T0, T1, ...)
         field_indexed_tys: [$($indexed_ty:ident),*],
 
@@ -96,7 +99,7 @@ macro_rules! setup_interned_struct {
         #[derive(Copy, Clone, PartialEq, Eq, Hash)]
         $vis struct $Struct< $($db_lt_arg)? >(
             $Id,
-            std::marker::PhantomData<fn() -> &$interior_lt ()>
+            ::std::marker::PhantomData<fn() -> &$interior_lt ()>
         );
 
         #[allow(clippy::all)]
@@ -123,28 +126,50 @@ macro_rules! setup_interned_struct {
             }
             let _ = _assert_fields_are_salsa_values;
 
-            type $StructDataIdent<$db_lt> = ($($field_ty,)*);
+            pub struct $StructDataIdent<$db_lt>(
+                ($($field_ty,)*),
+                $zalsa_struct::PhantomData<fn() -> &$db_lt ()>,
+            );
+
+            impl<$db_lt> ::std::hash::Hash for $StructDataIdent<$db_lt> {
+                fn hash<H: ::std::hash::Hasher>(&self, state: &mut H) {
+                    $( ::std::hash::Hash::hash(&self.0.$hash_eq_field_index, state); )*
+                }
+            }
+
+            impl<$db_lt> ::std::cmp::PartialEq for $StructDataIdent<$db_lt> {
+                fn eq(&self, other: &Self) -> bool {
+                    $( ::std::cmp::PartialEq::eq(&self.0.$hash_eq_field_index, &other.0.$hash_eq_field_index) && )*
+                        true
+                }
+            }
+
+            impl<$db_lt> ::std::cmp::Eq for $StructDataIdent<$db_lt> {}
+
+            fn __assert_eq(data: &$StructDataIdent<'_>) {
+                fn assert_field_eq<T: ::std::cmp::Eq>(_: &T) {}
+
+                $( assert_field_eq(&data.0.$hash_eq_field_index); )*
+            }
 
             /// Key to use during hash lookups. Each field is some type that implements `Lookup<T>`
             /// for the owned type. This permits interning with an `&str` when a `String` is required and so forth.
-            #[derive(Hash)]
             struct StructKey<$db_lt, $($indexed_ty),*>(
                 $($indexed_ty,)*
-                ::std::marker::PhantomData<&$db_lt ()>,
+                $zalsa_struct::PhantomData<&$db_lt ()>,
             );
 
-            impl<$db_lt, $($indexed_ty,)*> $zalsa::HashEqLike<StructKey<$db_lt, $($indexed_ty),*>>
-                for $StructDataIdent<$db_lt>
-                where
-                $($field_ty: $zalsa::HashEqLike<$indexed_ty>),*
-                {
-
+            impl<$db_lt, $($indexed_ty,)*> $zalsa::HashEqLike<$StructDataIdent<$db_lt>>
+                for StructKey<$db_lt, $($indexed_ty),*>
+            where
+                $($indexed_ty: $zalsa::HashEqLike<$field_ty>),*
+            {
                 fn hash<H: ::std::hash::Hasher>(&self, h: &mut H) {
-                    $($zalsa::HashEqLike::<$indexed_ty>::hash(&self.$field_index, &mut *h);)*
+                    $($zalsa::HashEqLike::hash(&self.$field_index, &mut *h);)*
                 }
 
-                fn eq(&self, data: &StructKey<$db_lt, $($indexed_ty),*>) -> bool {
-                    ($($zalsa::HashEqLike::<$indexed_ty>::eq(&self.$field_index, &data.$field_index) && )* true)
+                fn eq(&self, data: &$StructDataIdent<$db_lt>) -> bool {
+                    ($($zalsa::HashEqLike::eq(&self.$field_index, &data.0.$field_index) && )* true)
                 }
             }
 
@@ -152,8 +177,8 @@ macro_rules! setup_interned_struct {
                 for StructKey<$db_lt, $($indexed_ty),*> {
 
                 #[allow(unused_unit)]
-                fn into_owned(self) -> $StructDataIdent<$db_lt> {
-                    ($($zalsa::Lookup::into_owned(self.$field_index),)*)
+                fn into_owned(self, id: $zalsa::Id) -> $StructDataIdent<$db_lt> {
+                    $StructDataIdent(($($zalsa::Lookup::into_owned(self.$field_index, id),)*), $zalsa_struct::PhantomData)
                 }
             }
 
@@ -176,7 +201,7 @@ macro_rules! setup_interned_struct {
 
                 $(
                     fn heap_size(value: &Self::Fields<'_>) -> Option<usize> {
-                        Some($heap_size_fn(value))
+                        Some($heap_size_fn(&value.0))
                     }
                 )?
 
@@ -186,7 +211,7 @@ macro_rules! setup_interned_struct {
                 ) -> ::std::result::Result<S::Ok, S::Error> {
                     $zalsa::macro_if! {
                         if $persist {
-                            $($serialize_fn(fields, serializer))?
+                            $($serialize_fn(&fields.0, serializer))?
                         } else {
                             panic!("attempted to serialize value not marked with `persist` attribute")
                         }
@@ -198,7 +223,7 @@ macro_rules! setup_interned_struct {
                 ) -> ::std::result::Result<Self::Fields<'static>, D::Error> {
                     $zalsa::macro_if! {
                         if $persist {
-                            $($deserialize_fn(deserializer))?
+                            ::std::result::Result::Ok($StructDataIdent($($deserialize_fn(deserializer))??, $zalsa_struct::PhantomData))
                         } else {
                             panic!("attempted to deserialize value not marked with `persist` attribute")
                         }
@@ -227,7 +252,7 @@ macro_rules! setup_interned_struct {
 
             impl< $($db_lt_arg)? > $zalsa::FromId for $Struct< $($db_lt_arg)? > {
                 fn from_id(id: ::salsa::Id) -> Self {
-                    Self(<$Id>::from_id(id), ::std::marker::PhantomData)
+                    Self(<$Id>::from_id(id), $zalsa_struct::PhantomData)
                 }
             }
 
@@ -303,17 +328,17 @@ macro_rules! setup_interned_struct {
             unsafe impl< $($db_lt_arg)? > $zalsa::SalsaValue for $Struct< $($db_lt_arg)? > {}
 
             impl<$db_lt> $Struct< $($db_lt_arg)? >  {
-                pub fn $new_fn<$Db, $($indexed_ty: $zalsa::Lookup<$field_ty> + ::std::hash::Hash,)*>(db: &$db_lt $Db,  $($field_id: $indexed_ty),*) -> Self
+                pub fn $new_fn<$Db, $($indexed_ty: $zalsa::Lookup<$field_ty>,)*>(db: &$db_lt $Db,  $($field_id: $indexed_ty),*) -> Self
                 where
                     // FIXME(rust-lang/rust#65991): The `db` argument *should* have the type `dyn Database`
                     $Db: ?Sized + ::salsa::Database,
                     $(
-                        $field_ty: $zalsa::HashEqLike<$indexed_ty>,
+                        $indexed_ty: $zalsa::HashEqLike<$field_ty>,
                     )*
                 {
                     let (zalsa, zalsa_local) = db.zalsas();
                     $Configuration::ingredient(zalsa).intern(zalsa, zalsa_local,
-                        StructKey::<$db_lt>($($field_id,)* ::std::marker::PhantomData::default()), |_, data| $zalsa::Lookup::into_owned(data))
+                        StructKey::<$db_lt>($($field_id,)* $zalsa_struct::PhantomData::default()), |id, data| $zalsa::Lookup::into_owned(data, id))
                 }
 
                 $(
@@ -328,7 +353,7 @@ macro_rules! setup_interned_struct {
                         $zalsa::return_mode_expression!(
                             $field_option,
                             $field_ty,
-                            &fields.$field_index,
+                            &fields.0.$field_index,
                         )
                     }
                 )*
@@ -350,7 +375,7 @@ macro_rules! setup_interned_struct {
                                 let fields = $Configuration::ingredient(zalsa).fields(zalsa, this);
                                 let mut f = f.debug_struct(stringify!($Struct));
                                 $(
-                                    let f = f.field(stringify!($field_id), &fields.$field_index);
+                                    let f = f.field(stringify!($field_id), &fields.0.$field_index);
                                 )*
                                 f.finish()
                             }).unwrap_or_else(|| {
@@ -374,7 +399,7 @@ macro_rules! setup_interned_struct {
                                 let fields = $Configuration::ingredient(zalsa).fields(zalsa, this);
                                 let mut f = f.debug_struct(stringify!($Struct));
                                 $(
-                                    let f = f.field(stringify!($field_id), &fields.$field_index);
+                                    let f = f.field(stringify!($field_id), &fields.0.$field_index);
                                 )*
                                 f.finish()
                             }).unwrap_or_else(|| {

--- a/components/salsa-macros/src/interned.rs
+++ b/components/salsa-macros/src/interned.rs
@@ -1,4 +1,4 @@
-use proc_macro2::TokenStream;
+use proc_macro2::{Literal, TokenStream};
 
 use crate::hygiene::Hygiene;
 use crate::options::{AllowedOptions, AllowedPersistOptions, Options};
@@ -165,6 +165,11 @@ impl Macro {
             })
             .collect();
 
+        let hash_eq_field_indices = salsa_struct
+            .fields_iter()
+            .filter(|(_, field)| !field.has_no_eq_attr)
+            .map(|(index, _)| Literal::usize_unsuffixed(index));
+
         Ok(crate::debug::dump_tokens(
             struct_ident,
             quote! {
@@ -185,6 +190,7 @@ impl Macro {
                     field_getters: [#(#field_vis #field_getter_ids),*],
                     field_tys: [#(#field_tys),*],
                     field_indices: [#(#field_indices),*],
+                    hash_eq_field_indices: [#(#hash_eq_field_indices),*],
                     field_indexed_tys: [#(#field_indexed_tys),*],
                     field_attrs: [#([#(#field_unused_attrs),*]),*],
                     num_fields: #num_fields,

--- a/components/salsa-macros/src/salsa_struct.rs
+++ b/components/salsa-macros/src/salsa_struct.rs
@@ -421,6 +421,10 @@ where
         self.args.no_lifetime.is_none()
     }
 
+    pub fn fields_iter(&self) -> impl Iterator<Item = (usize, &SalsaField<'s>)> {
+        self.fields.iter().enumerate()
+    }
+
     pub fn tracked_fields_iter(&self) -> impl Iterator<Item = (usize, &SalsaField<'s>)> {
         self.fields
             .iter()

--- a/examples/lazy-input/main.rs
+++ b/examples/lazy-input/main.rs
@@ -197,14 +197,7 @@ fn parse(db: &dyn Db, input: File) -> ParsedFile<'_> {
         .filter_map(|path| {
             let relative_path = match path.parse::<PathBuf>() {
                 Ok(path) => path,
-                Err(err) => {
-                    Diagnostic::push_error(
-                        db,
-                        input,
-                        Report::new(err).wrap_err(format!("Failed to parse path: {path}")),
-                    );
-                    return None;
-                }
+                Err(err) => match err {},
             };
             let link_path = input.path(db).parent().unwrap().join(relative_path);
             match db.input(link_path) {

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -80,8 +80,8 @@ pub unsafe trait Configuration: Sized + 'static {
         D: plumbing::serde::Deserializer<'de>;
 }
 
-pub trait InternedData: Sized + Eq + Hash + Clone + Sync + Send {}
-impl<T: Eq + Hash + Clone + Sync + Send> InternedData for T {}
+pub trait InternedData: Sized + Eq + Hash + Sync + Send {}
+impl<T: Eq + Hash + Sync + Send> InternedData for T {}
 
 pub struct JarImpl<C: Configuration> {
     phantom: PhantomData<C>,
@@ -415,8 +415,7 @@ where
         assemble: impl FnOnce(Id, Key) -> C::Fields<'db>,
     ) -> C::Struct<'db>
     where
-        Key: Hash,
-        C::Fields<'db>: HashEqLike<Key>,
+        Key: HashEqLike<C::Fields<'db>>,
     {
         FromId::from_id(self.intern_id(zalsa, zalsa_local, key, assemble))
     }
@@ -439,12 +438,11 @@ where
         assemble: impl FnOnce(Id, Key) -> C::Fields<'db>,
     ) -> crate::Id
     where
-        Key: Hash,
         // We'd want the following predicate, but this currently implies `'static` due to a rustc
         // bug
         // for<'db> C::Data<'db>: HashEqLike<Key>,
         // so instead we go with this and transmute the lifetime in the `eq` closure
-        C::Fields<'db>: HashEqLike<Key>,
+        Key: HashEqLike<C::Fields<'db>>,
     {
         // Record the current revision as active.
         let current_revision = zalsa.current_revision();
@@ -453,7 +451,7 @@ where
         }
 
         // Hash the value before acquiring the lock.
-        let hash = self.hasher.hash_one(&key);
+        let hash = hash_one(&self.hasher, &key);
 
         let shard_index = self.shard(hash);
         // SAFETY: `shard_index` is guaranteed to be in-bounds for `self.shards`.
@@ -669,8 +667,7 @@ where
         hash: u64,
     ) -> crate::Id
     where
-        Key: Hash,
-        C::Fields<'db>: HashEqLike<Key>,
+        Key: HashEqLike<C::Fields<'db>>,
     {
         let current_revision = zalsa.current_revision();
 
@@ -952,12 +949,12 @@ where
     // The lock must be held for the shard containing the value.
     unsafe fn value_eq<'db, Key>(value: &'db Value<C>, key: &Key) -> bool
     where
-        C::Fields<'db>: HashEqLike<Key>,
+        Key: HashEqLike<C::Fields<'db>>,
     {
         // SAFETY: We hold the lock for the shard containing the value.
         let fields = unsafe { &*value.fields.get() };
 
-        HashEqLike::eq(Self::from_internal_data(fields), key)
+        HashEqLike::eq(key, Self::from_internal_data(fields))
     }
 
     /// Returns the database key index for an interned value with the given id.
@@ -1050,6 +1047,20 @@ where
             }
         })
     }
+}
+
+#[inline]
+fn hash_one<O>(hasher: &impl BuildHasher, value: &impl HashEqLike<O>) -> u64 {
+    struct Hashable<'a, T, O>(&'a T, PhantomData<O>);
+
+    impl<O, T: HashEqLike<O>> Hash for Hashable<'_, T, O> {
+        #[inline]
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            self.0.hash(state);
+        }
+    }
+
+    hasher.hash_one(Hashable(value, PhantomData))
 }
 
 /// Creates the sharded storage outside of the generic [`IngredientImpl::new`] context.
@@ -1431,12 +1442,15 @@ pub trait HashEqLike<O> {
 /// where `struct ViewStruct<L1: Lookup<K1>...>(K1...)`. The `Borrow` trait
 /// requires that `&(K1...)` be convertible to `&ViewStruct` which just isn't
 /// possible. `Lookup` instead offers direct `hash` and `eq` methods.
-pub trait Lookup<O> {
-    fn into_owned(self) -> O;
+pub trait Lookup<O>: Sized {
+    /// `id` is the [`Id`] of the to-be-created struct.
+    ///
+    /// **Warning:** Trying to lookup the ID before returning can result in a deadlock.
+    fn into_owned(self, id: Id) -> O;
 }
 
 impl<T> Lookup<T> for T {
-    fn into_owned(self) -> T {
+    fn into_owned(self, _id: Id) -> T {
         self
     }
 }
@@ -1484,20 +1498,19 @@ impl<T> Lookup<T> for &T
 where
     T: Clone,
 {
-    fn into_owned(self) -> T {
+    fn into_owned(self, _id: Id) -> T {
         Clone::clone(self)
     }
 }
 
-impl<'a, T> HashEqLike<&'a T> for Box<T>
+impl<T> HashEqLike<Box<T>> for &T
 where
     T: ?Sized + Hash + Eq,
-    Box<T>: From<&'a T>,
 {
     fn hash<H: Hasher>(&self, h: &mut H) {
         Hash::hash(self, &mut *h)
     }
-    fn eq(&self, data: &&T) -> bool {
+    fn eq(&self, data: &Box<T>) -> bool {
         **self == **data
     }
 }
@@ -1507,20 +1520,19 @@ where
     T: ?Sized + Hash + Eq,
     Box<T>: From<&'a T>,
 {
-    fn into_owned(self) -> Box<T> {
+    fn into_owned(self, _id: Id) -> Box<T> {
         Box::from(self)
     }
 }
 
-impl<'a, T> HashEqLike<&'a T> for Arc<T>
+impl<T> HashEqLike<Arc<T>> for &T
 where
     T: ?Sized + Hash + Eq,
-    Arc<T>: From<&'a T>,
 {
     fn hash<H: Hasher>(&self, h: &mut H) {
         Hash::hash(&**self, &mut *h)
     }
-    fn eq(&self, data: &&T) -> bool {
+    fn eq(&self, data: &Arc<T>) -> bool {
         **self == **data
     }
 }
@@ -1530,21 +1542,20 @@ where
     T: ?Sized + Hash + Eq,
     Arc<T>: From<&'a T>,
 {
-    fn into_owned(self) -> Arc<T> {
+    fn into_owned(self, _id: Id) -> Arc<T> {
         Arc::from(self)
     }
 }
 
 #[cfg(feature = "triomphe")]
-impl<'a, T> HashEqLike<&'a T> for triomphe::Arc<T>
+impl<'a, T> HashEqLike<triomphe::Arc<T>> for &'a T
 where
     T: ?Sized + Hash + Eq,
-    triomphe::Arc<T>: From<&'a T>,
 {
     fn hash<H: Hasher>(&self, h: &mut H) {
         Hash::hash(&**self, &mut *h)
     }
-    fn eq(&self, data: &&T) -> bool {
+    fn eq(&self, data: &triomphe::Arc<T>) -> bool {
         **self == **data
     }
 }
@@ -1555,189 +1566,191 @@ where
     T: ?Sized + Hash + Eq,
     triomphe::Arc<T>: From<&'a T>,
 {
-    fn into_owned(self) -> triomphe::Arc<T> {
+    fn into_owned(self, _id: Id) -> triomphe::Arc<T> {
         triomphe::Arc::from(self)
     }
 }
 
 impl Lookup<String> for &str {
-    fn into_owned(self) -> String {
+    fn into_owned(self, _id: Id) -> String {
         self.to_owned()
     }
 }
 
 #[cfg(feature = "compact_str")]
 impl Lookup<compact_str::CompactString> for &str {
-    fn into_owned(self) -> compact_str::CompactString {
+    fn into_owned(self, _id: Id) -> compact_str::CompactString {
         compact_str::CompactString::new(self)
     }
 }
 
 #[cfg(feature = "compact_str")]
-impl HashEqLike<&str> for compact_str::CompactString {
+impl HashEqLike<compact_str::CompactString> for &str {
     fn hash<H: Hasher>(&self, h: &mut H) {
         Hash::hash(self, &mut *h)
     }
 
-    fn eq(&self, data: &&str) -> bool {
-        self == *data
+    fn eq(&self, data: &compact_str::CompactString) -> bool {
+        *self == data
     }
 }
 
 #[cfg(feature = "compact_str")]
-impl HashEqLike<Cow<'_, str>> for compact_str::CompactString {
+impl HashEqLike<compact_str::CompactString> for Cow<'_, str> {
     fn hash<H: Hasher>(&self, h: &mut H) {
-        self.as_str().hash(h);
+        self.as_ref().hash(h);
     }
 
-    fn eq(&self, data: &Cow<'_, str>) -> bool {
-        self.as_str() == data.as_ref()
+    fn eq(&self, data: &compact_str::CompactString) -> bool {
+        self.as_ref() == data.as_str()
     }
 }
 
 #[cfg(feature = "compact_str")]
 impl Lookup<compact_str::CompactString> for Cow<'_, str> {
-    fn into_owned(self) -> compact_str::CompactString {
+    fn into_owned(self, _id: Id) -> compact_str::CompactString {
         compact_str::CompactString::new(Cow::into_owned(self))
     }
 }
 
-impl HashEqLike<&str> for String {
+impl HashEqLike<String> for &str {
     fn hash<H: Hasher>(&self, h: &mut H) {
         Hash::hash(self, &mut *h)
     }
 
-    fn eq(&self, data: &&str) -> bool {
-        self == *data
+    fn eq(&self, data: &String) -> bool {
+        *self == data
     }
 }
 
-impl<A, T: Hash + Eq + PartialEq<A>> HashEqLike<&[A]> for Vec<T> {
+impl<A: Hash + Eq + PartialEq<T>, T> HashEqLike<Vec<T>> for &[A] {
     fn hash<H: Hasher>(&self, h: &mut H) {
         Hash::hash(self, h);
     }
 
-    fn eq(&self, data: &&[A]) -> bool {
+    fn eq(&self, data: &Vec<T>) -> bool {
         self.len() == data.len() && data.iter().enumerate().all(|(i, a)| &self[i] == a)
     }
 }
 
 impl<A: Hash + Eq + PartialEq<T> + Clone + Lookup<T>, T> Lookup<Vec<T>> for &[A] {
-    fn into_owned(self) -> Vec<T> {
-        self.iter().map(|a| Lookup::into_owned(a.clone())).collect()
+    fn into_owned(self, id: Id) -> Vec<T> {
+        self.iter()
+            .map(|a| Lookup::into_owned(a.clone(), id))
+            .collect()
     }
 }
 
-impl<const N: usize, A, T: Hash + Eq + PartialEq<A>> HashEqLike<[A; N]> for Vec<T> {
+impl<const N: usize, A: Hash + Eq + PartialEq<T>, T> HashEqLike<Vec<T>> for [A; N] {
     fn hash<H: Hasher>(&self, h: &mut H) {
         Hash::hash(self, h);
     }
 
-    fn eq(&self, data: &[A; N]) -> bool {
+    fn eq(&self, data: &Vec<T>) -> bool {
         self.len() == data.len() && data.iter().enumerate().all(|(i, a)| &self[i] == a)
     }
 }
 
 impl<const N: usize, A: Hash + Eq + PartialEq<T> + Clone + Lookup<T>, T> Lookup<Vec<T>> for [A; N] {
-    fn into_owned(self) -> Vec<T> {
+    fn into_owned(self, id: Id) -> Vec<T> {
         self.into_iter()
-            .map(|a| Lookup::into_owned(a.clone()))
+            .map(|a| Lookup::into_owned(a, id))
             .collect()
     }
 }
 
-impl HashEqLike<&Path> for PathBuf {
+impl HashEqLike<PathBuf> for &Path {
     fn hash<H: Hasher>(&self, h: &mut H) {
         Hash::hash(self, h);
     }
 
-    fn eq(&self, data: &&Path) -> bool {
+    fn eq(&self, data: &PathBuf) -> bool {
         self == data
     }
 }
 
 impl Lookup<PathBuf> for &Path {
-    fn into_owned(self) -> PathBuf {
+    fn into_owned(self, _id: Id) -> PathBuf {
         self.to_owned()
     }
 }
 
-impl<T: Hash + Eq + Clone> HashEqLike<Cow<'_, T>> for T {
+impl<T: Hash + Eq + Clone> HashEqLike<T> for Cow<'_, T> {
     fn hash<H: Hasher>(&self, h: &mut H) {
         Hash::hash(self, h);
     }
 
-    fn eq(&self, data: &Cow<'_, T>) -> bool {
-        self == data.as_ref()
+    fn eq(&self, data: &T) -> bool {
+        self.as_ref() == data
     }
 }
 
 impl<T: Clone> Lookup<T> for Cow<'_, T> {
-    fn into_owned(self) -> T {
+    fn into_owned(self, _id: Id) -> T {
         Cow::into_owned(self)
     }
 }
 
-impl HashEqLike<Cow<'_, str>> for String {
-    fn hash<H: Hasher>(&self, h: &mut H) {
-        self.as_str().hash(h);
-    }
-
-    fn eq(&self, data: &Cow<'_, str>) -> bool {
-        self.as_str() == data.as_ref()
-    }
-}
-
-impl Lookup<String> for Cow<'_, str> {
-    fn into_owned(self) -> String {
-        Cow::into_owned(self)
-    }
-}
-
-impl HashEqLike<Cow<'_, Path>> for PathBuf {
-    fn hash<H: Hasher>(&self, h: &mut H) {
-        self.as_path().hash(h);
-    }
-
-    fn eq(&self, data: &Cow<'_, Path>) -> bool {
-        self.as_path() == data.as_ref()
-    }
-}
-
-impl Lookup<PathBuf> for Cow<'_, Path> {
-    fn into_owned(self) -> PathBuf {
-        Cow::into_owned(self)
-    }
-}
-
-impl<T: Hash + Eq + Clone> HashEqLike<Cow<'_, [T]>> for Box<[T]> {
+impl HashEqLike<String> for Cow<'_, str> {
     fn hash<H: Hasher>(&self, h: &mut H) {
         self.as_ref().hash(h);
     }
 
-    fn eq(&self, data: &Cow<'_, [T]>) -> bool {
+    fn eq(&self, data: &String) -> bool {
+        self.as_ref() == data.as_str()
+    }
+}
+
+impl Lookup<String> for Cow<'_, str> {
+    fn into_owned(self, _id: Id) -> String {
+        Cow::into_owned(self)
+    }
+}
+
+impl HashEqLike<PathBuf> for Cow<'_, Path> {
+    fn hash<H: Hasher>(&self, h: &mut H) {
+        self.as_ref().hash(h);
+    }
+
+    fn eq(&self, data: &PathBuf) -> bool {
+        self.as_ref() == data.as_path()
+    }
+}
+
+impl Lookup<PathBuf> for Cow<'_, Path> {
+    fn into_owned(self, _id: Id) -> PathBuf {
+        Cow::into_owned(self)
+    }
+}
+
+impl<T: Hash + Eq + Clone> HashEqLike<Box<[T]>> for Cow<'_, [T]> {
+    fn hash<H: Hasher>(&self, h: &mut H) {
+        self.as_ref().hash(h);
+    }
+
+    fn eq(&self, data: &Box<[T]>) -> bool {
         self.as_ref() == data.as_ref()
     }
 }
 
 impl<T: Clone> Lookup<Box<[T]>> for Cow<'_, [T]> {
-    fn into_owned(self) -> Box<[T]> {
+    fn into_owned(self, _id: Id) -> Box<[T]> {
         Cow::into_owned(self).into_boxed_slice()
     }
 }
 
-impl<T: Hash + Eq + Clone> HashEqLike<Cow<'_, [T]>> for Vec<T> {
+impl<T: Hash + Eq + Clone> HashEqLike<Vec<T>> for Cow<'_, [T]> {
     fn hash<H: Hasher>(&self, h: &mut H) {
-        self.as_slice().hash(h);
+        self.as_ref().hash(h);
     }
 
-    fn eq(&self, data: &Cow<'_, [T]>) -> bool {
-        self.as_slice() == data.as_ref()
+    fn eq(&self, data: &Vec<T>) -> bool {
+        self.as_ref() == data.as_slice()
     }
 }
 
 impl<T: Clone> Lookup<Vec<T>> for Cow<'_, [T]> {
-    fn into_owned(self) -> Vec<T> {
+    fn into_owned(self, _id: Id) -> Vec<T> {
         Cow::into_owned(self)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,6 +408,8 @@ pub mod plumbing {
     }
 
     pub mod interned {
+        pub use std::marker::PhantomData;
+
         pub use crate::interned::{Configuration, IngredientImpl, JarImpl, Value};
     }
 

--- a/tests/debug_db_contents.rs
+++ b/tests/debug_db_contents.rs
@@ -38,8 +38,8 @@ fn execute() {
     assert_eq!(interned.len(), 2);
     assert_eq!(interned[0].as_struct(), interned1);
     assert_eq!(interned[1].as_struct(), interned2);
-    assert_eq!(interned[0].value().fields().0, "Salsa");
-    assert_eq!(interned[1].value().fields().0, "Salsa2");
+    assert_eq!(interned[0].value().fields().0.0, "Salsa");
+    assert_eq!(interned[1].value().fields().0.0, "Salsa2");
 
     // test input structs
     let input1 = InputStruct::new(&db, 22);

--- a/tests/interned-revisions.rs
+++ b/tests/interned-revisions.rs
@@ -41,18 +41,18 @@ impl std::hash::Hash for PanickingLookup {
 }
 
 impl Lookup<BadHash> for PanickingLookup {
-    fn into_owned(self) -> BadHash {
+    fn into_owned(self, _id: salsa::Id) -> BadHash {
         assert_ne!(self.0, 2, "lookup panic");
         BadHash(self.0)
     }
 }
 
-impl HashEqLike<PanickingLookup> for BadHash {
+impl HashEqLike<BadHash> for PanickingLookup {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         state.write_i16(0);
     }
 
-    fn eq(&self, data: &PanickingLookup) -> bool {
+    fn eq(&self, data: &BadHash) -> bool {
         self.0 == data.0
     }
 }

--- a/tests/interned-structs.rs
+++ b/tests/interned-structs.rs
@@ -159,7 +159,7 @@ fn interned_structs_have_public_ingredients() {
     let underlying_id = s.0;
 
     let data = InternedString::ingredient(db.zalsa()).data(db.zalsa(), underlying_id.as_id());
-    assert_eq!(data.0, "Hello, world!");
+    assert_eq!(data.0.0, "Hello, world!");
 }
 
 #[test]

--- a/tests/interned-structs_self_ref.rs
+++ b/tests/interned-structs_self_ref.rs
@@ -3,10 +3,9 @@
 //! Test that a `tracked` fn on a `salsa::input`
 //! compiles and executes successfully.
 
-use std::any::TypeId;
 use std::convert::identity;
 
-use salsa::plumbing::Zalsa;
+use salsa::{Database, HashEqLike, Lookup};
 use test_log::test;
 
 #[test]
@@ -19,217 +18,39 @@ fn interning_returns_equal_keys_for_equal_data() {
     assert_eq!(s1, s1_2);
     assert_eq!(s2, s2_2);
 }
-// Recursive expansion of interned macro
-// #[salsa::interned]
-// struct InternedString<'db> {
-//     data: String,
-//     other: InternedString<'db>,
-// }
-// ======================================
 
-#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
-struct InternedString<'db>(
-    salsa::Id,
-    std::marker::PhantomData<&'db salsa::plumbing::interned::Value<InternedString<'static>>>,
-);
+#[salsa::interned(debug, constructor = new_impl)]
+struct InternedString<'db> {
+    data: String,
+    #[no_eq]
+    other: InternedString<'db>,
+}
 
-#[allow(warnings)]
-const _: () = {
-    use salsa::plumbing as zalsa_;
-    use zalsa_::interned as zalsa_struct_;
+impl<'db> InternedString<'db> {
+    pub fn new(
+        db: &'db dyn Database,
+        data: impl HashEqLike<String> + Lookup<String>,
+        other: impl FnOnce(InternedString<'db>) -> InternedString<'db>,
+    ) -> Self {
+        struct OtherLookup<F>(F);
 
-    type Configuration_ = InternedString<'static>;
-
-    impl<'db> zalsa_::HasJar for InternedString<'db> {
-        type Jar = zalsa_struct_::JarImpl<Configuration_>;
-        const KIND: zalsa_::JarKind = zalsa_::JarKind::Struct;
-    }
-
-    zalsa_::register_jar! {
-        zalsa_::ErasedJar::erase::<InternedString<'static>>()
-    }
-
-    #[derive(Clone, salsa::SalsaValue)]
-    struct StructData<'db>(String, InternedString<'db>);
-
-    impl<'db> Eq for StructData<'db> {}
-    impl<'db> PartialEq for StructData<'db> {
-        fn eq(&self, other: &Self) -> bool {
-            self.0 == other.0
-        }
-    }
-
-    impl<'db> std::hash::Hash for StructData<'db> {
-        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-            self.0.hash(state);
-        }
-    }
-
-    #[doc = r" Key to use during hash lookups. Each field is some type that implements `Lookup<T>`"]
-    #[doc = r" for the owned type. This permits interning with an `&str` when a `String` is required and so forth."]
-    #[derive(Hash)]
-    struct StructKey<'db, T0>(T0, std::marker::PhantomData<&'db ()>);
-
-    impl<'db, T0> zalsa_::HashEqLike<StructKey<'db, T0>> for StructData<'db>
-    where
-        String: zalsa_::HashEqLike<T0>,
-    {
-        fn hash<H: std::hash::Hasher>(&self, h: &mut H) {
-            zalsa_::HashEqLike::<T0>::hash(&self.0, &mut *h);
-        }
-        fn eq(&self, data: &StructKey<'db, T0>) -> bool {
-            (zalsa_::HashEqLike::<T0>::eq(&self.0, &data.0) && true)
-        }
-    }
-    // SAFETY: `StructData<'db>` contains only an owned `String` and a phantom lifetime.
-    unsafe impl zalsa_struct_::Configuration for Configuration_ {
-        const LOCATION: zalsa_::Location = zalsa_::Location {
-            file: file!(),
-            line: line!(),
-        };
-        const DEBUG_NAME: &'static str = "InternedString";
-        type Fields<'a> = StructData<'a>;
-        type Struct<'a> = InternedString<'a>;
-
-        const PERSIST: bool = false;
-
-        fn serialize<S>(value: &Self::Fields<'_>, serializer: S) -> Result<S::Ok, S::Error>
+        impl<'db, F> Lookup<InternedString<'db>> for OtherLookup<F>
         where
-            S: zalsa_::serde::Serializer,
+            F: FnOnce(InternedString<'db>) -> InternedString<'db>,
         {
-            panic!("attempted to serialize value not marked with `persist` attribute")
-        }
-
-        fn deserialize<'de, D>(deserializer: D) -> Result<Self::Fields<'static>, D::Error>
-        where
-            D: zalsa_::serde::Deserializer<'de>,
-        {
-            panic!("attempted to deserialize value not marked with `persist` attribute")
-        }
-    }
-    impl Configuration_ {
-        pub fn ingredient(zalsa: &zalsa_::Zalsa) -> &zalsa_struct_::IngredientImpl<Self> {
-            static CACHE: zalsa_::IngredientCache<zalsa_struct_::IngredientImpl<Configuration_>> =
-                zalsa_::IngredientCache::new();
-
-            // SAFETY: The ingredient at offset 0 in `JarImpl<Configuration_>` has type
-            // `IngredientImpl<Configuration_>`.
-            unsafe { CACHE.get_or_create::<zalsa_struct_::JarImpl<Configuration_>, 0>(zalsa) }
-        }
-    }
-    impl zalsa_::AsId for InternedString<'_> {
-        fn as_id(&self) -> salsa::Id {
-            self.0
-        }
-    }
-    impl zalsa_::FromId for InternedString<'_> {
-        fn from_id(id: salsa::Id) -> Self {
-            Self(id, std::marker::PhantomData)
-        }
-    }
-    unsafe impl Send for InternedString<'_> {}
-
-    unsafe impl Sync for InternedString<'_> {}
-
-    impl std::fmt::Debug for InternedString<'_> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            Self::default_debug_fmt(*self, f)
-        }
-    }
-    impl zalsa_::SalsaStructInDb for InternedString<'_> {
-        type MemoIngredientMap = zalsa_::MemoIngredientSingletonIndex;
-
-        const LEAF_TYPE_IDS: &'static [salsa::plumbing::ConstTypeId] =
-            &[salsa::plumbing::ConstTypeId::of::<InternedString>()];
-
-        fn lookup_ingredient_index(aux: &Zalsa) -> salsa::plumbing::IngredientIndices {
-            aux.lookup_jar_by_type::<zalsa_struct_::JarImpl<Configuration_>>()
-                .into()
-        }
-
-        fn entries(zalsa: &zalsa_::Zalsa) -> impl Iterator<Item = zalsa_::DatabaseKeyIndex> + '_ {
-            let ingredient_index =
-                zalsa.lookup_jar_by_type::<zalsa_struct_::JarImpl<Configuration_>>();
-            <Configuration_>::ingredient(zalsa)
-                .entries(zalsa)
-                .map(|entry| entry.key())
-        }
-
-        #[inline]
-        fn cast(id: zalsa_::Id, type_id: TypeId) -> Option<Self> {
-            if type_id == TypeId::of::<InternedString>() {
-                Some(<InternedString as zalsa_::FromId>::from_id(id))
-            } else {
-                None
+            fn into_owned(self, id: salsa::Id) -> InternedString<'db> {
+                (self.0)(salsa::plumbing::FromId::from_id(id))
             }
         }
 
-        #[inline]
-        unsafe fn memo_table(
-            zalsa: &zalsa_::Zalsa,
-            id: zalsa_::Id,
-            current_revision: zalsa_::Revision,
-        ) -> zalsa_::MemoTableWithTypes<'_> {
-            // SAFETY: Guaranteed by caller.
-            unsafe {
-                zalsa
-                    .table()
-                    .memos::<zalsa_struct_::Value<Configuration_>>(id, current_revision)
+        impl<'db, F> HashEqLike<InternedString<'db>> for OtherLookup<F> {
+            fn hash<H: std::hash::Hasher>(&self, _h: &mut H) {}
+
+            fn eq(&self, _data: &InternedString<'db>) -> bool {
+                true
             }
         }
-    }
 
-    unsafe impl zalsa_::SalsaValue for InternedString<'_> {}
-    impl<'db> InternedString<'db> {
-        pub fn new<Db_, T0: zalsa_::Lookup<String> + std::hash::Hash>(
-            db: &'db Db_,
-            data: T0,
-            other: impl FnOnce(InternedString<'db>) -> InternedString<'db>,
-        ) -> Self
-        where
-            Db_: ?Sized + salsa::Database,
-            String: zalsa_::HashEqLike<T0>,
-        {
-            Configuration_::ingredient(db.zalsa()).intern(
-                db.zalsa(),
-                db.zalsa_local(),
-                StructKey::<'db>(data, std::marker::PhantomData::default()),
-                |id, data| {
-                    StructData(
-                        zalsa_::Lookup::into_owned(data.0),
-                        other(zalsa_::FromId::from_id(id)),
-                    )
-                },
-            )
-        }
-        fn data<Db_>(self, db: &'db Db_) -> String
-        where
-            Db_: ?Sized + zalsa_::Database,
-        {
-            let fields = Configuration_::ingredient(db.zalsa()).fields(db.zalsa(), self);
-            std::clone::Clone::clone((&fields.0))
-        }
-        fn other<Db_>(self, db: &'db Db_) -> InternedString<'db>
-        where
-            Db_: ?Sized + zalsa_::Database,
-        {
-            let fields = Configuration_::ingredient(db.zalsa()).fields(db.zalsa(), self);
-            std::clone::Clone::clone((&fields.1))
-        }
-        #[doc = r" Default debug formatting for this struct (may be useful if you define your own `Debug` impl)"]
-        pub fn default_debug_fmt(this: Self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            zalsa_::with_attached_database(|db| {
-                let fields = Configuration_::ingredient(db.zalsa()).fields(db.zalsa(), this);
-                let mut f = f.debug_struct("InternedString");
-                let f = f.field("data", &fields.0);
-                let f = f.field("other", &fields.1);
-                f.finish()
-            })
-            .unwrap_or_else(|| {
-                f.debug_tuple("InternedString")
-                    .field(&zalsa_::AsId::as_id(&this))
-                    .finish()
-            })
-        }
+        Self::new_impl(db, data, OtherLookup(other))
     }
-};
+}


### PR DESCRIPTION
The main change is that now `Lookup` takes a `salsa::Id` representing the `Id` for the to-be-created struct. But for that to work, I also made some other changes:

 - The order of `HashEqLike` was reversed. Previously it was `<Owned as HashEqLike<Borrowed>>`, now it's `<Borrowed as HashEqLike<Owned>>`, matching `Lookup`.
 - It's now possible to put `#[no_eq]` on an interned field to exempt them from hashing & equality checks (`#[no_eq]` on tracked structs doesn't change hashing. I think this is a bug we need to fix, but didn't touch it).
 - That in turns mean that we can no longer use a tuple for the fields and have to use a custom struct.

This is a breaking change because of the changes to `Lookup` and `HashEqLike`.